### PR TITLE
sys-process/procps: backport fix of CVE-2023-4016 for procps-3.3.17

### DIFF
--- a/sys-process/procps/files/procps-3.3.17-backport-CVE-2023-4016-fix.patch
+++ b/sys-process/procps/files/procps-3.3.17-backport-CVE-2023-4016-fix.patch
@@ -1,0 +1,78 @@
+https://bugs.gentoo.org/913408
+
+This patch is a clone of v3-CVE-2023-4016.patch from:
+https://gitlab.com/kirinnee/nixpkgs/-/commit/60c6ab3fff28e4e22d9e0aa58025332cdfac2fb1
+with changes described here:
+https://gitlab.com/procps-ng/procps/-/commit/f5f843e257daeceaac2504b8957e84f4bf87a8f2
+
+So together patch backports fix of CVE-2023-4016 for procps-3.3.17
+---
+ ps/parser.c | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/ps/parser.c b/ps/parser.c
+index 4263a1fb..21c2488b 100644
+--- a/ps/parser.c
++++ b/ps/parser.c
+@@ -36,6 +36,14 @@
+ #include "common.h"
+ #include "c.h"
+ 
++static void *xxcalloc(const size_t nelems, const size_t size)
++{
++  void *ret = calloc(nelems, size);
++  if (!ret && size && nelems)
++    xerrx(EXIT_FAILURE, "cannot allocate %zu bytes", nelems*size);
++  return ret;
++}
++
+ #define ARG_GNU  0
+ #define ARG_END  1
+ #define ARG_PGRP 2
+@@ -184,8 +192,8 @@ static const char *parse_list(const char *arg, const char *(*parse_fn)(char *, s
+   const char *err;       /* error code that could or did happen */
+   /*** prepare to operate ***/
+   node = malloc(sizeof(selection_node));
+-  node->u = malloc(strlen(arg)*sizeof(sel_union)); /* waste is insignificant */
+   node->n = 0;
++  node->u = NULL;
+   buf = strdup(arg);
+   /*** sanity check and count items ***/
+   need_item = 1; /* true */
+@@ -199,12 +207,13 @@ static const char *parse_list(const char *arg, const char *(*parse_fn)(char *, s
+       need_item=1;
+       break;
+     default:
+-      if(need_item) items++;
++      if(need_item && items < INT_MAX) items++;
+       need_item=0;
+     }
+   } while (*++walk);
+   if(need_item) goto parse_error;
+   node->n = items;
++  node->u = xxcalloc(items, sizeof(sel_union));
+   /*** actually parse the list ***/
+   walk = buf;
+   while(items--){
+@@ -1031,15 +1040,15 @@ static const char *parse_trailing_pids(void){
+   thisarg = ps_argc - 1;   /* we must be at the end now */
+ 
+   pidnode = malloc(sizeof(selection_node));
+-  pidnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  pidnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   pidnode->n = 0;
+ 
+   grpnode = malloc(sizeof(selection_node));
+-  grpnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  grpnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   grpnode->n = 0;
+ 
+   sidnode = malloc(sizeof(selection_node));
+-  sidnode->u = malloc(i*sizeof(sel_union)); /* waste is insignificant */
++  sidnode->u = xxcalloc(i, sizeof(sel_union)); /* waste is insignificant */
+   sidnode->n = 0;
+ 
+   while(i--){
+-- 
+2.43.0
+

--- a/sys-process/procps/procps-3.3.17-r3.ebuild
+++ b/sys-process/procps/procps-3.3.17-r3.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+# See https://bugs.gentoo.org/835813 before bumping to 4.x!
+
+inherit flag-o-matic multilib-minimal usr-ldscript
+
+DESCRIPTION="Standard informational utilities and process-handling tools"
+HOMEPAGE="http://procps-ng.sourceforge.net/ https://gitlab.com/procps-ng/procps"
+SRC_URI="https://downloads.sourceforge.net/${PN}-ng/${PN}-ng-${PV}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0/8" # libprocps.so
+KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+IUSE="elogind +kill modern-top +ncurses nls selinux static-libs systemd test unicode"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	elogind? ( sys-auth/elogind )
+	ncurses? ( >=sys-libs/ncurses-5.7-r7:=[unicode(+)?] )
+	selinux? ( sys-libs/libselinux[${MULTILIB_USEDEP}] )
+	systemd? ( sys-apps/systemd[${MULTILIB_USEDEP}] )
+"
+BDEPEND="
+	elogind? ( virtual/pkgconfig )
+	ncurses? ( virtual/pkgconfig )
+	systemd? ( virtual/pkgconfig )
+	test? ( dev-util/dejagnu )
+"
+RDEPEND="${DEPEND}
+	kill? (
+		!sys-apps/coreutils[kill]
+		!sys-apps/util-linux[kill]
+	)
+	!<app-i18n/man-pages-l10n-4.2.0-r1
+	!<app-i18n/man-pages-de-2.12-r1
+	!<app-i18n/man-pages-pl-0.7-r1
+"
+
+# https://bugs.gentoo.org/898830
+QA_CONFIG_IMPL_DECL_SKIP=( makedev )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.3.11-sysctl-manpage.patch # 565304
+	"${FILESDIR}"/${PN}-3.3.12-proc-tests.patch # 583036
+	"${FILESDIR}/${P}-backport-CVE-2023-4016-fix.patch" # 913408
+)
+
+src_prepare() {
+	default
+
+	# Please drop this after 3.3.17 and instead use --disable-w on musl.
+	# bug #794997
+	use elibc_musl && eapply "${FILESDIR}"/${PN}-3.3.17-musl-fix.patch
+}
+
+multilib_src_configure() {
+	# http://www.freelists.org/post/procps/PATCH-enable-transparent-large-file-support
+	append-lfs-flags #471102
+
+	local myeconfargs=(
+		$(multilib_native_use_with elogind) # No elogind multilib support
+		$(multilib_native_use_enable kill)
+		$(multilib_native_use_enable modern-top)
+		$(multilib_native_use_with ncurses)
+		$(use_enable nls)
+		$(use_enable selinux libselinux)
+		$(use_enable static-libs static)
+		$(use_with systemd)
+		$(use_enable unicode watch8bit)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_test() {
+	emake check </dev/null #461302
+}
+
+multilib_src_install() {
+	default
+	dodoc "${S}"/sysctl.conf
+
+	if multilib_is_native_abi ; then
+		dodir /bin
+		mv "${ED}"/usr/bin/ps "${ED}"/bin/ || die
+		if use kill ; then
+			mv "${ED}"/usr/bin/kill "${ED}"/bin/ || die
+		fi
+
+		gen_usr_ldscript -a procps
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
As mentioned in https://bugs.gentoo.org/913408 sys-process/procp-3.3.17 is vulnerable to buffer overflow. This can be fixed by backport of patches mentioned in https://gitlab.com/procps-ng/procps/-/commit/2c933ecba3bb1d3041a5a7a53a7b4078a6003413.

Patch is mix of changes from:
https://gitlab.com/kirinnee/nixpkgs/-/commit/60c6ab3fff28e4e22d9e0aa58025332cdfac2fb1
https://gitlab.com/procps-ng/procps/-/commit/f5f843e257daeceaac2504b8957e84f4bf87a8f2


Bug: https://bugs.gentoo.org/913408
Closes: https://bugs.gentoo.org/913408
