### PR TITLE
sci-libs/hipBLAS: fix compilation when git is not installed

### DIFF
--- a/sci-libs/hipBLAS/files/hipBLAS-6.3.0-no-git.patch
+++ b/sci-libs/hipBLAS/files/hipBLAS-6.3.0-no-git.patch
@@ -1,0 +1,18 @@
+Git is not required and rev-parse does nothing for tarballs.
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -44,14 +44,6 @@ if( BUILD_VERBOSE )
+   message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
+ endif( )
+ 
+-# Get the git hash of the hipBLAS branch
+-find_package(Git REQUIRED)
+-
+-execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+-                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+-                OUTPUT_VARIABLE GIT_HASH_HIPBLAS
+-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+ set(hipblas_VERSION_COMMIT_ID "${GIT_HASH_HIPBLAS}")
+ 
+ # log build commits

--- a/sci-libs/hipBLAS/hipBLAS-6.3.0.ebuild
+++ b/sci-libs/hipBLAS/hipBLAS-6.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -24,6 +24,10 @@ RDEPEND="
 	sci-libs/rocSOLVER:${SLOT}[${ROCM_USEDEP}]
 "
 DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-6.3.0-no-git.patch
+)
 
 src_configure() {
 	# Note: hipcc is enforced; clang fails when libc++ is enabled


### PR DESCRIPTION
Git is not required and `git rev-parse` does nothing for tarballs.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
