### PR TITLE
sci-libs/rocThrust: fix compilation with libc++

### DIFF
--- a/sci-libs/rocThrust/files/rocThrust-6.3.0-fix-libcxx.patch
+++ b/sci-libs/rocThrust/files/rocThrust-6.3.0-fix-libcxx.patch
@@ -1,0 +1,13 @@
+_VSTD macro was removed from libcxx
+Upstream commit: https://github.com/ROCm/rocThrust/commit/bc24ef2613e282d57d96dcf4263e2fa2cab171e4
+--- a/thrust/type_traits/is_contiguous_iterator.h
++++ b/thrust/type_traits/is_contiguous_iterator.h
+@@ -139,7 +139,7 @@ struct is_libcxx_wrap_iter : false_type {};
+ #if defined(_LIBCPP_VERSION)
+ template <typename Iterator>
+ struct is_libcxx_wrap_iter<
+-  _VSTD::__wrap_iter<Iterator>
++  std::__wrap_iter<Iterator>
+ > : true_type {};
+ #endif
+ 

--- a/sci-libs/rocThrust/rocThrust-6.3.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-6.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -40,7 +40,10 @@ BDEPEND="
 	test? ( app-arch/unzip )
 "
 
-PATCHES=( "${FILESDIR}/${PN}-4.0-operator_new.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0-operator_new.patch"
+	"${FILESDIR}/${PN}-6.3.0-fix-libcxx.patch"
+)
 
 src_configure() {
 	rocm_use_hipcc


### PR DESCRIPTION
`_VSTD` macro was removed from libcxx.
Backports one line from commit: https://github.com/ROCm/rocThrust/commit/bc24ef2613e282d57d96dcf4263e2fa2cab171e4

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
