### PR TITLE
kernel-install.eclass: verify uki/kernel image before installing

### DIFF
--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.7.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.8.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.8.ebuild
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.9.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.9.ebuild
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.67.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.67.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.68-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.68-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.68.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.68.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.69.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.69.ebuild
@@ -53,6 +53,8 @@ BDEPEND="
 	dev-util/pahole
 	virtual/libelf
 	app-alternatives/yacc
+	amd64? ( app-crypt/sbsigntools )
+	arm64? ( app-crypt/sbsigntools )
 "
 
 QA_PREBUILT='*'


### PR DESCRIPTION
This avoids accidentally installing a kernel image or generic UKI with an
invalid signature in both gentoo-kernel and gentoo-kernel-bin. This means we
will catch regressions such as described below earlier, notably it will now
error out when building the binpkgs for gentoo-kernel-bin.

We also add some logic to recover from the case where the kernel image is
larger then it should be. This may be the case with `ukify>=257` because starting
from this version onwards the space that the kernel needs to extract and run
is reserved in the `.linux` section of the UKI as padding. `Objcopy` unfortunately
copies this padding along with the rest of the data, invalidating the signature.
In previous versions of ukify this was not an issue because the `.linux` section
was always the last section in the UKI and you could therefore usually get away
with not reserving the extra required space.

Sbverify helpfully reports a warning about this padding with the exact size
the kernel image should have. We use this to strip the padding from the
kernel image, and verify if the signature problem is now resolved. There may be
a better way to do this that does not involve parsing the output of sbverify,
but I have not been able to find any.

See-also: https://github.com/systemd/systemd/issues/35851
See-also: https://forums.gentoo.org/viewtopic-t-1172386.html
Signed-off-by: Nowa Ammerlaan <nowa@gentoo.org>

<!-- Please put the pull request description above -->

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
