### PR TITLE
net-misc/scponly: Fix broken USE=sftp, implicit decls in configure

### DIFF
--- a/net-misc/scponly/files/scponly-4.8-C23.patch
+++ b/net-misc/scponly/files/scponly-4.8-C23.patch
@@ -1,0 +1,26 @@
+diff -ru a/helper.c b/helper.c
+--- a/helper.c	2025-01-10 17:16:03.332900358 +0400
++++ b/helper.c	2025-01-10 17:17:24.801652374 +0400
+@@ -1,7 +1,9 @@
+ /*
+  *	helper functions for scponly
+  */
++#define _DEFAULT_SOURCE /* for strsep */
+ #include <stdio.h>	/* io */
++#include <strings.h>	/* for bzero */
+ #include <string.h>	/* for str* */
+ #include <sys/types.h>	/* for stat, getpwuid */
+ #include <sys/stat.h>	/* for stat */
+diff -ru a/scponly.c b/scponly.c
+--- a/scponly.c	2025-01-10 17:16:03.332900358 +0400
++++ b/scponly.c	2025-01-10 17:18:13.274524840 +0400
+@@ -6,7 +6,8 @@
+  *
+  *	see CONTRIB for additional credits
+  */
+- 
++
++#define _DEFAULT_SOURCE /* for seteuid */
+ #include <stdio.h>	/* io */
+ #include <string.h>	/* for str* */
+ #include <sys/types.h>	/* for fork, wait, stat */

--- a/net-misc/scponly/metadata.xml
+++ b/net-misc/scponly/metadata.xml
@@ -32,5 +32,6 @@
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">scponly</remote-id>
+		<remote-id type="github">scponly/scponly</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/net-misc/scponly/scponly-4.8-r9.ebuild
+++ b/net-misc/scponly/scponly-4.8-r9.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit readme.gentoo-r1 toolchain-funcs
+inherit readme.gentoo-r1 toolchain-funcs autotools
 
 DESCRIPTION="A tiny pseudoshell which only permits scp and sftp"
 HOMEPAGE="https://github.com/scponly/scponly"
@@ -32,18 +32,25 @@ PATCHES=(
 	"${FILESDIR}/${P}-rsync.patch"
 	"${FILESDIR}/${P}-gcc4.4.0.patch"
 	"${FILESDIR}/${P}-sftp-server-path.patch"
+	"${FILESDIR}/${P}-C23.patch"
 )
+
+src_prepare() {
+	default
+
+	# bug #900316
+	eautoreconf
+}
 
 src_configure() {
 	CFLAGS="${CFLAGS} ${LDFLAGS}" econf \
-		--with-sftp-server="/usr/$(get_libdir)/misc/sftp-server" \
 		--disable-restrictive-names \
 		$(use_enable chroot chrooted-binary) \
-		$(use_enable chroot chrooted-checkdir) \
+		$(use_enable chroot chroot-checkdir) \
 		$(use_enable winscp winscp-compat) \
 		$(use_enable gftp gftp-compat) \
 		$(use_enable scp scp-compat) \
-		$(use_enable sftp sftp) \
+		$(use_with sftp sftp-server "/usr/$(get_libdir)/misc/sftp-server") \
 		$(use_enable quota quota-compat) \
 		$(use_enable passwd passwd-compat) \
 		$(use_enable rsync rsync-compat) \


### PR DESCRIPTION
Now this package is compliant with C23, and doesn't have any implicit errors in configure.
Wile porting, I noted two QA errors - one with mistyped configure option chroot-checkdir another with sftp. --disable-sftp was not, apparently, correct way to disable sftp. Changed flag to right one.

Bug: https://bugs.gentoo.org/900316

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
