### PR TITLE
dev-libs/atf: fix error duing configure

### DIFF
--- a/dev-libs/atf/atf-0.21-r2.ebuild
+++ b/dev-libs/atf/atf-0.21-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit flag-o-matic
+inherit autotools flag-o-matic
 
 DESCRIPTION="Libraries to write tests in C, C++ and shell"
 HOMEPAGE="https://github.com/freebsd/atf"
@@ -17,11 +17,12 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=( "${FILESDIR}"/${P}-getopt-solaris.patch )
 
-src_configure() {
+src_prepare() {
+	default
+	eautoreconf # 879659
+
 	# Uses std::auto_ptr (deprecated in c++11, removed in c++17)
 	append-cxxflags "-std=c++14"
-
-	default
 }
 
 src_install() {


### PR DESCRIPTION
conftest.c:26:6: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
   26 | main ()
         |      ^
               |       void
               1 error generated.

it's fixed by autoconf already, so run eautoreconf to update configure

Closes: https://bugs.gentoo.org/879659

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
