### PR TITLE
dev-cpp/opentelemetry-cpp: fix build with clang, gcc-15 and [prometheus]

### DIFF
--- a/dev-cpp/opentelemetry-cpp/files/opentelemetry-cpp-1.16.1-cstdint.patch
+++ b/dev-cpp/opentelemetry-cpp/files/opentelemetry-cpp-1.16.1-cstdint.patch
@@ -1,0 +1,14 @@
+Fix compilation with gcc-15.
+Bug: https://bugs.gentoo.org/946146
+Upstream PR: https://github.com/open-telemetry/opentelemetry-cpp/pull/3240
+--- a/api/include/opentelemetry/logs/severity.h
++++ b/api/include/opentelemetry/logs/severity.h
+@@ -3,6 +3,8 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
++
+ #include "opentelemetry/nostd/string_view.h"
+ #include "opentelemetry/version.h"
+ 

--- a/dev-cpp/opentelemetry-cpp/files/opentelemetry-cpp-1.16.1-fix-clang-template.patch
+++ b/dev-cpp/opentelemetry-cpp/files/opentelemetry-cpp-1.16.1-fix-clang-template.patch
@@ -1,0 +1,43 @@
+Fix clang-19 error: a template argument list is expected after a name prefixed by the template keyword
+Upstream PR: https://github.com/open-telemetry/opentelemetry-cpp/pull/3133
+--- a/api/include/opentelemetry/logs/event_logger.h
++++ b/api/include/opentelemetry/logs/event_logger.h
+@@ -65,9 +65,8 @@ class EventLogger
+     }
+     nostd::unique_ptr<LogRecord> log_record = delegate_logger->CreateLogRecord();
+ 
+-    IgnoreTraitResult(
+-        detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(
+-            log_record.get(), std::forward<ArgumentType>(args))...);
++    IgnoreTraitResult(detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
++        log_record.get(), std::forward<ArgumentType>(args))...);
+ 
+     EmitEvent(event_name, std::move(log_record));
+   }
+--- a/api/include/opentelemetry/logs/logger.h
++++ b/api/include/opentelemetry/logs/logger.h
+@@ -72,9 +72,8 @@ class Logger
+       return;
+     }
+ 
+-    IgnoreTraitResult(
+-        detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(
+-            log_record.get(), std::forward<ArgumentType>(args))...);
++    IgnoreTraitResult(detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
++        log_record.get(), std::forward<ArgumentType>(args))...);
+ 
+     EmitLogRecord(std::move(log_record));
+   }
+--- a/api/include/opentelemetry/logs/logger_type_traits.h
++++ b/api/include/opentelemetry/logs/logger_type_traits.h
+@@ -166,8 +166,8 @@ struct LogRecordSetterTrait
+                 * = nullptr>
+   inline static LogRecord *Set(LogRecord *log_record, ArgumentType &&arg) noexcept
+   {
+-    return LogRecordSetterTrait<common::KeyValueIterable>::template Set(
+-        log_record, std::forward<ArgumentType>(arg));
++    return LogRecordSetterTrait<common::KeyValueIterable>::Set(log_record,
++                                                               std::forward<ArgumentType>(arg));
+   }
+ 
+   template <class ArgumentType,

--- a/dev-cpp/opentelemetry-cpp/opentelemetry-cpp-1.16.1.ebuild
+++ b/dev-cpp/opentelemetry-cpp/opentelemetry-cpp-1.16.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,6 +23,9 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	prometheus? (
+		dev-cpp/prometheus-cpp
+	)
 	test? (
 		dev-cpp/gtest
 		dev-cpp/benchmark
@@ -33,7 +36,9 @@ RESTRICT="!test? ( test )"
 
 PATCHES=(
 	# remove tests the need network
-	"${FILESDIR}/opentelemetry-cpp-1.5.0-tests.patch"
+	"${FILESDIR}/${PN}-1.5.0-tests.patch"
+	"${FILESDIR}/${PN}-1.16.1-cstdint.patch"
+	"${FILESDIR}/${PN}-1.16.1-fix-clang-template.patch"
 )
 
 src_configure() {

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sv. Lockal <lockalsash@gmail.com> (2025-01-11)
+# dev-cpp/prometheus-cpp is not keyworded
+dev-cpp/opentelemetry-cpp prometheus
+
 # Michał Górny <mgorny@gentoo.org> (2024-12-24)
 # OpenMP offloading is supported on 64-bit architectures only.
 llvm-core/clang-runtime -offload

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,5 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Sv. Lockal <lockalsash@gmail.com> (2025-01-11)
+# dev-cpp/prometheus-cpp is not keyworded
+dev-cpp/opentelemetry-cpp prometheus
 
 # Michał Górny <mgorny@gentoo.org> (2024-12-24)
 # OpenMP offloading is supported on 64-bit architectures only.


### PR DESCRIPTION
* Fix compilation with gcc-15 (incorrect template, fix will be in the next release)
* Fix compilation with clang-19 (incorrect template, backport change from the latest release)
* Fix missing dependency for `USE=prometheus` and mask this flag on arm64 and ppc64.

Closes: https://bugs.gentoo.org/946146
Closes: https://bugs.gentoo.org/946807

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
