### PR TITLE
media-libs/tiff-compat: Fix implicit declarations in configure

### DIFF
--- a/media-libs/tiff-compat/files/tiff-4.4.0-C23.patch
+++ b/media-libs/tiff-compat/files/tiff-4.4.0-C23.patch
@@ -1,0 +1,52 @@
+https://bugs.gentoo.org/910693
+Fix implicit declarations by regenerating configure,
+Fix config header templates, manually define _GNU_SOURCE  when
+correct header was not cooperating
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,7 @@
+ AC_CONFIG_AUX_DIR(config)
+ AC_CONFIG_MACRO_DIR(m4)
+ AC_LANG(C)
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ dnl Compute the canonical host (run-time) system type variable
+ AC_CANONICAL_HOST
+--- a/libtiff/tif_config.h.in
++++ b/libtiff/tif_config.h.in
+@@ -139,6 +139,11 @@
+ /* Support zstd compression */
+ #undef ZSTD_SUPPORT
+ 
++/* Enable GNU extensions on systems that have them.  */
++#ifndef _GNU_SOURCE
++# undef _GNU_SOURCE
++#endif
++
+ /* Enable large inode numbers on Mac OS X 10.5.  */
+ #ifndef _DARWIN_USE_64_BIT_INODE
+ # define _DARWIN_USE_64_BIT_INODE 1
+--- a/libtiff/tiffconf.h.in
++++ b/libtiff/tiffconf.h.in
+@@ -90,6 +90,11 @@
+ /* Support Deflate compression */
+ #undef ZIP_SUPPORT
+ 
++/* Enable GNU extensions on systems that have them.  */
++#ifndef _GNU_SOURCE
++# undef _GNU_SOURCE
++#endif
++
+ /* Support libdeflate enhanced compression */
+ #undef LIBDEFLATE_SUPPORT
+ 
+--- a/libtiff/mkg3states.c
++++ b/libtiff/mkg3states.c
+@@ -27,6 +27,7 @@
+  * in Frank Cringle's viewfax program;
+  *      Copyright (C) 1990, 1995  Frank D. Cringle.
+  */
++#define _GNU_SOURCE 1
+ #include "tif_config.h"
+ #include "libport.h"
+ 

--- a/media-libs/tiff-compat/tiff-compat-4.4.0-r2.ebuild
+++ b/media-libs/tiff-compat/tiff-compat-4.4.0-r2.ebuild
@@ -11,7 +11,7 @@ QA_PKGCONFIG_VERSION="$(ver_cut 1-3)"
 # GraphicsMagick maintainer Bob Friesenhahn. Please be careful when verifying
 # who made releases.
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rouault.asc
-inherit multilib-minimal verify-sig libtool flag-o-matic
+inherit multilib-minimal verify-sig flag-o-matic autotools
 
 MY_P="${P/_rc/rc}"
 DESCRIPTION="Tag Image File Format (TIFF) library (compat package for libtiff.so.5)"
@@ -23,7 +23,7 @@ S="${WORKDIR}/${PN/-compat}-$(ver_cut 1-3)"
 LICENSE="libtiff"
 SLOT="4"
 if [[ ${PV} != *_rc* ]] ; then
-	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 fi
 IUSE="+cxx jbig jpeg lzma test webp zlib zstd"
 RESTRICT="!test? ( test )"
@@ -51,13 +51,14 @@ MULTILIB_WRAPPED_HEADERS=(
 PATCHES=(
 	"${FILESDIR}"/${PN/-compat}-4.4.0_rc1-skip-thumbnail-test.patch
 	"${FILESDIR}"/${P/-compat}-hylafaxplus-regression.patch
+	"${FILESDIR}"/${P/-compat}-C23.patch
 )
 
 src_prepare() {
 	default
 
-	# Added to fix cross-compilation
-	elibtoolize
+	# Added to fix cross-compilation and bug #910693
+	eautoreconf
 }
 
 multilib_src_configure() {


### PR DESCRIPTION
by regenerating it with autotools.
Drop blocker on tiff-4.4* - it was dropped two years ago
Also fix C23 compliance by adding AC_SYSTEM_EXTENSIONS and updating config header templates, plus one stubborn source file.

Bug: https://bugs.gentoo.org/910693

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
