### PR TITLE
net-analyzer/nfdump: fix musl compilation for version 1.7.4

### DIFF
--- a/net-analyzer/nfdump/files/nfdump-1.7.2-musl.patch
+++ b/net-analyzer/nfdump/files/nfdump-1.7.2-musl.patch
@@ -1,0 +1,14 @@
+Backport patch from 1.7.5.
+
+https://github.com/phaag/nfdump/commit/925dd28f7e08e00479a2906d0343e6fa75a6a783
+
+--- a/src/lib/daemon.c
++++ b/src/lib/daemon.c
+@@ -41,6 +41,7 @@
+ #include <sys/types.h>
+ // some linux are picky
+ #define __USE_GNU
++#define _GNU_SOURCE
+ #include <unistd.h>
+ 
+ #include "util.h"

--- a/net-analyzer/nfdump/files/nfdump-1.7.2-nfreplay-gcc14.patch
+++ b/net-analyzer/nfdump/files/nfdump-1.7.2-nfreplay-gcc14.patch
@@ -1,0 +1,21 @@
+
+https://github.com/phaag/nfdump/commit/0b2796b52e1793b6e2eba29baf7f456217372965
+
+From: Peter Haag <peter@people.ops-trust.net>
+Date: Tue, 20 Aug 2024 21:00:18 +0200
+Subject: [PATCH] Make gcc-14 happy
+
+--- a/src/nfreplay/nfreplay.c
++++ b/src/nfreplay/nfreplay.c
+@@ -74,9 +74,11 @@
+ #ifdef HAVE___FPURGE
+ #define FPURGE __fpurge
+ #endif
++#ifndef FPURGE
+ #ifdef HAVE_FPURGE
+ #define FPURGE fpurge
+ #endif
++#endif
+ 
+ /* Local Variables */
+ static int verbose = 0;

--- a/net-analyzer/nfdump/nfdump-1.7.4.ebuild
+++ b/net-analyzer/nfdump/nfdump-1.7.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -45,6 +45,8 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.6.19-libft.patch
+	"${FILESDIR}"/${PN}-1.7.2-musl.patch
+	"${FILESDIR}"/${PN}-1.7.2-nfreplay-gcc14.patch
 	"${FILESDIR}"/${PN}-1.7.4-rrdtool-gcc14.patch
 )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/934056
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
