### PR TITLE
dev-scheme/sigscheme: fix configure warnings

### DIFF
--- a/dev-scheme/sigscheme/files/sigscheme-0.9.1-autoconf.patch
+++ b/dev-scheme/sigscheme/files/sigscheme-0.9.1-autoconf.patch
@@ -1,0 +1,31 @@
+From 1fd438ede105509488ae2f8a9f2d363097f4467d Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Sat, 11 Jan 2025 10:09:31 +0800
+Subject: [PATCH] m4/ax_check_page_aligned_malloc: Make macros
+ `-Wstrict-prototypes` compatible
+
+elimate compiler's warning:
+
+  warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+---
+ m4/ax_check_page_aligned_malloc.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/ax_check_page_aligned_malloc.m4 b/m4/ax_check_page_aligned_malloc.m4
+index 4bfa930..7aa7f74 100644
+--- a/m4/ax_check_page_aligned_malloc.m4
++++ b/m4/ax_check_page_aligned_malloc.m4
+@@ -35,7 +35,7 @@ AC_DEFUN([AX_CHECK_PAGE_ALIGNED_MALLOC],
+ # include <unistd.h>
+ #endif
+ 
+-int main()
++int main(void)
+ {
+   int pagesize = getpagesize();
+   int i;
+-- 
+2.45.2
+

--- a/dev-scheme/sigscheme/sigscheme-0.9.1.ebuild
+++ b/dev-scheme/sigscheme/sigscheme-0.9.1.ebuild
@@ -11,7 +11,19 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
+inherit autotools flag-o-matic
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.1-autoconf.patch
+)
+
+src_prepare() {
+	default
+	eautoconf # 879679
+}
+
 src_configure() {
+	use elibc_musl && append-cflags -D_GNU_SOURCE # 906864
 	econf --disable-static
 }
 


### PR DESCRIPTION
1. run eautoconf to modernize the build system
2. add -D_GNU_SOURCE so getpagesize is available if build w/ musl

Closes: https://bugs.gentoo.org/879679
Closes: https://bugs.gentoo.org/906864

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
