### PR TITLE
cargo.eclass: Emit a warning if the package uses 300+ crates

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -527,6 +527,12 @@ cargo_src_unpack() {
 		done < <(sha256sum -z "${crates[@]}" || die)
 
 		popd >/dev/null || die
+
+		if [[ ${#crates[@]} -ge 300 ]]; then
+			eqawarn "This package uses a very large number of CRATES.  Please provide"
+			eqawarn "a crate tarball instead and fetch it via SRC_URI.  You can use"
+			eqawarn "'pycargoebuild --crate-tarball' to create one."
+		fi
 	fi
 
 	cargo_gen_config


### PR DESCRIPTION
Emit a QA warning suggesting the use of crate tarball, when the package in question uses 300 crates or more.  Such a long crate lists cause ebuilds and Manifests to grow very fast, causing significant space consumption on end user systems (including users who are not using the package in question) and git history growth.  On top of that, fetching that many crates takes significant time.

The number of 300 is pretty arbitrary, chosen approximately to match Manifests that are over 100 KiB in size.  We should probably look into lowering in the future, as more packages are transitioned.