### PR TITLE
x11-misc/viewglob: update EAPI 7 -> 8, prepare for GCC-14/C23

### DIFF
--- a/x11-misc/viewglob/files/viewglob-2.0.4-C23.patch
+++ b/x11-misc/viewglob/files/viewglob-2.0.4-C23.patch
@@ -1,0 +1,56 @@
+https://bugs.gentoo.org/944019
+https://bugs.gentoo.org/921573
+Fix implicit defines in configure by defaulting to GNU_SOURCES, set include
+ordering straight for implicit define in code and fix sizes/declarations
+for C23
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,6 +1,7 @@
+ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT([viewglob], [2.0.4])
+ AM_INIT_AUTOMAKE
++AC_USE_SYSTEM_EXTENSIONS
+ AM_CONFIG_HEADER([config.h])
+ RELEASE_DATE="April 26, 2006"
+ 
+--- a/common/conf-to-args.c
++++ b/common/conf-to-args.c
+@@ -32,7 +32,7 @@
+ 	GString* arg_str = NULL;
+ 
+ 	gchar buf[1024];
+-	gint nread;
++	gssize nread;
+ 
+ 	gchar* home = getenv("HOME");
+ 	if (!home) {
+--- a/vgd/tcp-listen.c
++++ b/vgd/tcp-listen.c
+@@ -26,6 +26,8 @@
+ 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+ 
++#include "common.h"
++
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+@@ -34,7 +36,6 @@
+ 
+ #include <string.h>
+ 
+-#include "common.h"
+ #include "tcp-listen.h"
+ 
+ 
+--- a/vgseer/ptytty.c
++++ b/vgseer/ptytty.c
+@@ -112,7 +112,7 @@
+ #if defined(HAVE_GRANTPT) && defined(HAVE_UNLOCKPT)
+ # if defined(PTYS_ARE_GETPT) || defined(PTYS_ARE_PTMX)
+     {
+-	extern char    *ptsname();
++	extern char    *ptsname(int fd);
+ 
+ #  ifdef PTYS_ARE_GETPT
+ 	pfd = getpt();

--- a/x11-misc/viewglob/viewglob-2.0.4-r1.ebuild
+++ b/x11-misc/viewglob/viewglob-2.0.4-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools readme.gentoo-r1
 
 DESCRIPTION="Graphical display of directories and globs referenced at the shell prompt"
-HOMEPAGE="http://viewglob.sourceforge.net/"
+HOMEPAGE="https://viewglob.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/viewglob/${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -23,6 +23,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${P}-underlinking.patch
 	"${FILESDIR}"/${P}-format-security.patch
+	"${FILESDIR}"/${P}-C23.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Ordering of includes and correct function signatures for C23 And AC_USE_SYSTEM_EXTENSIONS for implicit delc in configure I noticed on my system (not a reported bug)

Bug: https://bugs.gentoo.org/928851
Closes: https://bugs.gentoo.org/944278
Closes: https://bugs.gentoo.org/944019

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
