### PR TITLE
sys-devel/gettext: fix warning during configure

### DIFF
--- a/sys-devel/gettext/gettext-0.22.5-r1.ebuild
+++ b/sys-devel/gettext/gettext-0.22.5-r1.ebuild
@@ -79,14 +79,6 @@ PATCHES=(
 
 QA_SONAME_NO_SYMLINK=".*/preloadable_libintl.so"
 
-QA_CONFIG_IMPL_DECL_SKIP=(
-	# bug #898570
-	unreachable
-	MIN
-	alignof
-	static_assert
-)
-
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 }

--- a/sys-devel/gettext/gettext-0.22.5-r2.ebuild
+++ b/sys-devel/gettext/gettext-0.22.5-r2.ebuild
@@ -74,14 +74,6 @@ PATCHES=(
 
 QA_SONAME_NO_SYMLINK=".*/preloadable_libintl.so"
 
-QA_CONFIG_IMPL_DECL_SKIP=(
-	# bug #898570
-	unreachable
-	MIN
-	alignof
-	static_assert
-)
-
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 }

--- a/sys-devel/gettext/gettext-0.22.5.ebuild
+++ b/sys-devel/gettext/gettext-0.22.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Note: Keep version bumps in sync with dev-libs/libintl.
@@ -78,14 +78,6 @@ PATCHES=(
 )
 
 QA_SONAME_NO_SYMLINK=".*/preloadable_libintl.so"
-
-QA_CONFIG_IMPL_DECL_SKIP=(
-	# bug #898570
-	unreachable
-	MIN
-	alignof
-	static_assert
-)
 
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp

--- a/sys-devel/gettext/gettext-0.23.1-r1.ebuild
+++ b/sys-devel/gettext/gettext-0.23.1-r1.ebuild
@@ -74,14 +74,6 @@ PATCHES=(
 
 QA_SONAME_NO_SYMLINK=".*/preloadable_libintl.so"
 
-QA_CONFIG_IMPL_DECL_SKIP=(
-	# bug #898570
-	unreachable
-	MIN
-	alignof
-	static_assert
-)
-
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 }


### PR DESCRIPTION
1. #include <unistd.h> fix warning on _exit
2. fpurge is removed in commit a34b0465ba14c70532b8eaba650a9eac228fce57 of musl
3. unreachable, MIN, alignof, static_assert had been suppressed by portage

Closes: https://bugs.gentoo.org/898570

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
