### PR TITLE
dev-util/cpputest: fix configure & test

### DIFF
--- a/dev-util/cpputest/cpputest-4.0-r1.ebuild
+++ b/dev-util/cpputest/cpputest-4.0-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -18,6 +18,11 @@ RESTRICT="!test? ( test )"
 DEPEND="test? ( >=dev-cpp/gtest-1.8.0 )"
 
 DOCS=( AUTHORS README.md README_CppUTest_for_C.txt )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.0-autoconf.patch
+	"${FILESDIR}"/${P}-replace-UB-by-abort.patch
+)
 
 src_prepare() {
 	default

--- a/dev-util/cpputest/files/cpputest-4.0-autoconf.patch
+++ b/dev-util/cpputest/files/cpputest-4.0-autoconf.patch
@@ -1,0 +1,46 @@
+patch submitted to upstream at https://github.com/cpputest/cpputest/pull/1837
+
+From 2ba7e10e73a1daf7194b83e952df58ce1c985644 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Sun, 12 Jan 2025 23:04:59 +0800
+Subject: [PATCH] configure.ac: fix call of AC_LANG_PROGRAM & unexpected
+ compilation errors
+
+1. multiple line should be enclosed by [[ ]], otherwise compilation of
+   conftest.cpp will failed with:
+     error: extra tokens at end of #include directive [-Werror,-Wextra-tokens]
+2. add #include <cstdint>
+3. size_t -> std::size_t
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+---
+ configure.ac | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index b19c9eb6..e91c4a27 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -325,13 +325,17 @@ AC_LANG_PUSH([C++])
+ # Can we use operator delete without exception handling specifier? (clang warns on this!)
+ CXXFLAGS="-Werror"
+ AC_MSG_CHECKING([whether CXX supports operator delete without exception handling specifier])
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <new>\nvoid operator delete(void* mem);])], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no]); UT_DELETE_MUST_HAVE_EXCEPTION_SPECIFIER="yes"])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <cstdint>
++#include <new>
++void operator delete(void* mem);]])], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no]); UT_DELETE_MUST_HAVE_EXCEPTION_SPECIFIER="yes"])
+ CXXFLAGS="$saved_cxxflags"
+ 
+ # Can we use operator new with exception specifier (g++4.7 on MacOSX is broken here)
+ CXXFLAGS="-Werror"
+ AC_MSG_CHECKING([whether CXX supports operator new with exception handling specifier])
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <new>\nvoid* operator new(size_t size) throw(std::bad_alloc);;])], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no]); UT_NEW_CANT_HAVE_EXCEPTION_SPECIFIER="yes"])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <cstdint>
++#include <new>
++void* operator new(std::size_t size) throw(std::bad_alloc);;]])], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no]); UT_NEW_CANT_HAVE_EXCEPTION_SPECIFIER="yes"])
+ CXXFLAGS="$saved_cxxflags"
+ 
+ # Flag -Wno-missing-exception-spec
+-- 
+2.45.2
+

--- a/dev-util/cpputest/files/cpputest-4.0-replace-UB-by-abort.patch
+++ b/dev-util/cpputest/files/cpputest-4.0-replace-UB-by-abort.patch
@@ -1,0 +1,33 @@
+fix tests hang with clang as reported in https://bugs.gentoo.org/924958
+
+patch from upstream PR at https://github.com/cpputest/cpputest/pull/1679
+commit https://github.com/cpputest/cpputest/commit/094df52c8f6dae1dccb30d0d39dd1eb832ded85c
+adapt to v4.0
+
+diff --git a/src/CppUTest/Utest.cpp b/src/CppUTest/Utest.cpp
+index d078bdf..3cbbcdf 100644
+--- a/src/CppUTest/Utest.cpp
++++ b/src/CppUTest/Utest.cpp
+@@ -153,7 +153,7 @@ UtestShell::~UtestShell()
+ // LCOV_EXCL_START - actually covered but not in .gcno due to race condition
+ static void defaultCrashMethod()
+ {
+-    UtestShell* ptr = (UtestShell*) NULLPTR; ptr->countTests();
++    abort();
+ }
+ // LCOV_EXCL_STOP
+ 
+diff --git a/tests/CppUTest/UtestTest.cpp b/tests/CppUTest/UtestTest.cpp
+index cf6ad1c..a26fb41 100644
+--- a/tests/CppUTest/UtestTest.cpp
++++ b/tests/CppUTest/UtestTest.cpp
+@@ -222,8 +222,7 @@ TEST(UtestShell, TestDefaultCrashMethodInSeparateProcessTest)
+     fixture.runAllTests();
+     fixture.assertPrintContains("Failed in separate process - killed by signal");
+ 
+-    /* Signal 11 usually happens, but with clang3.7 on Linux, it produced signal 4 */
+-    CHECK(fixture.getOutput().contains("signal 11") || fixture.getOutput().contains("signal 4"));
++    CHECK(fixture.getOutput().contains("signal 6"));
+ }
+ 
+ #endif

--- a/dev-util/cpputest/metadata.xml
+++ b/dev-util/cpputest/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>zhixu.liu@gmail.com</email>
+		<name>Z. Liu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">cpputest/cpputest</remote-id>
 	</upstream>


### PR DESCRIPTION
1. fix unexpected errors during configuration, patch submitted to upstream at
    https://github.com/cpputest/cpputest/pull/1837
2. adopt patch from https://github.com/cpputest/cpputest/pull/1679, fix
    tests hangs w/ clang

Closes: https://bugs.gentoo.org/879681
Closes: https://bugs.gentoo.org/924958

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
