### PR TITLE
sci-physics/yoda: add yamlcpp patch

### DIFF
--- a/sci-physics/yoda/files/yoda-2.0.2-yamlcpp.patch
+++ b/sci-physics/yoda/files/yoda-2.0.2-yamlcpp.patch
@@ -1,0 +1,22 @@
+From 3e74499ba8bbbd6a872e0563625193505c14df90 Mon Sep 17 00:00:00 2001
+From: Christian Gutschow <chris.g@cern.ch>
+Date: Wed, 11 Dec 2024 19:10:11 +0000
+Subject: [PATCH] add missing header
+
+---
+ src/yamlcpp/emitterutils.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/yamlcpp/emitterutils.cpp b/src/yamlcpp/emitterutils.cpp
+index 5e5f00ea..78615970 100644
+--- a/src/yamlcpp/emitterutils.cpp
++++ b/src/yamlcpp/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 
+-- 
+GitLab
+

--- a/sci-physics/yoda/yoda-2.0.2.ebuild
+++ b/sci-physics/yoda/yoda-2.0.2.ebuild
@@ -45,6 +45,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}"/${P}-yamlcpp.patch # 937405
+)
+
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
 }


### PR DESCRIPTION
Add patch for yamlcpp. I do not know why `sci-physics/yoda` bugs are not assigned to me. The `metadata.xml` looks similar enough to the `sci-physics/{hepmc,rivet}`?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
