### PR TITLE
dev-util/unicorn: fix unexpected implicit function declarations

### DIFF
--- a/dev-util/unicorn/files/unicorn-2.0.1-configure.patch
+++ b/dev-util/unicorn/files/unicorn-2.0.1-configure.patch
@@ -1,0 +1,34 @@
+From a78d690da54f3afbd3213502c997ba68b29aa404 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Tue, 14 Jan 2025 08:47:54 +0800
+Subject: [PATCH] configure: add <sys/timex.h> for clock_adjtime on musl
+ (#2085)
+
+for glibc, if _GNU_SOURCE is defined, <time.h> will include <sys/timex.h>
+but not for musl, so add "#include <sys/timex.h>"
+
+although `man clock_adjtime` said "#include <sys/timex.h>", but it won't
+work for glibc w/o "#include <time.h>", I don't known why yet.
+
+PS it seems clock_adjtime is used nowhere?
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+---
+ qemu/configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/qemu/configure b/qemu/configure
+index db820ca1..47d4a4c6 100755
+--- a/qemu/configure
++++ b/qemu/configure
+@@ -1455,6 +1455,7 @@ fi
+ clock_adjtime=no
+ cat > $TMPC <<EOF
+ #include <time.h>
++#include <sys/timex.h>
+ 
+ int main(void)
+ {
+-- 
+2.45.2
+

--- a/dev-util/unicorn/unicorn-2.0.1-r1.ebuild
+++ b/dev-util/unicorn/unicorn-2.0.1-r1.ebuild
@@ -37,15 +37,9 @@ BDEPEND="virtual/pkgconfig
 UNICORN_TARGETS="x86 arm aarch64 riscv mips sparc m68k ppc s390x tricore"
 
 PATCHES=(
+	"${FILESDIR}/${PN}-2.0.1-configure.patch"
 	"${FILESDIR}/${P}-strict-prototypes.patch"
 	"${FILESDIR}/${P}-old-style-declaration.patch"
-)
-
-# suppress warning wrt 'implicit function declaration' in config logs due to
-# auto-detection of some libc functions (bug #906919)
-QA_CONFIG_IMPL_DECL_SKIP=(
-	clock_adjtime
-	malloc_trim
 )
 
 wrap_python() {
@@ -66,6 +60,10 @@ src_prepare() {
 
 	cmake_src_prepare
 	wrap_python ${FUNCNAME}
+
+	if use elibc_musl ; then
+		QA_CONFIG_IMPL_DECL_SKIP=( malloc_trim )
+	fi
 }
 
 src_configure(){

--- a/dev-util/unicorn/unicorn-2.0.1.ebuild
+++ b/dev-util/unicorn/unicorn-2.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -36,11 +36,8 @@ BDEPEND="virtual/pkgconfig
 
 UNICORN_TARGETS="x86 arm aarch64 riscv mips sparc m68k ppc s390x tricore"
 
-# suppress warning wrt 'implicit function declaration' in config logs due to
-# auto-detection of some libc functions (bug #906919)
-QA_CONFIG_IMPL_DECL_SKIP=(
-	clock_adjtime
-	malloc_trim
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.1-configure.patch
 )
 
 wrap_python() {
@@ -61,6 +58,10 @@ src_prepare() {
 
 	cmake_src_prepare
 	wrap_python ${FUNCNAME}
+
+	if use elibc_musl ; then
+		QA_CONFIG_IMPL_DECL_SKIP=( malloc_trim )
+	fi
 }
 
 src_configure(){

--- a/dev-util/unicorn/unicorn-2.1.1.ebuild
+++ b/dev-util/unicorn/unicorn-2.1.1.ebuild
@@ -36,11 +36,8 @@ BDEPEND="virtual/pkgconfig
 
 UNICORN_TARGETS="x86 arm aarch64 riscv mips sparc m68k ppc s390x tricore"
 
-# suppress warning wrt 'implicit function declaration' in config logs due to
-# auto-detection of some libc functions (bug #906919)
-QA_CONFIG_IMPL_DECL_SKIP=(
-	clock_adjtime
-	malloc_trim
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.1-configure.patch
 )
 
 wrap_python() {
@@ -61,6 +58,10 @@ src_prepare() {
 
 	cmake_src_prepare
 	wrap_python ${FUNCNAME}
+
+	if use elibc_musl ; then
+		QA_CONFIG_IMPL_DECL_SKIP=( malloc_trim )
+	fi
 }
 
 src_configure(){

--- a/dev-util/unicorn/unicorn-9999.ebuild
+++ b/dev-util/unicorn/unicorn-9999.ebuild
@@ -36,13 +36,6 @@ BDEPEND="virtual/pkgconfig
 
 UNICORN_TARGETS="x86 arm aarch64 riscv mips sparc m68k ppc s390x tricore"
 
-# suppress warning wrt 'implicit function declaration' in config logs due to
-# auto-detection of some libc functions (bug #906919)
-QA_CONFIG_IMPL_DECL_SKIP=(
-	clock_adjtime
-	malloc_trim
-)
-
 wrap_python() {
 	if use python; then
 		# src_prepare
@@ -61,6 +54,9 @@ src_prepare() {
 
 	cmake_src_prepare
 	wrap_python ${FUNCNAME}
+	if use elibc_musl ; then
+		QA_CONFIG_IMPL_DECL_SKIP=( malloc_trim )
+	fi
 }
 
 src_configure(){


### PR DESCRIPTION
1. patch submitted to upstream at https://github.com/unicorn-engine/unicorn/pull/2085
2. malloc_trim is not available on musl only

Closes: https://bugs.gentoo.org/906919

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
