### PR TITLE
app-editors/wily: update EAPI 7 -> 8, prepare for GCC-15

### DIFF
--- a/app-editors/wily/files/wily-1.0-C23.patch
+++ b/app-editors/wily/files/wily-1.0-C23.patch
@@ -1,0 +1,101 @@
+DO NOT EAT ERRORS AND CONTINUE
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -4,12 +4,16 @@
+ srcdir=@srcdir@
+ VPATH=@srcdir@
+ 
+-subdirs=libmsg wily
++SUBDIRS=libmsg wily
++.PHONY: $(TOPTARGETS) $(SUBDIRS)
++
++wily: libmsg
+ 
+-all install clean nuke distclean::
+-	for i in $(subdirs); do \
+-		(cd $$i; $(MAKE) $(MFLAGS) $@); \
+-	done
++TOPTARGETS=all install clean nuke distclean
++
++$(TOPTARGETS):: $(SUBDIRS)
++$(SUBDIRS):
++	$(MAKE) -C $@ $(MAKECMDGOALS)
+ 
+ nuke distclean::
+ 	rm -f wily.* config.cache config.h config.log config.status Makefile
+bug https://bugs.gentoo.org/729238
+Do not call ar directly
+--- a/configure.in
++++ b/configure.in
+@@ -95,6 +95,7 @@
+ AC_PROG_MAKE_SET
+ AM_PROG_CC_STDC
+ AC_PROG_RANLIB
++AC_PROG_AR
+ 
+ dnl Checks for libraries.
+ AC_PATH_XTRA
+--- a/libmsg/Makefile.in
++++ b/libmsg/Makefile.in
+@@ -7,7 +7,7 @@
+ 
+ CC=@CC@
+ CFLAGS=@CFLAGS@ -I.. -I$(INCLUDES) @NINE_CFLAGS@
+-AR=ar
++AR=@AR@
+ RANLIB=@RANLIB@
+ INCLUDES=$(top_srcdir)/include
+ 
+C23 porting for GCC-15
+--- a/include/msg.h
++++ b/include/msg.h
+@@ -3,7 +3,11 @@
+ 
+ typedef struct Msg Msg;
+ typedef int Id;		/* Window identifier */
++#if __STDC_VERSION__ <= 201710L
+ typedef enum Bool {false, true} Bool;
++#else
++typedef bool Bool;
++#endif
+ typedef struct Range Range;
+ 
+ /* name of environment variable */
+--- a/wily/wily.h
++++ b/wily/wily.h
+@@ -9,6 +9,7 @@
+ #include <libc.h>
+ #include <libg.h>
+ #include <frame.h>
++#include <stdarg.h>
+ #include "config.h"
+ #include <msg.h>
+ 
+--- a/wily/include.c
++++ b/wily/include.c
+@@ -27,11 +27,11 @@
+ 	expanded = text_expand(t, r, notinclude);
+ 	len = RLEN(expanded);
+ 	if( len > (MAXPATH*UTFmax) || len < 2)
+-		return false;
++		return NULL;
+ 	len = text_copyutf(t, expanded, buf);
+ 	
+ 	if (!is_includebrackets(buf[0], buf[len-1]))
+-		return false;
++		return NULL;
+ 	
+ 	buf[len-1] = 0;
+ 	s = pathfind(getenv("INCLUDES"),  buf+1);
+--- a/wily/wily.c
++++ b/wily/wily.c
+@@ -4,6 +4,8 @@
+ 
+ #include "wily.h"
+ #include "tile.h"
++
++extern void initfont(char *fixed); /* from font.c */
+  
+ static int	ncolumns = 2;
+ int	tagheight;
+ 

--- a/app-editors/wily/wily-1.0-r3.ebuild
+++ b/app-editors/wily/wily-1.0-r3.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools
+
+MY_P="${P/1.0/9libs}"
+
+DESCRIPTION="An emulation of ACME, Plan9's hybrid window system, shell and editor"
+HOMEPAGE="https://www.netlib.org/research/9libs/"
+SRC_URI="https://www.netlib.org/research/9libs/${MY_P}.tar.gz"
+S=${WORKDIR}/${MY_P}
+
+LICENSE="Artistic"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+
+DEPEND="
+	dev-libs/9libs
+"
+RDEPEND="
+	${DEPEND}
+"
+DOCS=(
+	README
+)
+
+PATCHES=( "${FILESDIR}/${P}-C23.patch" )
+
+src_prepare() {
+	default
+
+	#bug https://bugs.gentoo.org/877123 and https://bugs.gentoo.org/906022
+	eautoreconf
+}
+
+src_configure() {
+	mhw_cv_mod_9libs_lib_path=/usr/$(get_libdir) \
+	mhw_cv_mod_9libs_inc_path=/usr/include/9libs \
+	econf
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/${PN}
+	doins "${S}"/misc/*
+}


### PR DESCRIPTION
Fixes great annoyance of compilation continuing even when errors happen halfway, explicit ar that fails compilation in clang-MUSL systems and autoreconf that fixes implicit declarations in configure.
Compiles without errors with -std=gnu23, but not -std=c23

Closes: https://bugs.gentoo.org/906022
Closes: https://bugs.gentoo.org/729238
Closes: https://bugs.gentoo.org/877123

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
