### PR TITLE
dev-java/openjdk-jre-bin: unkeyword 21.0.5_p11 for arm64

### DIFF
--- a/dev-java/openjdk-jre-bin/openjdk-jre-bin-21.0.5_p11.ebuild
+++ b/dev-java/openjdk-jre-bin/openjdk-jre-bin-21.0.5_p11.ebuild
@@ -21,7 +21,7 @@ SRC_URI="
 DESCRIPTION="Prebuilt Java JRE binaries provided by Eclipse Temurin"
 HOMEPAGE="https://adoptium.net/"
 LICENSE="GPL-2-with-classpath-exception"
-KEYWORDS="amd64 arm64"
+KEYWORDS="amd64"
 IUSE="alsa cups headless-awt selinux"
 
 RDEPEND="


### PR DESCRIPTION
This package should not have been been in the package list of bug #947769.

Closes: https://bugs.gentoo.org/947913

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
