### PR TITLE
media-sound/easytag: fix detection for id3lib

### DIFF
--- a/media-sound/easytag/easytag-2.4.3-r8.ebuild
+++ b/media-sound/easytag/easytag-2.4.3-r8.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
+GNOME2_EAUTORECONF="yes"
 inherit gnome2
 
 DESCRIPTION="GTK+ utility for editing MP2, MP3, MP4, FLAC, Ogg and other media tags"
@@ -60,6 +61,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-ogg-corruption.patch
 	"${FILESDIR}"/${P}-fix-build-taglib2.patch
+	"${FILESDIR}"/${P}-fix-check-id3.patch
 )
 
 src_configure() {
@@ -76,10 +78,4 @@ src_configure() {
 		$(use_enable flac) \
 		$(use_enable mp4) \
 		$(use_enable wavpack)
-}
-
-src_install() {
-	gnome2_src_install
-	# https://gitlab.gnome.org/GNOME/easytag/-/issues/82
-	mv "${ED}"/usr/share/{appdata,metainfo} || die
 }

--- a/media-sound/easytag/files/easytag-2.4.3-fix-check-id3.patch
+++ b/media-sound/easytag/files/easytag-2.4.3-fix-check-id3.patch
@@ -1,0 +1,42 @@
+https://gitlab.gnome.org/GNOME/easytag/-/merge_requests/3.patch
+From a41d48c8849aff8f6bc19ae1f449d8509c20d3ae Mon Sep 17 00:00:00 2001
+From: Ting-Wei Lan <lantw@src.gnome.org>
+Date: Sat, 20 Jul 2019 15:42:05 +0800
+Subject: [PATCH] Use C++ linker to check for id3lib
+
+Instead of manually adding -lstdc++ to the linker command line, which
+isn't going to work if the C++ runtime library isn't provided by GCC,
+use the C++ compiler driver to link the program to avoid the need to
+figure out the name of the C++ runtime library ourselves.
+
+This fixes the check on FreeBSD, which uses Clang and LLVM libc++ by
+default.
+---
+ configure.ac | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8d93ef65..3603da27 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -254,7 +254,8 @@ AS_IF([test "x$have_mp3" != "xno"],
+ AS_IF([test "x$have_mp3" = "xyes" -a "x$enable_id3v23" != "xno"],
+       dnl Check which libs are required by id3lib, libid3.la is fucked up
+       [LIBS_SAVE="$LIBS"
+-       AC_SEARCH_LIBS([ID3Tag_Link], ["id3" "id3 -lstdc++" "id3 -lz" "id3 -lz -lstdc++"], [have_id3lib=yes], [have_id3lib=no])
++       AC_LANG_PUSH([C++])
++       AC_SEARCH_LIBS([ID3Tag_Link], ["id3" "id3 -lz"], [have_id3lib=yes], [have_id3lib=no])
+         
+        dnl expected version for cross compiling
+        ID3LIB_MAJOR=3
+@@ -272,6 +273,7 @@ AS_IF([test "x$have_mp3" = "xyes" -a "x$enable_id3v23" != "xno"],
+     fclose(output);
+     return 0;
+ ]])], [. ./conftest.id3; AC_MSG_RESULT([${ID3LIB_MAJOR}.${ID3LIB_MINOR}.${ID3LIB_PATCH}])], [AC_MSG_ERROR([could not determine id3lib version])], [echo $ac_n "cross compiling; assuming ${ID3LIB_MAJOR}.${ID3LIB_MINOR}.${ID3LIB_PATCH} $ac_c"])
++       AC_LANG_POP([C++])
+        LIBS="$LIBS_SAVE"
+        AC_DEFINE_UNQUOTED([ID3LIB_MAJOR], [$ID3LIB_MAJOR], [id3lib major version])
+        AC_DEFINE_UNQUOTED([ID3LIB_MINOR], [$ID3LIB_MINOR], [id3lib minor version])
+-- 
+GitLab
+


### PR DESCRIPTION
see https://gitlab.gnome.org/GNOME/easytag/-/merge_requests/3

eautoreconf fixed location for metainfo too

Closes: https://bugs.gentoo.org/947107

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
