### PR TITLE
dev-python/tagpy: fix check version taglib

### DIFF
--- a/dev-python/tagpy/files/tagpy-2025.1-fix-check-taglib.patch
+++ b/dev-python/tagpy/files/tagpy-2025.1-fix-check-taglib.patch
@@ -1,0 +1,23 @@
+https://github.com/palfrey/tagpy/commit/04d02c8b057a7dd8d760b1d184e8b48ec7301ff6.patch
+From f873d3587357166155d381c60aae0c450eb09b45 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Tue, 14 Jan 2025 00:52:34 +0100
+Subject: [PATCH] fix check version
+
+---
+ src/wrapper/common.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/wrapper/common.hpp b/src/wrapper/common.hpp
+index 1a5be96..5c45a68 100644
+--- a/src/wrapper/common.hpp
++++ b/src/wrapper/common.hpp
+@@ -54,7 +54,7 @@ using namespace std;
+ 
+ #define TAGLIB_HEX_VERSION CHECK_VERSION(TAGLIB_MAJOR_VERSION, TAGLIB_MINOR_VERSION, TAGLIB_PATCH_VERSION)
+ 
+-#if CHECK_VERSION(1,9,0) < TAGLIB_HEX_VERSION
++#if TAGLIB_HEX_VERSION < CHECK_VERSION(1,9,0)
+ #warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ #warning TagPy is meant to wrap TagLib 1.9 and above.
+ #warning !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/dev-python/tagpy/tagpy-2025.1-r1.ebuild
+++ b/dev-python/tagpy/tagpy-2025.1-r1.ebuild
@@ -31,4 +31,9 @@ RDEPEND="
 	${DEPEND}
 "
 
+PATCHES=(
+	# https://github.com/palfrey/tagpy/pull/37
+	"${FILESDIR}"/${PN}-2025.1-fix-check-taglib.patch
+)
+
 distutils_enable_tests pytest


### PR DESCRIPTION
reverse check :
https://github.com/palfrey/tagpy/pull/37.patch

cc @mgorny 

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
