### PR TITLE
sys-apps/ucspi-tcp: fix -Wincompatible-pointer-types,  update EAPI, ...

### DIFF
--- a/sys-apps/ucspi-tcp/files/0.88-protype-alloc.patch
+++ b/sys-apps/ucspi-tcp/files/0.88-protype-alloc.patch
@@ -1,0 +1,34 @@
+https://bugs.gentoo.org/919874
+fix -Wincompatible-pointer-types
+ error: passing argument 1 of 'alloc_free' from incompatible pointer type [-Wincompatible-pointer-types]
+   66 |   alloc_free(e);
+      |              ^
+      |              |
+      |              char **
+
+diff --git a/alloc.c b/alloc.c
+index b7a3e67..4e258f4 100644
+--- a/alloc.c
++++ b/alloc.c
+@@ -21,7 +21,7 @@ unsigned int n;
+ }
+ 
+ void alloc_free(x)
+-char *x;
++void *x;
+ {
+   if (x >= space)
+     if (x < space + SPACE)
+diff --git a/alloc.h b/alloc.h
+index 24ef27e..680848e 100644
+--- a/alloc.h
++++ b/alloc.h
+@@ -4,7 +4,7 @@
+ #include <stdlib.h>
+ 
+ extern /*@null@*//*@out@*/char *alloc(unsigned int);
+-extern void alloc_free(char *);
++extern void alloc_free(void *);
+ extern int alloc_re();
+ 
+ #endif

--- a/sys-apps/ucspi-tcp/metadata.xml
+++ b/sys-apps/ucspi-tcp/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>zhixu.liu@gmail.com</email>
+		<name>Z. Liu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
 		ucspi-tcp is a replacement for inetd. It consists of tcpserver and
 		tcpclient. tcpserver can listen on sockets and start programs in an

--- a/sys-apps/ucspi-tcp/ucspi-tcp-0.88-r20.ebuild
+++ b/sys-apps/ucspi-tcp/ucspi-tcp-0.88-r20.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit qmail toolchain-funcs
 
@@ -21,30 +21,37 @@ IUSE="ipv6 qmail-spp selinux"
 RESTRICT="test"
 
 RDEPEND="
-	!app-doc/ucspi-tcp-man
 	selinux? ( sec-policy/selinux-ucspitcp )"
 
-src_prepare() {
-	eapply "${FILESDIR}"/${PV}-protos.patch
-	if use ipv6; then
-		eapply "${WORKDIR}"/${P}-ipv6.diff20
-		eapply "${FILESDIR}"/${PV}-protos-ipv6.patch
-		eapply "${FILESDIR}"/${PV}-tcprules.patch #135571
-		eapply "${FILESDIR}"/${PV}-bigendian.patch #18892
-		eapply "${FILESDIR}"/${PV}-implicit-int-ipv6.patch
-	else
-		eapply "${FILESDIR}"/${PV}-protos-no-ipv6.patch
-	fi
-	eapply "${DISTDIR}"/ucspi-rss.diff
-	eapply "${FILESDIR}"/${PV}-rblsmtpd-ignore-on-RELAYCLIENT.patch
-	eapply "${DISTDIR}"/${P}-rblspp.patch
-	eapply "${FILESDIR}"/${PV}-protos-rblspp.patch
-	eapply "${FILESDIR}"/${PV}-large-responses.patch
-	eapply "${FILESDIR}"/${PV}-uint-headers.patch
-	eapply "${FILESDIR}"/${PV}-ar-ranlib.patch
-	eapply "${FILESDIR}"/${PV}-implicit-int.patch
+PATCHES=(
+	"${FILESDIR}"/${PV}-protos.patch
+)
 
-	eapply_user
+src_prepare() {
+	if use ipv6 ; then
+		PATCHES+=(
+			"${WORKDIR}"/${P}-ipv6.diff20
+			"${FILESDIR}"/${PV}-protos-ipv6.patch
+			"${FILESDIR}"/${PV}-tcprules.patch #135571
+			"${FILESDIR}"/${PV}-bigendian.patch #18892
+			"${FILESDIR}"/${PV}-implicit-int-ipv6.patch
+		)
+	else
+		PATCHES+=( "${FILESDIR}"/${PV}-protos-no-ipv6.patch )
+	fi
+	PATCHES+=(
+		"${DISTDIR}"/ucspi-rss.diff
+		"${FILESDIR}"/${PV}-rblsmtpd-ignore-on-RELAYCLIENT.patch
+		"${DISTDIR}"/${P}-rblspp.patch
+		"${FILESDIR}"/${PV}-protos-rblspp.patch
+		"${FILESDIR}"/${PV}-large-responses.patch
+		"${FILESDIR}"/${PV}-uint-headers.patch
+		"${FILESDIR}"/${PV}-ar-ranlib.patch
+		"${FILESDIR}"/${PV}-implicit-int.patch
+		"${FILESDIR}"/${PV}-protype-alloc.patch
+	)
+
+	default
 }
 
 src_configure() {


### PR DESCRIPTION
1. add patch to fix -Wincompatible-pointer-types
2. update to EAPI 8
3. app-doc/ucspi-tcp-man is not exist
4. add myself as proxy maintainer

Closes: https://bugs.gentoo.org/919874

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
