### PR TITLE
sys-auth/sssd: Make Python optional at runtime again

### DIFF
--- a/sys-auth/sssd/files/sssd-2.9.6-conditional-python-install.patch
+++ b/sys-auth/sssd/files/sssd-2.9.6-conditional-python-install.patch
@@ -1,0 +1,16 @@
+diff '--color=auto' -Naur a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2024-12-05 12:16:16.000000000 +0000
++++ b/Makefile.am	2025-01-14 12:31:45.831435116 +0000
+@@ -21,7 +21,11 @@
+ endif
+ 
+ SUBDIRS += . src/tests/cwrap src/tests/intg src/tests/test_CA \
+-             src/tests/test_ECC_CA src/tools/analyzer
++             src/tests/test_ECC_CA
++
++if BUILD_PYTHON_BINDINGS
++SUBDIRS += src/tools/analyzer
++endif
+ 
+ # Some old versions of automake don't define builddir
+ builddir ?= .

--- a/sys-auth/sssd/sssd-2.10.1.ebuild
+++ b/sys-auth/sssd/sssd-2.10.1.ebuild
@@ -77,6 +77,8 @@ RDEPEND="${DEPEND}
 	acct-group/sssd
 	passkey? ( sys-apps/pcsc-lite[policykit] )
 	selinux? ( >=sec-policy/selinux-sssd-2.20120725-r9 )"
+DEPEND+="
+	sys-apps/shadow"
 BDEPEND="
 	acct-user/sssd
 	acct-group/sssd

--- a/sys-auth/sssd/sssd-2.10.1.ebuild
+++ b/sys-auth/sssd/sssd-2.10.1.ebuild
@@ -259,7 +259,8 @@ multilib_src_configure() {
 		# Annoyingly configure requires that you pick systemd XOR sysv
 		--with-initscript=$(usex systemd systemd sysv)
 		--with-sssd-user=sssd
-		 CPPFLAGS="${CPPFLAGS} -I/usr/include/samba-4.0"
+		KRB5_CONFIG="${ESYSROOT}"/usr/bin/krb5-config
+		CPPFLAGS="${CPPFLAGS} -I${ESYSROOT}/usr/include/samba-4.0"
 	)
 
 	use systemd && myconf+=(

--- a/sys-auth/sssd/sssd-2.9.6-r1.ebuild
+++ b/sys-auth/sssd/sssd-2.9.6-r1.ebuild
@@ -75,6 +75,8 @@ DEPEND="
 RDEPEND="${DEPEND}
 	passkey? ( sys-apps/pcsc-lite[policykit] )
 	selinux? ( >=sec-policy/selinux-sssd-2.20120725-r9 )"
+DEPEND+="
+	sys-apps/shadow"
 BDEPEND="
 	virtual/pkgconfig
 	app-text/docbook-xml-dtd:4.4

--- a/sys-auth/sssd/sssd-2.9.6-r1.ebuild
+++ b/sys-auth/sssd/sssd-2.9.6-r1.ebuild
@@ -9,12 +9,13 @@ PLOCALE_BACKUP="sv"
 PYTHON_COMPAT=( python3_{10..12} )
 
 inherit autotools linux-info multilib-minimal optfeature plocale \
-	python-single-r1 pam systemd tmpfiles udev toolchain-funcs
+	python-single-r1 pam systemd toolchain-funcs
 
 DESCRIPTION="System Security Services Daemon provides access to identity and authentication"
 HOMEPAGE="https://github.com/SSSD/sssd"
 if [[ ${PV} != 9999 ]]; then
 	SRC_URI="https://github.com/SSSD/sssd/releases/download/${PV}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 else
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/SSSD/sssd.git"
@@ -23,7 +24,7 @@ fi
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="doc +netlink nfsv4 nls passkey python samba selinux systemd systemtap test"
+IUSE="acl doc +netlink nfsv4 nls passkey python samba selinux systemd systemtap test"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 
@@ -40,16 +41,15 @@ DEPEND="
 	>=net-dns/bind-tools-9.9[gssapi]
 	>=net-dns/c-ares-1.10.0-r1:=[${MULTILIB_USEDEP}]
 	>=net-nds/openldap-2.4.30:=[sasl,experimental]
-	net-fs/cifs-utils[acl]
 	>=sys-apps/dbus-1.6
 	>=sys-apps/keyutils-1.5:=
-	sys-libs/libcap
 	>=sys-libs/pam-0-r1[${MULTILIB_USEDEP}]
 	>=sys-libs/talloc-2.0.7
 	>=sys-libs/tdb-1.2.9
 	>=sys-libs/tevent-0.9.16
 	virtual/ldb:=
 	virtual/libintl
+	acl? ( net-fs/cifs-utils[acl] )
 	netlink? ( dev-libs/libnl:3 )
 	nfsv4? ( >=net-fs/nfs-utils-2.3.1-r2 )
 	nls? ( >=sys-devel/gettext-0.18 )
@@ -73,19 +73,16 @@ DEPEND="
 	)
 	systemtap? ( dev-debug/systemtap )"
 RDEPEND="${DEPEND}
-	acct-user/sssd
-	acct-group/sssd
 	passkey? ( sys-apps/pcsc-lite[policykit] )
 	selinux? ( >=sec-policy/selinux-sssd-2.20120725-r9 )"
 BDEPEND="
-	acct-user/sssd
-	acct-group/sssd
-	sys-libs/libcap
 	virtual/pkgconfig
+	app-text/docbook-xml-dtd:4.4
+	>=dev-libs/libxslt-1.1.26
 	${PYTHON_DEPS}
 	doc? ( app-text/doxygen )
-	nls? (	app-text/po4a
-		sys-devel/gettext )
+	nls? ( sys-devel/gettext
+	       app-text/po4a )
 	test? (
 		dev-libs/check
 		dev-libs/softhsm:2
@@ -96,8 +93,6 @@ BDEPEND="
 		sys-libs/pam_wrapper
 		sys-libs/uid_wrapper
 	)
-	app-text/docbook-xml-dtd:4.4
-	>=dev-libs/libxslt-1.1.26
 "
 
 CONFIG_CHECK="~KEYS"
@@ -105,7 +100,6 @@ CONFIG_CHECK="~KEYS"
 PATCHES=(
 	"${FILESDIR}/${PN}-2.8.2-krb5_pw_locked.patch"
 	"${FILESDIR}/${PN}-2.9.6-conditional-python-install.patch"
-	"${FILESDIR}/${PN}-2.10.0_beta2-fix-systemd-systemconfdir.patch"
 )
 
 MULTILIB_WRAPPED_HEADERS=(
@@ -119,41 +113,9 @@ MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/sss_certmap.h
 )
 
-sssd_migrate_files() {
-	if has_version "<=sys-auth/sssd-2.9.9999"
-	then
-		einfo "Checking if sssd is running"
-		if [ -f /run/sssd.pid ]
-		then
-			elog "Please stop sssd after installing before"
-			elog "performing the migration process"
-		fi
-		einfo "Checking if /var/lib/sss ownership"
-		if [ -d /var/lib/sss ] && [ $(stat -c "%U:%G" /var/lib/sss) != "sssd:sssd" ]
-		then
-			elog "After installing, please execute"
-			elog "chown -R sssd:sssd /var/lib/sss"
-		fi
-		einfo "Checking if /var/log/sssd ownership"
-		if [ -d /var/log/sssd ] && [ $(stat -c "%U:%G" /var/log/sssd) != "sssd:sssd" ]
-		then
-			elog "After installing, please execute"
-			elog "chown -R sssd:sssd /var/log/sssd"
-		fi
-		einfo "Checking if /etc/sssd ownership"
-		if ! use systemd && [ -d /etc/sssd ] && [ $(stat -c "%U:%G" /etc/sssd) != "root:sssd" ]
-		then
-			elog "After installing, please execute"
-			elog "chown -R root:sssd /etc/sssd"
-		fi
-	fi
-}
-
 pkg_setup() {
 	linux-info_pkg_setup
 	python-single-r1_pkg_setup
-
-	sssd_migrate_files
 }
 
 src_prepare() {
@@ -190,12 +152,6 @@ src_prepare() {
 		Makefile.am \
 		|| die
 
-	# requires valgrind headers installed
-	sed -i \
-		-e '/^\s*test_iobuf[ \\]*$/d' \
-		Makefile.am \
-		|| die
-
 	eautoreconf
 
 	multilib_copy_sources
@@ -203,6 +159,11 @@ src_prepare() {
 
 src_configure() {
 	local native_dbus_cflags=$($(tc-getPKG_CONFIG) --cflags dbus-1 || die)
+
+	# Workaround for bug #938302
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		export DTRACE="${BROOT}"/usr/bin/stap-dtrace
+	fi
 
 	multilib-minimal_src_configure
 }
@@ -215,9 +176,9 @@ multilib_src_configure() {
 		--localstatedir="${EPREFIX}"/var
 		--runstatedir="${EPREFIX}"/run
 		--sbindir="${EPREFIX}"/usr/sbin
-		--with-pid-path="${EPREFIX}"/run/sssd
+		--with-pid-path="${EPREFIX}"/run
 		--with-plugin-path="${EPREFIX}"/usr/$(get_libdir)/sssd
-		--enable-pammoddir="${EPREFIX}"/$(getpam_mod_dir)
+		--enable-pammoddir="${EPREFIX}$(getpam_mod_dir)"
 		--with-ldb-lib-dir="${EPREFIX}"/usr/$(get_libdir)/samba/ldb
 		--with-db-path="${EPREFIX}"/var/lib/sss/db
 		--with-gpo-cache-path="${EPREFIX}"/var/lib/sss/gpo_cache
@@ -226,8 +187,6 @@ multilib_src_configure() {
 		--with-mcache-path="${EPREFIX}"/var/lib/sss/mc
 		--with-secrets-db-path="${EPREFIX}"/var/lib/sss/secrets
 		--with-log-path="${EPREFIX}"/var/log/sssd
-		--with-tmpfilesdir=/usr/lib/tmpfiles.d
-		--with-udevrulesdir="$(get_udevdir)/rules.d"
 		--with-kcm
 		--enable-kcm-renewal
 		--with-os=gentoo
@@ -237,8 +196,9 @@ multilib_src_configure() {
 		--disable-valgrind
 		$(use_with samba)
 		--with-smb-idmap-interface-version=6
-		--enable-cifs-idmap-plugin
+		$(multilib_native_use_enable acl cifs-idmap-plugin)
 		$(multilib_native_use_with selinux)
+		$(multilib_native_use_with selinux semanage)
 		--enable-krb5-locator-plugin
 		$(use_enable samba pac-responder)
 		$(multilib_native_use_with nfsv4 nfsv4-idmapd-plugin)
@@ -256,8 +216,9 @@ multilib_src_configure() {
 		$(multilib_native_use_with python python3-bindings)
 		# Annoyingly configure requires that you pick systemd XOR sysv
 		--with-initscript=$(usex systemd systemd sysv)
-		--with-sssd-user=sssd
-		 CPPFLAGS="${CPPFLAGS} -I/usr/include/samba-4.0"
+		KRB5_CONFIG="${ESYSROOT}"/usr/bin/krb5-config
+		# Needed for Samba 4.21
+		CPPFLAGS="${CPPFLAGS} -I${ESYSROOT}/usr/include/samba-4.0"
 	)
 
 	use systemd && myconf+=(
@@ -352,8 +313,6 @@ multilib_src_install_all() {
 	keepdir /var/lib/sss/pubconf/krb5.include.d
 	keepdir /var/lib/sss/secrets
 	keepdir /var/log/sssd
-	keepdir /etc/sssd/conf.d
-	keepdir /etc/sssd/pki
 
 	# strip empty dirs
 	if ! use doc; then
@@ -366,7 +325,6 @@ multilib_src_install_all() {
 }
 
 pkg_postinst() {
-	tmpfiles_process sssd-tmpfiles.conf
 	elog "You must set up sssd.conf (default installed into /etc/sssd)"
 	elog "and (optionally) configuration in /etc/pam.d in order to use SSSD"
 	elog "features."


### PR DESCRIPTION
As discussed in #39605, I can't see any reason why Python was made mandatory at runtime. No upstream changes have been made in this area recently. Flatcar needs sssd but needs to avoid Python at runtime. I have improved on the earlier patch.

This also restores the sys-apps/shadow dependency and restores cross fixes to 2.10.1.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.