### PR TITLE
net-analyzer/iplog: fix implicit declarations in configure, bool

### DIFF
--- a/net-analyzer/iplog/files/iplog-2.2.3-C23.patch
+++ b/net-analyzer/iplog/files/iplog-2.2.3-C23.patch
@@ -1,0 +1,36 @@
+https://bugs.gentoo.org/945194 - guard bool for modern compilers
+https://bugs.gentoo.org/712644 - type aliaces for musl
+--- a/src/iplog.h
++++ b/src/iplog.h
+@@ -21,6 +21,9 @@
+ #ifndef __IPLOG_H
+ #define __IPLOG_H
+ 
++#define _GNU_SOURCE 1
++#include <sys/types.h> /* for u_* types */
++
+ #ifndef HAVE_IPADDR_T
+ 	typedef u_int32_t ipaddr_t;
+ #endif
+@@ -82,7 +82,9 @@
+ #	define min(x,y) ((x) < (y) ? (x) : (y))
+ #endif
+ 
++#if __STDC_VERSION__ <= 201710L
+ typedef enum { false, true } bool;
++#endif
+ 
+ #ifdef HAVE_PATHS_H
+ #	include <paths.h>
+C23 and GNU-15 compatibility, explicitly cast sockaddr
+--- a/src/iplog_tcp.c
++++ b/src/iplog_tcp.c
+@@ -144,7 +144,7 @@
+ 
+ 		ret = sendto(raw_sock, (char *) xip,
+ 				sizeof(struct ip) + sizeof(struct tcphdr), 0,
+-#if !defined(__GLIBC__) || (__GLIBC__ < 2)
++#if !defined(__GLIBC__) || (__GLIBC__ < 2) || (__STDC_VERSION__ > 201710L)
+ 				(struct sockaddr *)
+ #endif
+ 				&fn_sin,

--- a/net-analyzer/iplog/iplog-2.2.3-r4.ebuild
+++ b/net-analyzer/iplog/iplog-2.2.3-r4.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs autotools
+
+DESCRIPTION="TCP/IP traffic logger"
+HOMEPAGE="https://ojnk.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/ojnk/${P}.tar.gz"
+
+LICENSE="|| ( GPL-2 FDL-1.1 )"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="net-libs/libpcap"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PV}-DLT_LINUX_SSL.patch"
+	"${FILESDIR}/${P}-C23.patch")
+
+DOCS=( AUTHORS NEWS README TODO example-iplog.conf )
+
+src_prepare() {
+	default
+
+	#https://bugs.gentoo.org/899936
+	#https://bugs.gentoo.org/875155
+	eautoreconf
+}
+
+src_compile() {
+	append-cppflags -D_REENTRANT
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" all
+}
+
+src_install() {
+	default
+	newinitd "${FILESDIR}"/iplog.rc6 iplog
+}


### PR DESCRIPTION
Port to modern compilers and C23, and also fix for MUSL compile problem

Bug: https://bugs.gentoo.org/712644
Bug: https://bugs.gentoo.org/875155
Bug: https://bugs.gentoo.org/899936
Bug: https://bugs.gentoo.org/945194

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
