### PR TITLE
dev-util/qdevicemonitor: fix build with Qt 6

### DIFF
--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-qt-6.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-qt-6.patch
@@ -1,0 +1,454 @@
+From 4d90f45d6c204ad87b2198791fe522be092bed98 Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@codonaft.com>
+Date: Tue, 14 Jan 2025 23:52:00 +0800
+Subject: [PATCH] Port to Qt 6
+
+https://bugs.gentoo.org/948065
+---
+ qdevicemonitor/StringRingBuffer.h             |  1 +
+ qdevicemonitor/devices/AndroidDevice.cpp      | 24 +++++++++++--------
+ qdevicemonitor/devices/AndroidDevice.h        |  8 +++----
+ qdevicemonitor/devices/BaseDevice.cpp         | 10 +++++---
+ qdevicemonitor/devices/BaseDevice.h           |  5 ++--
+ qdevicemonitor/devices/IOSDevice.cpp          | 24 ++++++++++++-------
+ qdevicemonitor/devices/IOSDevice.h            |  2 +-
+ qdevicemonitor/devices/TextFileDevice.cpp     | 16 +++++++------
+ qdevicemonitor/devices/TextFileDevice.h       |  2 +-
+ .../trackers/AndroidDevicesTracker.cpp        |  4 ++++
+ .../devices/trackers/IOSDevicesTracker.cpp    |  4 ++++
+ qdevicemonitor/ui/DeviceWidget.cpp            | 10 +++++---
+ qdevicemonitor/ui/DeviceWidget.h              |  4 ++--
+ qdevicemonitor/ui/MainWindow.cpp              |  3 +--
+ 14 files changed, 73 insertions(+), 44 deletions(-)
+
+diff --git a/qdevicemonitor/StringRingBuffer.h b/qdevicemonitor/StringRingBuffer.h
+index 5c6537b..76dee9d 100644
+--- a/qdevicemonitor/StringRingBuffer.h
++++ b/qdevicemonitor/StringRingBuffer.h
+@@ -18,6 +18,7 @@
+ #ifndef RINGBUFFER_H
+ #define RINGBUFFER_H
+ 
++#include <QObject>
+ #include <QPointer>
+ #include <QString>
+ #include <QVector>
+diff --git a/qdevicemonitor/devices/AndroidDevice.cpp b/qdevicemonitor/devices/AndroidDevice.cpp
+index e0785e9..a11e79f 100644
+--- a/qdevicemonitor/devices/AndroidDevice.cpp
++++ b/qdevicemonitor/devices/AndroidDevice.cpp
+@@ -146,7 +146,11 @@ void AndroidDevice::startLogger()
+         m_logFile.setFileName(currentLogAbsFileName);
+         m_logFile.open(QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate);
+         m_logFileStream = QSharedPointer<QTextStream>::create(&m_logFile);
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+         m_logFileStream->setCodec("UTF-8");
++#else
++        m_logFileStream->setEncoding(QStringConverter::Utf8);
++#endif
+ 
+         startLogProcess();
+ 
+@@ -230,13 +234,13 @@ void AndroidDevice::filterAndAddToTextEdit(const QString& line)
+     const QRegularExpressionMatch match = re.match(line);
+     if (match.hasMatch())
+     {
+-        const QStringRef date = match.capturedRef("date");
+-        const QStringRef time = match.capturedRef("time");
+-        const QStringRef pid = match.capturedRef("pid");
+-        const QStringRef tid = match.capturedRef("tid");
+-        const QStringRef verbosity = match.capturedRef("verbosity");
+-        const QStringRef tag = match.capturedRef("tag").trimmed();
+-        const QStringRef text = line.midRef(match.capturedEnd("tag") + 1);
++        const QStringView date = match.captured("date");
++        const QStringView time = match.captured("time");
++        const QStringView pid = match.captured("pid");
++        const QStringView tid = match.captured("tid");
++        const QStringView verbosity = match.captured("verbosity");
++        const QStringView tag = match.captured("tag").trimmed();
++        const QStringView text = line.mid(match.capturedEnd("tag") + 1);
+ 
+         const auto verbosityLevel = static_cast<VerbosityEnum>(Utils::verbosityCharacterToInt(verbosity.at(0).toLatin1()));
+ 
+@@ -261,7 +265,7 @@ void AndroidDevice::filterAndAddToTextEdit(const QString& line)
+         checkFilters(filtersMatch, m_filtersValid);
+         if (filtersMatch)
+         {
+-            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringRef(&line));
++            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringView(line));
+             m_deviceWidget->flushText();
+         }
+     }
+@@ -269,7 +273,7 @@ void AndroidDevice::filterAndAddToTextEdit(const QString& line)
+     m_deviceWidget->highlightFilterLineEdit(!m_filtersValid);
+ }
+ 
+-void AndroidDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const VerbosityEnum verbosityLevel, const QStringRef& pid, const QStringRef& tid, const QStringRef& tag, const QStringRef& text)
++void AndroidDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const VerbosityEnum verbosityLevel, const QStringView pid, const QStringView tid, const QStringView tag, const QStringView text)
+ {
+     filtersMatch = verbosityLevel <= m_deviceWidget->getVerbosityLevel();
+ 
+@@ -283,7 +287,7 @@ void AndroidDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const V
+ 
+     for (auto it = m_filters.constBegin(); it != m_filters.constEnd(); ++it)
+     {
+-        const QStringRef filter(&(*it));
++        const QStringView filter(*it);
+         bool columnFound = false;
+         if (!columnMatches("pid:", filter, pid, filtersValid, columnFound) ||
+             !columnMatches("tid:", filter, tid, filtersValid, columnFound) ||
+diff --git a/qdevicemonitor/devices/AndroidDevice.h b/qdevicemonitor/devices/AndroidDevice.h
+index 1012c43..f908d07 100644
+--- a/qdevicemonitor/devices/AndroidDevice.h
++++ b/qdevicemonitor/devices/AndroidDevice.h
+@@ -77,10 +77,10 @@ private:
+     void checkFilters(bool& filtersMatch,
+                       bool& filtersValid,
+                       const VerbosityEnum verbosityLevel = Verbose,
+-                      const QStringRef& pid = QStringRef(),
+-                      const QStringRef& tid = QStringRef(),
+-                      const QStringRef& tag = QStringRef(),
+-                      const QStringRef& text = QStringRef());
++                      const QStringView pid = QStringView(),
++                      const QStringView tid = QStringView(),
++                      const QStringView tag = QStringView(),
++                      const QStringView text = QStringView());
+ };
+ 
+ #endif // ANDROIDDEVICE_H
+diff --git a/qdevicemonitor/devices/BaseDevice.cpp b/qdevicemonitor/devices/BaseDevice.cpp
+index 21ee82c..628d7a4 100644
+--- a/qdevicemonitor/devices/BaseDevice.cpp
++++ b/qdevicemonitor/devices/BaseDevice.cpp
+@@ -47,7 +47,11 @@ BaseDevice::BaseDevice(
+ {
+     qDebug() << "new BaseDevice; type" << type << "; id" << id;
+ 
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     m_tempStream.setCodec("UTF-8");
++#else
++    m_tempStream.setEncoding(QStringConverter::Utf8);
++#endif
+     m_tempStream.setString(&m_tempBuffer, QIODevice::ReadWrite | QIODevice::Text);
+ 
+     updateLogBufferSpace();
+@@ -195,12 +199,12 @@ void BaseDevice::filterAndAddFromLogBufferToTextEdit()
+     }
+ }
+ 
+-bool BaseDevice::columnMatches(const QString& column, const QStringRef& filter, const QStringRef& originalValue, bool& filtersValid, bool& columnFound)
++bool BaseDevice::columnMatches(const QString& column, const QStringView filter, const QStringView originalValue, bool& filtersValid, bool& columnFound)
+ {
+     if (filter.startsWith(column))
+     {
+         columnFound = true;
+-        const QStringRef value = filter.mid(column.length());
++        const QStringView value = filter.mid(column.length());
+         if (value.isEmpty())
+         {
+             filtersValid = false;
+@@ -213,7 +217,7 @@ bool BaseDevice::columnMatches(const QString& column, const QStringRef& filter,
+     return true;
+ }
+ 
+-bool BaseDevice::columnTextMatches(const QStringRef& filter, const QString& text)
++bool BaseDevice::columnTextMatches(const QStringView filter, const QString& text)
+ {
+     if (filter.isEmpty() || text.contains(filter))
+     {
+diff --git a/qdevicemonitor/devices/BaseDevice.h b/qdevicemonitor/devices/BaseDevice.h
+index 504b78d..2990b02 100644
+--- a/qdevicemonitor/devices/BaseDevice.h
++++ b/qdevicemonitor/devices/BaseDevice.h
+@@ -28,7 +28,6 @@
+ #include <QRegularExpression>
+ #include <QSharedPointer>
+ #include <QString>
+-#include <QStringRef>
+ #include <QTabWidget>
+ #include <QTextStream>
+ #include <QTimer>
+@@ -93,8 +92,8 @@ public:
+ 
+     void updateLogBufferSpace();
+     void filterAndAddFromLogBufferToTextEdit();
+-    bool columnMatches(const QString& column, const QStringRef& filter, const QStringRef& originalValue, bool& filtersValid, bool& columnFound);
+-    bool columnTextMatches(const QStringRef& filter, const QString& text);
++    bool columnMatches(const QString& column, const QStringView filter, const QStringView originalValue, bool& filtersValid, bool& columnFound);
++    bool columnTextMatches(const QStringView filter, const QString& text);
+ 
+     void scheduleLogReady();
+     void stopLogReadyTimer();
+diff --git a/qdevicemonitor/devices/IOSDevice.cpp b/qdevicemonitor/devices/IOSDevice.cpp
+index 98fca1c..d47d200 100644
+--- a/qdevicemonitor/devices/IOSDevice.cpp
++++ b/qdevicemonitor/devices/IOSDevice.cpp
+@@ -38,7 +38,11 @@ IOSDevice::IOSDevice(
+ {
+     qDebug() << "IOSDevice::IOSDevice";
+ 
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     m_tempErrorsStream.setCodec("UTF-8");
++#else
++    m_tempErrorsStream.setEncoding(QStringConverter::Utf8);
++#endif
+     m_tempErrorsStream.setString(&m_tempErrorsBuffer, QIODevice::ReadWrite | QIODevice::Text);
+ 
+     m_deviceWidget->getFilterLineEdit().setToolTip(tr("Search for messages. Accepts<ul><li>Plain Text</li><li>Prefix <b>text:</b> with Plain Text</li><li>Regular Expressions</li></ul>"));
+@@ -160,7 +164,11 @@ void IOSDevice::startLogger()
+         m_logFile.setFileName(currentLogAbsFileName);
+         m_logFile.open(QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate);
+         m_logFileStream = QSharedPointer<QTextStream>::create(&m_logFile);
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+         m_logFileStream->setCodec("UTF-8");
++#else
++        m_logFileStream->setEncoding(QStringConverter::Utf8);
++#endif
+ 
+         startLogProcess();
+ 
+@@ -193,14 +201,14 @@ void IOSDevice::onUpdateFilter(const QString& filter)
+     maybeAddCompletionAfterDelay(filter);
+ }
+ 
+-void IOSDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const QStringRef& text)
++void IOSDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const QStringView text)
+ {
+     QString textString;
+     bool textStringInitialized = false;
+ 
+     for (auto it = m_filters.constBegin(); it != m_filters.constEnd(); ++it)
+     {
+-        const QStringRef filter(&(*it));
++        const QStringView filter(*it);
+         bool columnFound = false;
+         if (!columnMatches("text:", filter, text, filtersValid, columnFound))
+         {
+@@ -242,9 +250,9 @@ void IOSDevice::filterAndAddToTextEdit(const QString& line)
+     const QRegularExpressionMatch match = re.match(line);
+     if (match.hasMatch())
+     {
+-        const QStringRef prefix = match.capturedRef("prefix");
+-        const QStringRef deviceName = match.capturedRef("deviceName");
+-        const QStringRef text = line.midRef(match.capturedEnd("deviceName") + 1);
++        const QStringView prefix = match.captured("prefix");
++        const QStringView deviceName = match.captured("deviceName");
++        const QStringView text = QStringView(line).mid(match.capturedEnd("deviceName") + 1);
+ 
+         checkFilters(filtersMatch, m_filtersValid, text);
+ 
+@@ -258,11 +266,11 @@ void IOSDevice::filterAndAddToTextEdit(const QString& line)
+     }
+     else
+     {
+-        checkFilters(filtersMatch, m_filtersValid, QStringRef(&line));
++        checkFilters(filtersMatch, m_filtersValid, QStringView(line));
+ 
+         if (filtersMatch)
+         {
+-            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringRef(&line));
++            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringView(line));
+             m_deviceWidget->flushText();
+         }
+     }
+@@ -323,7 +331,7 @@ void IOSDevice::maybeReadErrorsPart()
+         if (m_tempErrorsStream.readLineInto(&line))
+ #endif
+         {
+-            m_deviceWidget->addText(ColorTheme::VerbosityAssert, QStringRef(&line));
++            m_deviceWidget->addText(ColorTheme::VerbosityAssert, QStringView(line));
+             m_deviceWidget->flushText();
+         }
+     }
+diff --git a/qdevicemonitor/devices/IOSDevice.h b/qdevicemonitor/devices/IOSDevice.h
+index e9ba086..cca3a15 100644
+--- a/qdevicemonitor/devices/IOSDevice.h
++++ b/qdevicemonitor/devices/IOSDevice.h
+@@ -62,7 +62,7 @@ private:
+     void stopInfoProcess();
+     void startLogger();
+     void stopLogger();
+-    void checkFilters(bool& filtersMatch, bool& filtersValid, const QStringRef& text);
++    void checkFilters(bool& filtersMatch, bool& filtersValid, const QStringView text);
+ 
+     void maybeReadErrorsPart();
+     void maybeReadLogPart();
+diff --git a/qdevicemonitor/devices/TextFileDevice.cpp b/qdevicemonitor/devices/TextFileDevice.cpp
+index 353d162..bd11b45 100644
+--- a/qdevicemonitor/devices/TextFileDevice.cpp
++++ b/qdevicemonitor/devices/TextFileDevice.cpp
+@@ -90,7 +90,7 @@ void TextFileDevice::onUpdateFilter(const QString& filter)
+     maybeAddCompletionAfterDelay(filter);
+ }
+ 
+-void TextFileDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const QStringRef& text)
++void TextFileDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const QStringView text)
+ {
+     filtersValid = true;
+ 
+@@ -98,7 +98,7 @@ void TextFileDevice::checkFilters(bool& filtersMatch, bool& filtersValid, const
+ 
+     for (auto it = m_filters.constBegin(); it != m_filters.constEnd(); ++it)
+     {
+-        const QStringRef filter(&(*it));
++        const QStringView filter(*it);
+         if (!columnTextMatches(filter, textString))
+         {
+             filtersMatch = false;
+@@ -113,14 +113,16 @@ void TextFileDevice::filterAndAddToTextEdit(const QString& line)
+         "(?<prefix>[A-Za-z]{3} +[\\d]{1,2} [\\d:]{8}) (?<hostname>.+) ",
+         QRegularExpression::InvertedGreedinessOption | QRegularExpression::DotMatchesEverythingOption
+     );
++    static const QString prefixPattern("prefix");
++    static const QString hostnamePattern("hostname");
+ 
+     bool filtersMatch = true;
+     const QRegularExpressionMatch match = re.match(line);
+     if (match.hasMatch())
+     {
+-        const QStringRef prefix = match.capturedRef("prefix");
+-        const QStringRef hostname = match.capturedRef("hostname");
+-        const QStringRef text = line.midRef(match.capturedEnd("hostname") + 1);
++        const QStringView prefix = match.capturedView(QStringView(prefixPattern));
++        const QStringView hostname = match.capturedView(QStringView(hostnamePattern));
++        const QStringView text = QStringView(line).mid(match.capturedEnd("hostname") + 1);
+ 
+         checkFilters(filtersMatch, m_filtersValid, text);
+ 
+@@ -134,10 +136,10 @@ void TextFileDevice::filterAndAddToTextEdit(const QString& line)
+     }
+     else
+     {
+-        checkFilters(filtersMatch, m_filtersValid, QStringRef(&line));
++        checkFilters(filtersMatch, m_filtersValid, QStringView(line));
+         if (filtersMatch)
+         {
+-            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringRef(&line));
++            m_deviceWidget->addText(ColorTheme::VerbosityVerbose, QStringView(line));
+             m_deviceWidget->flushText();
+         }
+     }
+diff --git a/qdevicemonitor/devices/TextFileDevice.h b/qdevicemonitor/devices/TextFileDevice.h
+index b943ff2..23622d7 100644
+--- a/qdevicemonitor/devices/TextFileDevice.h
++++ b/qdevicemonitor/devices/TextFileDevice.h
+@@ -51,7 +51,7 @@ private:
+     void startLogger();
+     void stopLogger();
+ 
+-    void checkFilters(bool& filtersMatch, bool& filtersValid, const QStringRef& text);
++    void checkFilters(bool& filtersMatch, bool& filtersValid, const QStringView text);
+ 
+ private slots:
+     void onLogReady() override;
+diff --git a/qdevicemonitor/devices/trackers/AndroidDevicesTracker.cpp b/qdevicemonitor/devices/trackers/AndroidDevicesTracker.cpp
+index e83d598..713805b 100644
+--- a/qdevicemonitor/devices/trackers/AndroidDevicesTracker.cpp
++++ b/qdevicemonitor/devices/trackers/AndroidDevicesTracker.cpp
+@@ -21,7 +21,11 @@
+ 
+ AndroidDevicesTracker::AndroidDevicesTracker()
+ {
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     m_codecStream.setCodec("UTF-8");
++#else
++    m_codecStream.setEncoding(QStringConverter::Utf8);
++#endif
+     m_codecStream.setString(&m_buffer, QIODevice::ReadWrite | QIODevice::Text);
+ }
+ 
+diff --git a/qdevicemonitor/devices/trackers/IOSDevicesTracker.cpp b/qdevicemonitor/devices/trackers/IOSDevicesTracker.cpp
+index e66a21d..da64678 100644
+--- a/qdevicemonitor/devices/trackers/IOSDevicesTracker.cpp
++++ b/qdevicemonitor/devices/trackers/IOSDevicesTracker.cpp
+@@ -21,7 +21,11 @@
+ 
+ IOSDevicesTracker::IOSDevicesTracker()
+ {
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     m_codecStream.setCodec("UTF-8");
++#else
++    m_codecStream.setEncoding(QStringConverter::Utf8);
++#endif
+     m_codecStream.setString(&m_buffer, QIODevice::ReadWrite | QIODevice::Text);
+ }
+ 
+diff --git a/qdevicemonitor/ui/DeviceWidget.cpp b/qdevicemonitor/ui/DeviceWidget.cpp
+index a665ab2..e317434 100644
+--- a/qdevicemonitor/ui/DeviceWidget.cpp
++++ b/qdevicemonitor/ui/DeviceWidget.cpp
+@@ -39,7 +39,11 @@ DeviceWidget::DeviceWidget(QPointer<QWidget> parent, QPointer<DeviceFacade> devi
+     m_redPalette = QPalette(Qt::red);
+     m_redPalette.setColor(QPalette::Highlight, Qt::red);
+ 
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+     m_textStream.setCodec("UTF-8");
++#else
++    m_textStream.setEncoding(QStringConverter::Utf8);
++#endif
+     m_textStream.setString(&m_stringStream, QIODevice::ReadWrite | QIODevice::Text);
+ 
+     //ui->textEdit->setFontFamily(m_deviceFacade->getFont());
+@@ -97,12 +101,12 @@ void DeviceWidget::maybeScrollTextEditToEnd()
+     }
+ }
+ 
+-void DeviceWidget::addText(const ColorTheme::ColorType color, const QStringRef& text)
++void DeviceWidget::addText(const ColorTheme::ColorType color, const QStringView text)
+ {
+     addText(m_deviceFacade->getThemeColor(color), text);
+ }
+ 
+-void DeviceWidget::addText(const QColor& color, const QStringRef& text)
++void DeviceWidget::addText(const QColor& color, const QStringView text)
+ {
+     m_textStream
+         << "<font style=\"font-family: " << m_deviceFacade->getFont()
+@@ -187,7 +191,7 @@ void DeviceWidget::focusFilterInput()
+ 
+ void DeviceWidget::on_markLogButton_clicked()
+ {
+-    addText(ColorTheme::VerbosityVerbose, QStringRef(&MARK_LINE));
++    addText(ColorTheme::VerbosityVerbose, QStringView(MARK_LINE));
+     m_deviceFacade->writeToLogFile(m_id, MARK_LINE);
+     flushText();
+ }
+diff --git a/qdevicemonitor/ui/DeviceWidget.h b/qdevicemonitor/ui/DeviceWidget.h
+index 9dcd608..9dcd7b4 100644
+--- a/qdevicemonitor/ui/DeviceWidget.h
++++ b/qdevicemonitor/ui/DeviceWidget.h
+@@ -55,8 +55,8 @@ public:
+     inline int getVerbosityLevel() const { return m_ui->verbositySlider->value(); }
+     void highlightFilterLineEdit(bool red);
+     void maybeScrollTextEditToEnd();
+-    void addText(const ColorTheme::ColorType color, const QStringRef& text);
+-    void addText(const QColor& color, const QStringRef& text);
++    void addText(const ColorTheme::ColorType color, const QStringView text);
++    void addText(const QColor& color, const QStringView text);
+     void flushText();
+     void clearTextEdit();
+     void onLogFileNameChanged(const QString& logFileName);
+diff --git a/qdevicemonitor/ui/MainWindow.cpp b/qdevicemonitor/ui/MainWindow.cpp
+index 69d4433..56ffb40 100644
+--- a/qdevicemonitor/ui/MainWindow.cpp
++++ b/qdevicemonitor/ui/MainWindow.cpp
+@@ -23,7 +23,6 @@
+ #include <cstdlib>
+ #include <QApplication>
+ #include <QDebug>
+-#include <QDesktopWidget>
+ #include <QDir>
+ #include <QFileDialog>
+ #include <QFileInfo>
+@@ -162,7 +161,7 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event)
+ 
+ void MainWindow::mouseReleaseEvent(QMouseEvent* event)
+ {
+-    if (event->button() == Qt::MidButton)
++    if (event->button() == Qt::MiddleButton)
+     {
+         const QTabBar& tabBar = *(m_ui->tabWidget->tabBar());
+         const QPoint mousePos = tabBar.mapFrom(this, event->pos());
+-- 
+2.45.2
+

--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r3.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,9 +22,7 @@ IUSE=""
 
 RDEPEND="
 	app-pda/usbmuxd
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	dev-qt/qtbase:6[gui,widgets]
 	dev-util/android-tools"
 DEPEND="${RDEPEND}"
 
@@ -35,12 +33,13 @@ PATCHES=(
 	"${FILESDIR}"/${P}-endl-is-deprecated.patch
 	"${FILESDIR}"/${P}-disable-warnings-as-errors.patch
 	"${FILESDIR}"/${P}-disable-pedantic-errors.patch
+	"${FILESDIR}"/${P}-qt-6.patch
 )
 
 src_configure() {
 	cd "${PN}" || die
 	export VERSION_WITH_BUILD_NUMBER="${PV}"
-	eqmake5
+	eqmake6
 }
 
 src_compile() {

--- a/dev-util/qdevicemonitor/qdevicemonitor-9999.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,15 +22,14 @@ IUSE=""
 
 RDEPEND="
 	app-pda/usbmuxd
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
+	dev-qt/qtbase:6[gui,widgets]
 	dev-util/android-tools"
 DEPEND="${RDEPEND}"
 
 src_configure() {
 	cd "${PN}" || die
 	export VERSION_WITH_BUILD_NUMBER="${PV}"
-	eqmake5
+	eqmake6
 }
 
 src_compile() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/948065

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
