### PR TITLE
media-gfx/phototonic: add 9999 - official fork qt6

### DIFF
--- a/media-gfx/phototonic/metadata.xml
+++ b/media-gfx/phototonic/metadata.xml
@@ -3,6 +3,6 @@
 <pkgmetadata>
   <!-- maintainer-needed -->
   <upstream>
-    <remote-id type="github">oferkv/phototonic</remote-id>
+    <remote-id type="github">luebking/phototonic</remote-id>
   </upstream>
 </pkgmetadata>

--- a/media-gfx/phototonic/phototonic-9999.ebuild
+++ b/media-gfx/phototonic/phototonic-9999.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit qmake-utils xdg
+
+DESCRIPTION="Image viewer and organizer"
+HOMEPAGE="https://github.com/luebking/phototonic"
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/luebking/phototonic.git"
+else
+	SRC_URI="https://github.com/luebking/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="GPL-3+"
+SLOT="0"
+IUSE="svg tiff"
+
+RDEPEND="
+	dev-qt/qtbase:6[gui,opengl,widgets]
+	media-gfx/exiv2:=
+	svg? ( dev-qt/qtsvg:6 )
+	tiff? ( dev-qt/qtimageformats:6 )
+"
+DEPEND="${RDEPEND}"
+
+src_configure() {
+	eqmake6
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+}


### PR DESCRIPTION
Initial project is unmaintained, a fork continues : https://github.com/oferkv/phototonic/commit/6d3f8f6f2a1fed57ca856e4e2a3e49ab18bc6e39

basic port to qt6 just works

no release for now : see issues/3

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
