### PR TITLE
media-sound/aumix: update EAPI 7 -> 8, fix erroneous configure error

### DIFF
--- a/media-sound/aumix/aumix-2.9.1-r1.ebuild
+++ b/media-sound/aumix/aumix-2.9.1-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools desktop
 
@@ -39,6 +39,7 @@ src_configure() {
 		$(use_enable nls)
 		$(usex gtk '' --without-gtk)
 		$(usex gpm '' --without-gpm)
+		--without-sysmouse #921162 
 	)
 
 	econf "${myeconfargs[@]}"


### PR DESCRIPTION
It checks for FreeBSD's sysmouse, badly. Explicitly disable check

May need to be merged with #36361

Closes: https://bugs.gentoo.org/939138
Bug: https://bugs.gentoo.org/930028

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
