### PR TITLE
sys-block/mbuffer: fix build failure w/ clang

### DIFF
--- a/sys-block/mbuffer/files/mbuffer-20240107-O0-for-libc-name-find.patch
+++ b/sys-block/mbuffer/files/mbuffer-20240107-O0-for-libc-name-find.patch
@@ -1,0 +1,38 @@
+https://bugs.gentoo.org/938689
+
+mbuffer use macro LIBC_(OPEN|READ|WRITE|FSTAT) whic are determined by
+'objdump -T ... | awk ...', but in the case of clag (at least for now),
+depend on the optimization levels, open|read will be optimized to other
+methods which cause LIBC_(OPEN|READ) become "", then error bellow:
+
+expected identifier or '('
+   55 | int LIBC_OPEN(const char *path, int oflag, ...)
+
+I don't know the reason to find the name of open|read|write|fstat by this
+test, so use -O0 for the feature test code.
+
+Upstream Replied:
+> this concept is needed for the tapedrive emulator that replicates the
+> behavior of specific devices.
+
+diff --git a/configure.in b/configure.in
+index 95d6772..081625a 100644
+--- a/configure.in
++++ b/configure.in
+@@ -155,6 +155,8 @@ AC_LANG(C)
+ if test -z "$OBJDUMP"; then
+ 	AC_MSG_WARN([unable to find objdump, which is needed to run tests])
+ else
++	m4_pushdef([ORIGINAL_CFLAGS], [$CFLAGS])
++	CFLAGS="-O0"
+ 	AC_MSG_CHECKING([linking open() and write() to detect libc names])
+ 	AC_LINK_IFELSE([
+ 	AC_LANG_SOURCE([[
+@@ -191,6 +193,7 @@ else
+ 	],
+ 	[AC_MSG_FAILURE([failed to link open/write test])]
+ 	)
++	CFLAGS="${ORIGINAL_CFLAGS}"
+ fi
+ 
+ 

--- a/sys-block/mbuffer/mbuffer-20240107.ebuild
+++ b/sys-block/mbuffer/mbuffer-20240107.ebuild
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-20180410-sysconfdir.patch"
 	"${FILESDIR}/${PN}-20200929-find-OBJDUMP.patch"
 	"${FILESDIR}/${PN}-20231216-autoconf-warning.patch"
+	"${FILESDIR}/${PN}-20240107-O0-for-libc-name-find.patch"
 )
 
 src_prepare() {

--- a/sys-block/mbuffer/mbuffer-20240707.ebuild
+++ b/sys-block/mbuffer/mbuffer-20240707.ebuild
@@ -28,6 +28,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-20180410-sysconfdir.patch"
 	"${FILESDIR}/${PN}-20200929-find-OBJDUMP.patch"
 	"${FILESDIR}/${PN}-20231216-autoconf-warning.patch"
+	"${FILESDIR}/${PN}-20240107-O0-for-libc-name-find.patch"
 )
 
 src_prepare() {

--- a/sys-block/mbuffer/mbuffer-20241007.ebuild
+++ b/sys-block/mbuffer/mbuffer-20241007.ebuild
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-20180410-sysconfdir.patch"
 	"${FILESDIR}/${PN}-20200929-find-OBJDUMP.patch"
 	"${FILESDIR}/${PN}-20231216-autoconf-warning.patch"
+	"${FILESDIR}/${PN}-20240107-O0-for-libc-name-find.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
use "-O0" to compile the feature test code

Closes: https://bugs.gentoo.org/938689

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
