### PR TITLE
media-gfx/xloadimage: fix incompatible function pointer types on musl

### DIFF
--- a/media-gfx/xloadimage/files/xloadimage-4.1-fix-incomp-function-pointer-musl.patch
+++ b/media-gfx/xloadimage/files/xloadimage-4.1-fix-incomp-function-pointer-musl.patch
@@ -1,0 +1,14 @@
+__signalhandler_t isn't defined on musl, one needs to drill down to bare type definition
+so code builds both on glibc and musl systems
+https://bugs.gentoo.org/924114
+--- a/window.c
++++ b/window.c
+@@ -833,7 +833,7 @@ char imageInWindow (Display *disp, int scrn, Image *image, OptionSet *global_opt
+       /* reset alarm to -delay seconds after every event */
+ #ifdef ENABLE_TIMEOUT
+       AlarmWentOff = 0;
+-      signal(SIGALRM, delayAlarmHandler);
++      signal(SIGALRM, (void (*)(int))delayAlarmHandler);
+       alarm(delay);
+ #endif /* ENABLE_TIMEOUT */
+   }

--- a/media-gfx/xloadimage/xloadimage-4.1-r18.ebuild
+++ b/media-gfx/xloadimage/xloadimage-4.1-r18.ebuild
@@ -1,0 +1,97 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Utility to view many different types of images under X11"
+HOMEPAGE="https://sioseis.ucsd.edu/xloadimage.html https://tracker.debian.org/pkg/xloadimage"
+SRC_URI="
+	ftp://ftp.x.org/R5contrib/${P/-/.}.tar.gz
+	mirror://gentoo/${P}-gentoo-r1.diff.bz2
+	https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-fix-build-for-clang16.patch.xz
+"
+S="${WORKDIR}"/${P/-/.}
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha amd64 ~arm ~hppa ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="tiff jpeg png"
+
+RDEPEND="x11-libs/libX11
+	tiff? ( media-libs/tiff:= )
+	png? ( media-libs/libpng:= )
+	jpeg? ( media-libs/libjpeg-turbo:= )
+	!media-gfx/xli"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${WORKDIR}"/${P}-gentoo-r1.diff
+	"${FILESDIR}"/${P}-zio-shell-meta-char.diff
+	"${FILESDIR}"/${P}-endif.patch
+	# Do not define errno extern, but rather include errno.h
+	# <azarah@gentoo.org> (1 Jan 2003)
+	"${FILESDIR}"/${P}-include-errno_h.patch
+	"${FILESDIR}"/xloadimage-gentoo.patch
+	"${FILESDIR}"/${P}-unaligned-access.patch
+	"${FILESDIR}"/${P}-ldflags_and_exit.patch
+	"${FILESDIR}"/${P}-libpng15.patch
+	"${WORKDIR}"/${P}-fix-build-for-clang16.patch
+	# One of the previous patches screws up a bracket...
+	"${FILESDIR}"/${P}-bracket.patch
+	"${FILESDIR}"/${P}-fix-incomp-function-pointer-musl.patch
+	"${FILESDIR}"/${P}-c99.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e "s|OPT_FLAGS=|OPT_FLAGS=$CFLAGS|" Make.conf || die
+	sed -i -e "s:^#include <varargs.h>:#include <stdarg.h>:" rlelib.c || die
+	# qa-sed sees no-op on the next sed on non-gentoo-prefix systems,
+	# but that is alright
+	sed -i -e "/^DEFS = /s:/etc:${EPREFIX}/etc:" Makefile.in || die
+	sed -i \
+		-e 's:png_set_gray_1_2_4_to_8:png_set_expand_gray_1_2_4_to_8:' \
+		png.c || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cflags -std=gnu17
+
+	# Set TIFFHeader to TIFFHeaderCommon wrt #319383
+	has_version '>=media-libs/tiff-4.0.0_pre' && \
+		append-flags -DTIFFHeader=TIFFHeaderCommon
+
+	tc-export CC
+	econf $(use_with jpeg) \
+		$(use_with png) \
+		$(use_with tiff)
+}
+
+src_compile() {
+	emake SYSPATHFILE="${EPREFIX}"/etc/X11/Xloadimage
+}
+
+src_install() {
+	dobin xloadimage uufilter
+
+	dosym xloadimage /usr/bin/xsetbg
+	dosym xloadimage /usr/bin/xview
+
+	insinto /etc/X11
+	doins xloadimagerc
+
+	newman xloadimage.man xloadimage.1
+	newman uufilter.man uufilter.1
+
+	echo ".so man1/xloadimage.1" > "${T}"/xsetbg.1 || die
+	doman "${T}"/xsetbg.1
+	newman "${T}"/xsetbg.1 xview.1
+
+	dodoc README
+}


### PR DESCRIPTION
Replaces previous patch that fixed it on glibc only

Bug: https://bugs.gentoo.org/924114

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
