### PR TITLE
media-sound/jack-rack: update EAPI 7 -> 8, port to C23

### DIFF
--- a/media-sound/jack-rack/files/jack-rack-1.4.8_rc1-C23.patch
+++ b/media-sound/jack-rack/files/jack-rack-1.4.8_rc1-C23.patch
@@ -1,0 +1,59 @@
+https://bugs.gentoo.org/946658
+Fix declaration without arguments
+--- a/src/plugin_desc.h
++++ b/src/plugin_desc.h
+@@ -59,7 +59,7 @@
+ plugin_desc_t * plugin_desc_new_with_descriptor (const char * object_file,
+                                                  unsigned long index,
+                                                  const LADSPA_Descriptor * descriptor);
+-void            plugin_desc_destroy ();
++void            plugin_desc_destroy (plugin_desc_t * pd);
+ 
+ void plugin_desc_set_object_file (plugin_desc_t * pd, const char * object_file);
+ void plugin_desc_set_index       (plugin_desc_t * pd, unsigned long index);
+https://bugs.gentoo.org/919502
+compatibility with Lash >= 0.5.2
+--- a/src/ui_callbacks.c	2025-01-15 17:07:29.738203642 +0400
++++ b/src/ui_callbacks.c	2025-01-15 17:07:57.206845017 +0400
+@@ -307,6 +307,41 @@
+ 
+ 
+ #ifdef HAVE_LASH
++
++/* function from LASH, is internal function in 0.5.4, but GPLv2+
++ *   Copyright (C) 2008 Juuso Alasuutari <juuso.alasuutari@gmail.com>
++ *   Copyright (C) 2002 Robert Ham <rah@bash.sh>
++ */
++const char *
++lash_get_fqn(const char *param_dir,
++             const char *param_file)
++{
++        static char *fqn = NULL;
++        static size_t fqn_size = 48;
++        size_t str_size;
++        char *dir, *file;
++
++        dir = strdup(param_dir);
++        file = strdup(param_file);
++
++        if (!fqn)
++                fqn = malloc(sizeof(char) * fqn_size);
++
++        str_size = strlen(dir) + 1 + strlen(file) + 1;
++
++        if (str_size > fqn_size) {
++                fqn_size = str_size;
++                fqn = realloc(fqn, sizeof(char) * fqn_size);
++        }
++
++        sprintf(fqn, "%s/%s", dir, file);
++
++        free(dir);
++        free(file);
++
++        return fqn;
++}
++
+ static int
+ lash_idle (ui_t * ui, lash_client_t * client)
+ {

--- a/media-sound/jack-rack/jack-rack-1.4.8_rc1-r2.ebuild
+++ b/media-sound/jack-rack/jack-rack-1.4.8_rc1-r2.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+MY_P=${PN}_${PV/_/\~}
+DEB_URI="mirror://debian/pool/main/j/${PN}"
+
+DESCRIPTION="JACK Rack is an effects rack for the JACK low latency audio API"
+HOMEPAGE="https://jack-rack.sourceforge.net/"
+SRC_URI="${DEB_URI}/${MY_P}.orig.tar.gz ${DEB_URI}/${MY_P}-1.debian.tar.gz"
+S="${WORKDIR}/${PN}-f9fb65d"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="alsa lash +xml"
+
+RDEPEND="
+	media-libs/ladspa-sdk
+	virtual/jack
+	virtual/libintl
+	x11-libs/gtk+:2
+	alsa? ( media-libs/alsa-lib:= )
+	lash? ( media-sound/lash:= )
+	xml? (
+		dev-libs/libxml2:=
+		media-libs/liblrdf:=
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${WORKDIR}"/debian/patches/01-desktop_file.patch
+	"${WORKDIR}"/debian/patches/02-gcc45_binutils_gold.patch
+	"${WORKDIR}"/debian/patches/03-remove_midi_when_replacing_plugin.patch
+	"${FILESDIR}"/${PN}-1.4.6-noalsa.patch
+	"${FILESDIR}"/${PN}-1.4.7-disable_deprecated.patch
+	"${FILESDIR}"/${P}-noxml.patch
+	"${FILESDIR}"/${P}-underlinking.patch
+	"${FILESDIR}"/${P}-QA-fix-desktop-file.patch
+	"${FILESDIR}"/${P}-C23.patch
+)
+
+src_prepare() {
+	default
+	eautopoint
+	eautoreconf
+}
+
+src_configure() {
+	# Use lrdf.pc to get -I/usr/include/raptor2 (lrdf.h -> raptor.h)
+	use xml && append-cppflags $($(tc-getPKG_CONFIG) --cflags lrdf)
+
+	econf \
+		$(use_enable alsa aseq) \
+		--disable-gnome \
+		$(use_enable lash) \
+		$(use_enable xml) \
+		$(use_enable xml lrdf)
+}


### PR DESCRIPTION
Fix wrong function declaration, copy an internal function from Lash for compatibility with Lash >= 0.5.2

Bug: https://bugs.gentoo.org/919502
Bug: https://bugs.gentoo.org/946658

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
