### PR TITLE
profiles/arch/arm64: drop media-libs/mesa[opencl] mask

### DIFF
--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -390,11 +390,6 @@ media-video/mplayer -sdl
 media-video/mpv -sdl
 >=x11-libs/wxGTK-3 -sdl
 
-# Jan Vesely <jano.vesely@gmail.com> (2018-06-15)
-# Mesa clover only works on r600 or radeonsi GPUs. The corresponding
-# video_cards useflags are not available on arm
-media-libs/mesa opencl
-
 # Mart Raudsepp <leio@gentoo.org> (2018-05-30)
 # app-text/pandoc not keyworded yet
 app-emulation/xen-tools doc

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -80,10 +80,6 @@ cpu_flags_arm_neon
 -cpu_flags_arm_vfpv4
 -cpu_flags_arm_vfp-d32
 
-# Michał Górny <mgorny@gentoo.org> (2018-07-09)
-# No OpenCL provider is available on arm64.
-opencl
-
 # Mart Raudsepp <leio@gentoo.org> (2018-02-13)
 # net-libs/libsmi not tested on arm64 yet
 smi

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -1,8 +1,12 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
+
+# Sam James <sam@gentoo.org> (2025-01-15)
+# virtual/opencl and friends not yet marked stable on arm64 (bug #941379)
+opencl
 
 # Matt Turner <mattst88@gentoo.org> (2024-05-10)
 # x11-drivers/xf86-video-vmware is not stable yet


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/941379
Signed-off-by: Sam James <sam@gentoo.org>