### PR TITLE
sci-chemistry/gperiodic: update EAPI 7 -> 8, incompatible pointer types

### DIFF
--- a/sci-chemistry/gperiodic/files/gperiodic-3.0.3-incompatible-pointers.patch
+++ b/sci-chemistry/gperiodic/files/gperiodic-3.0.3-incompatible-pointers.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/919213
+Cast pointer as it is cast everywhere around it
+--- a/gperiodic.c
++++ b/gperiodic.c
+@@ -137,7 +137,7 @@
+ 	    if (col == 0) gtk_label_set_markup (GTK_LABEL (label), _(header.info[row]));
+             else {
+ 	      gtk_label_set_markup (GTK_LABEL (label), _(entry->info[row]));
+-	      gtk_label_set_selectable (label, TRUE);
++	      gtk_label_set_selectable (GTK_LABEL (label), TRUE);
+ 	    }
+ 
+ 	    gtk_misc_set_alignment(GTK_MISC(label), 0, 0);

--- a/sci-chemistry/gperiodic/gperiodic-3.0.3-r1.ebuild
+++ b/sci-chemistry/gperiodic/gperiodic-3.0.3-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs xdg-utils
+
+DESCRIPTION="Periodic table application for Linux"
+HOMEPAGE="https://sourceforge.net/projects/gperiodic/"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="nls"
+
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )"
+RDEPEND="
+	sys-libs/ncurses:0
+	x11-libs/gtk+:2
+	x11-libs/cairo[X]"
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-incompatible-pointers.patch" )
+
+src_compile() {
+	emake \
+		CFLAGS="${CFLAGS}" \
+		LDFLAGS="${LDFLAGS}" \
+		CC="$(tc-getCC)" "enable_nls=$(usex nls 1 0)"
+}
+
+src_install() {
+	emake DESTDIR="${D}" "enable_nls=$(usex nls 1 0)" install
+	dodoc AUTHORS ChangeLog README
+	newdoc po/README README.translation
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Fix compilation problem with GCC-15

Bug: https://bugs.gentoo.org/919213

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
