### PR TITLE
x11-plugins/wminet: update EAPI 7 -> 8, fix C23 errors

### DIFF
--- a/x11-plugins/wminet/files/wminet-3.0.0-missing-include.patch
+++ b/x11-plugins/wminet/files/wminet-3.0.0-missing-include.patch
@@ -1,0 +1,11 @@
+for toupper(), implicit function declaration
+--- a/src/wminet.c
++++ b/src/wminet.c
+@@ -20,6 +20,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <ctype.h>
+ #include <unistd.h>
+ #include <string.h>
+ #include <signal.h>

--- a/x11-plugins/wminet/wminet-3.0.0-r3.ebuild
+++ b/x11-plugins/wminet/wminet-3.0.0-r3.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs autotools
+
+DESCRIPTION="dockapp for monitoring internet connections to and from your computer"
+HOMEPAGE="https://www.improbability.net/#wminet"
+SRC_URI="https://www.improbability.net/wmdock//${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-list.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-missing-include.patch
+	)
+
+DOCS=( AUTHORS ChangeLog NEWS README wminetrc )
+
+src_prepare() {
+	default
+
+	# bug https://bugs.gentoo.org/875137
+	# bug https://bugs.gentoo.org/908912
+	eautoreconf
+}
+
+src_compile() {
+	tc-export CC
+	emake LDFLAGS="${LDFLAGS}"
+}


### PR DESCRIPTION
Both in configure and previously unreported in code

Bug: https://bugs.gentoo.org/908912
Bug: https://bugs.gentoo.org/875137

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
