### PR TITLE
net-analyzer/firewalk: update EAPI 7 -> 8, C23 porting

### DIFF
--- a/net-analyzer/firewalk/files/firewalk-5.0-signal.patch
+++ b/net-analyzer/firewalk/files/firewalk-5.0-signal.patch
@@ -1,0 +1,36 @@
+https://bugs.gentoo.org/945297
+fix signature of signal
+--- a/include/firewalk.h
++++ b/include/firewalk.h
+@@ -248,7 +248,7 @@
+ int                                 /* 1 on success -1 or failure */
+ catch_sig(
+     int,                            /* signal to catch */
+-    void (*)()                      /* new signal handler */
++    void (*)(int)                      /* new signal handler */
+     );
+ 
+ /* handles SIGINT from user */
+--- a/src/signal.c
++++ b/src/signal.c
+@@ -40,7 +40,7 @@
+ extern int loop;
+ 
+ int
+-catch_sig(int signo, void (*handler)())
++catch_sig(int signo, void (*handler)(int))
+ {
+     struct sigaction action;
+ 
+https://bugs.gentoo.org/731202
+patch out unneedeed strip - portage does it instead, and right.
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -25,7 +25,6 @@
+ 
+ all:
+ 	cp firewalk $(top_srcdir)
+-	strip $(top_srcdir)/firewalk
+ 
+ clean:
+ 	rm -f $(top_srcdir)/firewalk

--- a/net-analyzer/firewalk/firewalk-5.0-r3.ebuild
+++ b/net-analyzer/firewalk/firewalk-5.0-r3.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A tool for determining a firewall's rule set"
+HOMEPAGE="http://packetfactory.openwall.net/projects/firewalk/"
+SRC_URI="mirror://gentoo/${P}.tgz"
+S=${WORKDIR}/${PN^}
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="
+	dev-libs/libdnet
+	net-libs/libnet:1.1
+	net-libs/libpcap
+"
+RDEPEND="
+	${DEPEND}
+"
+DOCS=( README TODO BUGS )
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc3.4.diff
+	"${FILESDIR}"/${P}-usage.diff
+	"${FILESDIR}"/${P}-signal.patch
+)
+
+src_prepare() {
+	default
+
+	# bug https://bugs.gentoo.org/899922
+	eautoreconf
+}
+
+src_install() {
+	default
+	doman man/firewalk.8
+}


### PR DESCRIPTION
Fixes wrong signature for signal-related functions, implicit decls in configure by autoreconfing, and explicit calls to strip by patching makefile and exporting toolchain value

Bug: https://bugs.gentoo.org/731202
Bug: https://bugs.gentoo.org/899922
Bug: https://bugs.gentoo.org/945297

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
