### PR TITLE
sys-apps/usbutils: add USE="-usbreset"

### DIFF
--- a/profiles/default/linux/package.use.mask
+++ b/profiles/default/linux/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Z. Liu <zhixu.liu@gmail.com> (2025-03-24)
+# Upstream considers that the usbreset could potentially damage hardware.
+# bug #948216
+sys-apps/usbutils usbreset
+
 # Sam James <sam@gentoo.org> (2023-06-06)
 # Needs linux-only dev-libs/libaio.
 app-emulation/qemu -aio

--- a/sys-apps/usbutils/metadata.xml
+++ b/sys-apps/usbutils/metadata.xml
@@ -5,4 +5,7 @@
 	<email>base-system@gentoo.org</email>
 	<name>Gentoo Base System</name>
 </maintainer>
+<use>
+	<flag name="usbreset">additionally compile the potentially problematic usbreset util</flag>
+</use>
 </pkgmetadata>

--- a/sys-apps/usbutils/usbutils-018-r1.ebuild
+++ b/sys-apps/usbutils/usbutils-018-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+inherit meson python-single-r1
+
+DESCRIPTION="USB enumeration utilities"
+HOMEPAGE="
+	https://www.kernel.org/pub/linux/utils/usb/usbutils/
+	https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usbutils.git/
+"
+SRC_URI="https://www.kernel.org/pub/linux/utils/usb/${PN}/${P}.tar.xz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="python usbreset"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+DEPEND="
+	virtual/libusb:1=
+	virtual/libudev:=
+"
+RDEPEND="
+	${DEPEND}
+	python? (
+		${PYTHON_DEPS}
+		sys-apps/hwdata
+	)
+"
+BDEPEND="
+	virtual/pkgconfig
+	python? ( ${PYTHON_DEPS} )
+"
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	use python && python_fix_shebang lsusb.py
+}
+
+src_install() {
+	meson_src_install
+
+	if use usbreset ; then
+		# https://github.com/gregkh/usbutils/issues/214
+		dobin ${BUILD_DIR}/usbreset
+		doman man/usbreset.1
+	fi
+
+	if ! use python ; then
+		rm -f "${ED}"/usr/bin/lsusb.py || die
+	fi
+}
+
+pkg_postinst() {
+	if use usbreset ; then
+		ewarn "Please be warned that 'usbreset' has been built and installed, but it could"
+		ewarn "damage your hardware, see upstream issue:"
+		ewarn "  https://github.com/gregkh/usbutils/issues/214"
+	fi
+}


### PR DESCRIPTION
it could damage the hardware, so it will be built only with both USE="usbreset" and environment variable "I_ALLOW_TO_BREAK_MY_HARDWARE=yes".


Closes: https://bugs.gentoo.org/948216

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
