### PR TITLE
dev-libs/protobuf: give unique subslot for live

### DIFF
--- a/dev-libs/protobuf/protobuf-9999.ebuild
+++ b/dev-libs/protobuf/protobuf-9999.ebuild
@@ -14,20 +14,19 @@ ABSEIL_MIN_VER="${ABSEIL_MIN_VER//_/}"
 if [[ "${PV}" == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/protocolbuffers/protobuf.git"
 	EGIT_SUBMODULES=( '-*' )
-	MY_SLOT="28.0"
+	SLOT="0/9999"
 
 	inherit git-r3
 else
 	SRC_URI="https://github.com/protocolbuffers/protobuf/releases/download/v${PV}/${P}.tar.gz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~mips ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~x64-macos"
-	MY_SLOT=$(ver_cut 1-2)
+	SLOT="0/$(ver_cut 1-2).0"
 fi
 
 DESCRIPTION="Google's Protocol Buffers - Extensible mechanism for serializing structured data"
 HOMEPAGE="https://protobuf.dev/"
 
 LICENSE="BSD"
-SLOT="0/${MY_SLOT}.0"
 IUSE="conformance debug emacs examples +libprotoc libupb +protobuf +protoc test zlib"
 
 # Require protobuf for the time being


### PR DESCRIPTION
Otherwise it's going go stale and cause issues for portage dependency resolution.

@thesamesam @negril 

```
kde-test-9999 ~ # emerge -1a dev-libs/libphonenumber

Local copy of remote index is up-to-date and will be used.

These are the packages that would be merged, in order:

Calculating dependencies... done!
Dependency resolution took 15.61 s (backtrack: 2/20).

[binary     UD ] dev-libs/boost-1.85.0-r1-6 [1.87.0]
[ebuild     U *] dev-libs/protobuf-9999 [29.2]
[binary  N     ] dev-libs/libphonenumber-8.13.47-1  USE="-test" 

The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by dev-libs/libphonenumber-8.13.47::gentoo
# required by dev-libs/libphonenumber (argument)
=dev-libs/protobuf-9999 **

NOTE: The --autounmask-keep-masks option will prevent emerge
      from creating package.unmask or ** keyword changes.

Would you like to add these changes to your config files? [Yes/No]

kde-test-9999 ~ # emerge -1a dev-libs/libphonenumber \=dev-libs/protobuf-29.2

Local copy of remote index is up-to-date and will be used.

These are the packages that would be merged, in order:

Calculating dependencies... done!
Dependency resolution took 15.76 s (backtrack: 2/20).

[binary     UD ] dev-libs/boost-1.85.0-r1-6 [1.87.0]
[ebuild   R    ] dev-libs/protobuf-29.2 
[ebuild     U *] dev-libs/protobuf-9999 [29.2]
[binary  N     ] dev-libs/libphonenumber-8.13.47-1  USE="-test" 

!!! Multiple package instances within a single package slot have been pulled
!!! into the dependency graph, resulting in a slot conflict:

dev-libs/protobuf:0

  (dev-libs/protobuf-29.2:0/29.2.0::gentoo, ebuild scheduled for merge) USE="libprotoc protobuf protoc zlib -conformance -debug -emacs -examples -libupb -test" ABI_X86="(64) -32 (-x32)" pulled in by
    =dev-libs/protobuf-29.2 (Argument)

  (dev-libs/protobuf-9999:0/28.0.0::gentoo, ebuild scheduled for merge) USE="libprotoc protobuf protoc zlib -conformance -debug -emacs -examples -libupb -test" ABI_X86="(64) -32 (-x32)" pulled in by
    dev-libs/protobuf:0/28.0.0= required by (dev-libs/libphonenumber-8.13.47-1:0/0::gentoo, binary scheduled for merge) USE="-test" ABI_X86="(64)"
                     ^^^^^^^^^^                                                                                                                                                                                             


It may be possible to solve this problem by using package.mask to
prevent one of those packages from being selected. However, it is also
possible that conflicting dependencies exist such that they are
impossible to satisfy simultaneously.  If such a conflict exists in
the dependencies of two different packages, then those packages can
not be installed simultaneously.

For more information, see MASKED PACKAGES section in the emerge man
page or refer to the Gentoo Handbook.


The following keyword changes are necessary to proceed:
 (see "package.accept_keywords" in the portage(5) man page for more details)
# required by dev-libs/libphonenumber-8.13.47::gentoo
# required by dev-libs/libphonenumber (argument)
=dev-libs/protobuf-9999 **

NOTE: The --autounmask-keep-masks option will prevent emerge
      from creating package.unmask or ** keyword changes.

Would you like to add these changes to your config files? [Yes/No] 
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
