### PR TITLE
net-misc/dropbox: call missing xdg phase

### DIFF
--- a/net-misc/dropbox/dropbox-214.4.5217.ebuild
+++ b/net-misc/dropbox/dropbox-214.4.5217.ebuild
@@ -101,6 +101,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	xdg_pkg_postinst
+
 	einfo "Warning: while running, dropbox may attempt to autoupdate itself in"
 	einfo " your user's home directory.  To prevent this, run the following as"
 	einfo " each user who will run dropbox:"

--- a/net-misc/dropbox/dropbox-215.4.7202.ebuild
+++ b/net-misc/dropbox/dropbox-215.4.7202.ebuild
@@ -101,6 +101,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	xdg_pkg_postinst
+
 	einfo "Warning: while running, dropbox may attempt to autoupdate itself in"
 	einfo " your user's home directory.  To prevent this, run the following as"
 	einfo " each user who will run dropbox:"


### PR DESCRIPTION
Otherwise xdg_icon_cache_update wont be called when the package is installed.

```
 * Messages for package net-misc/dropbox-215.4.7202:
 * Log file: /var/log/portage/build/net-misc/dropbox-215.4.7202:20250117-140802.log.gz

 * QA Notice: new icons were found installed but icon cache
 * has not been updated:
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-x.png
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-logo.png
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-idle.png
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-busy2.png
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-busy.png
 *   /usr/share/icons/hicolor/16x16/status/dropboxstatus-blank.png
 *   /usr/share/icons/hicolor/scalable/apps/dropbox.svg
 * Please make sure to call xdg_icon_cache_update()
 * in pkg_postinst() and pkg_postrm() phases of appropriate pkgs.
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
