### PR TITLE
ecm.eclass: Drop qttols[assistant] dependency if doc is not set

### DIFF
--- a/eclass/ecm.eclass
+++ b/eclass/ecm.eclass
@@ -284,7 +284,7 @@ case ${ECM_QTHELP} in
 		COMMONDEPEND+=" doc? ( dev-qt/qt-docs:${_KFSLOT} )"
 		BDEPEND+=" doc? ( >=app-text/doxygen-1.8.13-r1 )"
 		if [[ ${_KFSLOT} == 6 ]]; then
-			BDEPEND+=" dev-qt/qttools:${_KFSLOT}[assistant]"
+			BDEPEND+=" doc? ( dev-qt/qttools:${_KFSLOT}[assistant] )"
 		else
 			BDEPEND+=" doc? ( dev-qt/qthelp:${_KFSLOT} )"
 		fi


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
