### PR TITLE
mail-filter/rblcheck: EAPI 7 -> 8, fix implicit declarations in confi…

### DIFF
--- a/mail-filter/rblcheck/files/rblcheck-1.5-autoconf.patch
+++ b/mail-filter/rblcheck/files/rblcheck-1.5-autoconf.patch
@@ -1,0 +1,56 @@
+Update and fix configure.ac so it works with autoreconf and builds program
+correctly. Logic is preserved, chain invocation is replaced with right macro
+https://bugs.gentoo.org/875734
+https://bugs.gentoo.org/899780
+--- a/configure.in
++++ b/configure.ac
+@@ -1,5 +1,6 @@
+ dnl Process this file with autoconf to produce a configure script.
+-AC_INIT(rblcheck.c)
++AC_INIT
++AC_CONFIG_SRCDIR([rblcheck.c])
+ AC_CONFIG_AUX_DIR(config)
+ AM_CONFIG_HEADER(config.h:config.in)
+ AM_INIT_AUTOMAKE(rblcheck, 1.5)
+@@ -10,9 +11,8 @@
+ AC_PROG_CC
+ AC_PROG_INSTALL
+ 
+-dnl Checks for header files.
+-AC_HEADER_STDC
+-AC_CHECK_HEADERS(unistd.h)
++AC_CHECK_INCLUDES_DEFAULT
++
+ AC_CHECK_HEADERS(getopt.h)
+ AC_CHECK_HEADERS(libc.h)
+ 
+@@ -24,10 +24,8 @@
+ dnl (generally, if you've installed bind 8, you're going to want to use
+ dnl the new library). Finally, check for libresolv (which should exist
+ dnl on most systems).
+-AC_CHECK_FUNC(res_query,,
+-	AC_CHECK_LIB(resolv,res_query,,
+-		AC_CHECK_LIB(bind,res_query,,
+-			AC_MSG_ERROR(cannot locate res_query function))))
++AC_SEARCH_LIBS([res_query], [bind resolv], [],AC_MSG_ERROR([cannot locate res_query function]))
+ 
+ dnl All done.
+-AC_OUTPUT(Makefile docs/Makefile config/rblcheck.spec config/pkginfo)
++AC_CONFIG_FILES([Makefile docs/Makefile config/rblcheck.spec config/pkginfo])
++AC_OUTPUT
+Don't have a dependency on docbook that can appear in QA, every other file is generated
+already
+--- a/docs/Makefile.am
++++ b/docs/Makefile.am
+@@ -4,11 +4,6 @@
+ DISTCLEANFILES = rblcheck.ps rblcheck.rtf html/*.html
+ MAINTAINERCLEANFILES = Makefile.in
+ 
+-html/index.html: rblcheck.sgml
+-	-srcdir=`cd $(srcdir) && pwd`; \
+-	db2html $$srcdir/rblcheck.sgml
+-	-mv rblcheck html
+-
+ rblcheck.ps: rblcheck.sgml
+ 	-srcdir=`cd $(srcdir) && pwd`; \
+ 	db2ps $$srcdir/rblcheck.sgml

--- a/mail-filter/rblcheck/rblcheck-1.5-r3.ebuild
+++ b/mail-filter/rblcheck/rblcheck-1.5-r3.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs autotools
+
+DESCRIPTION="Perform lookups in RBL-styles services"
+HOMEPAGE="https://github.com/logic/rblcheck"
+SRC_URI="https://github.com/logic/rblcheck/releases/download/${P}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~mips ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-autoconf.patch
+)
+
+DOCS=( README docs/rblcheck.ps docs/rblcheck.rtf )
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}


### PR DESCRIPTION
…gure

Fixes build issues by updating configure.ac and letting autoreconf loose. Adds src_prepare, removes src_install. This accidentally reveals optional dependency to docbook. Fails to generate html files without docbook. We don't install html files. Skip that step.

Closes: https://bugs.gentoo.org/899780
Closes: https://bugs.gentoo.org/875734

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
