### PR TITLE
sys-block/mbuffer: fix fails to compile

### DIFF
--- a/sys-block/mbuffer/files/mbuffer-20240107-O0-for-libc-name-find.patch
+++ b/sys-block/mbuffer/files/mbuffer-20240107-O0-for-libc-name-find.patch
@@ -23,7 +23,7 @@ index 95d6772..081625a 100644
  if test -z "$OBJDUMP"; then
  	AC_MSG_WARN([unable to find objdump, which is needed to run tests])
  else
-+	m4_pushdef([ORIGINAL_CFLAGS], [$CFLAGS])
++	old_CFLAGS="${CFLAGS}"
 +	CFLAGS="-O0"
  	AC_MSG_CHECKING([linking open() and write() to detect libc names])
  	AC_LINK_IFELSE([
@@ -32,7 +32,7 @@ index 95d6772..081625a 100644
  	],
  	[AC_MSG_FAILURE([failed to link open/write test])]
  	)
-+	CFLAGS="${ORIGINAL_CFLAGS}"
++	CFLAGS="${old_CFLAGS}"
  fi
  
  


### PR DESCRIPTION
save and restore CFLAGS by using shell syntax

Fixes: 69fee45923a0a9b2734f3bb150a1f576499904b0
Closes: https://bugs.gentoo.org/948358

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
