### PR TITLE
media-sound/gstreamripper: Port to C23, fix implicit decls in configure

### DIFF
--- a/media-sound/gstreamripper/files/gstreamripper-0.2-C23-fixes.patch
+++ b/media-sound/gstreamripper/files/gstreamripper-0.2-C23-fixes.patch
@@ -1,0 +1,62 @@
+https://bugs.gentoo.org/945203
+Fix remaining incorrect usage of a function, prepare for autoreconf
+--- a/configure.in
++++ b/configure.in
+@@ -3,7 +3,7 @@
+ dnl If you don't want it to overwrite it,
+ dnl 	Please disable it in the Anjuta project configuration
+ 
+-AC_INIT(configure.in)
++AC_INIT(configure.ac)
+ AM_INIT_AUTOMAKE(GStreamripperX, 0.2)
+ AM_CONFIG_HEADER(config.h)
+ 
+--- a/src/callbacks.c
++++ b/src/callbacks.c
+@@ -86,7 +86,7 @@
+ 				    (GTK_WIDGET(Mainwidget), "entry1")), "");
+ 
+ 		if(child_pid <= 0)
+-			showError(GTK_WIDGET(button));
++			showError();
+ 	}
+ }
+ 
+@@ -161,7 +161,7 @@
+ 			  error->message);
+ 		g_error_free(error);
+ 		error = NULL;
+-		showError(GTK_WIDGET(Mainwidget));
++		showError();
+ 		return 0;
+ 	}
+ 
+@@ -550,7 +550,7 @@
+ 		{
+ 			gint child_pid = startNewThread();
+ 			if(child_pid <= 0)
+-				showError(GTK_WIDGET(button));
++				showError();
+ 		}
+ 		else
+ 		{
+@@ -571,7 +571,7 @@
+ }
+ 
+ //open location
+-void on_locateButton_clicked(GtkWidget * button, gpointer * user_data)
++void on_locateButton_clicked(GtkWidget * button, gpointer user_data)
+ {
+ 	gchar *file = getFile(dialog1, 1);
+ 	if(file != NULL)
+--- a/src/callbacks.h
++++ b/src/callbacks.h
+@@ -34,7 +34,7 @@
+ 
+ void kill_proc(gboolean all, gint curtab);
+ 
+-void on_locateButton_clicked();
++void on_locateButton_clicked(GtkWidget * button, gpointer user_data);
+ 
+ gboolean on_window1_delete_event(GtkButton * button,GdkEvent * event,
+                                                         gpointer user_data);

--- a/media-sound/gstreamripper/gstreamripper-0.2-r2.ebuild
+++ b/media-sound/gstreamripper/gstreamripper-0.2-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit desktop
+inherit desktop autotools
 
 MY_P=GStreamripperX-${PV}
 
@@ -22,9 +22,17 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
-PATCHES="
-	${FILESDIR}/${P}-C99-fixes.patch
-"
+PATCHES=(
+	"${FILESDIR}/${P}-C99-fixes.patch"
+	"${FILESDIR}/${P}-C23-fixes.patch"
+)
+
+src_prepare() {
+	default
+
+	# bug https://bugs.gentoo.org/879711
+	eautoreconf
+}
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}"


### PR DESCRIPTION
As usual, autoreconf, patch for configure.in to work after autoreconf, and patches to fix function definitions or usage that weren't problematic last time, with C99 port

Closes: https://bugs.gentoo.org/945203
Closes: https://bugs.gentoo.org/899850
Closes: https://bugs.gentoo.org/879711

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
