### PR TITLE
net-misc/memcached: htonll is Windows-only, don't raise QA warnings

### DIFF
--- a/net-misc/memcached/memcached-1.6.27.ebuild
+++ b/net-misc/memcached/memcached-1.6.27.ebuild
@@ -37,6 +37,10 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.4.17-EWOULDBLOCK.patch"
 )
 
+QA_CONFIG_IMPL_DECL_SKIP=(
+	htonll
+)
+
 src_prepare() {
 	default
 

--- a/net-misc/memcached/memcached-1.6.31.ebuild
+++ b/net-misc/memcached/memcached-1.6.31.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,6 +42,10 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.4.0-fix-as-needed-linking.patch"
+)
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	htonll
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/899912

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
