### PR TITLE
dev-lang/mmix: fix compilation errors with modern compilers

### DIFF
--- a/dev-lang/mmix/files/mmix-20160804-implicit-int.patch
+++ b/dev-lang/mmix/files/mmix-20160804-implicit-int.patch
@@ -1,0 +1,27 @@
+Fix function definition to be modern C
+https://bugs.gentoo.org/883275
+diff '--color=auto' -ru work.old/abstime.w work/abstime.w
+--- a/abstime.w	2025-01-19 17:06:19.952342044 +0400
++++ b/abstime.w	2025-01-19 17:10:33.521811824 +0400
+@@ -18,7 +18,7 @@
+ #include <stdio.h>
+ #include <time.h>
+ @#
+-main()
++int main(void)
+ {
+   printf("#define ABSTIME %ld\n",time(NULL));
+   return 0;
+Additional dependency in build graph
+https://bugs.gentoo.org/818889
+--- a/Makefile	2025-01-19 17:19:21.271627004 +0400
++++ b/Makefile	2025-01-19 17:21:03.933007472 +0400
+@@ -81,6 +81,8 @@
+ 
+ mmix-config.o: mmix-pipe.o
+ 
++mmix-mem.o: mmix-pipe.o
++
+ mmmix:  mmix-arith.o mmix-pipe.o mmix-config.o mmix-mem.o mmix-io.o mmmix.c
+ 	$(CC) $(CFLAGS) $(LDFLAGS) mmmix.c \
+ 	  mmix-arith.o mmix-pipe.o mmix-config.o mmix-mem.o mmix-io.o -o mmmix

--- a/dev-lang/mmix/mmix-20160804-r2.ebuild
+++ b/dev-lang/mmix/mmix-20160804-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="Donald Knuth's MMIX Assembler and Simulator"
+HOMEPAGE="https://www-cs-faculty.stanford.edu/~knuth/mmix.html http://mmix.cs.hm.edu"
+SRC_URI="http://mmix.cs.hm.edu/src/${P}.tgz"
+S="${WORKDIR}"
+
+DEPEND="virtual/tex-base
+	doc? ( dev-texlive/texlive-plaingeneric )"
+# media-sound/mmix and dev-lang/mmix both install 'mmix' binary, bug #426874
+RDEPEND="!!media-sound/mmix"
+
+LICENSE="mmix"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE="doc"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-20110420-makefile.patch
+	"${FILESDIR}"/${PN}-20131017-format-security.patch
+	"${FILESDIR}"/${PN}-20160804-gcc-10.patch
+	"${FILESDIR}"/${PN}-20160804-implicit-int.patch
+)
+
+src_compile() {
+	append-flags -std=gnu17
+	export VARTEXFONTS=${T}/fonts
+	emake all \
+		CFLAGS="${CFLAGS}" \
+		CC="$(tc-getCC)"
+
+	if use doc ; then
+		emake doc
+	fi
+}
+
+src_install() {
+	dobin ${PN} ${PN}al m${PN} mmotype abstime
+	dodoc README ${PN}.1
+
+	use doc && dodoc *.ps
+}


### PR DESCRIPTION
Can't be ported to C23 without massive rewrite due to hand-rolled trinary bool, but other compilation problems aren't that engaging They are fixed by patch to add an edge to build graph and a type to main()

Closes: https://bugs.gentoo.org/946527
Closes: https://bugs.gentoo.org/818889
Closes: https://bugs.gentoo.org/883275

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
