### PR TITLE
games-emulation/dolphin: require newer sdl2

### DIFF
--- a/games-emulation/dolphin/dolphin-2412-r1.ebuild
+++ b/games-emulation/dolphin/dolphin-2412-r1.ebuild
@@ -101,7 +101,7 @@ RDEPEND="
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )
 	profile? ( dev-util/oprofile )
 	pulseaudio? ( media-libs/libpulse )
-	sdl? ( media-libs/libsdl2 )
+	sdl? ( >=media-libs/libsdl2-2.30.9 )
 	systemd? ( sys-apps/systemd:0= )
 	upnp? ( net-libs/miniupnpc:= )
 "


### PR DESCRIPTION
Dolphin v2412 requires >=media-libs/libsdl2-2.30.9 when built with the sdl USE flag.

See upstream commit: https://github.com/dolphin-emu/dolphin/commit/f642cd465828e3f70b0ef5f992c5e1389c307c9a

Closes: https://bugs.gentoo.org/948415

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
