### PR TITLE
dev-games/godot: fix for c23 in 4.3-r1

### DIFF
--- a/dev-games/godot/files/godot-4.3-r1-c23-fix.patch
+++ b/dev-games/godot/files/godot-4.3-r1-c23-fix.patch
@@ -1,0 +1,23 @@
+From: OldManSeph7818 <sschaefering@gmail.com>
+Date: Sun, 19 Jan 2025 22:30
+Subject: [PATCH] fix gcc-15 build
+
+--- a/thirdparty/glslang/SPIRV/SpvBuilder.h
++++ b/thirdparty/glslang/SPIRV/SpvBuilder.h
+@@ -63,3 +63,4 @@
+-#include <stack>
+-#include <unordered_map>
+-#include <map>
++#include <stack>
++#include <cstdint>
++#include <unordered_map>
++#include <map>
+
+--- a/thirdparty/thorvg/inc/thorvg.h
++++ b/thirdparty/thorvg/inc/thorvg.h
+@@ -7,2 +7,3 @@
+-#include <list>
+-
++#include <list>
++#include <cstdint>
++

--- a/dev-games/godot/godot-4.3-r1.ebuild
+++ b/dev-games/godot/godot-4.3-r1.ebuild
@@ -92,6 +92,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.3-scons.patch
+	"${FILESDIR}"/${PN}-4.3-r1-c23-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
SpvBuilder.h and thorvg.h needed `'#include <cstdint>'` added to includes to compile with c23

Closes: https://bugs.gentoo.org/940190
Signed-off-by: OldManSeph7818 <sschaefering@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
