### PR TITLE
dev-libs/openct: update EAPI 7 -> 8, fix incompatible pointers

### DIFF
--- a/dev-libs/openct/files/openct-0.6.20-incompatible-pointers.patch
+++ b/dev-libs/openct/files/openct-0.6.20-incompatible-pointers.patch
@@ -1,0 +1,26 @@
+Correct types so all pointer types are compatibile.
+https://bugs.gentoo.org/920193
+diff '--color=auto' -ru openct-0.6.20.old/src/ifd/process.c openct-0.6.20/src/ifd/process.c
+--- openct-0.6.20.old/src/ifd/process.c	2025-01-20 19:26:08.226266610 +0400
++++ openct-0.6.20/src/ifd/process.c	2025-01-20 19:28:06.168582649 +0400
+@@ -450,7 +450,7 @@
+ 			   ct_tlv_parser_t * args, ct_tlv_builder_t * resp)
+ {
+ 	unsigned char *data;
+-	unsigned int data_len;
++	size_t data_len;
+ 	unsigned int address;
+ 	int rc;
+ 
+diff '--color=auto' -ru openct-0.6.20.old/src/include/openct/socket.h openct-0.6.20/src/include/openct/socket.h
+--- openct-0.6.20.old/src/include/openct/socket.h	2025-01-20 19:34:34.479330790 +0400
++++ openct-0.6.20/src/include/openct/socket.h	2025-01-20 19:36:19.708720553 +0400
+@@ -37,7 +37,7 @@
+ 			listener : 1;
+ 
+ 	/* events to poll for */
+-	int		events;
++	short		events;
+ 
+ 	void *		user_data;
+ 	int		(*poll)(struct ct_socket *, struct pollfd *);

--- a/dev-libs/openct/openct-0.6.20-r6.ebuild
+++ b/dev-libs/openct/openct-0.6.20-r6.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic udev
+
+DESCRIPTION="library for accessing smart card terminals"
+HOMEPAGE="https://github.com/OpenSC/openct/wiki"
+SRC_URI="https://downloads.sourceforge.net/opensc/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="doc debug pcsc-lite selinux usb"
+
+DEPEND="
+	pcsc-lite? ( >=sys-apps/pcsc-lite-1.7.2-r1:= )
+	usb? ( virtual/libusb:0 )
+	dev-libs/libltdl:0=
+"
+RDEPEND="
+	${DEPEND}
+	acct-group/openct
+	acct-user/openctd
+	selinux? ( sec-policy/selinux-openct )
+"
+BDEPEND="doc? ( app-text/doxygen )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-automake.patch
+	"${FILESDIR}"/${P}-slibtool.patch
+	"${FILESDIR}"/${P}-incompatible-pointers.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	use debug && append-cppflags -DDEBUG_IFDH
+
+	econf \
+		--localstatedir=/var \
+		--with-udev="$(get_udevdir)" \
+		--enable-non-privileged \
+		--with-daemon-user=openctd \
+		--with-daemon-groups=usb \
+		--enable-shared \
+		--disable-static \
+		$(use_enable doc) \
+		$(use_enable doc api-doc) \
+		$(use_enable pcsc-lite pcsc) \
+		$(use_with pcsc-lite bundle /usr/$(get_libdir)/readers/usb) \
+		$(use_enable usb)
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+	rm -f "${ED}"/usr/$(get_libdir)/openct-ifd.* || die
+
+	udev_newrules etc/openct.udev 70-openct.rules
+
+	newinitd "${FILESDIR}"/openct.initd openct
+}
+
+pkg_postinst() {
+	elog
+	elog "You need to edit /etc/openct.conf to enable serial readers."
+	elog
+	elog "You should add \"openct\" to your default runlevel. To do so"
+	elog "type \"rc-update add openct default\"."
+	elog
+	elog "You need to be a member of the (newly created) group openct to"
+	elog "access smart card readers connected to this system. Set users'"
+	elog "groups with usermod -G.  root always has access."
+	elog
+
+	# bug https://bugs.gentoo.org/843071
+	udev_reload
+
+}
+
+pkg_postrm() {
+	udev_reload
+}


### PR DESCRIPTION
Fixes QA warning about lack of udev rules reload after install, fixes build on modern compilers

Bug: https://bugs.gentoo.org/843071
Closes: https://bugs.gentoo.org/920193

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
