### PR TITLE
sys-libs/libxcrypt: drop glibc crypt use flag dep

### DIFF
--- a/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
@@ -26,10 +26,6 @@ RESTRICT="!test? ( test )"
 
 DEPEND="
 	system? (
-		elibc_glibc? (
-			${CATEGORY}/glibc[-crypt(-)]
-			!${CATEGORY}/glibc[crypt(-)]
-		)
 		elibc_musl? (
 			${CATEGORY}/musl[-crypt(+)]
 			!${CATEGORY}/musl[crypt(+)]


### PR DESCRIPTION
glibc upstream has disabled libcrypt builds since 2.39 and
our recent glibc ebuilds don't even have a crypt USE flag
anymore, so remove it from here as well.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
