### PR TITLE
Update knem to use linux-mod-r1, and drop non-git version

### DIFF
--- a/sys-cluster/knem/knem-9999.ebuild
+++ b/sys-cluster/knem/knem-9999.ebuild
@@ -1,19 +1,13 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
 
-inherit autotools linux-mod linux-info toolchain-funcs udev
+inherit autotools git-r3 linux-mod-r1 toolchain-funcs udev
 
 DESCRIPTION="High-Performance Intra-Node MPI Communication"
-HOMEPAGE="https://knem.gforge.inria.fr/"
-if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="https://gitlab.inria.fr/knem/knem.git"
-	inherit git-r3
-else
-	SRC_URI="https://gitlab.inria.fr/knem/knem/uploads/4a43e3eb860cda2bbd5bf5c7c04a24b6/${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
-fi
+HOMEPAGE="https://knem.gitlabpages.inria.fr/"
+EGIT_REPO_URI="https://gitlab.inria.fr/knem/knem.git"
 
 LICENSE="GPL-2 LGPL-2"
 SLOT="0"
@@ -26,15 +20,11 @@ RDEPEND="
 		sys-apps/hwloc:=
 		sys-apps/kmod[tools]"
 
-MODULE_NAMES="knem(misc:${S}/driver/linux)"
-BUILD_TARGETS="all"
-BUILD_PARAMS="KDIR=${KERNEL_DIR}"
-
 pkg_setup() {
 	linux-info_pkg_setup
 	CONFIG_CHECK="DMA_ENGINE"
 	check_extra_config
-	linux-mod_pkg_setup
+	linux-mod-r1_pkg_setup
 	ARCH="$(tc-arch-kernel)"
 	ABI="${KERNEL_ABI}"
 }
@@ -54,10 +44,11 @@ src_configure() {
 }
 
 src_compile() {
+	local modlist=( knem=misc )
 	default
 	if use modules; then
 		cd "${S}/driver/linux"
-		linux-mod_src_compile || die "failed to build driver"
+		linux-mod-r1_src_compile || die "failed to build driver"
 	fi
 }
 
@@ -65,10 +56,10 @@ src_install() {
 	default
 	if use modules; then
 		cd "${S}/driver/linux"
-		linux-mod_src_install || die "failed to install driver"
+		linux-mod-r1_src_install
 	fi
 
-	# Drop funny unneded stuff
+	# Drop funny unneeded stuff
 	rm "${ED}/usr/sbin/knem_local_install" || die
 	rmdir "${ED}/usr/sbin" || die
 	# install udev rules
@@ -77,6 +68,7 @@ src_install() {
 }
 
 pkg_postinst() {
+	linux-mod-r1_pkg_postinst
 	udev_reload
 }
 


### PR DESCRIPTION
Changes

Upstream has decided to stop having release, and will only provide fixes to their git repo. [1]

1. Removed non-git SRC from -9999 ebuild
2. Migrated -9999 ebuild to linux-mod-r1 Bug #908727
3. Minor spelling fix

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
