### PR TITLE
net-mail/mailutils: fix build with slibtool

### DIFF
--- a/net-mail/mailutils/files/mailutils-3.18-slibtool.patch
+++ b/net-mail/mailutils/files/mailutils-3.18-slibtool.patch
@@ -1,0 +1,73 @@
+https://git.savannah.gnu.org/cgit/mailutils.git/commit/?id=ec3b17c65d6dfa22684963965efd333a2b63d503
+https://savannah.gnu.org/patch/index.php?10497
+
+From 14665c43af281ace7c46450074bfe51a182f05cf Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 20 Jan 2025 20:53:17 -0800
+Subject: [PATCH] libproto: link using the libtool archives
+
+When using slibtool the build fails when it doesn't find -lmu_tesh. This
+can be solved by linking internal dependencies with the generated
+libtool archive (.la) file.
+---
+ libproto/dotmail/tests/Makefile.am | 2 +-
+ libproto/maildir/tests/Makefile.am | 2 +-
+ libproto/mbox/tests/Makefile.am    | 2 +-
+ libproto/mh/tests/Makefile.am      | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libproto/dotmail/tests/Makefile.am b/libproto/dotmail/tests/Makefile.am
+index 36f6c04..51818c8 100644
+--- a/libproto/dotmail/tests/Makefile.am
++++ b/libproto/dotmail/tests/Makefile.am
+@@ -27,7 +27,7 @@ AM_CPPFLAGS = \
+ 
+ noinst_PROGRAMS = \
+  mbop
+-LDADD = -L$(top_builddir)/libmailutils/tests -lmu_tesh $(MU_LIB_DOTMAIL) $(MU_LIB_MAILUTILS)
++LDADD = $(top_builddir)/libmailutils/tests/libmu_tesh.la $(MU_LIB_DOTMAIL) $(MU_LIB_MAILUTILS)
+ 
+ ## ------------ ##
+ ## Test suite.  ##
+diff --git a/libproto/maildir/tests/Makefile.am b/libproto/maildir/tests/Makefile.am
+index 04bef0a..e0cf7a1 100644
+--- a/libproto/maildir/tests/Makefile.am
++++ b/libproto/maildir/tests/Makefile.am
+@@ -28,7 +28,7 @@ AM_CPPFLAGS = \
+ noinst_PROGRAMS = \
+  mbop
+ 
+-LDADD =  -L$(top_builddir)/libmailutils/tests -lmu_tesh $(MU_LIB_MAILDIR) $(MU_LIB_MAILUTILS)
++LDADD = $(top_builddir)/libmailutils/tests/libmu_tesh.la $(MU_LIB_MAILDIR) $(MU_LIB_MAILUTILS)
+ 
+ ## ------------ ##
+ ## Test suite.  ##
+diff --git a/libproto/mbox/tests/Makefile.am b/libproto/mbox/tests/Makefile.am
+index f8871ae..461d19c 100644
+--- a/libproto/mbox/tests/Makefile.am
++++ b/libproto/mbox/tests/Makefile.am
+@@ -27,7 +27,7 @@ AM_CPPFLAGS = \
+ 
+ noinst_PROGRAMS = \
+  mbop
+-LDADD = -L$(top_builddir)/libmailutils/tests -lmu_tesh $(MU_LIB_MBOX) $(MU_LIB_MAILUTILS)
++LDADD = $(top_builddir)/libmailutils/tests/libmu_tesh.la $(MU_LIB_MBOX) $(MU_LIB_MAILUTILS)
+ 
+ ## ------------ ##
+ ## Test suite.  ##
+diff --git a/libproto/mh/tests/Makefile.am b/libproto/mh/tests/Makefile.am
+index a949c34..df42255 100644
+--- a/libproto/mh/tests/Makefile.am
++++ b/libproto/mh/tests/Makefile.am
+@@ -28,7 +28,7 @@ AM_CPPFLAGS = \
+ noinst_PROGRAMS = \
+  mbop
+ 
+-LDADD =  -L$(top_builddir)/libmailutils/tests -lmu_tesh $(MU_LIB_MH) $(MU_LIB_MAILUTILS)
++LDADD =  $(top_builddir)/libmailutils/tests/libmu_tesh.la $(MU_LIB_MH) $(MU_LIB_MAILUTILS)
+ 
+ ## ------------ ##
+ ## Test suite.  ##
+-- 
+2.45.3
+

--- a/net-mail/mailutils/mailutils-3.18.ebuild
+++ b/net-mail/mailutils/mailutils-3.18.ebuild
@@ -63,6 +63,7 @@ REQUIRED_USE="
 DOCS=( ABOUT-NLS AUTHORS COPYING COPYING.LESSER ChangeLog INSTALL NEWS README THANKS TODO )
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.5-add-include.patch
+	"${FILESDIR}"/${PN}-3.18-slibtool.patch
 	"${FILESDIR}"/${PN}-tests-use-mbox.patch
 )
 


### PR DESCRIPTION
Upstream-Commit: https://git.savannah.gnu.org/cgit/mailutils.git/commit/?id=ec3b17c65d6dfa22684963965efd333a2b63d503
Upstream-PR: https://savannah.gnu.org/patch/index.php?10497

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
