### PR TITLE
net-dns/idnkit: Fix incompatible pointers

### DIFF
--- a/net-dns/idnkit/files/idnkit-2.3-incompatible-pointers.patch
+++ b/net-dns/idnkit/files/idnkit-2.3-incompatible-pointers.patch
@@ -1,0 +1,29 @@
+Fix incompatible pointers for modern C, hope that restrict qualifier
+holds in this scenario
+https://bugs.gentoo.org/919224
+--- a/lib/localconverter.c
++++ b/lib/localconverter.c
+@@ -599,12 +599,12 @@
+ 	inleft = 0;
+ 	outbuf = NULL;
+ 	outleft = 0;
+-	iconv(ictx, (const char **)NULL, &inleft, &outbuf, &outleft);
++	iconv(ictx, NULL, &inleft, &outbuf, &outleft);
+ 
+ 	inleft = strlen(from);
+ 	inbuf = from;
+ 	outleft = tolen - 1;	/* reserve space for terminating NUL */
+-	sz = iconv(ictx, (const char **)&inbuf, &inleft, &to, &outleft);
++	sz = iconv(ictx, (char ** restrict)&inbuf, &inleft, &to, &outleft);
+ 
+ 	if (sz == (size_t)(-1) || inleft > 0) {
+ 		switch (errno) {
+@@ -630,7 +630,7 @@
+ 	 * Append a sequence of state reset.
+ 	 */
+ 	inleft = 0;
+-	sz = iconv(ictx, (const char **)NULL, &inleft, &to, &outleft);
++	sz = iconv(ictx, NULL, &inleft, &to, &outleft);
+ 	if (sz == (size_t)(-1)) {
+ 		switch (errno) {
+ 		case EILSEQ:

--- a/net-dns/idnkit/idnkit-2.3-r2.ebuild
+++ b/net-dns/idnkit/idnkit-2.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,6 +18,8 @@ DEPEND="
 	${RDEPEND}
 	dev-lang/perl
 "
+
+PATCHES=( "${FILESDIR}"/"${P}"-incompatible-pointers.patch )
 
 src_configure() {
 	econf $(use_enable liteonly)


### PR DESCRIPTION
Part of modern C conversion

Bug: https://bugs.gentoo.org/919224

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
