### PR TITLE
app-arch/sharutils: update EAPI 7 -> 8, fix modern C issues

### DIFF
--- a/app-arch/sharutils/files/sharutils-4.15.2-C23.patch
+++ b/app-arch/sharutils/files/sharutils-4.15.2-C23.patch
@@ -1,0 +1,50 @@
+https://bugs.gentoo.org/900248
+https://bugs.gentoo.org/894322
+missing include for textdomain and bindtextdomain
+This is only one place we can put include, else weird
+macro dance messes with it or we use gettext before we
+mark it for assembly operations.
+--- a/src/shar-opts.h
++++ b/src/shar-opts.h
+@@ -373,6 +373,8 @@
+ #     include <libintl.h>
+ #   endif
+ 
++#include "gettext.h"
++
+ # ifndef ATTRIBUTE_FORMAT_ARG
+ #   define ATTRIBUTE_FORMAT_ARG(_a)
+ # endif
+--- a/src/unshar-opts.h
++++ b/src/unshar-opts.h
+@@ -210,6 +210,8 @@
+ #     include <libintl.h>
+ #   endif
+ 
++#include "gettext.h"
++
+ # ifndef ATTRIBUTE_FORMAT_ARG
+ #   define ATTRIBUTE_FORMAT_ARG(_a)
+ # endif
+--- a/src/uudecode-opts.h
++++ b/src/uudecode-opts.h
+@@ -188,6 +188,8 @@
+ #     include <libintl.h>
+ #   endif
+ 
++#include "gettext.h"
++
+ # ifndef ATTRIBUTE_FORMAT_ARG
+ #   define ATTRIBUTE_FORMAT_ARG(_a)
+ # endif
+--- a/src/uuencode-opts.h
++++ b/src/uuencode-opts.h
+@@ -184,6 +184,8 @@
+ #     include <libintl.h>
+ #   endif
+ 
++#include "gettext.h"
++
+ # ifndef ATTRIBUTE_FORMAT_ARG
+ #   define ATTRIBUTE_FORMAT_ARG(_a)
+ # endif

--- a/app-arch/sharutils/files/sharutils-4.15.2-dewhich.patch
+++ b/app-arch/sharutils/files/sharutils-4.15.2-dewhich.patch
@@ -1,0 +1,32 @@
+https://bugs.gentoo.org/941724
+which-hunt
+diff '--color=auto' -ru sharutils-4.15.2.old/libopts/m4/libopts.m4 sharutils-4.15.2/libopts/m4/libopts.m4
+--- sharutils-4.15.2.old/libopts/m4/libopts.m4	2025-01-22 13:17:52.302369061 +0000
++++ sharutils-4.15.2/libopts/m4/libopts.m4	2025-01-22 13:19:46.096362975 +0000
+@@ -114,9 +114,9 @@
+   AC_PROG_SED
+   [while :
+   do
+-      POSIX_SHELL=`which bash`
++      POSIX_SHELL=`command -v bash`
+       test -x "$POSIX_SHELL" && break
+-      POSIX_SHELL=`which dash`
++      POSIX_SHELL=`command -v dash`
+       test -x "$POSIX_SHELL" && break
+       POSIX_SHELL=/usr/xpg4/bin/sh
+       test -x "$POSIX_SHELL" && break
+diff '--color=auto' -ru sharutils-4.15.2.old/m4/libopts.m4 sharutils-4.15.2/m4/libopts.m4
+--- sharutils-4.15.2.old/m4/libopts.m4	2025-01-22 13:17:52.365018511 +0000
++++ sharutils-4.15.2/m4/libopts.m4	2025-01-22 13:19:17.856525747 +0000
+@@ -114,9 +114,9 @@
+   AC_PROG_SED
+   [while :
+   do
+-      POSIX_SHELL=`which bash`
++      POSIX_SHELL=`command -v bash`
+       test -x "$POSIX_SHELL" && break
+-      POSIX_SHELL=`which dash`
++      POSIX_SHELL=`command -v dash`
+       test -x "$POSIX_SHELL" && break
+       POSIX_SHELL=/usr/xpg4/bin/sh
+       test -x "$POSIX_SHELL" && break

--- a/app-arch/sharutils/sharutils-4.15.2-r3.ebuild
+++ b/app-arch/sharutils/sharutils-4.15.2-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=8
 
-inherit flag-o-matic strip-linguas
+inherit flag-o-matic strip-linguas autotools
 
 MY_P="${P/_/-}"
 DESCRIPTION="Tools to deal with shar archives"
@@ -21,9 +21,15 @@ DEPEND="app-arch/xz-utils
 	nls? ( >=sys-devel/gettext-0.10.35 )"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-4.15.2-glibc228.patch
-	"${FILESDIR}"/${PN}-4.15.2-CVE-2018-1000097.patch
-	"${FILESDIR}"/${PN}-4.15.2-gcc-10.patch
+	"${FILESDIR}"/${P}-glibc228.patch
+	"${FILESDIR}"/${P}-CVE-2018-1000097.patch
+	"${FILESDIR}"/${P}-gcc-10.patch
+	"${FILESDIR}"/${P}-dewhich.patch
+	"${FILESDIR}"/${P}-C23.patch
+)
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	pathfind
 )
 
 src_prepare() {
@@ -35,6 +41,10 @@ src_prepare() {
 
 	# bug #943901
 	append-cflags -std=gnu17
+
+	# bug https://bugs.gentoo.org/941724
+	# regenerate config after which removal
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
Patch removes which from m4 macros and regenerates configure. Patch adds include of lib/gettext.h into only place it can go so it works in glibc and musl - in the middle of *-opts.h file, after condifional declaration of gettext or inclusion of libintl, but before gettext is actually used.
In other places funky macro dance either undefines gettext or uses it before marking it with asm attributes.
This supercedes other PR, and also lets all code to be aware of all the defines from config.h and friends.

Closes: https://bugs.gentoo.org/941724
Closes: https://bugs.gentoo.org/894322
Bug: https://bugs.gentoo.org/900248
Closes: #31725

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
