### PR TITLE
app-metrics/collectd: update HOMEPAGE, update EAPI 7 -> 8

### DIFF
--- a/app-metrics/collectd/collectd-5.12.0-r11.ebuild
+++ b/app-metrics/collectd/collectd-5.12.0-r11.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=8
 
 JAVA_PKG_OPT_USE="collectd_plugins_java"
 LUA_COMPAT=( lua5-{1..4} )
@@ -11,7 +11,7 @@ inherit autotools fcaps java-pkg-opt-2 linux-info lua-single perl-functions pyth
 
 DESCRIPTION="Collects system statistics and provides mechanisms to store the values"
 
-HOMEPAGE="https://collectd.org/"
+HOMEPAGE="https://www.collectd.org/"
 SRC_URI="https://github.com/${PN}/${PN}/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="MIT GPL-2 GPL-2+ GPL-3 GPL-3+"
@@ -155,10 +155,10 @@ BDEPEND="virtual/pkgconfig"
 # Enforcing !=sys-kernel/linux-headers-4.5 > due to #577846
 DEPEND="${COMMON_DEPEND}
 	collectd_plugins_iptables?		( || ( <=sys-kernel/linux-headers-4.4 >=sys-kernel/linux-headers-4.6 ) )
-	collectd_plugins_java?			( >=virtual/jdk-1.8 )"
+	collectd_plugins_java?			( >=virtual/jdk-1.8:* )"
 
 RDEPEND="${COMMON_DEPEND}
-	collectd_plugins_java?			( >=virtual/jre-1.8 )
+	collectd_plugins_java?			( >=virtual/jre-1.8:* )
 	collectd_plugins_syslog?		( virtual/logger )
 	selinux?				( sec-policy/selinux-collectd )"
 


### PR DESCRIPTION
@ConiKost it's one of the last two candidates in [java-pkg-opt-2.eclass](https://qa-reports.gentoo.org/output/eapi-per-eclass/java-pkg-opt-2.eclass/7.txt) (`OpenNI{,2}` got their own PR.)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
