### PR TITLE
gui-libs/hyprcursor: fixed an error preventing successful build

### DIFF
--- a/gui-libs/hyprcursor/hyprcursor-0.1.10-r1.ebuild
+++ b/gui-libs/hyprcursor/hyprcursor-0.1.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -27,4 +27,5 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/0.1.10-llvm-fix.patch
+	"${FILESDIR}"/0.1.10-fstream.patch
 )


### PR DESCRIPTION
Signed-off-by: Loravis <subarashiloravis@gmail.com>

Added 0.1.10-fstream.patch to the ebuild. It was initially not added, for some reason, which prevented this package from emerging
  successfully.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
