### PR TITLE
app-text/lowdown: Fix false positive QA notice, Gentoo/prefix installation

### DIFF
--- a/app-text/lowdown/lowdown-1.3.2.ebuild
+++ b/app-text/lowdown/lowdown-1.3.2.ebuild
@@ -38,6 +38,8 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	strtonum
 	TAILQ_FOREACH_SAFE
 	unveil
+	arc4random
+	b64_ntop
 )
 
 PATCHES=(

--- a/app-text/lowdown/lowdown-1.3.2.ebuild
+++ b/app-text/lowdown/lowdown-1.3.2.ebuild
@@ -52,11 +52,11 @@ src_configure() {
 	tc-export CC AR
 
 	./configure \
-		PREFIX="/usr" \
-		MANDIR="/usr/share/man" \
+		PREFIX="${EPREFIX}/usr" \
+		MANDIR="${EPREFIX}/usr/share/man" \
 		LDFLAGS="${LDFLAGS}" \
 		CPPFLAGS="${CPPFLAGS}" \
-		LIBDIR="/usr/$(get_libdir)" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
 		|| die "./configure failed"
 }
 

--- a/app-text/lowdown/lowdown-1.4.0.ebuild
+++ b/app-text/lowdown/lowdown-1.4.0.ebuild
@@ -38,6 +38,8 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	strtonum
 	TAILQ_FOREACH_SAFE
 	unveil
+	arc4random
+	b64_ntop
 )
 
 PATCHES=(

--- a/app-text/lowdown/lowdown-1.4.0.ebuild
+++ b/app-text/lowdown/lowdown-1.4.0.ebuild
@@ -52,11 +52,11 @@ src_configure() {
 	tc-export CC AR
 
 	./configure \
-		PREFIX="/usr" \
-		MANDIR="/usr/share/man" \
+		PREFIX="${EPREFIX}/usr" \
+		MANDIR="${EPREFIX}/usr/share/man" \
 		LDFLAGS="${LDFLAGS}" \
 		CPPFLAGS="${CPPFLAGS}" \
-		LIBDIR="/usr/$(get_libdir)" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
 		|| die "./configure failed"
 }
 


### PR DESCRIPTION
QA notice about implicit function declarations on MUSL system relates to functions that either never called, or have an implementation in compatibility file.
gentoo/prefix is a simple fix, in a bug from <chrissicool@gmail.com>, but manual invocation of configure can't be switched to econf, because it uses https://github.com/kristapsdz/oconfigure as configure and doesn't recognize `--prefix`, only `PREFIX`

Bug: https://bugs.gentoo.org/942443
Bug: https://bugs.gentoo.org/947349

<!-- Please put the pull request description above -->
---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
