### PR TITLE
net-p2p/gtk-gnutella: pin C version to gnu17

### DIFF
--- a/net-p2p/gtk-gnutella/gtk-gnutella-1.2.2-r1.ebuild
+++ b/net-p2p/gtk-gnutella/gtk-gnutella-1.2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,8 +9,8 @@ DESCRIPTION="GTK+ Gnutella client"
 HOMEPAGE="https://gtk-gnutella.sourceforge.net/"
 SRC_URI="https://github.com/gtk-gnutella/gtk-gnutella/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-SLOT="0"
 LICENSE="CC-BY-SA-4.0 GPL-2"
+SLOT="0"
 KEYWORDS="amd64 ppc ppc64 x86"
 
 IUSE="nls dbus ssl +gtk"
@@ -28,6 +28,10 @@ BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
 	filter-lto
+	# bug https://bugs.gentoo.org/944982
+	# we have custom bool we interoperate with gboolean
+	append-cflags -std=gnu17
+
 	strip-linguas -i po
 
 	echo "# Gentoo-selected LINGUAS" > po/LINGUAS

--- a/net-p2p/gtk-gnutella/gtk-gnutella-1.2.3.ebuild
+++ b/net-p2p/gtk-gnutella/gtk-gnutella-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,8 +9,8 @@ DESCRIPTION="GTK+ Gnutella client"
 HOMEPAGE="https://gtk-gnutella.sourceforge.io/"
 SRC_URI="https://github.com/gtk-gnutella/gtk-gnutella/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-SLOT="0"
 LICENSE="CC-BY-SA-4.0 GPL-2"
+SLOT="0"
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 
 IUSE="nls dbus ssl +gtk"
@@ -28,6 +28,10 @@ BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
 	filter-lto
+	# bug https://bugs.gentoo.org/944982
+	# we have custom bool we interoperate with gboolean
+	append-cflags -std=gnu17
+
 	strip-linguas -i po
 
 	echo "# Gentoo-selected LINGUAS" > po/LINGUAS


### PR DESCRIPTION
This package freely casts between pointers to gbooleans and internally defined bools (in this case, ints). Defining off internal definition of bool for C23 and then casting everywhere may cause serious problems in interoperability over the network. I feel the best would be to pin language version.

Closes: https://bugs.gentoo.org/944982
Bug: https://bugs.gentoo.org/879745

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
