### PR TITLE
Fix -Werror on OBS extensions

### DIFF
--- a/media-plugins/obs-composite-blur/obs-composite-blur-1.1.0.ebuild
+++ b/media-plugins/obs-composite-blur/obs-composite-blur-1.1.0.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-composite-blur/obs-composite-blur-9999.ebuild
+++ b/media-plugins/obs-composite-blur/obs-composite-blur-9999.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-move-transition/obs-move-transition-3.1.1.ebuild
+++ b/media-plugins/obs-move-transition/obs-move-transition-3.1.1.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-move-transition/obs-move-transition-9999.ebuild
+++ b/media-plugins/obs-move-transition/obs-move-transition-9999.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-clone/obs-source-clone-0.1.5.ebuild
+++ b/media-plugins/obs-source-clone/obs-source-clone-0.1.5.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-clone/obs-source-clone-9999.ebuild
+++ b/media-plugins/obs-source-clone/obs-source-clone-9999.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-dock/obs-source-dock-0.4.1.ebuild
+++ b/media-plugins/obs-source-dock/obs-source-dock-0.4.1.ebuild
@@ -25,6 +25,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-dock/obs-source-dock-9999.ebuild
+++ b/media-plugins/obs-source-dock/obs-source-dock-9999.ebuild
@@ -25,6 +25,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-record/obs-source-record-0.4.4.ebuild
+++ b/media-plugins/obs-source-record/obs-source-record-0.4.4.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins

--- a/media-plugins/obs-source-record/obs-source-record-9999.ebuild
+++ b/media-plugins/obs-source-record/obs-source-record-9999.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i '/-Werror$/d' cmake/ObsPluginHelpers.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLIB_OUT_DIR=/lib64/obs-plugins


### PR DESCRIPTION
This PR fixes various issues reported in bgo: All ebuilds using `cmake/ObsPluginHelpers.cmake` set `-Werror` on their own.

This PR removes the offending line in `src_prepare()`.

I wasn't sure if a revbump is needed in that case, so I just did it. Let me know if I should squash some commits.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
