### PR TITLE
media-sound/sexypsf: update EAPI 7 -> 8; port to C23

### DIFF
--- a/media-sound/sexypsf/files/sexypsf-0.4.8-C23.patch
+++ b/media-sound/sexypsf/files/sexypsf-0.4.8-C23.patch
@@ -1,0 +1,43 @@
+Fix compilation errors from C23
+Casting of pointers to ints made no sense originally and affected code
+may behave incorrectly.
+https://bugs.gentoo.org/875719
+https://bugs.gentoo.org/885533
+--- a/Linux/LnxMain.c
++++ b/Linux/LnxMain.c
+@@ -28,6 +28,8 @@
+ #include "driver.h"
+ #include "Linux.h"
+ 
++extern void SetupSound(void); /* from oss.c */
++
+ int main(int argc, char *argv[]) {
+ 	PSFINFO *pi;
+ 
+--- a/Linux/oss.c
++++ b/Linux/oss.c
+@@ -56,6 +56,7 @@
+ #include "oss.h"
+ static int oss_audio_fd = -1;
+ extern int errno;
++extern void sexy_stop(void);
+ 
+ ////////////////////////////////////////////////////////////////////////
+ // SETUP SOUND
+--- a/PsxMem.c
++++ b/PsxMem.c
+@@ -78,11 +78,11 @@
+ 	memcpy(psxMemLUT + 0x8000, psxMemLUT, 0x80 * sizeof *psxMemLUT);
+ 	memcpy(psxMemLUT + 0xa000, psxMemLUT, 0x80 * sizeof *psxMemLUT);
+ 
+-	for (i=0; i<0x01; i++) psxMemLUT[i + 0x1f00] = (u32)&psxP[i << 16];
++	for (i=0; i<0x01; i++) psxMemLUT[i + 0x1f00] = &psxP[i << 16];
+ 
+-	for (i=0; i<0x01; i++) psxMemLUT[i + 0x1f80] = (u32)&psxH[i << 16];
++	for (i=0; i<0x01; i++) psxMemLUT[i + 0x1f80] = &psxH[i << 16];
+ 
+-	for (i=0; i<0x08; i++) psxMemLUT[i + 0xbfc0] = (u32)&psxR[i << 16];
++	for (i=0; i<0x08; i++) psxMemLUT[i + 0xbfc0] = &psxR[i << 16];
+ 
+ 	return 0;
+ }

--- a/media-sound/sexypsf/sexypsf-0.4.8-r1.ebuild
+++ b/media-sound/sexypsf/sexypsf-0.4.8-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Open-source PSF1 (Playstation music) file player"
+HOMEPAGE="https://projects.raphnet.net/#sexypsf"
+SRC_URI="https://projects.raphnet.net/sexypsf/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="sys-libs/zlib"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.4.8-Makefile.patch
+	"${FILESDIR}"/${PN}-0.4.8-fno-common.patch
+	"${FILESDIR}"/${PN}-0.4.8-C23.patch
+)
+
+src_configure() {
+	tc-export CC
+}
+
+src_compile() {
+	emake -C Linux
+}
+
+src_install() {
+	dobin Linux/sexypsf
+	dodoc -r Docs/.
+}


### PR DESCRIPTION
Add function declarations; remove casting of pointers to ints. It made no sense originally. So this change may be causing a bug or fixing existing bug.

Closes: https://bugs.gentoo.org/885533
Closes: https://bugs.gentoo.org/875719

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
