### PR TITLE
sys-auth/pam_mysql: update EAPI 7 -> 8, Skip QA warning for Solaris

### DIFF
--- a/sys-auth/pam_mysql/metadata.xml
+++ b/sys-auth/pam_mysql/metadata.xml
@@ -10,5 +10,6 @@
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">pam-mysql</remote-id>
+		<remote-id type="github">NigelCunningham/pam-MySQL</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-auth/pam_mysql/pam_mysql-0.8.2-r2.ebuild
+++ b/sys-auth/pam_mysql/pam_mysql-0.8.2-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="7"
+EAPI=8
 
 inherit autotools pam
 
@@ -24,6 +24,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 DOCS=( AUTHORS ChangeLog NEWS README )
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	md5_calc # for Solaris, bug #908580
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
md5_calc is implicitly declared in "checking if md5.h is Solaris's" test

Closes: https://bugs.gentoo.org/908580

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
