### PR TITLE
kde-plasma/plasma-mimeapps-list: replace plasma-desktop kde-mimeapps.list

### DIFF
--- a/kde-plasma/plasma-desktop/plasma-desktop-6.2.4-r1.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-6.2.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -111,7 +111,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
 	>=kde-plasma/oxygen-${PVCUT}:6
-	kde-plasma/plasma-mimeapps-list
+	>=kde-plasma/plasma-mimeapps-list-3
 	media-fonts/noto-emoji
 	sys-apps/util-linux
 	x11-apps/setxkbmap
@@ -173,6 +173,13 @@ src_test() {
 	)
 
 	ecm_src_test
+}
+
+src_install() {
+	cmake_src_install
+
+	# Provide kde-mimeapps.list with distribution kde-plasma/plasma-mimeapps-list
+	rm "${ED}"/usr/share/applications/kde-mimeapps.list || die
 }
 
 pkg_postinst() {

--- a/kde-plasma/plasma-desktop/plasma-desktop-6.2.5-r1.ebuild
+++ b/kde-plasma/plasma-desktop/plasma-desktop-6.2.5-r1.ebuild
@@ -110,7 +110,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
 	>=kde-frameworks/qqc2-desktop-style-${KFMIN}:6
 	>=kde-plasma/oxygen-${KDE_CATV}:6
-	kde-plasma/plasma-mimeapps-list
+	>=kde-plasma/plasma-mimeapps-list-3
 	media-fonts/noto-emoji
 	sys-apps/util-linux
 	x11-apps/setxkbmap
@@ -172,6 +172,13 @@ src_test() {
 	)
 
 	ecm_src_test
+}
+
+src_install() {
+	cmake_src_install
+
+	# Provide kde-mimeapps.list with distribution kde-plasma/plasma-mimeapps-list
+	rm "${ED}"/usr/share/applications/kde-mimeapps.list || die
 }
 
 pkg_postinst() {

--- a/kde-plasma/plasma-mimeapps-list/plasma-mimeapps-list-3.ebuild
+++ b/kde-plasma/plasma-mimeapps-list/plasma-mimeapps-list-3.ebuild
@@ -13,14 +13,15 @@ SLOT="0"
 KEYWORDS="amd64 arm64 ~loong ~ppc64 ~riscv ~x86"
 IUSE=""
 
-RDEPEND=""
+# 6.2.4 and 6.2.5 both modified with a new revision to stop installing kde-mimeapps.list.
+RDEPEND="
+	!<kde-plasma/plasma-desktop-6.2.4-r1
+	!=kde-plasma/plasma-desktop-6.2.5-r0
+"
 
 src_install() {
 	default
 
-	# TODO: Should we just remove the upstream one in /usr/share?
-	# /etc/xdg should really be available for site-local overrides, but then
-	# again we have CONFIG_PROTECT...
-	insinto /etc/xdg
-	doins "${FILESDIR}"/mimeapps.list
+	insinto /usr/share/applications/
+	newins "${FILESDIR}"/mimeapps.list kde-mimeapps.list
 }


### PR DESCRIPTION
Stop installing from plasma-desktop and replace it with distribution modified version.

Bug: https://bugs.gentoo.org/948681

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
