### PR TITLE
games-strategy/wesnoth: fix build with boost-1.87

### DIFF
--- a/games-strategy/wesnoth/files/wesnoth-1.18.3-boost-1.87.patch
+++ b/games-strategy/wesnoth/files/wesnoth-1.18.3-boost-1.87.patch
@@ -1,0 +1,175 @@
+diff --git a/src/server/campaignd/server.cpp b/src/server/campaignd/server.cpp
+index 31a7df8..88a141a 100644
+--- a/src/server/campaignd/server.cpp
++++ b/src/server/campaignd/server.cpp
+@@ -735,7 +735,7 @@ void server::handle_sighup(const boost::system::error_code&, int)
+ 
+ void server::flush_cfg()
+ {
+-	flush_timer_.expires_from_now(std::chrono::minutes(10));
++	flush_timer_.expires_after(std::chrono::minutes(10));
+ 	flush_timer_.async_wait(std::bind(&server::handle_flush, this, std::placeholders::_1));
+ }
+ 
+diff --git a/src/server/common/forum_user_handler.cpp b/src/server/common/forum_user_handler.cpp
+index ed689cb..1fbac6e 100644
+--- a/src/server/common/forum_user_handler.cpp
++++ b/src/server/common/forum_user_handler.cpp
+@@ -207,7 +207,7 @@ std::string fuh::get_tournaments(){
+ 	return conn_.get_tournaments();
+ }
+ 
+-void fuh::async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
++void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
+ 	boost::asio::post([this, &s, player, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
+ 		boost::asio::post(io_service, [player, &s, doc = conn_.get_game_history(player_id, offset, search_game_name, search_content_type, search_content)]{
+ 			s.send_to_player(player, *doc);
+@@ -235,7 +235,7 @@ void fuh::db_set_oos_flag(const std::string& uuid, int game_id){
+ 	conn_.set_oos_flag(uuid, game_id);
+ }
+ 
+-void fuh::async_test_query(boost::asio::io_service& io_service, int limit) {
++void fuh::async_test_query(boost::asio::io_context& io_service, int limit) {
+ 	boost::asio::post([this, limit, &io_service] {
+ 		ERR_UH << "async test query starts!";
+ 		int i = conn_.async_test_query(limit);
+diff --git a/src/server/common/forum_user_handler.hpp b/src/server/common/forum_user_handler.hpp
+index d050f90..f8c2b01 100644
+--- a/src/server/common/forum_user_handler.hpp
++++ b/src/server/common/forum_user_handler.hpp
+@@ -133,7 +133,7 @@ public:
+ 	 * @param search_content_type The content type to query for (ie: scenario)
+ 	 * @param search_content Query for games using this content ID. Supports leading and/or trailing wildcards.
+ 	 */
+-	void async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content);
++	void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content);
+ 
+ 	/**
+ 	 * Inserts game related information.
+@@ -203,7 +203,7 @@ public:
+ 	 * @param io_service The boost io_service to use to post the query results back to the main boost::asio thread.
+ 	 * @param limit How many recursions to make in the query.
+ 	 */
+-	void async_test_query(boost::asio::io_service& io_service, int limit);
++	void async_test_query(boost::asio::io_context& io_service, int limit);
+ 
+ 	/**
+ 	 * Checks whether a forum thread with @a topic_id exists.
+diff --git a/src/server/common/server_base.cpp b/src/server/common/server_base.cpp
+index 2c1a581..0aca915 100644
+--- a/src/server/common/server_base.cpp
++++ b/src/server/common/server_base.cpp
+@@ -41,6 +41,10 @@
+ #ifndef _WIN32
+ #include <boost/asio/read_until.hpp>
+ #endif
++#ifndef BOOST_NO_EXCEPTIONS
++#include <boost/exception/diagnostic_information.hpp>
++#endif
++
+ #include <boost/asio/write.hpp>
+ 
+ #include <array>
+diff --git a/src/server/common/server_base.hpp b/src/server/common/server_base.hpp
+index 94aac7e..e40b6ca 100644
+--- a/src/server/common/server_base.hpp
++++ b/src/server/common/server_base.hpp
+@@ -30,7 +30,7 @@
+ #include "serialization/unicode_cast.hpp"
+ #endif
+ 
+-#include <boost/asio/io_service.hpp>
++#include <boost/asio/io_context.hpp>
+ #include <boost/asio/ip/tcp.hpp>
+ #ifndef _WIN32
+ #include <boost/asio/posix/stream_descriptor.hpp>
+@@ -150,7 +150,7 @@ public:
+ protected:
+ 	unsigned short port_;
+ 	bool keep_alive_;
+-	boost::asio::io_service io_service_;
++	boost::asio::io_context io_service_;
+ 	boost::asio::ssl::context tls_context_ { boost::asio::ssl::context::sslv23 };
+ 	bool tls_enabled_ { false };
+ 	boost::asio::ip::tcp::acceptor acceptor_v6_;
+diff --git a/src/server/common/user_handler.hpp b/src/server/common/user_handler.hpp
+index d8e72f1..24b727f 100644
+--- a/src/server/common/user_handler.hpp
++++ b/src/server/common/user_handler.hpp
+@@ -22,7 +22,7 @@ class config;
+ #include <ctime>
+ #include <string>
+ 
+-#include <boost/asio/io_service.hpp>
++#include <boost/asio/io_context.hpp>
+ 
+ #include "server/wesnothd/player_connection.hpp"
+ 
+@@ -139,13 +139,13 @@ public:
+ 
+ 	virtual std::string get_uuid() = 0;
+ 	virtual std::string get_tournaments() = 0;
+-	virtual void async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
++	virtual void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, wesnothd::player_iterator player, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
+ 	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
+ 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;
+ 	virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user, const std::string& leaders) = 0;
+ 	virtual unsigned long long db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& name, const std::string& id, const std::string& addon_id, const std::string& addon_version) = 0;
+ 	virtual void db_set_oos_flag(const std::string& uuid, int game_id) = 0;
+-	virtual void async_test_query(boost::asio::io_service& io_service, int limit) = 0;
++	virtual void async_test_query(boost::asio::io_context& io_service, int limit) = 0;
+ 	virtual bool db_topic_id_exists(int topic_id) = 0;
+ 	virtual void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id, const std::string uploader) = 0;
+ 	virtual unsigned long long db_insert_login(const std::string& username, const std::string& ip, const std::string& version) = 0;
+diff --git a/src/server/wesnothd/game.cpp b/src/server/wesnothd/game.cpp
+index faeb255..ec95bd4 100644
+--- a/src/server/wesnothd/game.cpp
++++ b/src/server/wesnothd/game.cpp
+@@ -27,6 +27,8 @@
+ #include <iomanip>
+ #include <sstream>
+ 
++#include <boost/coroutine/exceptions.hpp>
++
+ static lg::log_domain log_server("server");
+ #define ERR_GAME LOG_STREAM(err, log_server)
+ #define WRN_GAME LOG_STREAM(warn, log_server)
+diff --git a/src/server/wesnothd/server.cpp b/src/server/wesnothd/server.cpp
+index 7c4b2a0..587b02a 100644
+--- a/src/server/wesnothd/server.cpp
++++ b/src/server/wesnothd/server.cpp
+@@ -293,14 +293,14 @@ void server::handle_graceful_timeout(const boost::system::error_code& error)
+ 		process_command("msg All games ended. Shutting down now. Reconnect to the new server instance.", "system");
+ 		BOOST_THROW_EXCEPTION(server_shutdown("graceful shutdown timeout"));
+ 	} else {
+-		timer_.expires_from_now(std::chrono::seconds(1));
++		timer_.expires_after(std::chrono::seconds(1));
+ 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
+ 	}
+ }
+ 
+ void server::start_lan_server_timer()
+ {
+-	lan_server_timer_.expires_from_now(std::chrono::seconds(lan_server_));
++	lan_server_timer_.expires_after(std::chrono::seconds(lan_server_));
+ 	lan_server_timer_.async_wait([this](const boost::system::error_code& ec) { handle_lan_server_shutdown(ec); });
+ }
+ 
+@@ -2120,7 +2120,7 @@ void server::shut_down_handler(
+ 		acceptor_v6_.close();
+ 		acceptor_v4_.close();
+ 
+-		timer_.expires_from_now(std::chrono::seconds(10));
++		timer_.expires_after(std::chrono::seconds(10));
+ 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
+ 
+ 		process_command(
+@@ -2151,7 +2151,7 @@ void server::restart_handler(const std::string& issuer_name,
+ 		graceful_restart = true;
+ 		acceptor_v6_.close();
+ 		acceptor_v4_.close();
+-		timer_.expires_from_now(std::chrono::seconds(10));
++		timer_.expires_after(std::chrono::seconds(10));
+ 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
+ 
+ 		start_new_server();

--- a/games-strategy/wesnoth/wesnoth-1.18.3.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.18.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake flag-o-matic xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
-HOMEPAGE="http://www.wesnoth.org
+HOMEPAGE="https://www.wesnoth.org
 	https://github.com/wesnoth/wesnoth"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.bz2"
 
@@ -42,6 +42,8 @@ BDEPEND="
 	sys-devel/gettext
 	virtual/pkgconfig
 "
+
+PATCHES=( "${FILESDIR}"/${PN}-1.18.3-boost-1.87.patch )
 
 src_prepare() {
 	cmake_src_prepare


### PR DESCRIPTION
The patch included herein is based upon the upstream patch at commit [782ab2df3efd4abc1fbab416b9a87d50cc5d066d](https://github.com/wesnoth/wesnoth/commit/782ab2df3efd4abc1fbab416b9a87d50cc5d066d). The upstream patch did not cleanly apply due to other repository changes since the release of this version of wesnoth.

No revbump has been applied in accordance with the devmanual, i.e. it fixes a build-time issue.

I have tested that the package correctly builds after patching and successfully runs after limited runtime testing.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
