### PR TITLE
sci-libs/med: fix building with USE=mpi

### DIFF
--- a/sci-libs/med/med-4.1.1-r3.ebuild
+++ b/sci-libs/med/med-4.1.1-r3.ebuild
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.1.0-0001-Gentoo-specific-Adjust-install-path-for-build-dir.patch"
 	"${FILESDIR}/${PN}-4.1.0-0002-Re-add-option-for-building-Fortran-library.patch"
 	"${FILESDIR}/${PN}-4.1.0-0003-build-against-hdf5-1.14.patch"
+	"${FILESDIR}/${PN}-4.1.0-0004-mpi.patch"
 )
 
 DOCS=( AUTHORS ChangeLog NEWS README README.CMAKE TODO )
@@ -60,6 +61,13 @@ src_prepare() {
 	# bug #862900, already reported upstream. CHECK on updates!
 	filter-lto
 
+	if use mpi ; then
+		export CC=mpicc
+		export CXX=mpic++
+		export F77=mpif77
+		export FC=mpif90
+	fi
+
 	cmake_src_prepare
 }
 
@@ -77,6 +85,7 @@ src_configure() {
 		-DMEDFILE_USE_MPI=$(usex mpi)
 		-DMEDFILE_USE_UNICODE=ON
 	)
+
 	cmake_src_configure
 }
 

--- a/sci-libs/med/med-4.1.1-r4.ebuild
+++ b/sci-libs/med/med-4.1.1-r4.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.1.0-0001-Gentoo-specific-Adjust-install-path-for-build-dir.patch"
 	"${FILESDIR}/${PN}-4.1.0-0002-Re-add-option-for-building-Fortran-library.patch"
 	"${FILESDIR}/${PN}-4.1.0-0003-build-against-hdf5-1.14.patch"
+	"${FILESDIR}/${PN}-4.1.0-0004-mpi.patch"
 )
 
 DOCS=( AUTHORS ChangeLog NEWS README README.CMAKE TODO )
@@ -59,6 +60,13 @@ src_prepare() {
 	# bug #862900, already reported upstream. CHECK on updates!
 	filter-lto
 
+	if use mpi ; then
+		export CC=mpicc
+		export CXX=mpic++
+		export F77=mpif77
+		export FC=mpif90
+	fi
+
 	cmake_src_prepare
 }
 
@@ -79,6 +87,7 @@ src_configure() {
 		-DMEDFILE_USE_MPI=$(usex mpi)
 		-DMEDFILE_USE_UNICODE=ON
 	)
+
 	cmake_src_configure
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/948678

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
