### PR TITLE
sys-devel/dwz: fix compilation on different locales

### DIFF
--- a/sys-devel/dwz/dwz-0.15-r1.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r1.ebuild
@@ -41,6 +41,8 @@ src_prepare() {
 }
 
 src_compile() {
+	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
+
 	emake CFLAGS="${CFLAGS}" srcdir="${S}"
 }
 

--- a/sys-devel/dwz/dwz-0.15-r4.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r4.ebuild
@@ -52,6 +52,8 @@ src_prepare() {
 }
 
 src_compile() {
+	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
+
 	tc-export PKG_CONFIG
 
 	export LIBS="-lelf"

--- a/sys-devel/dwz/dwz-9999.ebuild
+++ b/sys-devel/dwz/dwz-9999.ebuild
@@ -41,6 +41,8 @@ src_prepare() {
 }
 
 src_compile() {
+	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
+
 	emake CFLAGS="${CFLAGS}" srcdir="${S}"
 }
 


### PR DESCRIPTION
otherwise "readelf | grep" will return nothing for non-ascii locales

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
