### PR TITLE
net-dialup/mwavem: update EAPI 7 -> 8, fix compilation errors

### DIFF
--- a/net-dialup/mwavem/files/mwavem-2.0-C23.patch
+++ b/net-dialup/mwavem/files/mwavem-2.0-C23.patch
@@ -1,0 +1,128 @@
+Just use system definitions and don't shortcut externs,
+wherever possible.
+There's a default way to use va_args, don't reinvent wheel
+https://bugs.gentoo.org/715926
+https://bugs.gentoo.org/921186
+https://bugs.gentoo.org/945184
+--- a/configure.in
++++ b/configure.in
+@@ -5,6 +5,7 @@
+ 
+ dnl Find operating system, vendor, architecture
+ AC_CANONICAL_SYSTEM
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ AM_INIT_AUTOMAKE(mwavem,2.0)
+ 
+--- a/src/meio/meiovect.c
++++ b/src/meio/meiovect.c
+@@ -65,14 +65,14 @@
+ /*   external function declarations					  */
+ /*------------------------------------------------------------------------*/
+ 
+-extern ULONG APIENTRY dspMeioOpeni();
+-extern ULONG dspMeioClosei();
+-extern ULONG APIENTRY dspMeioQueryi();
+-extern ULONG APIENTRY dspMeioConnecti();
+-extern ULONG APIENTRY dspMeioDisconnecti();
+-extern ULONG APIENTRY dspMeioUpdateConnectioni();
+-extern ULONG APIENTRY dspMeioQueryConnectioni();
+-extern ULONG APIENTRY dspMeioResynci();
++extern ULONG APIENTRY dspMeioOpeni(HDSP hDsp, HMEIO FAR *phMeio, ULONG Options);
++extern ULONG dspMeioClosei(HMEIO hMeio, ULONG Options);
++extern ULONG APIENTRY dspMeioQueryi(HMEIO MMeio, MEIO_QUERYTYPE Request, ULONG FAR *fpBufferSize, VOID FAR *fpBuffer);
++extern ULONG APIENTRY dspMeioConnecti(HMEIO hMeio, HCONNECTION FAR *fpConnection, ULONG OwnerPort, ULONG UserPort, ULONG SharingOptions, ULONG ulState, ULONG Reserved);
++extern ULONG APIENTRY dspMeioDisconnecti(HCONNECTION hConnection, ULONG ulReserved);
++extern ULONG APIENTRY dspMeioUpdateConnectioni(HCONNECTION hConnection, MEIO_CONNECTATTRIBUTE Attribute, LONG lValue);
++extern ULONG APIENTRY dspMeioQueryConnectioni(HCONNECTION hConnection, MEIO_CONNECTATTRIBUTE Attribute, LONG FAR *fpValue);
++extern ULONG APIENTRY dspMeioResynci(MEIO_OBJ_TYPE ObjectType, ULONG Object, ULONG ulOptions);
+ 
+ /*------------------------------------------------------------------------*/
+ /* MeioAPIDispatch()                                                      */
+--- a/src/mwmlw32/mwmload.c
++++ b/src/mwmlw32/mwmload.c
+@@ -53,6 +53,7 @@
+ #include <sys/timeb.h>
+ #include <time.h>
+ #include <mwqservr.h>
++#include <stdarg.h>
+ #include "mww32.h"
+ /*#include <pbmplus.h>*/
+ #include <mwave.h>
+@@ -74,6 +75,8 @@
+ #define MODNAME "MWMODEM"
+ void mwavem_dprintf(char *szFormat, ...)
+ {
++  va_list args;
++  va_start(args, szFormat);
+   /*if (usDebugWindow)
+   {*/
+     struct timeb timebuffer;
+@@ -91,11 +94,12 @@
+       else
+         strcpy(ach, MODNAME ": ");
+ 
+-    vsprintf(ach+strlen(ach),szFormat,(char *)(&szFormat+1));
++    vsprintf(ach+strlen(ach),szFormat, args);
+     strcat(ach, "\r\n");
+ 
+     OutputDebugString(ach);
+  /* } */
++  va_end(args);
+ }
+ 
+ 
+--- a/src/mwmlw32/mwmrsp.c
++++ b/src/mwmlw32/mwmrsp.c
+@@ -44,9 +44,9 @@
+  *            First release to the public
+  *
+  */
++#include <unistd.h>
+ #include <mwmspcfc.h>
+ static char szThisFile[] = "MWMRSP.C";
+-extern void swab();
+ 
+ ULONG mwmrspEchoFAXResponse(PMWM_DSPINFO pmwmDspInfo,USHORT usControlStat)
+ {
+--- a/src/mwmpw32/mwmclss2.c
++++ b/src/mwmpw32/mwmclss2.c
+@@ -1227,8 +1227,6 @@
+ 
+ 
+ 
+-extern void swab() __THROW;
+-
+ USHORT  mwmClss2FLIDCommand(STATEINFO *psi)
+ {
+   USHORT usParserStatus = 0;
+--- a/src/mwmpw32/mwmparse.c
++++ b/src/mwmpw32/mwmparse.c
+@@ -54,6 +54,7 @@
+ #include <stddef.h>
+ #include <sys/timeb.h>
+ #include <time.h>
++#include <unistd.h>
+ 
+ #include <port_types.h>
+ #include <port_functions.h>
+@@ -324,8 +325,6 @@
+   return 0;
+ }
+ 
+-extern void swab() __THROW;
+-
+ USHORT mwmParseEchoString(STATEINFO *psi,PSZ achString)
+ {
+   USHORT usParserStatus = 0;
+--- a/src/mwmutil/mwmutil.c
++++ b/src/mwmutil/mwmutil.c
+@@ -189,8 +189,6 @@
+ 
+ } /*readFile*/
+ 
+-extern char *strcasestr () __THROW __attribute_pure__;
+-
+ /* Give a file buffer, find a return ptr to section name (or NULL if not found) */
+ char * getSection(LPCTSTR lpSectionName,char *file) {    // Section name, bracket delimited
+   char *line;

--- a/net-dialup/mwavem/files/mwavem-2.0-pthread.patch
+++ b/net-dialup/mwavem/files/mwavem-2.0-pthread.patch
@@ -1,0 +1,14 @@
+Use correct type for thread handle. It already uses pthread_t for other half of the
+assignment
+https://bugs.gentoo.org/897844
+--- a/src/manager/mwaveapi.c
++++ b/src/manager/mwaveapi.c
+@@ -79,7 +79,7 @@
+ BOOL g_bIPCSupportActive = FALSE;         // True if our IPC support layer is initialized and active
+ unsigned g_uIPCsInUse;                    // One bit per IPC in use for this subsystem
+ BOOL g_abCancellingIPCs[MWAPI_MaxIPCs];   // TRUE if we're attempting to cancel an IPC thread
+-HANDLE g_ahIPCThreads[MWAPI_MaxIPCs];     // Thread handle of IPC thread
++pthread_t g_ahIPCThreads[MWAPI_MaxIPCs];  // Thread handle of IPC thread
+ PFN g_pfnIPCNotice[MWAPI_MaxIPCs];
+ 
+ BOOL   bDspDisabled = FALSE;

--- a/net-dialup/mwavem/mwavem-2.0-r3.ebuild
+++ b/net-dialup/mwavem/mwavem-2.0-r3.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="User level application for IBM Mwave modem"
+HOMEPAGE="http://oss.software.ibm.com/acpmodem/"
+SRC_URI="ftp://www-126.ibm.com/pub/acpmodem/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-glibc-2.10.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-ar.patch
+	"${FILESDIR}"/${P}-C23.patch
+	"${FILESDIR}"/${P}-pthread.patch
+)
+
+HTML_DOCS=( doc/mwave.html )
+DOCS=( doc/mwave.sgml doc/mwave.txt )
+
+src_prepare() {
+	default
+	rm README.freebsd || die
+
+	AT_M4DIR=m4 eautoreconf
+}
+
+src_install() {
+	default
+
+	dosbin "${FILESDIR}"/mwave-dev-handler
+
+	insinto /etc/devfs.d
+	newins "${FILESDIR}"/mwave.devfs mwave
+
+	insinto /etc/modprobe.d
+	newins "${FILESDIR}"/mwave.modules mwave.conf
+}
+
+pkg_postinst() {
+	if [[ -e "${EROOT}"/dev/.devfsd ]]; then
+		# device node is created by devfs
+		ebegin "Restarting devfsd to reread devfs rules"
+			killall -HUP devfsd
+		eend $?
+	else
+		elog "Create device node if needed, using command like this:"
+		elog "# mknod --mode=0660 \"${EROOT}/dev/modems/mwave\" c 10 219"
+	fi
+}


### PR DESCRIPTION
Fixes C23 problems and difference in pthread_t between musl and glibc
Included in C23 problems: Actual usage of va_args instead of handrolled pointers, system includes, removal of redefinitions of system functions and completion of externs with function arguments.

Closes: https://bugs.gentoo.org/897844
Closes: https://bugs.gentoo.org/715926
Closes: https://bugs.gentoo.org/945184
Closes: https://bugs.gentoo.org/921186

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
