### PR TITLE
app-i18n/ibus-1.5.31: enable py3.13

### DIFF
--- a/app-i18n/ibus/ibus-1.5.31.ebuild
+++ b/app-i18n/ibus/ibus-1.5.31.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools bash-completion-r1 gnome2-utils flag-o-matic python-r1 toolchain-funcs vala virtualx
 


### PR DESCRIPTION
Per upstream bug[^1], this version works on Fedora 41 with python 3.13

[^1]: https://github.com/ibus/ibus/issues/2714

Closes: https://bugs.gentoo.org/948577

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
