### PR TITLE
dev-debug/valgrind: add FreeBSD function to false positive configure implicit decls

### DIFF
--- a/dev-debug/valgrind/valgrind-3.23.0_p3.ebuild
+++ b/dev-debug/valgrind/valgrind-3.23.0_p3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -69,6 +69,8 @@ QA_CONFIG_IMPL_DECL_SKIP+=(
 	# errors and reports both "function definition is not allowed here" and
 	# -Wimplicit-function-declaration. bug #900396
 	foo
+	# FreeBSD function, bug #932822
+	aio_readv
 )
 
 src_unpack() {

--- a/dev-debug/valgrind/valgrind-3.24.0.ebuild
+++ b/dev-debug/valgrind/valgrind-3.24.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -69,6 +69,8 @@ QA_CONFIG_IMPL_DECL_SKIP+=(
 	# errors and reports both "function definition is not allowed here" and
 	# -Wimplicit-function-declaration. bug #900396
 	foo
+	# FreeBSD function, bug #932822
+	aio_readv
 )
 
 src_unpack() {

--- a/dev-debug/valgrind/valgrind-3.24.0_p1.ebuild
+++ b/dev-debug/valgrind/valgrind-3.24.0_p1.ebuild
@@ -71,6 +71,8 @@ QA_CONFIG_IMPL_DECL_SKIP+=(
 	# errors and reports both "function definition is not allowed here" and
 	# -Wimplicit-function-declaration. bug #900396
 	foo
+	# FreeBSD function, bug #932822
+	aio_readv
 )
 
 src_unpack() {


### PR DESCRIPTION
aio_readv() is not a linux function and should be safely ignored. Patch to add vectored async io functions to linux was not accepted back in 2004

Closes: https://bugs.gentoo.org/932822

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
