### PR TITLE
mail-client/alpine: fixes for eautoreconf with gettext-0.23 & libtool error

### DIFF
--- a/mail-client/alpine/alpine-2.26-r5.ebuild
+++ b/mail-client/alpine/alpine-2.26-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -33,6 +33,12 @@ src_prepare() {
 
 	# optional extra features, see https://alpineapp.email/alpine/index.html
 	use chappa && eapply "${WORKDIR}/${P}-patches/chappa-rebased.patch"
+
+	# fix gettext macros to work with >=0.23 (bug #946128)
+	# eautoreconf will call autopoint, which will install any necessary files
+	# from the version we set in configure.ac
+	local gettext_version=$(gettextize --version | awk '/GNU gettext-tools/{print $NF}' || die)
+	sed -i "s/^AM_GNU_GETTEXT_VERSION(.*)/AM_GNU_GETTEXT_VERSION([${gettext_version}])/g" configure.ac || die
 
 	eautoreconf
 	tc-export CC RANLIB AR

--- a/mail-client/alpine/alpine-2.26-r5.ebuild
+++ b/mail-client/alpine/alpine-2.26-r5.ebuild
@@ -40,6 +40,9 @@ src_prepare() {
 	local gettext_version=$(gettextize --version | awk '/GNU gettext-tools/{print $NF}' || die)
 	sed -i "s/^AM_GNU_GETTEXT_VERSION(.*)/AM_GNU_GETTEXT_VERSION([${gettext_version}])/g" configure.ac || die
 
+	# do not override $RM for libtool (bug #880323)
+	sed -i "/^AC_PATH_PROG(RM/d" configure.ac || die
+
 	eautoreconf
 	tc-export CC RANLIB AR
 	export CC_FOR_BUILD="$(tc-getBUILD_CC)"


### PR DESCRIPTION
Tested against gettext-0.22.5-r1 and 0.23.0.

Closes: https://bugs.gentoo.org/946128
Closes: https://bugs.gentoo.org/880323

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
