### PR TITLE
dev-util/sysprof: fix sysprof when using llvm-runtimes/libunwind

### DIFF
--- a/dev-util/sysprof/files/sysprof-llvm-libunwind-fix.patch
+++ b/dev-util/sysprof/files/sysprof-llvm-libunwind-fix.patch
@@ -1,0 +1,51 @@
+From 7579b60a5aa697d4d1185a22d3c50d8ecd953181 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gon=C3=A7alo=20Negrier=20Duarte?=
+ <gonegrier.duarte@gmail.com>
+Date: Fri, 31 Jan 2025 12:51:49 +0000
+Subject: [PATCH] Patch: Check for unw_set_caching_policy and uwn_backtrace
+ before using llvm-runtimes/libunwind does not implement unw_* functions yet
+ Include execinfo.h for backtrace
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Gonçalo Negrier Duarte <gonegrier.duarte@gmail.com>
+---
+ src/preload/backtrace-helper.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/preload/backtrace-helper.h b/src/preload/backtrace-helper.h
+index ac4f8e9a..389ac699 100644
+--- a/src/preload/backtrace-helper.h
++++ b/src/preload/backtrace-helper.h
+@@ -22,11 +22,14 @@
+ 
+ #define UNW_LOCAL_ONLY
+ #include <libunwind.h>
++#include <execinfo.h>
+ 
+ static void
+ backtrace_init (void)
+ {
++#ifdef UNW_CACHE_PER_THREAD
+   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
++#endif
+ #ifdef HAVE_UNW_SET_CACHE_SIZE
+   unw_set_cache_size (unw_local_addr_space, 1024, 0);
+ #endif
+@@ -45,7 +48,11 @@ backtrace_func (SysprofCaptureAddress  *addrs,
+    * and subtract an offset from addrs to avoid having to
+    * copy frame pointers around.
+    */
+-  return unw_backtrace (((void **)addrs) - 2, n_addrs) - 2;
++  #ifdef UNW_CACHE_PER_THREAD
++    return unw_backtrace ((void **)addrs - 2, n_addrs) - 2;
++  #else
++    return backtrace ((void **)addrs - 2, n_addrs) - 2;
++  #endif
+ #else
+   static const int skip = 2;
+   void **stack = alloca (n_addrs * sizeof (gpointer));
+-- 
+2.48.0
+

--- a/dev-util/sysprof/sysprof-48.0-r2.ebuild
+++ b/dev-util/sysprof/sysprof-48.0-r2.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnome.org gnome2-utils greadme meson systemd xdg
+
+DESCRIPTION="System-wide Linux Profiler"
+HOMEPAGE="https://www.sysprof.com/"
+
+LICENSE="GPL-3+ GPL-2+"
+API_VERSION="4"
+SLOT="0/${API_VERSION}"
+KEYWORDS="~amd64 ~arm64 ~loong ~x86"
+IUSE="gtk llvm-libunwind systemd test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-libs/elfutils
+	>=dev-libs/glib-2.76.0:2
+	gtk? (
+		>=gui-libs/gtk-4.15:4
+		>=gui-libs/libadwaita-1.6.0:1
+		x11-libs/cairo
+		x11-libs/pango
+	)
+	systemd? ( sys-apps/systemd )
+	dev-libs/json-glib
+	>=dev-libs/libdex-0.9
+	>=gui-libs/libpanel-1.4
+	|| (
+		llvm-libunwind? ( llvm-runtimes/libunwind )
+		!llvm-libunwind? ( sys-libs/libunwind )
+	)
+	>=sys-auth/polkit-0.114[daemon(+)]
+	>=dev-util/sysprof-common-${PV}
+	>=dev-util/sysprof-capture-${PV}:${API_VERSION}
+"
+DEPEND="
+	${RDEPEND}
+	!systemd? ( !!sys-apps/systemd )
+"
+BDEPEND="
+	dev-libs/appstream-glib
+	dev-util/gdbus-codegen
+	dev-util/itstool
+	>=sys-devel/gettext-0.19.8
+	>=sys-kernel/linux-headers-2.6.32
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-48.0-shadowed-variable.patch
+)
+
+src_prepare() {
+	xdg_environment_reset
+
+	# These are installed by dev-util/sysprof-capture
+	sed -i \
+			-e '/install: not meson.is_subproject/d' \
+			-e '/install.*sysprof_header_subdir/d' \
+			-e 's/pkgconfig\.generate/subdir_done()\npkgconfig\.generate/' \
+			src/libsysprof-capture/meson.build || die
+
+	if use llvm-libunwind ; then
+		PATCHES+=( "${FILESDIR}"/${PN}-llvm-libunwind-fix.patch )
+	fi
+	default
+}
+
+src_configure() {
+	# similar to samba bug #874633
+	if use llvm-libunwind ; then
+		mkdir -p "${T}"/${ABI}/pkgconfig || die
+
+		local -x PKG_CONFIG_PATH="${T}/${ABI}/pkgconfig:${PKG_CONFIG_PATH}"
+
+		cat <<-EOF > "${T}"/${ABI}/pkgconfig/libunwind-generic.pc || die
+
+		Name: libunwind-generic
+		Description: libunwind generic library
+		Version: 1.70
+		Libs: -L/usr/\$(get_libdir) -lunwind
+		EOF
+	fi
+
+	# -Dsysprofd=host currently unavailable from ebuild
+	local emesonargs=(
+		$(meson_use gtk)
+		-Dlibsysprof=true
+		-Dinstall-static=false
+		-Dsysprofd=bundled
+		-Dsystemdunitdir=$(systemd_get_systemunitdir)
+		# -Ddebugdir
+		-Dhelp=true
+		-Dtools=true
+		$(meson_use test tests)
+		-Dexamples=false
+	)
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# We want to ship org.gnome.Sysprof3.Profiler.xml in sysprof-common for the benefit of x11-wm/mutter
+	rm "${ED}"/usr/share/dbus-1/interfaces/org.gnome.Sysprof3.Profiler.xml || die
+
+	greadme_stdin <<-EOF
+	On many systems, especially amd64, it is typical that with a modern
+	toolchain -fomit-frame-pointer for gcc is the default, because
+	debugging is still possible thanks to gcc/gdb location list feature.
+	However sysprof is not able to construct call trees if frame pointers
+	are not present. Therefore -fno-omit-frame-pointer CFLAGS is suggested
+	for the libraries and applications involved in the profiling. That
+	means a CPU register is used for the frame pointer instead of other
+	purposes, which means a very minimal performance loss when there is
+	register pressure.
+EOF
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+	gnome2_schemas_savelist
+	greadme_pkg_preinst
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+	greadme_pkg_postinst
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}

--- a/dev-util/sysprof/sysprof-48.1-r2.ebuild
+++ b/dev-util/sysprof/sysprof-48.1-r2.ebuild
@@ -49,6 +49,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-48.0-shadowed-variable.patch
+)
+
 src_prepare() {
 	xdg_environment_reset
 


### PR DESCRIPTION
This PR fixes `dev-util/sysprof` on the llvm profile while using `llvm-runtimes/libunwind`, this change is required because unw_* function dosent exist in llvm-libunwind project.
~I not 100% sure if this changes break the application in any way, but this at least will allow `gnome-base/gnome` to be install on llvm profile.~

Edit: Test versions 47.2, 48.0 and 48.1 with my change, via gui and cli, it works without any crash or bugs, with this patch makes possible to emerge `gnome-base/gnome` without any `block` on llvm profile.

Also, I did a little bit of research and LLVM libunwind seems to use per-thread caching by default and the `backtrace` implementation is similar to `unw_backtrace`, but I can be wrong.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
