### PR TITLE
media-libs/oidn: fix dependency on hipcc; and fix flags in media-gfx/blender accordingly

### DIFF
--- a/media-gfx/blender/blender-4.1.1-r2.ebuild
+++ b/media-gfx/blender/blender-4.1.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -86,14 +86,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp[cxx] )
 	gnome? ( gui-libs/libdecor )
-	hip? (
-		llvm_slot_17? (
-			dev-util/hip:0/5.7
-		)
-		llvm_slot_18? (
-			>=dev-util/hip-6.1:=[llvm_slot_18(-)]
-		)
-	)
+	hip? ( >=dev-util/hip-5.7 )
 	jack? ( virtual/jack )
 	jemalloc? ( dev-libs/jemalloc:= )
 	jpeg2k? ( media-libs/openjpeg:2= )
@@ -103,7 +96,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	nls? ( virtual/libiconv )
 	openal? ( media-libs/openal )
-	oidn? ( >=media-libs/oidn-2.1.0[${LLVM_USEDEP}] )
+	oidn? ( >=media-libs/oidn-2.1.0 )
 	oneapi? ( dev-libs/intel-compute-runtime[l0] )
 	openexr? (
 		>=dev-libs/imath-3.1.7:=

--- a/media-gfx/blender/blender-4.2.1.ebuild
+++ b/media-gfx/blender/blender-4.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -85,14 +85,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp[cxx] )
 	gnome? ( gui-libs/libdecor )
-	hip? (
-		llvm_slot_17? (
-			dev-util/hip:0/5.7
-		)
-		llvm_slot_18? (
-			>=dev-util/hip-6.1:=[llvm_slot_18(-)]
-		)
-	)
+	hip? ( >=dev-util/hip-5.7 )
 	jack? ( virtual/jack )
 	jemalloc? ( dev-libs/jemalloc:= )
 	jpeg2k? ( media-libs/openjpeg:2= )
@@ -102,7 +95,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	nls? ( virtual/libiconv )
 	openal? ( media-libs/openal )
-	oidn? ( >=media-libs/oidn-2.1.0[${LLVM_USEDEP}] )
+	oidn? ( >=media-libs/oidn-2.1.0 )
 	oneapi? ( dev-libs/intel-compute-runtime[l0] )
 	openexr? (
 		>=dev-libs/imath-3.1.7:=

--- a/media-gfx/blender/blender-4.2.4.ebuild
+++ b/media-gfx/blender/blender-4.2.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -85,14 +85,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp[cxx] )
 	gnome? ( gui-libs/libdecor )
-	hip? (
-		llvm_slot_17? (
-			dev-util/hip:0/5.7
-		)
-		llvm_slot_18? (
-			>=dev-util/hip-6.1:=[llvm_slot_18(-)]
-		)
-	)
+	hip? ( >=dev-util/hip-5.7 )
 	jack? ( virtual/jack )
 	jemalloc? ( dev-libs/jemalloc:= )
 	jpeg2k? ( media-libs/openjpeg:2= )
@@ -102,7 +95,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	nls? ( virtual/libiconv )
 	openal? ( media-libs/openal )
-	oidn? ( >=media-libs/oidn-2.1.0[${LLVM_USEDEP}] )
+	oidn? ( >=media-libs/oidn-2.1.0 )
 	oneapi? ( dev-libs/intel-compute-runtime[l0] )
 	openexr? (
 		>=dev-libs/imath-3.1.7:=

--- a/media-gfx/blender/blender-4.3.2.ebuild
+++ b/media-gfx/blender/blender-4.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -85,14 +85,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp[cxx] )
 	gnome? ( gui-libs/libdecor )
-	hip? (
-		llvm_slot_17? (
-			dev-util/hip:0/5.7
-		)
-		llvm_slot_18? (
-			>=dev-util/hip-6.1:=[llvm_slot_18(-)]
-		)
-	)
+	hip? ( >=dev-util/hip-5.7 )
 	jack? ( virtual/jack )
 	jemalloc? ( dev-libs/jemalloc:= )
 	jpeg2k? ( media-libs/openjpeg:2= )
@@ -102,7 +95,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	nls? ( virtual/libiconv )
 	openal? ( media-libs/openal )
-	oidn? ( >=media-libs/oidn-2.1.0[${LLVM_USEDEP}] )
+	oidn? ( >=media-libs/oidn-2.1.0 )
 	oneapi? ( dev-libs/intel-compute-runtime[l0] )
 	openexr? (
 		>=dev-libs/imath-3.1.7:=

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -85,14 +85,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp[cxx] )
 	gnome? ( gui-libs/libdecor )
-	hip? (
-		llvm_slot_17? (
-			dev-util/hip:0/5.7
-		)
-		llvm_slot_18? (
-			>=dev-util/hip-6.1:=[llvm_slot_18(-)]
-		)
-	)
+	hip? ( >=dev-util/hip-5.7 )
 	jack? ( virtual/jack )
 	jemalloc? ( dev-libs/jemalloc:= )
 	jpeg2k? ( media-libs/openjpeg:2= )
@@ -102,7 +95,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	nls? ( virtual/libiconv )
 	openal? ( media-libs/openal )
-	oidn? ( >=media-libs/oidn-2.1.0[${LLVM_USEDEP}] )
+	oidn? ( >=media-libs/oidn-2.1.0 )
 	oneapi? ( dev-libs/intel-compute-runtime[l0] )
 	openexr? (
 		>=dev-libs/imath-3.1.7:=

--- a/media-libs/oidn/files/oidn-2.3.0-hip-clang-19.patch
+++ b/media-libs/oidn/files/oidn-2.3.0-hip-clang-19.patch
@@ -1,0 +1,18 @@
+Fix compilation with Clang 19 (rocm-6.3.0 and above).
+
+Backports commit https://github.com/ROCm/composable_kernel/commit/c44137838e2cb30bbe5a3b9903c357b476a34d52
+Upstream bug: https://github.com/RenderKit/oidn/issues/250
+--- a/external/composable_kernel/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
++++ b/external/composable_kernel/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+@@ -781,11 +781,6 @@ struct BlockwiseGemmXdlops_v2
+                       "wrong!");
+     }
+ 
+-    __host__ __device__ BlockwiseGemmXdlops_v2(const BlockwiseGemmXdlops_v2& other)
+-        : a_thread_copy_(other.a_origin), b_thread_copy_(other.b_origin)
+-    {
+-    }
+-
+     // transposed XDL output supporting C_xdl' = B_xdl' * A_xdl'
+     __host__ __device__ static constexpr auto GetCThreadDescriptor_M0_N0_M1_N1_M2_N2_N3_N4()
+     {

--- a/media-libs/oidn/metadata.xml
+++ b/media-libs/oidn/metadata.xml
@@ -11,8 +11,7 @@
 	</maintainer>
 	<longdescription>
 		Intel Open Image Denoise is an open source library of high-performance,
-		high-quality denoising filters for images rendered with ray tracing. Intel
-		Open Image Denoise is part of the Intel® oneAPI Rendering Toolkit and is
+		high-quality denoising filters for images rendered with ray tracing.
 	</longdescription>
 	<use>
 		<flag name="apps">

--- a/media-libs/oidn/oidn-2.3.0.ebuild
+++ b/media-libs/oidn/oidn-2.3.0.ebuild
@@ -4,10 +4,9 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-LLVM_COMPAT=( {15..18} )
 ROCM_VERSION=5.7
 
-inherit cmake cuda llvm-r1 python-any-r1 rocm
+inherit cmake cuda python-any-r1 rocm
 
 DESCRIPTION="Intel® Open Image Denoise library"
 HOMEPAGE="https://www.openimagedenoise.org https://github.com/RenderKit/oidn"
@@ -36,16 +35,12 @@ RDEPEND="
 	hip? ( dev-util/hip )
 	openimageio? ( media-libs/openimageio:= )
 "
-DEPEND="${RDEPEND}
-	$(llvm_gen_dep '
-		llvm-core/clang:${LLVM_SLOT}=
-		llvm-core/llvm:${LLVM_SLOT}=
-	')
-"
+DEPEND="${RDEPEND}"
 BDEPEND="${PYTHON_DEPS}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.2.2-amdgpu-targets.patch"
+	"${FILESDIR}/${PN}-2.3.0-hip-clang-19.patch"
 )
 
 src_prepare() {
@@ -55,8 +50,15 @@ src_prepare() {
 	fi
 
 	if use hip; then
+		# Fix Clang 19 error
+		# Bug: https://github.com/RenderKit/oidn/issues/250
+		sed -i "s/.template Run(/.template Run<>(/g" \
+			external/composable_kernel/include/ck/tensor_operation/gpu/block/blockwise_gemm_wmma.hpp \
+			external/composable_kernel/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops_skip_b_lds.hpp \
+			external/composable_kernel/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp || die
+
 		# https://bugs.gentoo.org/930391
-		sed "/-Wno-unused-result/s:): --rocm-path=${EPREFIX}/usr/lib):" \
+		sed "/-Wno-unused-result/s:): --rocm-path=${EPREFIX}/usr):" \
 			-i devices/hip/CMakeLists.txt || die
 	fi
 
@@ -86,7 +88,7 @@ src_configure() {
 	if use hip; then
 		mycmakeargs+=(
 			-DROCM_PATH="${EPREFIX}/usr"
-			-DOIDN_DEVICE_HIP_COMPILER="$(get_llvm_prefix)/bin/clang++" # use HIPHOSTCOMPILER
+			-DOIDN_DEVICE_HIP_COMPILER="${ESYSROOT}/usr/bin/hipcc"
 			-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		)
 	fi


### PR DESCRIPTION
Before this change `media-libs/oidn[hip]` had both `llvm-core/clang` (some version) and `dev-util/hip` (some version) in dependencies, while not attempting to keep in sync both packages. 
However specifying dependency on `llvm-core/clang` manually is not needed. Open Image Denoise exposes C99 API with C++11 wrapper, users of this library _has no interest_ in specifying specific version of LLVM using slots. 
For example, it is possible to use LLVM-18-based Mesa (as Mesa is traditionally lagging behind) with Cycles+OIDN compiled by hipcc-6.3.0 (LLVM-19-based).

This change is followed by change in `media-gfx/blender`, which removes `[${LLVM_USEDEP}]` from media-libs/oidn dependency (otherwise the dependency graph can't be solved). There is no revbump as no binary code change is expected. `blender->hip->clang` and `oidn->hip->clang` dependency is still locked, it is just locked in another place. See more details in https://bugs.gentoo.org/936899#c11

Closes: https://bugs.gentoo.org/936899

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
