### PR TITLE
dev-libs/elfutils: use error-standalone-2.0

### DIFF
--- a/dev-libs/elfutils/elfutils-0.191-r2.ebuild
+++ b/dev-libs/elfutils/elfutils-0.191-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2003-2024 Gentoo Authors
+# Copyright 2003-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -65,6 +65,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.189-musl-aarch64-regs.patch
 	"${FILESDIR}"/${PN}-0.191-musl-macros.patch
 	"${FILESDIR}"/${PN}-0.191-avoid-overriding-libcxx-system-header.patch
+	"${FILESDIR}"/${PN}-0.191-musl-configure-better-error-h-check.patch
 )
 
 src_prepare() {

--- a/dev-libs/elfutils/elfutils-0.192-r1.ebuild
+++ b/dev-libs/elfutils/elfutils-0.192-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2003-2024 Gentoo Authors
+# Copyright 2003-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -68,6 +68,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-libelf-static-link-libeu.patch
 	"${FILESDIR}"/${P}-configure-better-error-message.patch
 	"${FILESDIR}"/${P}-stacktrace-maybe-uninit.patch
+	"${FILESDIR}"/${PN}-0.191-musl-configure-better-error-h-check.patch
 )
 
 src_prepare() {

--- a/dev-libs/elfutils/files/elfutils-0.191-musl-configure-better-error-h-check.patch
+++ b/dev-libs/elfutils/files/elfutils-0.191-musl-configure-better-error-h-check.patch
@@ -1,0 +1,32 @@
+From 43ddbe073025fe2ff454dabb84674ccdbd013487 Mon Sep 17 00:00:00 2001
+From: Alfred Wingate <parona@protonmail.com>
+Date: Wed, 29 Jan 2025 09:32:49 +0200
+Subject: [PATCH] Declare HAVE_ERROR_H only if error symbol is available
+
+Musl doesn't provide error.h. But there exists a standalone implementation
+that installs /usr/include/error.h but requires explicit linkage. This
+leads linkage errors later on due to the assumption that error
+symbols are provided by the libc.
+
+Bug: https://bugs.gentoo.org/948878
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1da2a12c..7a2f2540 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -477,7 +477,7 @@ AC_CHECK_FUNCS([process_vm_readv mremap])
+ AS_IF([test "x$ac_cv_func_mremap" = "xno"],
+       [AC_MSG_WARN([elf_update needs mremap to support ELF_C_RDWR_MMAP])])
+ 
+-AC_CHECK_HEADERS([error.h])
++AC_CHECK_HEADER([error.h], [AC_CHECK_FUNC([error], AC_DEFINE([HAVE_ERROR_H], [1], [Define if error.h is usable]))])
+ AC_CHECK_HEADERS([err.h])
+ 
+ dnl for debuginfod concurrency heuristics
+-- 
+2.48.1
+


### PR DESCRIPTION
error() is available in glibc, not in musl, configure check header file "error.h" only. If error-standalone is installed, check report ok, but link will fail.

~mips is dropped to make pkgcheck happy, can be added back after added for sys-libs/error-standalone.

Closes: https://bugs.gentoo.org/948878

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
