### PR TITLE
sys-devel/dwz: fix build w/ llvm profile

### DIFF
--- a/sys-devel/dwz/dwz-0.15-r4.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r4.ebuild
@@ -54,7 +54,10 @@ src_prepare() {
 src_compile() {
 	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
 
-	tc-export PKG_CONFIG
+	local current_binutils_path=$(binutils-config -B)
+	export READELF="${current_binutils_path}/readelf"
+
+	tc-export PKG_CONFIG READELF
 
 	export LIBS="-lelf"
 	if use elibc_musl; then

--- a/sys-devel/dwz/dwz-0.15-r5.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r5.ebuild
@@ -54,7 +54,10 @@ src_prepare() {
 src_compile() {
 	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
 
-	tc-export PKG_CONFIG
+	local current_binutils_path=$(binutils-config -B)
+	export READELF="${current_binutils_path}/readelf"
+
+	tc-export PKG_CONFIG READELF
 
 	export LIBS="-lelf"
 	if use elibc_musl; then

--- a/sys-devel/dwz/dwz-9999.ebuild
+++ b/sys-devel/dwz/dwz-9999.ebuild
@@ -48,7 +48,10 @@ src_prepare() {
 src_compile() {
 	export LANG=C LC_ALL=C  # grep find nothing for non-ascii locales
 
-	tc-export PKG_CONFIG
+	local current_binutils_path=$(binutils-config -B)
+	export READELF="${current_binutils_path}/readelf"
+
+	tc-export PKG_CONFIG READELF
 
 	export LIBS="-lelf"
 	if use elibc_musl; then


### PR DESCRIPTION
llvm-readelf has different arguments w/ gnu readelf, so if READELF is llvm one, try get pointer size by using llvm-dwarfdump.

Closes: https://bugs.gentoo.org/945628

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
