### PR TITLE
sci-libs/superlu: update EAPI 7 -> 8, fix C version on gnu89

### DIFF
--- a/sci-libs/superlu/superlu-4.3-r4.ebuild
+++ b/sci-libs/superlu/superlu-4.3-r4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit autotools fortran-2 multilib toolchain-funcs
+inherit autotools fortran-2 multilib toolchain-funcs flag-o-matic
 
 MY_PN=SuperLU
 
@@ -33,6 +33,7 @@ PATCHES=(
 
 src_prepare() {
 	unset VERBOSE
+	append-cflags -std=gnu89
 	sed \
 		-e "s:= ar:= $(tc-getAR):g" \
 		-e "s:= ranlib:= $(tc-getRANLIB):g" \


### PR DESCRIPTION
We have a newer package where woes of modern C are solved. This one for dependencies.

Closes: https://bugs.gentoo.org/926310
Closes: https://bugs.gentoo.org/948886

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
