### PR TITLE
sci-lib/mc: update EAPI 7 -> 8, port to C23

### DIFF
--- a/sci-libs/mc/files/mc-1.5-missing-decl.patch
+++ b/sci-libs/mc/files/mc-1.5-missing-decl.patch
@@ -1,0 +1,13 @@
+Fix missing function declaration, so package could build with modern compilers
+https://bugs.gentoo.org/886457
+--- a/src/aprx/estim.c
++++ b/src/aprx/estim.c
+@@ -41,6 +41,8 @@
+     Bvec *u, Bvec *ud, Bvec *r);
+ VEXTERNC void Aprx_estFaceBump(Aprx *thee, int color,
+     Bvec *u, Bvec *ud, Bvec *r);
++VPUBLIC int Aprx_markRefineDorfler (Aprx *thee, double percentToRefine,
++    int color);
+ 
+ /*
+  * ***************************************************************************

--- a/sci-libs/mc/mc-1.5.ebuild
+++ b/sci-libs/mc/mc-1.5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools fortran-2
 
@@ -38,6 +38,7 @@ PATCHES=(
 	"${FILESDIR}"/1.4-multilib.patch
 	"${FILESDIR}"/1.4-doc.patch
 	"${FILESDIR}"/${P}-unbundle.patch
+	"${FILESDIR}"/${P}-missing-decl.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Fixes build failure with gcc-14.
Drops pre-revision version.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
