### PR TITLE
app-containers/netavark: Allow nonexistent flag for dev-libs/protobuf

### DIFF
--- a/app-containers/netavark/netavark-1.12.2-r1.ebuild
+++ b/app-containers/netavark/netavark-1.12.2-r1.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0"
 LICENSE+=" Apache-2.0-with-LLVM-exceptions BSD BSD-2 Boost-1.0 MIT Unicode-DFS-2016 Unlicense ZLIB"
 SLOT="0"
 BDEPEND="dev-go/go-md2man
-	dev-libs/protobuf[protoc]"
+	dev-libs/protobuf[protoc(+)]"
 
 QA_FLAGS_IGNORED="
 	usr/libexec/podman/${PN}"

--- a/app-containers/netavark/netavark-9999.ebuild
+++ b/app-containers/netavark/netavark-9999.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0"
 LICENSE+=" Apache-2.0-with-LLVM-exceptions BSD BSD-2 Boost-1.0 MIT Unicode-DFS-2016 Unlicense ZLIB"
 SLOT="0"
 BDEPEND="dev-go/go-md2man
-	dev-libs/protobuf[protoc]"
+	dev-libs/protobuf[protoc(+)]"
 
 QA_FLAGS_IGNORED="
 	usr/libexec/podman/${PN}"


### PR DESCRIPTION
This USE flag does not exist in older versions of protobuf.

Related issue: https://bugs.gentoo.org/948353

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
