### PR TITLE
Update mc-4.8.33.ebuild

### DIFF
--- a/app-misc/mc/mc-4.8.33.ebuild
+++ b/app-misc/mc/mc-4.8.33.ebuild
@@ -62,18 +62,6 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64
 )
 
-src_prepare() {
-	default
-
-	# Bug #906194, #922483
-	if use elibc_musl; then
-		eapply "${FILESDIR}"/${PN}-4.8.30-musl-tests.patch
-		eapply "${FILESDIR}"/${PN}-4.8.31-musl-tests.patch
-	fi
-
-	eautoreconf
-}
-
 src_configure() {
 	[[ ${CHOST} == *-solaris* ]] && append-ldflags "-lnsl -lsocket"
 
@@ -99,18 +87,13 @@ src_configure() {
 }
 
 src_test() {
-	# Bug #759466
+	# Bug #759466 - tracked upstream at https://midnight-commander.org/ticket/4643
 	if [[ ${EUID} == 0 ]] ; then
 		ewarn "You are emerging ${PN} as root with 'userpriv' disabled."
 		ewarn "Expect some test failures, or emerge with 'FEATURES=userpriv'!"
 	fi
 
-	# CK_FORK=no to avoid using fork() in check library
-	# as mc mocks fork() itself: bug #644462.
-	#
-	# VERBOSE=1 to make test failures contain detailed
-	# information.
-	CK_FORK=no emake check VERBOSE=1
+	emake check VERBOSE=1
 }
 
 src_install() {


### PR DESCRIPTION
Hi there,

All these issues ought to be fixed in 4.8.33:

* I have taken care of the charset problems on musl
* I have modified the tests such that they also pass when run as `root`
* I have re-written our mocking implementation, so it should work with `check`

I don't have/use Gentoo, so I can't tick the last box.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
