### PR TITLE
dev-libs/appstream: Add vala support

### DIFF
--- a/dev-libs/appstream/appstream-1.0.3.ebuild
+++ b/dev-libs/appstream/appstream-1.0.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit meson xdg-utils
+inherit meson xdg-utils vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -21,7 +21,7 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Distributions/AppStream/"
 LICENSE="LGPL-2.1+ GPL-2+"
 # check as_api_level
 SLOT="0/5"
-IUSE="apt doc +introspection qt6 systemd test"
+IUSE="apt doc +introspection qt6 systemd vala test"
 RESTRICT="test" # bug 691962
 
 RDEPEND="
@@ -44,6 +44,7 @@ BDEPEND="
 	>=sys-devel/gettext-0.19.8
 	doc? ( app-text/docbook-xml-dtd:4.5 )
 	test? ( dev-qt/qttools:6[linguist] )
+	vala? ( $(vala_depend) )
 "
 
 PATCHES=( "${FILESDIR}"/${PN}-1.0.0-disable-Werror-flags.patch ) # bug 733774
@@ -54,6 +55,8 @@ src_prepare() {
 	if ! use test; then
 		sed -e "/^subdir.*tests/s/^/#DONT /" -i {,qt/}meson.build || die # bug 675944
 	fi
+
+	use vala && vala_setup
 }
 
 src_configure() {
@@ -66,7 +69,7 @@ src_configure() {
 		-Dmaintainer=false
 		-Dstatic-analysis=false
 		-Dstemming=true
-		-Dvapi=false
+		-Dvapi=$(usex vala true false)
 		-Dapt-support=$(usex apt true false)
 		-Dinstall-docs=$(usex doc true false)
 		-Dgir=$(usex introspection true false)

--- a/dev-libs/appstream/appstream-1.0.4.ebuild
+++ b/dev-libs/appstream/appstream-1.0.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson xdg-utils
+inherit meson xdg-utils vala
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -21,7 +21,7 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Distributions/AppStream/"
 LICENSE="LGPL-2.1+ GPL-2+"
 # check as_api_level
 SLOT="0/5"
-IUSE="apt compose doc +introspection qt6 systemd test"
+IUSE="apt compose doc +introspection qt6 systemd test vala"
 RESTRICT="test" # bug 691962
 
 RDEPEND="
@@ -51,6 +51,7 @@ BDEPEND="
 	>=sys-devel/gettext-0.19.8
 	doc? ( app-text/docbook-xml-dtd:4.5 )
 	test? ( dev-qt/qttools:6[linguist] )
+	vala? ( $(vala_depend) )
 "
 
 PATCHES=( "${FILESDIR}"/${PN}-1.0.0-disable-Werror-flags.patch ) # bug 733774
@@ -61,6 +62,8 @@ src_prepare() {
 	if ! use test; then
 		sed -e "/^subdir.*tests/s/^/#DONT /" -i {,qt/}meson.build || die # bug 675944
 	fi
+
+	use vala && vala_setup
 }
 
 src_configure() {
@@ -73,7 +76,7 @@ src_configure() {
 		-Dmaintainer=false
 		-Dstatic-analysis=false
 		-Dstemming=true
-		-Dvapi=false
+		-Dvapi=$(usex vala true false)
 		-Dapt-support=$(usex apt true false)
 		-Dcompose=$(usex compose true false)
 		-Dinstall-docs=$(usex doc true false)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733768

The ebuilds have `-Dvapi=false` in the src_configure and should be a proper useflag vala instead. This fixes that and allow packages to ask for appstream with vala build support.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
