### PR TITLE
sys-libs/libxcrypt: fix CHOST != CTARGET builds

### DIFF
--- a/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
@@ -116,8 +116,6 @@ src_configure() {
 	MYSYSROOT=${ESYSROOT}
 
 	if target_is_not_host; then
-		local CHOST=${CTARGET}
-
 		MYPREFIX=
 		MYSYSROOT=${ESYSROOT}/usr/${CTARGET}
 
@@ -160,6 +158,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local myconf=(
+		--host="${CTARGET}"
 		--disable-werror
 		--prefix="${MYPREFIX}/usr"
 		--libdir="${MYPREFIX}/usr/$(get_libdir)$(usev !system /xcrypt)"


### PR DESCRIPTION
commit 03f1639e3 ("sys-libs/libxcrypt: general clean up") had what I believe to be an unintended side-effect of setting CHOST=CTARGET: host tools like pkg-config were replaced with their ${CTARGET} prefixed equivalents.

This likely went under the radar because crossdev defaults to CHOST == CTARGET, so the same tools were used in this case, however it broke some toolchains like the ChromeOS LLVM which have CHOST != CTARGET and expect a different set of tools to run for CHOST vs CTARGET.

According to documentation [1] [2], CHOST should also remain fixed and not change in the majority of cases, so we go back to the old behaviour.

Link: https://wiki.gentoo.org/wiki/CHOST [1]
Link: https://wiki.gentoo.org/wiki/Changing_the_CHOST_variable [2]

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
