### PR TITLE
dev-libs/efl: fix build w/ musl

### DIFF
--- a/dev-libs/efl/efl-1.27.0-r1.ebuild
+++ b/dev-libs/efl/efl-1.27.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ LUA_COMPAT=( lua5-{1,2} luajit )
 
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit lua-single meson python-any-r1 xdg
+inherit flag-o-matic lua-single meson python-any-r1 xdg
 
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 HOMEPAGE="https://www.enlightenment.org"
@@ -280,6 +280,11 @@ src_configure() {
 	# Not all arm CPU's have neon instruction set, #722552
 	if use arm && ! use cpu_flags_arm_neon; then
 		emesonargs+=( -D native-arch-optimization=false )
+	fi
+
+	if use elibc_musl ; then
+		append-cflags -D__USE_MISC
+		append-cflags -D_LARGEFILE64_SOURCE
 	fi
 
 	meson_src_configure

--- a/dev-libs/efl/efl-1.28.0.ebuild
+++ b/dev-libs/efl/efl-1.28.0.ebuild
@@ -8,7 +8,7 @@ LUA_COMPAT=( lua5-{1,2} luajit )
 
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit lua-single meson python-any-r1 xdg
+inherit flag-o-matic lua-single meson python-any-r1 xdg
 
 DESCRIPTION="Enlightenment Foundation Libraries all-in-one package"
 HOMEPAGE="https://www.enlightenment.org"
@@ -283,6 +283,10 @@ src_configure() {
 	# Not all arm CPU's have neon instruction set, #722552
 	if use arm && ! use cpu_flags_arm_neon; then
 		emesonargs+=( -D native-arch-optimization=false )
+	fi
+
+	if use elibc_musl ; then
+		append-cflags -D_LARGEFILE64_SOURCE
 	fi
 
 	meson_src_configure


### PR DESCRIPTION
in file src/lib/eina/eina_file_posix.c
1. __USE_MISC is a glibc-specific macro, use of it has been removed in upstream (e.g for 1.28.0), defined here for simplicity.
2. ino64_t is available only if _LARGEFILE64_SOURCE is defined

Closes: https://bugs.gentoo.org/928586

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
