### PR TITLE
dev-java/bcel: adjust CP_DEPEND with newer version of commons-lang

### DIFF
--- a/dev-java/bcel/bcel-6.10.0-r2.ebuild
+++ b/dev-java/bcel/bcel-6.10.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,7 @@ KEYWORDS="amd64 arm64 ppc64 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-s
 
 VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/commons.apache.org.asc"
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-apache-commons )"
-CP_DEPEND="dev-java/commons-lang:3.6"
+CP_DEPEND=">=dev-java/commons-lang-3.17.0:3.6"
 DEPEND="${CP_DEPEND}
 	>=virtual/jdk-11:*"
 RDEPEND="${CP_DEPEND}


### PR DESCRIPTION
There was a mismatch in JAVA_AUTOMATIC_MODULE_NAME of commons-lang-3.14.0 causing a build error.

Closes: https://bugs.gentoo.org/948872

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
