### PR TITLE
net-nntp/slrn: add implicit decl of __va_copy to QA whitelist

### DIFF
--- a/net-nntp/slrn/slrn-1.0.3-r2.ebuild
+++ b/net-nntp/slrn/slrn-1.0.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -32,6 +32,10 @@ RDEPEND+=" selinux? ( sec-policy/selinux-slrnpull )"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.2-make.patch
 	"${FILESDIR}"/${P}-configure.patch
+)
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	__va_copy # bug #900270, pre-C99 extension, using standard va_copy() instead
 )
 
 src_configure() {


### PR DESCRIPTION
pre-C99 extension, not in musl or clang, free to ignore - we are using standard va_copy instead.

Closes: https://bugs.gentoo.org/900270

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
