### PR TITLE
app-misc/beep: remove ld option "--cref"

### DIFF
--- a/app-misc/beep/beep-1.4.12-r2.ebuild
+++ b/app-misc/beep/beep-1.4.12-r2.ebuild
@@ -16,6 +16,8 @@ KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 # Tests require a speaker
 RESTRICT="test"
 
+PATCHES=( "${FILESDIR}"/${P}-avoid-cref-linker-option.patch )
+
 src_prepare() {
 	default
 

--- a/app-misc/beep/files/beep-1.4.12-avoid-cref-linker-option.patch
+++ b/app-misc/beep/files/beep-1.4.12-avoid-cref-linker-option.patch
@@ -1,0 +1,19 @@
+from upstream commit d3c3fb6e18a6b359c263156f556a5520121ca7fd
+
+Not all linkers support that option, and it seems the option was included
+solely for informational purposes (possibly to debug issues in the past).
+Therefore, it appears safe to remove the option from the makefile.
+
+diff --git a/GNUmakefile b/GNUmakefile
+index a27b453..11bc3a1 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -261,7 +261,7 @@ beep-usage.c: beep-usage.txt
+ define LINK_RULE
+ $(1): $$($(2)_OBJS)
+ 	@: echo "LINK_RULE $$@: $$^"
+-	$(CC) -Wl,-Map=$$(@:%=%.map),--cref $(CFLAGS) $(common_CFLAGS) $(LDFLAGS) $(common_LDFLAGS) -o $$@ $$^ $$($(2)_LIBS) $(common_LIBS) $(LIBS)
++	$(CC) -Wl,-Map=$$(@:%=%.map) $(CFLAGS) $(common_CFLAGS) $(LDFLAGS) $(common_LDFLAGS) -o $$@ $$^ $$($(2)_LIBS) $(common_LIBS) $(LIBS)
+ 
+ $$(patsubst %.o,.deps/%.o.dep,$$($(2)_OBJS))):
+ 


### PR DESCRIPTION
which is unavailbe for mold

Closes: https://bugs.gentoo.org/947768

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
