### PR TITLE
net-wireless/broadcom-sta: Handle new name of header file in kernels …

### DIFF
--- a/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r8.ebuild
+++ b/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -39,6 +39,7 @@ PATCHES=(
 	"${FILESDIR}/014-linux414.patch"
 	"${FILESDIR}/015-linux600.patch"
 	"${FILESDIR}/016-linux601.patch"
+	"${FILESDIR}/017-handle_new_header_name.patch"
 )
 
 pkg_pretend() {

--- a/net-wireless/broadcom-sta/files/017-handle_new_header_name.patch
+++ b/net-wireless/broadcom-sta/files/017-handle_new_header_name.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/947928
+
+Adds support for the new name of the asm/unaligned.h header file for kernels >=6.12.0 (header file was renamed to "linux/unaligned.h")
+Bug found by Sam Petch 
+Patch by Sam Petch
+
+TESTING DETAILS:
+
+Bugfix tested by Sam Petch on kernels: gentoo-sources:6.6.67, gentoo-sources:6.12.4-r1, gentoo-sources:6.12.9
+
+Patch tested on kernels: gentoo-sources:6.6.67, gentoo-sources:6.12.9
+
+Bugfix and patch tested on device: 2012 Macbook Pro (A1278) running Gentoo Linux with Gnome Desktop / OpenRC profile
+
+Chipset: BCM4331 (Broadcom)
+
+Contact: sam.petch.recall824@passinbox.com
+
+--- a/src/wl/sys/wl_linux.c	2025-01-17 22:18:10.152359697 -0500
++++ b/src/wl/sys/wl_linux.c	2025-01-16 23:05:34.548987574 -0500
+@@ -56,7 +56,12 @@
+ #include <asm/irq.h>
+ #include <asm/pgtable.h>
+ #include <asm/uaccess.h>
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++#include <linux/unaligned.h>
++#else
+ #include <asm/unaligned.h>
++#endif
+ 
+ #include <proto/802.1d.h>
+ 


### PR DESCRIPTION
…>=6.12.0 (asm/unaligned.h ---> linux/unaligned.h)

Bug: https://bugs.gentoo.org/947928

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
