### PR TITLE
dev-libs/libdex: use libucontext on musl

### DIFF
--- a/dev-libs/libdex/files/libdex-0.8.1-libucontext-musl.patch
+++ b/dev-libs/libdex/files/libdex-0.8.1-libucontext-musl.patch
@@ -1,0 +1,61 @@
+https://bugs.gentoo.org/928892
+https://gitlab.gnome.org/GNOME/libdex/-/commit/fc0ef0544dd61ff6d825c53323d4b4cba4481a03
+https://gitlab.gnome.org/GNOME/libdex/-/merge_requests/17
+
+From fc0ef0544dd61ff6d825c53323d4b4cba4481a03 Mon Sep 17 00:00:00 2001
+From: Alfred Wingate <parona@protonmail.com>
+Date: Wed, 29 Jan 2025 07:16:41 +0200
+Subject: [PATCH] build: try libucontext if symbols are not present
+
+Musl includes uncontext.h but doesn't implement the symbols. This means
+that HAVE_CONTEXT_H will be set and linking will fail due to missing
+symbols.
+
+https://wiki.musl-libc.org/open-issues.html#ucontext.h
+
+If the symbols are missing depend on libucontext which is an implementation
+of these functions for musl.
+
+https://github.com/kaniini/libucontext
+
+Bug: https://bugs.gentoo.org/928892
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+--- a/meson.build
++++ b/meson.build
+@@ -44,14 +44,14 @@ if get_option('sysprof')
+   config_h.set10('HAVE_SYSPROF', true)
+ endif
+ 
+-check_headers = [
+-  'ucontext.h',
+-]
+-foreach h : check_headers
+-  if cc.has_header(h)
+-    config_h.set('HAVE_' + h.underscorify().to_upper(), 1)
++if cc.has_header('ucontext.h')
++  if not cc.has_function('makecontext', prefix : '#include <ucontext.h>')
++    libucontext_dep = dependency('libucontext', required: false)
++  else
++    libucontext_dep = disabler()
+   endif
+-endforeach
++  config_h.set('HAVE_UCONTEXT_H', 1)
++endif
+ 
+ if host_machine.system() == 'darwin'
+   # known alignment for darwin where we're using helpers
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -95,6 +95,9 @@ if host_machine.system() != 'windows'
+     'dex-unix-signal.c',
+     'dex-ucontext.c',
+   ]
++  if libucontext_dep.found()
++    libdex_deps += [libucontext_dep]
++  endif
+ 
+   # If we're on Linux and mips we might still need asm.S.
+   # But otherwise linux can do it all without any custom
+-- 
+GitLab
+

--- a/dev-libs/libdex/libdex-0.8.1.ebuild
+++ b/dev-libs/libdex/libdex-0.8.1.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 	liburing? ( >=sys-libs/liburing-0.7:= )
 	introspection? ( dev-libs/gobject-introspection:= )
 	sysprof? ( dev-util/sysprof-capture:4 )
+	elibc_musl? ( sys-libs/libucontext )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
@@ -32,6 +33,10 @@ BDEPEND="
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gi-docgen )
 "
+
+PATCHES=(
+	"${FILESDIR}"/libdex-0.8.1-libucontext-musl.patch
+)
 
 pkg_setup() {
 	if use eventfd && linux_config_exists; then


### PR DESCRIPTION
No revbump because musl could never be built

Bug: https://bugs.gentoo.org/928892

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
