### PR TITLE
sys-devel/clang-crossdev-wrappers: Sync keywords with llvm-core/clang, add 20

### DIFF
--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-16.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,6 @@ inherit crossdev
 
 DESCRIPTION="Symlinks to a Clang crosscompiler"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
-SRC_URI=""
 S=${WORKDIR}
 
 LICENSE="public-domain"

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-16.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-16.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 "
 
 src_install() {
-	local llvm_path="${EPREFIX}/usr/lib/llvm/${SLOT}"
+	local llvm_path="/usr/lib/llvm/${SLOT}"
 	into "${llvm_path}"
 
 	for exe in "clang" "clang++" "clang-cpp"; do

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-17.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,6 @@ inherit crossdev
 
 DESCRIPTION="Symlinks to a Clang crosscompiler"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
-SRC_URI=""
 S=${WORKDIR}
 
 LICENSE="public-domain"

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-17.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-17.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 "
 
 src_install() {
-	local llvm_path="${EPREFIX}/usr/lib/llvm/${SLOT}"
+	local llvm_path="/usr/lib/llvm/${SLOT}"
 	into "${llvm_path}"
 
 	for exe in "clang" "clang++" "clang-cpp"; do

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,6 @@ inherit crossdev
 
 DESCRIPTION="Symlinks to a Clang crosscompiler"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
-SRC_URI=""
 S=${WORKDIR}
 
 LICENSE="public-domain"

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 "
 
 src_install() {
-	local llvm_path="${EPREFIX}/usr/lib/llvm/${SLOT}"
+	local llvm_path="/usr/lib/llvm/${SLOT}"
 	into "${llvm_path}"
 
 	for exe in "clang" "clang++" "clang-cpp"; do

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-18.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~arm64-macos ~x64-macos"
 
 RDEPEND="
 	llvm-core/clang:${SLOT}

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-19.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,12 +7,10 @@ inherit crossdev
 
 DESCRIPTION="Symlinks to a Clang crosscompiler"
 HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
-SRC_URI=""
 S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS=""
 PROPERTIES="live"
 
 RDEPEND="

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-19.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-19.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 "
 
 src_install() {
-	local llvm_path="${EPREFIX}/usr/lib/llvm/${SLOT}"
+	local llvm_path="/usr/lib/llvm/${SLOT}"
 	into "${llvm_path}"
 
 	for exe in "clang" "clang++" "clang-cpp"; do

--- a/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-20.ebuild
+++ b/sys-devel/clang-crossdev-wrappers/clang-crossdev-wrappers-20.ebuild
@@ -11,7 +11,6 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~arm64-macos ~x64-macos"
 PROPERTIES="live"
 
 RDEPEND="


### PR DESCRIPTION
<!-- Please put the pull request description above -->

* Sync keywords with llvm-core/clang in versions 18 and 19.
* Add version 20, without keywords.


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
