### PR TITLE
games-puzzle/pingus: gcc15 fix for 0.7.6-r5

### DIFF
--- a/games-puzzle/pingus/files/pingus-0.7.6-gcc15-fix.patch
+++ b/games-puzzle/pingus/files/pingus-0.7.6-gcc15-fix.patch
@@ -1,0 +1,23 @@
+From: OldManSeph7818 <sschaefering@gmail.com>
+Date: Wed, 29 Jan, 2025 12:21
+Subject: [PATCH] fix gcc-15 build
+
+--- a/src/engine/display/font.hpp
++++ b/src/engine/display/font.hpp
+
+@@ -22,2 +22,3 @@
+-#include "math/rect.hpp"
+-
++#include "math/rect.hpp"
++#include <cstdint>
++
+
+--- a/src/pingus/collision_map.hpp
++++ b/src/pingus/collision_map.hpp
+
+@@ -23,2 +23,3 @@
+-#include "pingus/groundtype.hpp"
+-
++#include "pingus/groundtype.hpp"
++#include <cstdint>
++

--- a/games-puzzle/pingus/pingus-0.7.6-r5.ebuild
+++ b/games-puzzle/pingus/pingus-0.7.6-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -36,6 +36,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-python3.patch
 	"${FILESDIR}"/${P}-gcc13.patch
 	"${FILESDIR}"/${P}-ar-detection.patch
+	"${FILESDIR}"/${P}-gcc15-fix.patch
 )
 
 src_compile() {


### PR DESCRIPTION
patch to build with gcc15/gnu23

Closes: https://bugs.gentoo.org/937559
Signed-off-by: OldManSeph7818 [sschaefering@gmail.com](mailto:sschaefering@gmail.com)


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
