### PR TITLE
sys-block/endpoint: update EAPI 7 -> 8, fix impl decl in configure

### DIFF
--- a/sys-block/endpoint/endpoint-0.1.0-r2.ebuild
+++ b/sys-block/endpoint/endpoint-0.1.0-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Endpoint turns a Linux machine with a firewire card into an SBP-2 device"
 HOMEPAGE="http://oss.oracle.com/projects/endpoint/"
@@ -21,6 +21,8 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-errormessages.patch
+	"${FILESDIR}"/${P}-impl-exit.patch
+	"${FILESDIR}"/${P}-ar.patch
 )
 
 src_install() {

--- a/sys-block/endpoint/files/endpoint-0.1.0-ar.patch
+++ b/sys-block/endpoint/files/endpoint-0.1.0-ar.patch
@@ -1,0 +1,32 @@
+Use toolchain ar instead of declaring it explicitly
+https://bugs.gentoo.org/725772
+--- a/libjconfig/Makefile.in
++++ b/libjconfig/Makefile.in
+@@ -163,7 +163,6 @@
+ Makefile: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.in  $(top_builddir)/config.status
+ 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)
+ 
+-AR = ar
+ 
+ clean-noinstLIBRARIES:
+ 	-test -z "$(noinst_LIBRARIES)" || rm -f $(noinst_LIBRARIES)
+--- a/librbc/Makefile.in
++++ b/librbc/Makefile.in
+@@ -169,7 +169,6 @@
+ Makefile: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.in  $(top_builddir)/config.status
+ 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)
+ 
+-AR = ar
+ 
+ clean-noinstLIBRARIES:
+ 	-test -z "$(noinst_LIBRARIES)" || rm -f $(noinst_LIBRARIES)
+--- a/libsbp2/Makefile.in
++++ b/libsbp2/Makefile.in
+@@ -185,7 +185,6 @@
+ Makefile: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.in  $(top_builddir)/config.status
+ 	cd $(top_builddir) && $(SHELL) ./config.status $(subdir)/$@ $(am__depfiles_maybe)
+ 
+-AR = ar
+ 
+ clean-noinstLIBRARIES:
+ 	-test -z "$(noinst_LIBRARIES)" || rm -f $(noinst_LIBRARIES)

--- a/sys-block/endpoint/files/endpoint-0.1.0-impl-exit.patch
+++ b/sys-block/endpoint/files/endpoint-0.1.0-impl-exit.patch
@@ -1,0 +1,12 @@
+https://bugs.gentoo.org/908584
+Add include with exit so test doesn't fail
+--- a/configure
++++ b/configure
+@@ -3291,6 +3291,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))


### PR DESCRIPTION
And also fix ar problem.
Autoreconf requires rewriting configure.ac and also clobbers over handwritten library version check. Patching configure is better in this case

Closes: https://bugs.gentoo.org/725772
Closes: https://bugs.gentoo.org/908584

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
