### PR TITLE
dev-debug/gdb[rocm]: limit dependencies for dev-libs/rocdbgapi

### DIFF
--- a/dev-debug/gdb/gdb-15.2-r101.ebuild
+++ b/dev-debug/gdb/gdb-15.2-r101.ebuild
@@ -98,7 +98,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 	guile? ( ${GUILE_DEPS} )
 	xml? ( dev-libs/expat )
-	rocm? ( dev-libs/rocdbgapi )
+	rocm? ( <dev-libs/rocdbgapi-6.3 )
 	source-highlight? (
 		dev-util/source-highlight
 	)

--- a/dev-debug/gdb/gdb-16.2.ebuild
+++ b/dev-debug/gdb/gdb-16.2.ebuild
@@ -102,7 +102,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 	guile? ( ${GUILE_DEPS} )
 	xml? ( dev-libs/expat )
-	rocm? ( dev-libs/rocdbgapi )
+	rocm? ( >=dev-libs/rocdbgapi-6.3 )
 	source-highlight? (
 		dev-util/source-highlight
 	)

--- a/dev-debug/gdb/gdb-9999.ebuild
+++ b/dev-debug/gdb/gdb-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -102,7 +102,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 	guile? ( ${GUILE_DEPS} )
 	xml? ( dev-libs/expat )
-	rocm? ( dev-libs/rocdbgapi )
+	rocm? ( >=dev-libs/rocdbgapi-6.3 )
 	source-highlight? (
 		dev-util/source-highlight
 	)

--- a/dev-libs/rocdbgapi/rocdbgapi-5.7.1.ebuild
+++ b/dev-libs/rocdbgapi/rocdbgapi-5.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,6 +16,7 @@ SLOT="0/$(ver_cut 1-2)"
 IUSE="doc"
 
 BDEPEND="
+	dev-build/cmake
 	doc? (
 		app-text/doxygen[dot]
 		virtual/latex-base
@@ -26,6 +27,7 @@ BDEPEND="
 RDEPEND="
 	dev-libs/rocm-comgr:${SLOT}
 	dev-libs/rocr-runtime:${SLOT}
+	sys-apps/hwdata
 "
 DEPEND="${RDEPEND}"
 

--- a/dev-libs/rocdbgapi/rocdbgapi-6.1.1.ebuild
+++ b/dev-libs/rocdbgapi/rocdbgapi-6.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,6 +17,7 @@ KEYWORDS="~amd64"
 IUSE="doc"
 
 BDEPEND="
+	dev-build/cmake
 	doc? (
 		app-text/doxygen[dot]
 		virtual/latex-base
@@ -27,6 +28,7 @@ BDEPEND="
 RDEPEND="
 	dev-libs/rocm-comgr:${SLOT}
 	dev-libs/rocr-runtime:${SLOT}
+	sys-apps/hwdata
 "
 DEPEND="${RDEPEND}"
 

--- a/dev-libs/rocdbgapi/rocdbgapi-6.3.0.ebuild
+++ b/dev-libs/rocdbgapi/rocdbgapi-6.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,6 +17,7 @@ KEYWORDS="~amd64"
 IUSE="doc"
 
 BDEPEND="
+	dev-build/cmake
 	doc? (
 		app-text/doxygen[dot]
 		virtual/latex-base
@@ -27,6 +28,7 @@ BDEPEND="
 RDEPEND="
 	dev-libs/rocm-comgr:${SLOT}
 	dev-libs/rocr-runtime:${SLOT}
+	sys-apps/hwdata
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
`gdb-15.2` fails to compile with `>=rocdbgapi-6.3` due to API change.

`gdb-16.1` and `gdb-9999` fail to compile with `<=rocdbgapi-6.3` (e. g. `rocdbgapi-6.1.1`)  due to `amd-dbgapi >= 0.75.0` requirement.

This change includes unmasking of  
```
>=dev-libs/rocdbgapi-6.3.0
>=dev-libs/rocm-comgr-6.3.0
>=dev-libs/rocr-runtime-6.3.0
>=dev-libs/rocm-device-libs-6.3.0
>=dev-libs/roct-thunk-interface-6.3.0
>=dev-util/hipcc-6.3.0
```
, otherwise fails with `NonsolvableDepsInDev`.

Also few missing dependencies added to `dev-libs/rocdbgapi` (required on clean system).

All changes are just compilation fixes, so no revision bumps.

Closes: https://bugs.gentoo.org/948372

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
