### PR TITLE
games-emulation/snes9x: gcc15 fix for 1.62.3

### DIFF
--- a/games-emulation/snes9x/files/snes9x-1.62.3-gcc15-fix.patch
+++ b/games-emulation/snes9x/files/snes9x-1.62.3-gcc15-fix.patch
@@ -1,0 +1,14 @@
+From: OldManSeph7818 <sschaefering@gmail.com>
+Date: Wed, 29 Jan, 2025 13:58
+Subject: [PATCH] fix gcc-15 build
+
+--- a/external/glslang/SPIRV/SpvBuilder.h
++++ b/external/glslang/SPIRV/SpvBuilder.h
+
+@@ -63,2 +63,3 @@
+-#include <stack>
+-#include <unordered_map>
++#include <stack>
++#include <cstdint>
++#include <unordered_map>
+

--- a/games-emulation/snes9x/snes9x-1.62.3.ebuild
+++ b/games-emulation/snes9x/snes9x-1.62.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit autotools cmake flag-o-matic python-any-r1 toolchain-funcs xdg
 
 # TODO: try unbundling, albeit compatibility with (and between) these
@@ -69,6 +69,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.62.1-flags.patch
 	"${FILESDIR}"/${PN}-1.62.1-gcc13.patch
 	"${FILESDIR}"/${PN}-1.62.1-optional-wayland.patch
+	"${FILESDIR}"/${PN}-1.62.1-gcc15.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
patch for gcc15/gnu23
add python3_13 to python compat range

Signed-off-by: OldManSeph7818 "sschaefering@gmail.com"

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
