### PR TITLE
net-wireless/broadcom-sta: Handle new name of header file in kernels …

### DIFF
--- a/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r8.ebuild
+++ b/net-wireless/broadcom-sta/broadcom-sta-6.30.223.271-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -39,6 +39,9 @@ PATCHES=(
 	"${FILESDIR}/014-linux414.patch"
 	"${FILESDIR}/015-linux600.patch"
 	"${FILESDIR}/016-linux601.patch"
+	"${FILESDIR}/017-handle-new-header-name-6.12.patch"
+	"${FILESDIR}/018-broadcom-wl-fix-linux-6.13.patch"
+	"${FILESDIR}/019-broadcom-wl-fix-linux-6.14.patch"
 )
 
 pkg_pretend() {
@@ -62,6 +65,7 @@ pkg_setup() {
 	# b43 via udev rules. Moreover, previous fix broke binpkgs support.
 	CONFIG_CHECK="~!B43 ~!BCMA ~!SSB ~!X86_INTEL_LPSS"
 	CONFIG_CHECK2="LIB80211 ~!MAC80211 ~LIB80211_CRYPT_TKIP"
+	CONFIG_CHECK3="~!MAC80211"
 	ERROR_B43="B43: If you insist on building this, you must blacklist it!"
 	ERROR_BCMA="BCMA: If you insist on building this, you must blacklist it!"
 	ERROR_SSB="SSB: If you insist on building this, you must blacklist it!"
@@ -70,7 +74,9 @@ pkg_setup() {
 	ERROR_PREEMPT_RCU="PREEMPT_RCU: Please do not set the Preemption Model to \"Preemptible Kernel\"; choose something else."
 	ERROR_LIB80211_CRYPT_TKIP="LIB80211_CRYPT_TKIP: You will need this for WPA."
 	ERROR_X86_INTEL_LPSS="X86_INTEL_LPSS: Please disable it. The module does not work with it enabled."
-	if kernel_is ge 3 8 8; then
+	if kernel_is ge 6 1 127; then
+		CONFIG_CHECK="${CONFIG_CHECK} ${CONFIG_CHECK3} CFG80211 ~!PREEMPT_RCU ~!PREEMPT"
+	elif kernel_is ge 3 8 8; then
 		CONFIG_CHECK="${CONFIG_CHECK} ${CONFIG_CHECK2} CFG80211 ~!PREEMPT_RCU ~!PREEMPT"
 	elif kernel_is ge 2 6 32; then
 		CONFIG_CHECK="${CONFIG_CHECK} ${CONFIG_CHECK2} CFG80211"

--- a/net-wireless/broadcom-sta/files/001-null-pointer-fix.patch
+++ b/net-wireless/broadcom-sta/files/001-null-pointer-fix.patch
@@ -4,12 +4,6 @@ Origin: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773713
 Bug-Ubuntu: https://launchpad.net/bugs/1415880
 Last-Update: 2015-08-18
 
----
- src/wl/sys/wl_linux.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
-index 860b935..295156f 100644
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c
 @@ -2157,8 +2157,8 @@ wl_start(struct sk_buff *skb, struct net_device *dev)
@@ -25,8 +19,8 @@ index 860b935..295156f 100644
 -- 
 1.9.1
 
---- a/src/wl/sys/wl_linux.a	2023-04-16 23:06:52.255588442 -0500
-+++ b/src/wl/sys/wl_linux.c	2023-04-16 23:07:22.315309655 -0500
+--- a/src/wl/sys/wl_linux.a
++++ b/src/wl/sys/wl_linux.c
 @@ -737,9 +737,6 @@
  		dev->name, device,
  		WL_ALL_PASSIVE_ENAB(wl) ?  ", Passive Mode" : "", EPI_VERSION_STR);

--- a/net-wireless/broadcom-sta/files/002-rdtscl.patch
+++ b/net-wireless/broadcom-sta/files/002-rdtscl.patch
@@ -5,9 +5,8 @@ new function. References:
 https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=fe47ae6e1a5005b2e82f7eab57b5c3820453293a
 https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=4ea1636b04dbd66536fa387bae2eea463efc705b
 
-diff -ru a/src/shared/linux_osl.c b/src/shared/linux_osl.c
---- a/src/shared/linux_osl.c	2015-09-19 01:47:15.000000000 +0300
-+++ b/src/shared/linux_osl.c	2015-11-21 15:20:30.585902518 +0200
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
 @@ -932,7 +932,11 @@
  	uint cycles;
  

--- a/net-wireless/broadcom-sta/files/003-linux47.patch
+++ b/net-wireless/broadcom-sta/files/003-linux47.patch
@@ -9,8 +9,8 @@ This patch refactors the references of IEEE80211_BAND_* to NL80211_BAND_*
 Reference:
 https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=57fbcce37be7c1d2622b56587c10ade00e96afa3
 
---- a/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:57:36.159340297 -0500
-+++ b/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:58:18.442323435 -0500
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -236,7 +236,7 @@
  #endif				
  

--- a/net-wireless/broadcom-sta/files/004-linux48.patch
+++ b/net-wireless/broadcom-sta/files/004-linux48.patch
@@ -4,12 +4,6 @@ Date: Fri, 2 Sep 2016 17:35:34 +0200
 Subject: [PATCH 1/1] Add support for Linux 4.8
 
 Orginal author: Krzysztof Kolasa
----
- src/wl/sys/wl_cfg80211_hybrid.c | 22 ++++++++++++++++++++++
- 1 file changed, 22 insertions(+)
-
-diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
-index 2fc71fe..ec5e472 100644
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -2388,8 +2388,16 @@ wl_bss_connect_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,

--- a/net-wireless/broadcom-sta/files/006-linux411.patch
+++ b/net-wireless/broadcom-sta/files/006-linux411.patch
@@ -1,4 +1,3 @@
-diff -u sys0/wl_cfg80211_hybrid.c sys/wl_cfg80211_hybrid.c
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -39,6 +39,10 @@
@@ -12,7 +11,6 @@ diff -u sys0/wl_cfg80211_hybrid.c sys/wl_cfg80211_hybrid.c
  #define EVENT_TYPE(e) dtoh32((e)->event_type)
  #define EVENT_FLAGS(e) dtoh16((e)->flags)
  #define EVENT_STATUS(e) dtoh32((e)->status)
-diff -u sys0/wl_linux.c sys/wl_linux.c
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c
 @@ -2915,7 +2915,9 @@

--- a/net-wireless/broadcom-sta/files/007-linux412.patch
+++ b/net-wireless/broadcom-sta/files/007-linux412.patch
@@ -5,12 +5,6 @@ Subject: [PATCH] Apply patch from Debian bug #867258
 
 Compile fix with kernel 4.12
 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867258
----
- src/wl/sys/wl_cfg80211_hybrid.c | 29 +++++++++++++++++++++++++----
- 1 file changed, 25 insertions(+), 4 deletions(-)
-
-diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
-index c46944a..1a9840a 100644
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -53,7 +53,11 @@ u32 wl_dbg_level = WL_DBG_ERR;

--- a/net-wireless/broadcom-sta/files/008-linux415.patch
+++ b/net-wireless/broadcom-sta/files/008-linux415.patch
@@ -1,5 +1,5 @@
---- a/src/wl/sys/wl_linux.c	2017-07-17 00:11:24.000000000 +0100
-+++ b/src/wl/sys/wl_linux.c	2018-01-27 09:49:47.057799596 +0000
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
 @@ -93,7 +93,11 @@
  
  #include <wlc_wowl.h>

--- a/net-wireless/broadcom-sta/files/009-fix_mac_profile_discrepancy.patch
+++ b/net-wireless/broadcom-sta/files/009-fix_mac_profile_discrepancy.patch
@@ -1,5 +1,5 @@
---- a/src/wl/sys/wl_cfg80211_hybrid.c	2015-09-19 00:47:30.000000000 +0200
-+++ b/src/wl/sys/wl_cfg80211_hybrid.c	2018-11-14 14:06:03.313487995 +0100
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -1444,11 +1444,10 @@
  	s32 rate;
  	s32 err = 0;

--- a/net-wireless/broadcom-sta/files/010-linux56.patch
+++ b/net-wireless/broadcom-sta/files/010-linux56.patch
@@ -1,5 +1,3 @@
-diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
-index 6157d18..8237ec7 100644
 --- a/src/shared/linux_osl.c
 +++ b/src/shared/linux_osl.c
 @@ -942,7 +942,7 @@ osl_getcycles(void)
@@ -11,8 +9,6 @@ index 6157d18..8237ec7 100644
  }
  
  void
-diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
-index 0d05100..2ed1f0d 100644
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c
 @@ -582,7 +582,7 @@ wl_attach(uint16 vendor, uint16 device, ulong regs,

--- a/net-wireless/broadcom-sta/files/011-linux59.patch
+++ b/net-wireless/broadcom-sta/files/011-linux59.patch
@@ -15,16 +15,6 @@ See also: https://lwn.net/Articles/722267/
           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5e6e9852d6f76e01b2e6803c74258afa5b432bc5
 
 Signed-off-by: Joan Bruguera <joanbrugueram@gmail.com>
----
- src/wl/sys/wl_cfg80211_hybrid.c | 25 ++-------------------
- src/wl/sys/wl_iw.c              | 25 ++-------------------
- src/wl/sys/wl_linux.c           | 40 ++++++++++++++++++++++++++++-----
- src/wl/sys/wl_linux.h           |  2 ++
- src/wl/sys/wlc_pub.h            |  1 +
- 5 files changed, 42 insertions(+), 51 deletions(-)
-
-diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
-index 7b606e0..1e0adb7 100644
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -38,6 +38,7 @@
@@ -67,8 +57,6 @@ index 7b606e0..1e0adb7 100644
  }
  
  static s32
-diff --git a/src/wl/sys/wl_iw.c b/src/wl/sys/wl_iw.c
-index c4c610b..e346b15 100644
 --- a/src/wl/sys/wl_iw.c
 +++ b/src/wl/sys/wl_iw.c
 @@ -37,6 +37,7 @@ typedef const struct si_pub	si_t;
@@ -110,8 +98,6 @@ index c4c610b..e346b15 100644
  }
  
  static int
-diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
-index 947cef3..f04c148 100644
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c
 @@ -1643,10 +1643,7 @@ wl_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
@@ -175,8 +161,6 @@ index 947cef3..f04c148 100644
  static struct net_device_stats*
  wl_get_stats(struct net_device *dev)
  {
-diff --git a/src/wl/sys/wl_linux.h b/src/wl/sys/wl_linux.h
-index 5b1048e..c8c1f41 100644
 --- a/src/wl/sys/wl_linux.h
 +++ b/src/wl/sys/wl_linux.h
 @@ -22,6 +22,7 @@
@@ -195,8 +179,6 @@ index 5b1048e..c8c1f41 100644
  extern struct net_device * wl_netdev_get(wl_info_t *wl);
  
  #endif 
-diff --git a/src/wl/sys/wlc_pub.h b/src/wl/sys/wlc_pub.h
-index 53a98b8..2b5a029 100644
 --- a/src/wl/sys/wlc_pub.h
 +++ b/src/wl/sys/wlc_pub.h
 @@ -24,6 +24,7 @@

--- a/net-wireless/broadcom-sta/files/012-linux517.patch
+++ b/net-wireless/broadcom-sta/files/012-linux517.patch
@@ -16,12 +16,6 @@ Applies on top of all the patches applied to broadcom-wl-dkms 6.30.223.271-28 on
 
 See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=adeef3e32146a8d2a73c399dc6f5d76a449131b1
           https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=359745d78351c6f5442435f81549f0207ece28aa
----
- src/wl/sys/wl_linux.c | 16 +++++++++++++---
- 1 file changed, 13 insertions(+), 3 deletions(-)
-
-diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
-index e491df7..e4614fb 100644
 --- a/src/wl/sys/wl_linux.c
 +++ b/src/wl/sys/wl_linux.c
 @@ -93,6 +93,10 @@ struct iw_statistics *wl_get_wireless_stats(struct net_device *dev);

--- a/net-wireless/broadcom-sta/files/013-linux518.patch
+++ b/net-wireless/broadcom-sta/files/013-linux518.patch
@@ -1,6 +1,5 @@
-diff -u -r a/src/shared/linux_osl.c b/src/shared/linux_osl.c
---- a/src/shared/linux_osl.c	2022-05-24 20:51:15.662604980 +0000
-+++ b/src/shared/linux_osl.c	2022-05-24 21:13:38.264472425 +0000
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
 @@ -599,6 +599,8 @@
  	va = kmalloc(size, GFP_ATOMIC | __GFP_ZERO);
  	if (va)

--- a/net-wireless/broadcom-sta/files/014-linux414.patch
+++ b/net-wireless/broadcom-sta/files/014-linux414.patch
@@ -4,12 +4,6 @@ Subject: linux414
 Origin: https://bugs.debian.org/885885
 
 linux 4.14 changed the kernel_read function prototype.
----
- src/shared/linux_osl.c | 12 +++++++++++-
- 1 files changed, 12 insertions(+), 1 deletion(-)
-
-diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
-index 9adc392..b24a973 100644
 --- a/src/shared/linux_osl.c
 +++ b/src/shared/linux_osl.c
 @@ -1076,11 +1076,21 @@ osl_os_get_image_block(char *buf, int len, void *image)

--- a/net-wireless/broadcom-sta/files/015-linux600.patch
+++ b/net-wireless/broadcom-sta/files/015-linux600.patch
@@ -9,12 +9,6 @@ See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/com
 
 Original patch by Joan Bruguera:
 https://gist.github.com/joanbm/207210d74637870c01ef5a3c262a597d
----
- src/wl/sys/wl_cfg80211_hybrid.c | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
-index 5e9e6d3..5ec35c5 100644
 --- a/src/wl/sys/wl_cfg80211_hybrid.c
 +++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -2412,7 +2412,11 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,

--- a/net-wireless/broadcom-sta/files/016-linux601.patch
+++ b/net-wireless/broadcom-sta/files/016-linux601.patch
@@ -1,6 +1,5 @@
-diff -Nurp -u -r a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
---- a/src/wl/sys/wl_cfg80211_hybrid.c	2022-12-12 00:23:30.821615599 +0000
-+++ b/src/wl/sys/wl_cfg80211_hybrid.c	2022-12-12 00:35:47.854975024 +0000
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
 @@ -105,14 +105,28 @@ static s32 wl_cfg80211_get_tx_power(stru
  static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm);
  #endif

--- a/net-wireless/broadcom-sta/files/017-handle-new-header-name-6.12.patch
+++ b/net-wireless/broadcom-sta/files/017-handle-new-header-name-6.12.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/947928
+
+Adds support for the new name of the asm/unaligned.h header file for kernels >=6.12.0 (header file was renamed to "linux/unaligned.h")
+Bug found by Sam Petch 
+Patch by Sam Petch
+
+TESTING DETAILS:
+
+Bugfix tested by Sam Petch on kernels: gentoo-sources:6.6.67, gentoo-sources:6.12.4-r1, gentoo-sources:6.12.9
+
+Patch tested on kernels: gentoo-sources:6.6.67, gentoo-sources:6.12.9
+
+Bugfix and patch tested on device: 2012 Macbook Pro (A1278) running Gentoo Linux with Gnome Desktop / OpenRC profile
+
+Chipset: BCM4331 (Broadcom)
+
+Contact: sam.petch.recall824@passinbox.com
+
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -56,7 +56,12 @@
+ #include <asm/irq.h>
+ #include <asm/pgtable.h>
+ #include <asm/uaccess.h>
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++#include <linux/unaligned.h>
++#else
+ #include <asm/unaligned.h>
++#endif
+ 
+ #include <proto/802.1d.h>
+ 

--- a/net-wireless/broadcom-sta/files/018-broadcom-wl-fix-linux-6.13.patch
+++ b/net-wireless/broadcom-sta/files/018-broadcom-wl-fix-linux-6.13.patch
@@ -1,0 +1,27 @@
+From  https://gist.github.com/joanbm/72189c81ff67b39d36a660cf00483ccb
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sat, 12 Oct 2024 11:54:40 +0000
+Subject: [PATCH] Tentative patch for broadcom-wl 6.30.223.271 driver for Linux
+ 6.13-rc1
+
+The net/lib80211.h header has been removed by commit
+"wifi: ipw2x00/lib80211: move remaining lib80211 into libipw"
+(Johannes Berg, 7 Oct 2024).
+The header does not appear to be actually used anywhere, so remove it.
+
+ #include <asm/irq.h>
+ #include <asm/pgtable.h>
+--- a/src/include/linuxver.h
++++ b/src/include/linuxver.h
+@@ -147,7 +147,7 @@ typedef irqreturn_t(*FN_ISR) (int irq, void *dev_id, struct pt_regs *ptregs);
+ #include <linux/sched.h>
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ #include <net/lib80211.h>
+ #endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+-- 
+2.47.0
+

--- a/net-wireless/broadcom-sta/files/019-broadcom-wl-fix-linux-6.14.patch
+++ b/net-wireless/broadcom-sta/files/019-broadcom-wl-fix-linux-6.14.patch
@@ -1,0 +1,40 @@
+From https://gist.github.com/joanbm/b711bafdcb065d57364a701061b902a3
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sun, 8 Dec 2024 17:57:43 +0000
+Subject: [PATCH] Tentative fix for broadcom-wl 6.30.223.271 driver for Linux
+ 6.14-rc1
+
+Related to the new parameter for get_tx_power introduced in
+"wifi: cfg80211: send MLO links tx power info in GET_INTERFACE"
+(Rameshkumar Sundaram, 25 Nov 2024).
+
+As the driver doesn't support Multi-Link, we just ignore it afterwards.
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -99,7 +99,10 @@ static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy,
+            enum tx_power_setting type, s32 dbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    unsigned int link_id, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm);
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm);
+@@ -1152,7 +1155,10 @@ wl_cfg80211_set_tx_power(struct wiphy *wiphy, enum tx_power_setting type, s32 db
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    unsigned int link_id, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm)
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm)
+-- 
+2.48.1
+


### PR DESCRIPTION
…>=6.12.0 (asm/unaligned.h ---> linux/unaligned.h)

Bug: https://bugs.gentoo.org/947928

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
