### PR TITLE
net-misc/nx: fix compilation with gcc14 for 32bit systems

### DIFF
--- a/net-misc/nx/files/nx-3.5.99.26-gcc14-32bit.patch
+++ b/net-misc/nx/files/nx-3.5.99.26-gcc14-32bit.patch
@@ -1,0 +1,51 @@
+Bugs: https://bugs.gentoo.org/927780
+https://github.com/ArcticaProject/nx-libs/pull/1087
+
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date: Wed, 15 Jan 2025 22:03:00 +0000
+Subject: [PATCH] dix: Fix a warning about GetTimeInMillis return value in
+ XFont2.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ported over from XOrg Server:
+
+    commit e1ccd0fa0e1081edf8a2c69ce6e8e3f67a4aecba
+    Author: Emma Anholt <emma@anholt.net>
+    Date:   Mon May 7 16:46:15 2018 -0700
+
+        dix: Fix a warning about GetTimeInMillis return value in XFont2.
+
+        Signed-off-by: Eric Anholt <eric@anholt.net>
+        Reviewed-by: Adam Jackson <ajax@redhat.com>
+
+This resolves the following issue when built with GCC-14 (and beyond):
+
+    ../../dix/dixfonts.c: At top level:
+    ../../dix/dixfonts.c:2485:27: error: initialization of âuint32_t (*)(void)â {aka âunsigned int (*)(void)â} from incompatible pointer type âCARD32 (*)(void)â {aka âlong unsigned int (*)(void)â} [-Wincompatible-pointer-types]
+     2485 |     .get_time_in_millis = GetTimeInMillis,
+          |
+--- a/nx-X11/programs/Xserver/dix/dixfonts.c
++++ b/nx-X11/programs/Xserver/dix/dixfonts.c
+@@ -2471,6 +2471,11 @@ remove_fs_handlers(FontPathElementPtr fpe, BlockHandlerProcPtr block_handler, Bo
+     RemoveFontWakeup(fpe);
+ }
+ 
++static uint32_t wrap_time_in_millis(void)
++{
++    return GetTimeInMillis();
++}
++
+ #ifdef HAS_XFONT2
+ static const xfont2_client_funcs_rec xfont2_client_funcs = {
+     .version = XFONT2_CLIENT_FUNCS_VERSION,
+@@ -2482,7 +2487,7 @@ static const xfont2_client_funcs_rec xfont2_client_funcs = {
+     .get_client_resolutions = get_client_resolutions,
+     .get_default_point_size = get_default_point_size,
+     .get_new_font_client_id = get_new_font_client_id,
+-    .get_time_in_millis = GetTimeInMillis,
++    .get_time_in_millis = wrap_time_in_millis,
+     .init_fs_handlers = _init_fs_handlers,
+     .register_fpe_funcs = register_fpe_funcs,
+     .remove_fs_handlers = _remove_fs_handlers,

--- a/net-misc/nx/nx-3.5.99.26.ebuild
+++ b/net-misc/nx/nx-3.5.99.26.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -50,6 +50,8 @@ PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.26-riscv64-support.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-musl.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-which.patch"
+	# https://github.com/ArticaProject/nx-libs/pull/1087
+	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
 )
 
 src_prepare() {

--- a/net-misc/nx/nx-3.5.99.27.ebuild
+++ b/net-misc/nx/nx-3.5.99.27.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -43,6 +43,8 @@ S="${WORKDIR}/nx-libs-${PV}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.26-musl.patch"
+	# https://github.com/ArcticaProject/nx-libs/pull/1087
+	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
 	"${FILESDIR}/${PN}-3.5.99.27-which.patch"
 )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927780
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

Patch available from upstream: https://github.com/ArcticaProject/nx-libs/pull/1087
Backport from XOrg: https://gitlab.freedesktop.org/xorg/xserver/-/commit/e1ccd0fa0e1081edf8a2c69ce6e8e3f67a4aecba

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
