### PR TITLE
app-i18n/xvnkb: Add meson build manifest instead of bash

### DIFF
--- a/app-i18n/xvnkb/files/config.h.in
+++ b/app-i18n/xvnkb/files/config.h.in
@@ -1,0 +1,5 @@
+#define VERSION "@version@"
+#mesondefine VK_USE_ABCSTROKE
+#mesondefine VK_USE_PROSTROKE
+#mesondefine VK_USE_EXTSTROKE
+#mesondefine VK_CHECK_SPELLING

--- a/app-i18n/xvnkb/files/meson.build
+++ b/app-i18n/xvnkb/files/meson.build
@@ -1,0 +1,72 @@
+project('xvnkb', 'c', version: '0.2.11', meson_version: '>=1.4.0')
+
+add_project_arguments('-DVK_NEED_UCHAR', language: 'c')
+
+conf_data = configuration_data()
+conf_data.set('version', meson.project_version())
+conf_data.set('VK_USE_ABCSTROKE', get_option('abcstroke'))
+conf_data.set('VK_USE_EXTSTROKE', get_option('extstroke'))
+conf_data.set('VK_USE_PROSTROKE', get_option('prostroke'))
+conf_data.set('VK_CHECK_SPELLING', get_option('spellcheck'))
+
+configure_file(
+    output: 'config.h',
+    input: 'config.h.in',
+    configuration: conf_data,
+)
+
+dl_dep = dependency('dl')
+xlib_dep = dependency('X11')
+
+xft_dep = dependency('xft', required: get_option('xft'))
+if get_option('xft').enabled()
+    add_project_arguments('-DUSE_XFT', language: 'c')
+endif
+
+deps = [dl_dep, xlib_dep, xft_dep]
+
+core_src = ['xvnkb.c', 'visckey.c']
+core = library(
+    'xvnkb',
+    core_src,
+    name_prefix: '',
+    soversion: meson.project_version(),
+    dependencies: deps,
+    install: true,
+)
+
+src = [
+    'data.c',
+    'flash.c',
+    'main.c',
+    'event.c',
+    'mainwin.c',
+    'menu.c',
+    'hotkey.c',
+    'systray.c',
+    'mode.c',
+    'property.c',
+    'session.c',
+    'xconfig.c',
+    'xresource.c',
+    'label.c',
+    'button.c',
+    'msgbox.c',
+]
+executable('xvnkb', src, dependencies: deps, link_with: core, install: true)
+
+ctrl_src = [
+    'tools/xvnkb_ctrl.c',
+    'tools/data.c',
+    'tools/mode.c',
+    'tools/property.c',
+    'tools/xconfig.c',
+]
+executable(
+    'xvnkb_ctlr',
+    ctrl_src,
+    dependencies: deps,
+    link_with: core,
+    install: true,
+)
+

--- a/app-i18n/xvnkb/files/meson.options
+++ b/app-i18n/xvnkb/files/meson.options
@@ -1,0 +1,20 @@
+option(
+    'abcstroke',
+    type: 'boolean',
+    value: false,
+    description: 'Enable ABC liked Telex keystroke',
+)
+option(
+    'extstroke',
+    type: 'boolean',
+    value: true,
+    description: 'Enable extended keystroke',
+)
+option(
+    'prostroke',
+    type: 'boolean',
+    value: false,
+    description: 'Enable programmer keystroke',
+)
+option('spellcheck', type: 'boolean', value: true, description: 'Spelling check')
+option('xft', type: 'feature', value: 'enabled', description: 'X freetype')

--- a/app-i18n/xvnkb/xvnkb-0.2.11-r1.ebuild
+++ b/app-i18n/xvnkb/xvnkb-0.2.11-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit flag-o-matic meson
+
+DESCRIPTION="Vietnamese input keyboard for X"
+HOMEPAGE="https://xvnkb.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="spell xft"
+
+RDEPEND="x11-libs/libX11:=
+	xft? ( x11-libs/libXft:= )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+BDEPEND="xft? ( virtual/pkgconfig )"
+
+src_prepare() {
+	default
+	cp "${FILESDIR}"/meson.build . ||die "Unable to move build system"
+	cp "${FILESDIR}"/meson.options . ||die "Unable to move build system"
+	cp "${FILESDIR}"/config.h.in . ||die "Unable to move build system"
+}
+
+src_configure() {
+	append-cflags -std=gnu17
+
+	local emesonargs=(
+		$(meson_use spell spellcheck)
+		$(meson_feature xft)
+		-Dextstroke=true
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	einstalldocs
+	dodoc -r doc/. scripts contrib
+}
+
+pkg_postinst() {
+	elog "Remember to"
+	elog "$ export LANG=en_US.UTF-8"
+	elog "(or any other UTF-8 locale) and"
+	elog "$ export LD_PRELOAD=/usr/$(get_libdir)/${PN}.so"
+	elog "before starting X Window"
+	elog "More documents are in ${EROOT}/usr/share/doc/${PF}"
+
+	ewarn "Programs with suid/sgid will have LD_PRELOAD cleared"
+	ewarn "You have to unset suid/sgid to use with ${PN}"
+}

--- a/app-i18n/xvnkb/xvnkb-0.2.11.ebuild
+++ b/app-i18n/xvnkb/xvnkb-0.2.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -7,7 +7,7 @@ inherit toolchain-funcs
 
 DESCRIPTION="Vietnamese input keyboard for X"
 HOMEPAGE="https://xvnkb.sourceforge.net/"
-SRC_URI="https://${PN}.sourceforge.net/${P}.tar.bz2"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"
 SLOT="0"


### PR DESCRIPTION
We are better tree-cleaning this, of course. But I learned some Meson while making this fix, so some utility was gained by this work.

First patch is minimum maintenance - fix SRC_URI due to sourceforge's url movement.
Second patch makes a revision with meson as build system, and puts meson files into files dir.
    
Bug: https://bugs.gentoo.org/879631
Bug: https://bugs.gentoo.org/926090
Bug: https://bugs.gentoo.org/900398

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
