### PR TITLE
app-crypt/mit-krb5-appl: port to C99, pin to C17, mask on musl

### DIFF
--- a/app-crypt/mit-krb5-appl/files/mit-krb5-appl-c99.patch
+++ b/app-crypt/mit-krb5-appl/files/mit-krb5-appl-c99.patch
@@ -1,0 +1,71 @@
+Port to C99/ up to C17: declare all implicit ints explicitly
+https://bugs.gentoo.org/878615
+--- a/gssftp/ftp/cmds.c
++++ b/gssftp/ftp/cmds.c
+@@ -312,8 +312,7 @@
+ /*
+  * Set control channel protection level.
+  */
+-void setclevel(argc, argv)
+-	char *argv[];
++void setclevel(int argc, char *argv[])
+ {
+ 	register struct levels *p;
+ 	int comret;
+@@ -365,8 +364,7 @@
+  * Set data channel protection level.
+  */
+ void
+-setdlevel(argc, argv)
+-	char *argv[];
++setdlevel(int argc, char *argv[])
+ {
+ 	register struct levels *p;
+ 	int comret;
+@@ -845,10 +843,7 @@
+ /*
+  * Receive one file.
+  */
+-static int getit(argc, argv, restartit, rmode)
+-	int argc;
+-	char *argv[];
+-	char *rmode;
++static int getit(int argc, char *argv[], int restartit, char *rmode)
+ {
+ 	int loc = 0;
+ 	char *oldargv1, *oldargv2;
+@@ -1164,8 +1159,7 @@
+  * Show status.
+  */
+ /*ARGSUSED*/
+-void status(argc, argv)
+-	char *argv[];
++void status(int argc, char *argv[])
+ {
+ 	int i;
+ 
+--- a/telnet/telnet/commands.c
++++ b/telnet/telnet/commands.c
+@@ -1890,8 +1890,7 @@
+ }
+ 
+ 	unsigned char *
+-env_default(init, welldefined)
+-	int init;
++env_default(int init, int welldefined)
+ {
+ 	static struct env_lst *nep = NULL;
+ 
+--- a/telnet/telnet/sys_bsd.c
++++ b/telnet/telnet/sys_bsd.c
+@@ -976,8 +976,8 @@
+  */
+ 
+     int
+-process_rings(netin, netout, netex, ttyin, ttyout, poll)
+-    int poll;		/* If 0, then block until something to do */
++process_rings(int netin, int netout, int netex, int ttyin,
++	int ttyout, int poll)		/* If 0, then block until something to do */
+ {
+     register int c;
+ 		/* One wants to be a bit careful about setting returnValue

--- a/app-crypt/mit-krb5-appl/mit-krb5-appl-1.0.3-r5.ebuild
+++ b/app-crypt/mit-krb5-appl/mit-krb5-appl-1.0.3-r5.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+MY_P=${P/mit-}
+MAJOR_MINOR="$(ver_cut 1-2)"
+DESCRIPTION="Kerberized applications split from the main MIT Kerberos V distribution"
+HOMEPAGE="https://web.mit.edu/kerberos/www/"
+SRC_URI="https://web.mit.edu/kerberos/dist/krb5-appl/${MAJOR_MINOR}/${MY_P}-signed.tar"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="openafs-krb5-a BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+
+BDEPEND="virtual/pkgconfig"
+RDEPEND=">=app-crypt/mit-krb5-1.8.0
+	sys-fs/e2fsprogs
+	sys-libs/ncurses:=
+	virtual/libcrypt:="
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-tinfo.patch"
+	"${FILESDIR}/${PN}-sig_t.patch"
+	"${FILESDIR}/${PN}-autoconf-2.72.patch"
+	"${FILESDIR}/${PN}-c99.patch"
+)
+
+src_unpack() {
+	unpack ${A}
+	unpack ./"${MY_P}".tar.gz
+}
+
+src_prepare() {
+	default
+
+	sed -i -e "s/-lncurses/$($(tc-getPKG_CONFIG) --libs ncurses)/" configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags "-I/usr/include/et"
+	append-cppflags -fno-strict-aliasing
+	append-cppflags -fno-strict-overflow
+	# bug https://bugs.gentoo.org/946064 and others
+	append-cflags -std=gnu17
+
+	econf
+}
+
+src_install() {
+	emake DESTDIR="${ED}" install
+	for i in {telnetd,ftpd} ; do
+		mv "${ED}"/usr/share/man/man8/${i}.8 "${ED}"/usr/share/man/man8/k${i}.8 \
+			|| die "mv failed (man)"
+		mv "${ED}"/usr/sbin/${i} "${ED}"/usr/sbin/k${i} || die "mv failed"
+	done
+
+	for i in {rcp,rlogin,rsh,telnet,ftp} ; do
+		mv "${ED}"/usr/share/man/man1/${i}.1 "${ED}"/usr/share/man/man1/k${i}.1 \
+			|| die "mv failed (man)"
+		mv "${ED}"/usr/bin/${i} "${ED}"/usr/bin/k${i} || die "mv failed"
+	done
+
+	rm "${ED}"/usr/share/man/man1/tmac.doc || die
+	dodoc README
+}

--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# NHOrus <jy6x2b32pie9@yahoo.com> (2025-02-01)
+# not ported to musl, bug #713434
+app-crypt/mit-krb5-appl
+
 # Arthur Zamarin <arthurzam@gentoo.org> (2025-01-25)
 # depends on vscode/vscodium, which are glibc binary package
 kde-misc/krunner-vscodeprojects


### PR DESCRIPTION
Porting to C23 demands patching many, many function pointers with variable being declared as `(int*)()` and function pointer being of types either `(int*)()` or `(int*)(int, char**)`. Modifying that most likely to introduce subtle bugs in ftp client and possibly other places.
Also, many of `extern function()` declarations are repeated, often re-defining either previous `extern function(args)` declarations or library functions
Porting to C99 and to C17 required adding implied ints in K&R function definitions, and changing them to ANSI function definitions. Possibility of mistake is rather low in this case.

Don't know how to prevent dealing with functions not implemented in musl, masking felt like best solution. Upstream is kinda dead for this package, and unlikely to get any new patches.

Bug: https://bugs.gentoo.org/713434
Bug: https://bugs.gentoo.org/878615
Closes: https://bugs.gentoo.org/878615

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
