### PR TITLE
sys-process/nvtop: add a few more GPUs use flags

### DIFF
--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors.
+# Copyright 1999-2025 Gentoo Authors.
 # Distributed under the terms of the GNU General Public License v2
 
 # This file contains descriptions of VIDEO_CARDS USE_EXPAND flags.
@@ -25,6 +25,7 @@ nvk - VIDEO_CARDS setting to build nouveau vulkan driver for nvidia cards (Turin
 omap - VIDEO_CARDS setting to build DRM driver for TI OMAP video cards
 qxl - VIDEO_CARDS setting to build driver for qxl (QEMU virtual GPU)
 panfrost - VIDEO_CARDS setting to build driver for Mali 600/700/800 video cards
+panthor - VIDEO_CARDS setting to support for Mali 10th video cards
 r100 - VIDEO_CARDS setting to build only r100 based chips code for radeon
 r128 - VIDEO_CARDS setting to build driver for ATI r128 video cards
 r200 - VIDEO_CARDS setting to build only r200 based chips code for radeon

--- a/sys-process/nvtop/nvtop-3.1.0.ebuild
+++ b/sys-process/nvtop/nvtop-3.1.0.ebuild
@@ -19,13 +19,15 @@ fi
 LICENSE="GPL-3"
 SLOT="0"
 
-IUSE="unicode video_cards_intel video_cards_amdgpu video_cards_nvidia video_cards_freedreno"
+IUSE="unicode video_cards_intel video_cards_amdgpu video_cards_nvidia video_cards_freedreno video_cards_panfrost video_cards_panthor"
 
 RDEPEND="
 	video_cards_intel?  ( virtual/udev )
 	video_cards_amdgpu? ( x11-libs/libdrm[video_cards_amdgpu] )
 	video_cards_nvidia? ( x11-drivers/nvidia-drivers )
 	video_cards_freedreno? ( x11-libs/libdrm[video_cards_freedreno] )
+	video_cards_panfrost? ( x11-libs/libdrm )
+	video_cards_panthor? ( x11-libs/libdrm )
 	sys-libs/ncurses[unicode(+)?]
 "
 
@@ -46,6 +48,8 @@ src_configure() {
 		-DNVIDIA_SUPPORT=$(usex video_cards_nvidia)
 		-DAMDGPU_SUPPORT=$(usex video_cards_amdgpu)
 		-DMSM_SUPPORT=$(usex video_cards_freedreno)
+		-DPANFROST_SUPPORT=$(usex video_cards_panfrost)
+		-DPANTHOR_SUPPORT=$(usex video_cards_panthor)
 	)
 
 	cmake_src_configure

--- a/sys-process/nvtop/nvtop-9999.ebuild
+++ b/sys-process/nvtop/nvtop-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,13 +19,15 @@ fi
 LICENSE="GPL-3"
 SLOT="0"
 
-IUSE="unicode video_cards_intel video_cards_amdgpu video_cards_nvidia video_cards_freedreno"
+IUSE="unicode video_cards_intel video_cards_amdgpu video_cards_nvidia video_cards_freedreno video_cards_panfrost video_cards_panthor"
 
 RDEPEND="
 	video_cards_intel?  ( virtual/udev )
 	video_cards_amdgpu? ( x11-libs/libdrm[video_cards_amdgpu] )
 	video_cards_nvidia? ( x11-drivers/nvidia-drivers )
 	video_cards_freedreno? ( x11-libs/libdrm[video_cards_freedreno] )
+	video_cards_panfrost? ( x11-libs/libdrm )
+	video_cards_panthor? ( x11-libs/libdrm )
 	sys-libs/ncurses[unicode(+)?]
 "
 
@@ -42,6 +44,8 @@ src_configure() {
 		-DNVIDIA_SUPPORT=$(usex video_cards_nvidia)
 		-DAMDGPU_SUPPORT=$(usex video_cards_amdgpu)
 		-DMSM_SUPPORT=$(usex video_cards_freedreno)
+		-DPANFROST_SUPPORT=$(usex video_cards_panfrost)
+		-DPANTHOR_SUPPORT=$(usex video_cards_panthor)
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
It will handle case of building package only for Intel GPUs without libdrm on system

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
