### PR TITLE
sys-libs/ncurses: weak block older x11-terms/ghostty versions

### DIFF
--- a/sys-libs/ncurses/ncurses-6.5_p20250118.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250118.ebuild
@@ -137,6 +137,7 @@ RDEPEND="
 	!<sys-libs/slang-2.3.2_pre23
 	!<x11-terms/rxvt-unicode-9.06-r3
 	!<x11-terms/st-0.6-r1
+	!minimal? ( !<x11-terms/ghostty-1.1.0 )
 "
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-thomasdickey )"
 

--- a/sys-libs/ncurses/ncurses-6.5_p20250125.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250125.ebuild
@@ -138,6 +138,7 @@ RDEPEND="
 	!<sys-libs/slang-2.3.2_pre23
 	!<x11-terms/rxvt-unicode-9.06-r3
 	!<x11-terms/st-0.6-r1
+	!minimal? ( !<x11-terms/ghostty-1.1.0 )
 "
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-thomasdickey )"
 

--- a/x11-terms/ghostty-terminfo/ghostty-terminfo-1.1.0-r1.ebuild
+++ b/x11-terms/ghostty-terminfo/ghostty-terminfo-1.1.0-r1.ebuild
@@ -64,7 +64,9 @@ RESTRICT="test"
 
 IUSE="symlink"
 RDEPEND="
+	!<x11-terms/ghostty-1.1.0-r1
 	symlink? (
+		!>=sys-libs/ncurses-6.5_p20250118[-minimal]
 		|| (
 			<sys-libs/ncurses-6.5_p20250118
 			>=sys-libs/ncurses-6.5_p20250118[minimal]

--- a/x11-terms/ghostty-terminfo/metadata.xml
+++ b/x11-terms/ghostty-terminfo/metadata.xml
@@ -12,4 +12,7 @@
 	<upstream>
 		<remote-id type="github">ghostty-org/ghostty</remote-id>
 	</upstream>
+	<use>
+		<flag name="symlink">Install symlink for a "ghostty" terminfo entry</flag>
+	</use>
 </pkgmetadata>

--- a/x11-terms/ghostty/ghostty-1.1.0-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.1.0-r1.ebuild
@@ -75,10 +75,7 @@ COMMON_DEPEND="
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="
 	${COMMON_DEPEND}
-	|| (
-		>=sys-libs/ncurses-6.5_p20250118[-minimal]
-		~x11-terms/ghostty-terminfo-${PV}
-	)
+	~x11-terms/ghostty-terminfo-${PV}
 "
 BDEPEND="
 	man? ( virtual/pandoc )


### PR DESCRIPTION
~~Opened as a draft PR, because there is still a discussion to be had about how to handle the fact that Ghostty defaults to `TERM=xterm-ghostty`. ncurses only ships a terminfo database entry for `ghostty`, so out-of-the-box Ghostty will cause issues such as `unknown terminal type` with various programs. This can be fixed with a configuration option. We can approach this in two ways:~~
- ~~Warn the user if the `xterm-ghostty` terminfo entry is missing, and let them set the configuration option.~~
- ~~Unconditionally install `x11-terms/ghostty-terminfo`, and either:~~
  + ~~Install both `xterm-ghostty` and `ghostty` terminfo entries if `ncurses[minimal]` is installed,~~
  + ~~Or just install a symlink from `xterm-ghostty` to `ghostty` if `ncurses[-minimal]` is installed.~~

We now have a new USE flag, "symlink", on ghostty-terminfo which installs the symlink and correctly handles cases where ncurses would install the "ghostty" terminfo entry.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
