### PR TITLE
net-nntp/leafnode: Fix implicit decl in configure

### DIFF
--- a/net-nntp/leafnode/files/leafnode-1.11.11-configure.patch
+++ b/net-nntp/leafnode/files/leafnode-1.11.11-configure.patch
@@ -1,0 +1,12 @@
+Fix handwritten check for SIOCGIFALIAS on FreeBSD
+https://bugs.gentoo.org/900268
+--- a/configure.ac
++++ b/configure.ac
+@@ -413,6 +413,7 @@
+     #include <stddef.h>
+     #include <sys/types.h>
+     #include <sys/socket.h>
++    #include <sys/ioctl.h>
+     #ifdef HAVE_SYS_SOCKIO_H
+     #include <sys/sockio.h>
+     #endif

--- a/net-nntp/leafnode/leafnode-1.11.11-r2.ebuild
+++ b/net-nntp/leafnode/leafnode-1.11.11-r2.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
+inherit autotools
 
 DESCRIPTION="A USENET software package designed for small sites"
 HOMEPAGE="http://leafnode.sourceforge.net/"
@@ -9,19 +11,33 @@ SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="amd64 ppc x86"
+IUSE="ipv6"
 
-DEPEND=">=dev-libs/libpcre2-10"
+DEPEND=">=dev-libs/libpcre-3.9"
 RDEPEND="${DEPEND}
 	virtual/inetd"
-DOCS=( CREDITS ChangeLog FAQ.txt FAQ.pdf INSTALL NEWS UNINSTALL-daemontools README README-MAINTAINER README-FQDN )
+DOCS=( CREDITS ChangeLog FAQ.txt FAQ.pdf INSTALL NEWS README-daemontools \
+	UNINSTALL-daemontools README README-MAINTAINER README-FQDN )
+
+PATCHES=(
+	"${FILESDIR}/${P}-checkpeerlocal_ipv6_fix.patch"
+	 "${FILESDIR}/${PN}-1.11.11-configure.patch"
+	)
+
+src_prepare() {
+	default
+
+	# bug https://bugs.gentoo.org/900268
+	eautoreconf
+}
 
 src_configure() {
 	econf \
 		--sysconfdir=/etc/leafnode \
 		--localstatedir=/var \
 		--with-spooldir=/var/spool/news \
-		--with-ipv6
+		$(use_with ipv6)
 }
 
 src_install() {

--- a/net-nntp/leafnode/leafnode-1.12.0-r1.ebuild
+++ b/net-nntp/leafnode/leafnode-1.12.0-r1.ebuild
@@ -1,30 +1,38 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
+inherit autotools
+
 DESCRIPTION="A USENET software package designed for small sites"
-HOMEPAGE="http://leafnode.sourceforge.net/"
+HOMEPAGE="https://leafnode.sourceforge.io/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
-IUSE="ipv6"
+KEYWORDS="~amd64 ~ppc ~x86"
 
-DEPEND=">=dev-libs/libpcre-3.9"
+DEPEND=">=dev-libs/libpcre2-10"
 RDEPEND="${DEPEND}
 	virtual/inetd"
-DOCS=( CREDITS ChangeLog FAQ.txt FAQ.pdf INSTALL NEWS README-daemontools UNINSTALL-daemontools README README-MAINTAINER README-FQDN )
+DOCS=( CREDITS ChangeLog FAQ.txt FAQ.pdf INSTALL NEWS UNINSTALL-daemontools README README-MAINTAINER README-FQDN )
 
-PATCHES=( "${FILESDIR}/${P}-checkpeerlocal_ipv6_fix.patch" )
+PATCHES=( "${FILESDIR}/${PN}-1.11.11-configure.patch" )
+
+src_prepare() {
+	default
+
+	# bug https://bugs.gentoo.org/900268
+	eautoreconf
+}
 
 src_configure() {
 	econf \
 		--sysconfdir=/etc/leafnode \
 		--localstatedir=/var \
 		--with-spooldir=/var/spool/news \
-		$(use_with ipv6)
+		--with-ipv6
 }
 
 src_install() {


### PR DESCRIPTION
It's FreeBSD ioctl, but adding correct include feels more correct than QA_SKIPping it.
Not submitted upstream: I can't sourceforge.

Closes: https://bugs.gentoo.org/900268

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
