### PR TITLE
media-libs/libsoundtouch: fix undefined symbol: __kmpc_xxx

### DIFF
--- a/media-libs/libsoundtouch/libsoundtouch-2.3.3.ebuild
+++ b/media-libs/libsoundtouch/libsoundtouch-2.3.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools multilib-minimal toolchain-funcs
+inherit autotools flag-o-matic multilib-minimal toolchain-funcs
 
 MY_PN=${PN/lib}
 MY_P=${MY_PN}-${PV}
@@ -31,6 +31,11 @@ pkg_setup() {
 src_prepare() {
 	default
 	sed -i "s:^\(dist_doc_DATA=\)COPYING.TXT :\1:" Makefile.am || die
+
+	if tc-is-clang && use openmp ; then
+		append-libs omp
+	fi
+
 	eautoreconf
 }
 


### PR DESCRIPTION
when called with "-fopenmp" and "-nostdlib", clang won't add "-lomp" automatically, while gcc always add "-lgomp". See below:

For gcc, "-lgomp" is added always:
```
  # echo 'int main() { return 0; }' | gcc -fopenmp -v -x c - 2>&1|grep -- "-lgomp"
   /usr/libexec/gcc/x86_64-pc-linux-gnu/14/collect2 -plugin ... -lgomp -lgcc ...
  # echo 'int main() { return 0; }' | gcc -fopenmp -nostdlib -v -x c - 2>&1 | grep -- "-lgomp"
   /usr/libexec/gcc/x86_64-pc-linux-gnu/14/collect2 -plugin ... -lgomp
```

For clang, "-lomp" is not added when both "-fopenmp" and "-nostdlib" exist:
```
  # echo 'int main() { return 0; }' | clang -fopenmp -v -x c - 2>&1|grep -- "-lomp"
   "/usr/bin/x86_64-pc-linux-gnu-ld.bfd" --hash-style=gnu ... -lomp -L/usr/lib/llvm/19/lib64 ...
  # echo 'int main() { return 0; }' | clang -fopenmp -nostdlib -v -x c - 2>&1 | grep -- "-lomp"
```

In case of libsoundtouch, command to build .so is:

`  clang++ -fPIC -DPIC -shared -nostdlib ...  -Wl,-soname -Wl,libSoundTouchDll.so.1 -o .libs/libSoundTouchDll.so.1.0.0
`

So LDFLAGS "-lomp" is needed if compiler is clang and openmp is enabled.

Otherwise, libomp.so won't be defined in Dynamic Section as show bellow:

```
  # LC_ALL=C objdump -x /usr/lib64/libSoundTouch.so
  ...
  Dynamic Section:
    NEEDED               libomp.so
  ...
```

cause package depend on libsoundtouch either failed to build or failed to start (if libsoundtouch is reemerged with openmp).

Closes: https://bugs.gentoo.org/740310

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
