### PR TITLE
media-libs/libraw: fix handling of openmp library

### DIFF
--- a/media-libs/libraw/libraw-0.21.1-r1.ebuild
+++ b/media-libs/libraw/libraw-0.21.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal toolchain-funcs
+inherit flag-o-matic multilib-minimal toolchain-funcs
 
 MY_PN=LibRaw
 MY_PV="${PV/_b/-B}"
@@ -12,6 +12,7 @@ MY_P="${MY_PN}-${MY_PV}"
 DESCRIPTION="LibRaw is a library for reading RAW files obtained from digital photo cameras"
 HOMEPAGE="https://www.libraw.org/ https://github.com/LibRaw/LibRaw"
 SRC_URI="https://www.libraw.org/data/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="LGPL-2.1 CDDL"
 # SONAME isn't exactly the same as PV but it does correspond and
@@ -28,8 +29,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
-S="${WORKDIR}/${MY_P}"
-
 DOCS=( Changelog.txt README.md )
 
 PATCHES=( "${FILESDIR}/${P}-CVE-2023-1729.patch" )
@@ -40,6 +39,14 @@ pkg_pretend() {
 
 pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_prepare() {
+	default
+
+	if tc-is-clang && use openmp ; then
+		append-libs omp
+	fi
 }
 
 multilib_src_configure() {

--- a/media-libs/libraw/libraw-0.21.2.ebuild
+++ b/media-libs/libraw/libraw-0.21.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal toolchain-funcs
+inherit flag-o-matic multilib-minimal toolchain-funcs
 
 MY_PN=LibRaw
 MY_PV="${PV/_b/-B}"
@@ -12,6 +12,7 @@ MY_P="${MY_PN}-${MY_PV}"
 DESCRIPTION="LibRaw is a library for reading RAW files obtained from digital photo cameras"
 HOMEPAGE="https://www.libraw.org/ https://github.com/LibRaw/LibRaw"
 SRC_URI="https://www.libraw.org/data/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="LGPL-2.1 CDDL"
 # SONAME isn't exactly the same as PV but it does correspond and
@@ -28,8 +29,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
-S="${WORKDIR}/${MY_P}"
-
 DOCS=( Changelog.txt README.md )
 
 pkg_pretend() {
@@ -38,6 +37,14 @@ pkg_pretend() {
 
 pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_prepare() {
+	default
+
+	if tc-is-clang && use openmp ; then
+		append-libs omp
+	fi
 }
 
 multilib_src_configure() {


### PR DESCRIPTION
quick workaround, for same reason in media-libs/libsountch

upstream fix should be handled in autotools, still working

Closes: https://bugs.gentoo.org/881311
Closes: https://bugs.gentoo.org/896220
Closes: https://bugs.gentoo.org/915833

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
