### PR TITLE
net-im/discord: 0.0.84 einfo add for kwin[screencast] support

### DIFF
--- a/net-im/discord/discord-0.0.84.ebuild
+++ b/net-im/discord/discord-0.0.84.ebuild
@@ -143,4 +143,10 @@ pkg_postinst() {
 	optfeature "sound support" \
 		media-sound/pulseaudio media-sound/apulse[sdk] media-video/pipewire
 	optfeature "emoji support" media-fonts/noto-emoji
+	if has_version kde-plasma/kwin[-screencast] && use wayland; then
+		einfo " "
+		einfo "When using KWin on Wayland, the kde-plasma/kwin[screencast] USE flag"
+		einfo "must be enabled for screensharing."
+		einfo " "
+	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/948978
Added einfo to notify users to enable kwin[screencast] in order for discord to be able to share screen with wayland.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

