### PR TITLE
net-analyzer/isic: fix configure for modern C

### DIFF
--- a/net-analyzer/isic/files/isic-0.07-configure.patch
+++ b/net-analyzer/isic/files/isic-0.07-configure.patch
@@ -1,0 +1,39 @@
+Make build system respect DESTDIR, fix just the configure
+as a path of least resistance.
+Autoreconf stuffs spaces where they don't belong and produces
+broken configure
+https://bugs.gentoo.org/899938
+https://bugs.gentoo.org/874531
+--- a/configure
++++ b/configure
+@@ -652,7 +652,7 @@
+ #line 653 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:658: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes
+@@ -1092,6 +1092,7 @@
+ #line 1119 "configure"
+ #include "confdefs.h"
+ #include <ctype.h>
++#include <stdlib.h>
+ #define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -63,7 +63,7 @@
+ 	  tar -czvf isic-$(VERSION).tgz ./isic-$(VERSION)/* )
+ 
+ install: $(BINS) $(MAN)
+-	$(INSTALL) -m 0755 -d $(PREFIX)/bin
+-	$(INSTALL) -m 0755 -c $(BINS) $(PREFIX)/bin
+-	$(INSTALL) -m 0755 -d $(PREFIX)/man/man1
+-	${INSTALL} -m 0755 -c $(MAN) $(PREFIX)/man/man1
++	$(INSTALL) -m 0755 -d $(DESTDIR)/$(PREFIX)/bin
++	$(INSTALL) -m 0755 -c $(BINS) $(DESTDIR)/$(PREFIX)/bin
++	$(INSTALL) -m 0755 -d $(DESTDIR)/$(PREFIX)/share/man/man1
++	${INSTALL} -m 0755 -c $(MAN) $(DESTDIR)/$(PREFIX)/share/man/man1

--- a/net-analyzer/isic/isic-0.07-r3.ebuild
+++ b/net-analyzer/isic/isic-0.07-r3.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="IP Stack Integrity Checker"
+HOMEPAGE="https://isic.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/isic/${P}.tgz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="net-libs/libnet:1.1"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-configure.patch"
+)
+
+src_prepare() {
+	default
+	# Add two missing includes
+	echo "#include <netinet/udp.h>" >> isic.h || die
+	echo "#include <netinet/tcp.h>" >> isic.h || die
+
+}
+
+src_configure() {
+	tc-export CC
+
+	econf
+}


### PR DESCRIPTION
Straight-up autoreconf fails, autoupdate produces non-viable configure. Also make build system respect our DESTDID, which also replaces sed with a patch

Closes: https://bugs.gentoo.org/874531
Closes: https://bugs.gentoo.org/899938
Closes: https://bugs.gentoo.org/836081

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
