### PR TITLE
sys-libs/lwp: update EAPI 7 -> 8, fix bool

### DIFF
--- a/sys-libs/lwp/files/lwp-2.8-bool.patch
+++ b/sys-libs/lwp/files/lwp-2.8-bool.patch
@@ -1,0 +1,14 @@
+Used for declaration of private function only, so change
+causes no visible effects
+https://bugs.gentoo.org/943734
+--- a/src/timer.c
++++ b/src/timer.c
+@@ -48,7 +48,7 @@
+ #include <lwp/timer.h>
+ #include "lwp.private.h"
+ 
+-typedef unsigned char bool;
++#include <stdbool.h>
+ 
+ #define expiration TotalTime
+ 

--- a/sys-libs/lwp/lwp-2.8-r1.ebuild
+++ b/sys-libs/lwp/lwp-2.8-r1.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Light-weight process library (used by Coda)"
+HOMEPAGE="http://www.coda.cs.cmu.edu/"
+SRC_URI="http://www.coda.cs.cmu.edu/pub/lwp/src/${P}.tar.xz"
+
+LICENSE="LGPL-2.1"
+SLOT="1"
+KEYWORDS="~alpha ~amd64 ~hppa ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/"${P}"-ia64.patch
+	"${FILESDIR}"/"${P}"-bool.patch
+)
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
As bool definition is very private, replacement with stdbool.h doesn't affect ABI or API

Closes: https://bugs.gentoo.org/943734

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
