### PR TITLE
sys-fs/zfs: enable py3.13

### DIFF
--- a/sys-fs/zfs/zfs-2.3.0.ebuild
+++ b/sys-fs/zfs/zfs-2.3.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_OPTIONAL=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools bash-completion-r1 dist-kernel-utils distutils-r1 flag-o-matic linux-info pam systemd udev usr-ldscript
 

--- a/sys-fs/zfs/zfs-9999.ebuild
+++ b/sys-fs/zfs/zfs-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_OPTIONAL=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools bash-completion-r1 dist-kernel-utils distutils-r1 flag-o-matic linux-info pam systemd udev usr-ldscript
 


### PR DESCRIPTION
This was tested using ZFS's test suite which can be flakely as running the same test twice will give different results, however no new Python issues were uncovered between 3.12 and 3.13.

[zfs-2.3.0-test.-py313.log](https://github.com/user-attachments/files/18677433/zfs-2.3.0-test.-py313.log)

[zfs-2.3.0-test-py312.log](https://github.com/user-attachments/files/18677416/zfs-2.3.0-test-py312.log)

[diff.log](https://github.com/user-attachments/files/18677439/diff.log)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x]  I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
