### PR TITLE
net-misc/nx: fix compilation with gcc14 (access.c)

### DIFF
--- a/net-misc/nx/files/nx-3.5.99.26-gcc14-access.patch
+++ b/net-misc/nx/files/nx-3.5.99.26-gcc14-access.patch
@@ -1,0 +1,28 @@
+Bugs: https://bugs.gentoo.org/934131
+https://gitlab.freedesktop.org/xorg/xserver/-/commit/0ddcd8785199c08d9bded3c767a3b1227c670999
+
+Backport from XOrg server:
+
+    commit 0ddcd8785199c08d9bded3c767a3b1227c670999
+    Author: Joaquim Monteiro <joaquim.monteiro@protonmail.com>
+    Date: Sun, 23 Jun 2024 21:17:25 +0100
+
+        [PATCH 1/2] os: Fix assignment with incompatible pointer type
+
+        struct hostent->h_addr_list is of type char**, not const char**.
+        GCC considers this an error when in C99 mode or later.
+
+        Signed-off-by: Joaquim Monteiro <joaquim.monteiro@protonmail.com>
+        Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1572>
+
+--- a/nx-X11/programs/Xserver/os/access.c
++++ b/nx-X11/programs/Xserver/os/access.c
+@@ -1941,7 +1941,7 @@
+ 	char hostname[SI_HOSTNAME_MAXLEN];
+ 	int f, hostaddrlen;
+ 	void * hostaddr;
+-	const char **addrlist;
++	char **addrlist;
+ 
+ 	if (siAddrLen >= sizeof(hostname)) 
+ 	    return FALSE;

--- a/net-misc/nx/nx-3.5.99.26.ebuild
+++ b/net-misc/nx/nx-3.5.99.26.ebuild
@@ -50,8 +50,9 @@ PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.26-riscv64-support.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-musl.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-which.patch"
-	# https://github.com/ArticaProject/nx-libs/pull/1087
+	# https://github.com/ArcticaProject/nx-libs/pull/1087
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
+	"${FILESDIR}/${PN}-3.5.99.26-gcc14-access.patch"
 )
 
 src_prepare() {

--- a/net-misc/nx/nx-3.5.99.27.ebuild
+++ b/net-misc/nx/nx-3.5.99.27.ebuild
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.27-which.patch"
 	# https://github.com/ArcticaProject/nx-libs/pull/1087
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
+	"${FILESDIR}/${PN}-3.5.99.26-gcc14-access.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Backport from XOrg.
This PR also fixes a small URL typo from my previous patch ;-)

Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/0ddcd8785199c08d9bded3c767a3b1227c670999
Closes: https://bugs.gentoo.org/934131
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
