### PR TITLE
net-misc/minidlna: add patch to fix build with ffmpeg 7

### DIFF
--- a/net-misc/minidlna/files/minidlna-1.3.3-ffmpeg7.patch
+++ b/net-misc/minidlna/files/minidlna-1.3.3-ffmpeg7.patch
@@ -1,0 +1,21 @@
+https://bugs.gentoo.org/938728
+https://sourceforge.net/p/minidlna/discussion/879956/thread/81e45c3d64
+
+With ffmpeg 7, the channels field that was previously deprecated with
+ffmpeg 6 has been removed entirely, which breaks the build for this
+package. This patch switches to the correct way of doing it now,
+which is ch_layout.nb_channels.
+
+diff --git a/libav.h b/libav.h
+index b69752c..aed9d18 100644
+--- a/libav.h
++++ b/libav.h
+@@ -174,7 +174,7 @@ lav_get_interlaced(AVStream *s)
+ #define lav_codec_tag(s) s->codecpar->codec_tag
+ #define lav_sample_rate(s) s->codecpar->sample_rate
+ #define lav_bit_rate(s) s->codecpar->bit_rate
+-#define lav_channels(s) s->codecpar->channels
++#define lav_channels(s) s->codecpar->ch_layout.nb_channels
+ #define lav_width(s) s->codecpar->width
+ #define lav_height(s) s->codecpar->height
+ #define lav_profile(s) s->codecpar->profile

--- a/net-misc/minidlna/minidlna-1.3.3.ebuild
+++ b/net-misc/minidlna/minidlna-1.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,6 +42,7 @@ CONFIG_CHECK="~INOTIFY_USER"
 
 PATCHES=(
 	"${WORKDIR}"/minidlna-gentoo-artwork.patch
+	"${FILESDIR}"/minidlna-1.3.3-ffmpeg7.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
With ffmpeg 7, the channels field that was previously deprecated with ffmpeg 6 has been removed entirely, which breaks the build for this package. The patch switches to the correct way of doing it now, which is ch_layout.nb_channels.

Doesn't break building with ffmpeg 6.
    
Closes: https://bugs.gentoo.org/938728
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
