### PR TITLE
gui-apps/wf-recorder: add patch to fix build with ffmpeg 7

### DIFF
--- a/gui-apps/wf-recorder/files/wf-recorder-0.5.0-ffmpeg-7.patch
+++ b/gui-apps/wf-recorder/files/wf-recorder-0.5.0-ffmpeg-7.patch
@@ -1,0 +1,26 @@
+https://github.com/ammen99/wf-recorder/pull/279
+https://bugs.gentoo.org/948264
+
+From 8d665957864899576035abaa968667d1f221b2de Mon Sep 17 00:00:00 2001
+From: Scott Moreau <oreaus@gmail.com>
+Date: Mon, 16 Sep 2024 13:55:35 -0600
+Subject: [PATCH] frame-writer: Track ffmpeg changes
+
+The frame_rate variable has been made private API.
+---
+ src/frame-writer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/frame-writer.cpp b/src/frame-writer.cpp
+index 2a5ba17..b8abe51 100644
+--- a/src/frame-writer.cpp
++++ b/src/frame-writer.cpp
+@@ -371,7 +371,7 @@ void FrameWriter::init_video_filters(const AVCodec *codec)
+     this->videoCodecCtx->height = filter_output->h;
+     this->videoCodecCtx->pix_fmt = (AVPixelFormat)filter_output->format;
+     this->videoCodecCtx->time_base = filter_output->time_base;
+-    this->videoCodecCtx->framerate = filter_output->frame_rate; // can be 1/0 if unknown
++    this->videoCodecCtx->framerate = AVRational{1,0};
+     this->videoCodecCtx->sample_aspect_ratio = filter_output->sample_aspect_ratio;
+
+     this->hw_frame_context = av_buffersink_get_hw_frames_ctx(

--- a/gui-apps/wf-recorder/wf-recorder-0.5.0-r1.ebuild
+++ b/gui-apps/wf-recorder/wf-recorder-0.5.0-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 2020-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Screen recorder for wlroots-based compositors"
+HOMEPAGE="https://github.com/ammen99/wf-recorder"
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/ammen99/wf-recorder.git"
+else
+	SRC_URI="https://github.com/ammen99/wf-recorder/releases/download/v${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="pipewire pulseaudio"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-build-with-no-audio.patch"
+	"${FILESDIR}/${P}-ffmpeg-7.patch"
+)
+
+DEPEND="
+	dev-libs/wayland
+	media-libs/mesa[opengl,wayland]
+	media-video/ffmpeg[pulseaudio?,x264]
+	x11-libs/libdrm
+	pipewire? ( >=media-video/pipewire-1.0.5:= )
+	pulseaudio? ( media-libs/libpulse )
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-libs/wayland-protocols
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature pulseaudio pulse)
+		$(meson_feature pipewire)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
With ffmpeg 7 the frame_rate variable has been made private API which breaks the build for this package. The patch fixes that by setting the frame_rate variable to a sentinel value because the frame rate cannot be accessed and is unknown.
    
Doesn't break building with ffmpeg 6.
    
Closes: https://bugs.gentoo.org/948264
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
