### PR TITLE
media-video/ffmpeg: add av-stream-get-first-dts use flag

### DIFF
--- a/media-video/ffmpeg/ffmpeg-6.1.1-r8.ebuild
+++ b/media-video/ffmpeg/ffmpeg-6.1.1-r8.ebuild
@@ -129,7 +129,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc
+	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc av-stream-get-first-dts
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -415,6 +415,9 @@ src_prepare() {
 
 	use soc &&
 		eapply "${DISTDIR}"/${SOC_PATCH}
+
+	# https://crbug.com/1251779, bug #831487
+	use av-stream-get-first-dts && eapply "${FILESDIR}"/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
 
 	default
 

--- a/media-video/ffmpeg/ffmpeg-6.1.2.ebuild
+++ b/media-video/ffmpeg/ffmpeg-6.1.2.ebuild
@@ -129,7 +129,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc
+	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc av-stream-get-first-dts
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -413,6 +413,9 @@ src_prepare() {
 
 	use soc &&
 		eapply "${DISTDIR}"/${SOC_PATCH}
+
+	# https://crbug.com/1251779, bug #831487
+	use av-stream-get-first-dts && eapply "${FILESDIR}"/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
 
 	default
 

--- a/media-video/ffmpeg/ffmpeg-7.0.2-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-7.0.2-r1.ebuild
@@ -131,7 +131,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc
+	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc av-stream-get-first-dts
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -410,6 +410,9 @@ src_prepare() {
 
 	use soc &&
 		eapply "${DISTDIR}"/${SOC_PATCH}
+
+	# https://crbug.com/1251779, bug #831487
+	use av-stream-get-first-dts && eapply "${FILESDIR}"/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
 
 	default
 

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -131,7 +131,7 @@ FFMPEG_ENCODER_FLAG_MAP=(
 )
 
 IUSE="
-	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc
+	alsa chromium doc +encode oss +pic sndio static-libs test v4l soc av-stream-get-first-dts
 	${FFMPEG_FLAG_MAP[@]%:*}
 	${FFMPEG_ENCODER_FLAG_MAP[@]%:*}
 "
@@ -410,6 +410,9 @@ src_prepare() {
 
 	use soc &&
 		eapply "${DISTDIR}"/${SOC_PATCH}
+
+	# https://crbug.com/1251779, bug #831487
+	use av-stream-get-first-dts && eapply "${FILESDIR}"/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
 
 	default
 

--- a/media-video/ffmpeg/files/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
+++ b/media-video/ffmpeg/files/ffmpeg-5.1-add-av_stream_get_first_dts-for-chromium.patch
@@ -1,0 +1,31 @@
+diff '--color=auto' -rupN ffmpeg.orig/libavformat/avformat.h ffmpeg/libavformat/avformat.h
+--- ffmpeg.orig/libavformat/avformat.h	2022-08-19 17:42:47.323422603 +0200
++++ ffmpeg/libavformat/avformat.h	2022-08-19 17:42:51.347130436 +0200
+@@ -1128,6 +1128,10 @@ struct AVCodecParserContext *av_stream_g
+  */
+ int64_t    av_stream_get_end_pts(const AVStream *st);
+ 
++// Chromium: We use the internal field first_dts vvv
++int64_t    av_stream_get_first_dts(const AVStream *st);
++// Chromium: We use the internal field first_dts ^^^
++
+ #define AV_PROGRAM_RUNNING 1
+ 
+ /**
+diff '--color=auto' -rupN ffmpeg.orig/libavformat/mux_utils.c ffmpeg/libavformat/mux_utils.c
+--- ffmpeg.orig/libavformat/mux_utils.c	2022-08-19 17:42:47.346758108 +0200
++++ ffmpeg/libavformat/mux_utils.c	2022-08-19 17:47:28.549589002 +0200
+@@ -37,6 +37,13 @@ int64_t av_stream_get_end_pts(const AVSt
+         return AV_NOPTS_VALUE;
+ }
+ 
++// Chromium: We use the internal field first_dts vvv
++int64_t av_stream_get_first_dts(const AVStream *st)
++{
++  return cffstream(st)->first_dts;
++}
++// Chromium: We use the internal field first_dts ^^^
++
+ int avformat_query_codec(const AVOutputFormat *ofmt, enum AVCodecID codec_id,
+                          int std_compliance)
+ {

--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -88,6 +88,7 @@
 		<flag name="zeromq">Enables <pkg>net-libs/zeromq</pkg> support with the zmq/azmq filters.</flag>
 		<flag name="zimg">Enables <pkg>media-libs/zimg</pkg> based scale filter.</flag>
 		<flag name="zvbi">Enables <pkg>media-libs/zvbi</pkg> based teletext decoder.</flag>
+		<flag name="av-stream-get-first-dts">Add av_stream_get_first_dts for Chromium to be built with system ffmpeg</flag>
 	</use>
 	<slots>
 		<slot name="0">For building against. This is the only slot that provides


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/831487

This is intended to add an option to debug first, allowing future system-ffmpeg support. And it's also useful for other chromium-based packages to be built with system ffmpeg, like [www-client/ungoogled-chromium::pf4public](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium), which received a lot of repeated issues on this. It's optional and does no harm.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
