### PR TITLE
sys-devel/binutils: Switch to previous patches for 2.44

### DIFF
--- a/sys-devel/binutils/binutils-2.44.9999.ebuild
+++ b/sys-devel/binutils/binutils-2.44.9999.ebuild
@@ -141,8 +141,8 @@ src_prepare() {
 			# This is applied conditionally for now just out of caution.
 			# It should be okay on non-prefix systems though. See bug #892549.
 			if is_cross || use prefix; then
-				eapply "${FILESDIR}"/binutils-2.43-linker-search-path.patch \
-					   "${FILESDIR}"/binutils-2.43-linker-prefix.patch
+				eapply "${FILESDIR}"/binutils-2.40-linker-search-path.patch \
+					   "${FILESDIR}"/binutils-2.41-linker-prefix.patch
 			fi
 		fi
 	fi

--- a/sys-devel/binutils/binutils-2.44.ebuild
+++ b/sys-devel/binutils/binutils-2.44.ebuild
@@ -141,8 +141,8 @@ src_prepare() {
 			# This is applied conditionally for now just out of caution.
 			# It should be okay on non-prefix systems though. See bug #892549.
 			if is_cross || use prefix; then
-				eapply "${FILESDIR}"/binutils-2.43-linker-search-path.patch \
-					   "${FILESDIR}"/binutils-2.43-linker-prefix.patch
+				eapply "${FILESDIR}"/binutils-2.40-linker-search-path.patch \
+					   "${FILESDIR}"/binutils-2.41-linker-prefix.patch
 			fi
 		fi
 	fi


### PR DESCRIPTION
The change that necessitated the new patches in 2.43 seems to have been reverted in 2.44.

Closes: https://bugs.gentoo.org/949373

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
