### PR TITLE
www-client/chromium: dev-build/ninja -> app-alternatives/ninja

### DIFF
--- a/www-client/chromium/chromium-132.0.6834.159.ebuild
+++ b/www-client/chromium/chromium-132.0.6834.159.ebuild
@@ -181,7 +181,7 @@ BDEPEND="
 	)
 	>=dev-util/bindgen-0.68.0
 	>=dev-build/gn-${GN_MIN_VER}
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/chromium/chromium-132.0.6834.83.ebuild
+++ b/www-client/chromium/chromium-132.0.6834.83.ebuild
@@ -188,7 +188,7 @@ BDEPEND="
 	)
 	>=dev-util/bindgen-0.68.0
 	>=dev-build/gn-${GN_MIN_VER}
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/chromium/chromium-133.0.6943.27.ebuild
+++ b/www-client/chromium/chromium-133.0.6943.27.ebuild
@@ -181,7 +181,7 @@ BDEPEND="
 	)
 	>=dev-util/bindgen-0.68.0
 	>=dev-build/gn-${GN_MIN_VER}
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/chromium/chromium-133.0.6943.53.ebuild
+++ b/www-client/chromium/chromium-133.0.6943.53.ebuild
@@ -181,7 +181,7 @@ BDEPEND="
 	)
 	>=dev-util/bindgen-0.68.0
 	>=dev-build/gn-${GN_MIN_VER}
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/chromium/chromium-134.0.6998.3.ebuild
+++ b/www-client/chromium/chromium-134.0.6998.3.ebuild
@@ -208,7 +208,7 @@ BDEPEND="
 	)
 	>=dev-util/bindgen-0.68.0
 	>=dev-build/gn-${GN_MIN_VER}
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git


### PR DESCRIPTION
All of these will be using app-alternatives/ninja anyway as they're not calling ninja-reference, so make the dep reflect reality.

Closes: https://bugs.gentoo.org/949551

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
