### PR TITLE
app-containers/podman: fix restart behavior of unless-stopped

### DIFF
--- a/app-containers/podman/files/podman-restart-5.0.0_rc4.initd
+++ b/app-containers/podman/files/podman-restart-5.0.0_rc4.initd
@@ -2,21 +2,21 @@
 # Copyright 2015-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-description="Start all containers with restart-policy set to always"
+description="Start all containers with restart-policy set to always or unless-stopped"
 
 command_user="${RUN_AS_USER:=root:root}"
 command="/usr/bin/podman"
-command_args="--log-level ${LOG_LEVEL:=info} start --all --filter restart-policy=always"
+command_args="--log-level ${LOG_LEVEL:=info} start --all --filter restart-policy=always --filter restart-policy=unless-stopped"
 
 depend() {
 	after net
 }
 
 stop() {
-	ebegin "Stopping all containers with restart-policy set to always"
+	ebegin "Stopping all containers with restart-policy set to always or unless-stopped"
 	${command} \
 		--log-level ${LOG_LEVEL} \
 		stop \
-		$(${command} container ls --filter restart-policy=always -q)
-	eend $? "Failed to stop containers with restart-policy set to always"
+		$(${command} container ls --filter restart-policy=always --filter restart-policy=unless-stopped -q)
+	eend $? "Failed to stop containers with restart-policy set to always or unless-stopped"
 }


### PR DESCRIPTION
This pull request fixes the problem where containers with restart policy set to `unless-stopped` do not restart automatically. According to the [Podman documentation](https://docs.podman.io/en/latest/markdown/podman-run.1.html#restart-policy), `unless-stopped` should be identical to `always`.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
