### PR TITLE
app-emulation/libvirt: Fix patch name in live build

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -156,7 +156,7 @@ PDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-11.0.0-fix_paths_in_libvirt-guests_sh.patch
+	"${FILESDIR}"/${PN}-11.0.0-Fix-paths-in-libvirt-guests.sh.in.patch
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-10.7.0-fix-paths-for-apparmor.patch
 )


### PR DESCRIPTION
The actual patch is named
libvirt-11.0.0-Fix-paths-in-libvirt-guests.sh.in.patch not libvirt-11.0.0-fix_paths_in_libvirt-guests_sh.patch. Subtle difference, big consequence.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
