### PR TITLE
dev-util/fuzz: fix compilation on musl

### DIFF
--- a/dev-util/fuzz/files/fuzz-0.6-musl.patch
+++ b/dev-util/fuzz/files/fuzz-0.6-musl.patch
@@ -1,0 +1,34 @@
+Fix missing include on musl, as strcmp is not transitively included
+Remove arg-less declaration for non-glibc case: we have POSIX here,
+getopt has same prototype in glibc and in musl
+https://bugs.gentoo.org/934059
+https://bugs.gentoo.org/944111
+--- a/getopt.c
++++ b/getopt.c
+@@ -43,6 +43,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C
+--- a/getopt.h
++++ b/getopt.h
+@@ -99,14 +99,12 @@
+ #define optional_argument	2
+ 
+ #if defined (__STDC__) && __STDC__
+-#ifdef __GNU_LIBRARY__
+ /* Many other libraries have conflicting prototypes for getopt, with
+    differences in the consts, in stdlib.h.  To avoid compilation
+    errors, only prototype getopt for the GNU C library.  */
++/* But in Gentoo we have glibc and musl, and they have same POSIX
++   definition */
+ extern int getopt (int argc, char *const *argv, const char *shortopts);
+-#else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
+-#endif /* __GNU_LIBRARY__ */
+ extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+ 		        const struct option *longopts, int *longind);
+ extern int getopt_long_only (int argc, char *const *argv,

--- a/dev-util/fuzz/fuzz-0.6-r4.ebuild
+++ b/dev-util/fuzz/fuzz-0.6-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,10 @@ KEYWORDS="~amd64 ~x86"
 DEPEND="sys-libs/readline:="
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${WORKDIR}"/${DEB_P}-${DEB_PR}.diff )
+PATCHES=(
+	"${WORKDIR}"/"${DEB_P}-${DEB_PR}.diff"
+	"${FILESDIR}"/"${P}-musl.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Missing include for string.h, glibc transitively included strcmp Removed different getopt definition for non-glibc situation: we are all living in POSIX-land (Somewhat. Hopefully. Mostly.) and definitions for getopt are the same on musl and glibc.

Closes: https://bugs.gentoo.org/944111
Closes: https://bugs.gentoo.org/934059

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
