### PR TITLE
net-misc/nx: fix compilation with clang

### DIFF
--- a/net-misc/nx/files/nx-3.5.99.26-clang-bind.patch
+++ b/net-misc/nx/files/nx-3.5.99.26-clang-bind.patch
@@ -1,0 +1,17 @@
+Fix:
+
+Loop.cpp:4224:34: error: invalid operands to binary expression ('__bind<int &, sockaddr *&, unsigned int &>' and 'int')
+
+https://github.com/ArcticaProject/nx-libs/issues/1044
+https://bugs.gentoo.org/930440
+--- a/nxcomp/src/Loop.cpp
++++ b/nxcomp/src/Loop.cpp
+@@ -4221,7 +4221,7 @@
+       goto SetupSocketError;
+     }
+ 
+-  if (bind(newFD, addr, addrlen) == -1)
++  if (::bind(newFD, addr, addrlen) == -1)
+   {
+     nxfatal << "Loop: PANIC! Call to bind failed for " << label
+             << ". Error is " << EGET()

--- a/net-misc/nx/nx-3.5.99.26.ebuild
+++ b/net-misc/nx/nx-3.5.99.26.ebuild
@@ -7,6 +7,7 @@ inherit autotools flag-o-matic toolchain-funcs
 DESCRIPTION="NX compression technology core libraries"
 HOMEPAGE="https://github.com/ArcticaProject/nx-libs"
 SRC_URI="https://github.com/ArcticaProject/nx-libs/archive/${PV}.tar.gz -> nx-libs-${PV}.tar.gz"
+S="${WORKDIR}/nx-libs-${PV}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -41,8 +42,6 @@ BDEPEND="virtual/pkgconfig
 
 RDEPEND+=" selinux? ( sec-policy/selinux-nx )"
 
-S="${WORKDIR}/nx-libs-${PV}"
-
 PATCHES=(
 	# https://github.com/ArcticaProject/nx-libs/pull/1012
 	"${FILESDIR}/${PN}-3.5.99.26-binutils-2.36.patch"
@@ -53,6 +52,8 @@ PATCHES=(
 	# https://github.com/ArcticaProject/nx-libs/pull/1087
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-access.patch"
+	# https://github.com/ArcticaProject/nx-libs/issues/1044
+	"${FILESDIR}/${PN}-3.5.99.26-clang-bind.patch"
 )
 
 src_prepare() {

--- a/net-misc/nx/nx-3.5.99.27.ebuild
+++ b/net-misc/nx/nx-3.5.99.27.ebuild
@@ -8,6 +8,7 @@ DESCRIPTION="NX compression technology core libraries"
 HOMEPAGE="https://github.com/ArcticaProject/nx-libs"
 
 SRC_URI="https://github.com/ArcticaProject/nx-libs/archive/${PV}.tar.gz -> nx-libs-${PV}.tar.gz"
+S="${WORKDIR}/nx-libs-${PV}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -39,14 +40,14 @@ BDEPEND="virtual/pkgconfig
 	x11-misc/gccmakedep
 	x11-misc/imake"
 
-S="${WORKDIR}/nx-libs-${PV}"
-
 PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.26-musl.patch"
 	"${FILESDIR}/${PN}-3.5.99.27-which.patch"
 	# https://github.com/ArcticaProject/nx-libs/pull/1087
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-32bit.patch"
 	"${FILESDIR}/${PN}-3.5.99.26-gcc14-access.patch"
+	# https://github.com/ArcticaProject/nx-libs/issues/1044
+	"${FILESDIR}/${PN}-3.5.99.26-clang-bind.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Also fix ```VariableOrderWrong``` for the ```${S}``` variable

Link: https://github.com/ArcticaProject/nx-libs/issues/1044
Link: https://trac.macports.org/ticket/71014
Closes: https://bugs.gentoo.org/930440
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
