### PR TITLE
app-editors/logseq-desktop-bin: added wayland USE flag

### DIFF
--- a/app-editors/logseq-desktop-bin/logseq-desktop-bin-0.10.9-r1.ebuild
+++ b/app-editors/logseq-desktop-bin/logseq-desktop-bin-0.10.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,6 +19,7 @@ S="${WORKDIR}/Logseq-linux-x64"
 LICENSE="AGPL-3"
 SLOT="0"
 KEYWORDS="-* ~amd64"
+IUSE="wayland"
 
 RESTRICT="mirror splitdebug"
 
@@ -84,7 +85,11 @@ src_install() {
 
 	dosym ../logseq-desktop/Logseq /opt/bin/logseq
 
-	make_desktop_entry "/opt/bin/logseq %U" Logseq logseq Office \
+	local exec_extra_flags=()
+	if use wayland; then
+		exec_extra_flags+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+	fi
+	make_desktop_entry "/opt/bin/logseq ${exec_extra_flags[*]} %U" Logseq logseq Office \
 		"StartupWMClass=logseq\nTerminal=false\nMimeType=x-scheme-handler/logseq"
 	# some releases do not have an icon included, but we dont fail if that happens
 	doicon resources/app/icons/logseq.png || true

--- a/app-editors/logseq-desktop-bin/metadata.xml
+++ b/app-editors/logseq-desktop-bin/metadata.xml
@@ -5,6 +5,9 @@
 		<email>mschiff@gentoo.org</email>
 		<name>Marc Schiffbauer</name>
 	</maintainer>
+	<use>
+		<flag name="wayland">Run in wayland mode under wayland sessions, xwayland otherwise. This flag doesn't affect x11 sessions.</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">logseq/logseq</remote-id>
 	</upstream>


### PR DESCRIPTION
also make fcitx5 work under Wayland.

Closes: https://bugs.gentoo.org/949511

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
