### PR TITLE
profiles/default/linux: Make sure awk is in stage1

### DIFF
--- a/profiles/default/linux/packages.build
+++ b/profiles/default/linux/packages.build
@@ -5,6 +5,7 @@
 # profile.  Packages in this file are built in order.
 
 app-admin/eselect
+app-alternatives/awk
 app-arch/bzip2
 app-arch/gzip
 app-arch/xz-utils


### PR DESCRIPTION
There is sys-apps/gawk listed, but recently its pkg_postinst function was removed and that function was making sure that awk symlink was installed in stage1 if it was missing.

We had a failure during Flatcar SDK build with catalyst. Some packages in stage3 failed, because awk was missing. I worked it around with https://github.com/flatcar/scripts/commit/347cacdbb2fade33d4b7ce8a3ece2bd4d5b01dfa (I think I didn't need to add the package to coreos/base/packages, because Gentoo's base/packages already has it).

cc: @thesamesam (CCing you since you made the modification at 4d6c697c399f1e323bbe29964a8b5660f393ab14)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
