### PR TITLE
x11-themes/gtk-engines: update EAPI 7 -> 8, fix USE=lua with GCC-14+

### DIFF
--- a/x11-themes/gtk-engines/files/gtk-engines-2.20.2-lua.patch
+++ b/x11-themes/gtk-engines/files/gtk-engines-2.20.2-lua.patch
@@ -1,0 +1,69 @@
+Change non-returning gtk macros to returning gtk macros and add correct values
+to them.
+Deal with bad "convenience" redefine of lua API function, so it works with system
+lua.
+Add missing includes, both from system gtk-2 and this library.
+https://bugs.gentoo.org/919421
+--- a/engines/lua/src/lua_style.c
++++ b/engines/lua/src/lua_style.c
+@@ -21,6 +21,7 @@
+ 
+ 
+ #include <gtk/gtk.h>
++#include <glib/gprintf.h>
+ #include <cairo.h>
+ #include <math.h>
+ #include <string.h>
+@@ -34,6 +35,7 @@
+ 
+ #include "lua_utils.h"
+ #include "misc_utils.h"
++#include "draw_lib.h"
+ 
+ /* #define DEBUG 1 */
+ 
+@@ -142,8 +144,8 @@
+ lua_style_draw (LuaStyle *style, GtkWidget *widget, GtkStateType state_type,
+                 gchar *name, gint width, gint height)
+ {
+-	g_return_if_fail (style);
+-	g_return_if_fail (style->L);
++	g_return_val_if_fail (style, FALSE);
++	g_return_val_if_fail (style->L, FALSE);
+ 
+ 	lua_style_push_widget_params (style, widget, state_type);
+ 
+@@ -175,9 +177,9 @@
+ 	gchar *state;
+ 	int i;
+ 
+-	g_return_if_fail (style);
++	g_return_val_if_fail (style, NULL);
+ 	
+-	L = lua_open ();
++	L = luaL_newstate ();
+ 	luaopen_base (L);
+ 	luaopen_math (L);
+ 	luaopen_draw (L);
+@@ -233,8 +235,8 @@
+ lua_style_prepare_cairo (LuaStyle *style, GdkWindow *window, GdkRectangle *area, gint x, gint y)
+ {
+ 	cairo_t *cr;
+-	g_return_if_fail (style);
+-	g_return_if_fail (style->L);
++	g_return_val_if_fail (style, FALSE);
++	g_return_val_if_fail (style->L, FALSE);
+ 	
+ 	cr = gdk_cairo_create (window);
+ 	cairo_set_source_rgb (cr, 0, 0, 0);
+--- a/engines/lua/src/lua_utils.c
++++ b/engines/lua/src/lua_utils.c
+@@ -27,7 +27,7 @@
+ {
+ 	void *res;
+ 	
+-	g_return_if_fail (L);
++	g_return_val_if_fail (L, NULL);
+ 	
+ 	lua_getfield (L, LUA_REGISTRYINDEX, name);
+ 	if (!lua_isuserdata (L, -1))

--- a/x11-themes/gtk-engines/gtk-engines-2.20.2-r102.ebuild
+++ b/x11-themes/gtk-engines/gtk-engines-2.20.2-r102.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+GNOME2_EAUTORECONF="yes"
+GNOME2_LA_PUNT="yes"
+GNOME_TARBALL_SUFFIX="bz2"
+LUA_COMPAT=( lua5-{1..4} )
+
+inherit gnome2 lua-single multilib-minimal
+
+DESCRIPTION="GTK+2 standard engines and themes"
+HOMEPAGE="https://www.gtk.org/"
+
+LICENSE="LGPL-2.1"
+SLOT="2"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-solaris"
+IUSE="accessibility lua"
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
+
+# Lua dependency uses lua_gen_impl_dep() because LUA_REQ_USE doesn't seem
+# to play nicely with MULTILIB_USEDEP.
+RDEPEND="
+	>=x11-libs/gtk+-2.24.23:2[${MULTILIB_USEDEP}]
+	lua? ( ${LUA_DEPS} )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	>=dev-util/intltool-0.31
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-glib.h.patch
+	"${FILESDIR}"/${P}-java-look.patch
+	"${FILESDIR}"/${P}-auto-mnemonics.patch
+	"${FILESDIR}"/${P}-change-bullet.patch
+	"${FILESDIR}"/${P}-tooltips.patch
+	"${FILESDIR}"/${P}-window-dragging.patch
+	"${FILESDIR}"/${P}-slibtool.patch #766680
+	"${FILESDIR}"/${P}-automake-1.14.patch # taken from Debian
+	"${FILESDIR}/${P}-lua.patch" #919421
+)
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
+
+src_prepare() {
+	# pkgconfig wrapper set up by lua-single.eclass is not multilib-compatible
+	# at present so point Autoconf directly to the correct implementation.
+	sed -i -e "/PKG_CHECK_MODULES(LUA,/s|lua|${ELUA}|" configure.ac || die
+
+	gnome2_src_prepare
+}
+
+multilib_src_configure() {
+	local confopts=(
+		--enable-animation
+		$(multilib_native_use_enable lua)
+		$(multilib_native_use_with lua system-lua)
+	)
+	ECONF_SOURCE=${S} gnome2_src_configure "${confopts[@]}"
+}
+
+multilib_src_install() {
+	gnome2_src_install
+}


### PR DESCRIPTION
Fixed incorrect usage of gtk macros, missing glib include, missing local include and single-use "convenience" redefine of Lua API.

Bug: https://bugs.gentoo.org/919421
Closes: https://bugs.gentoo.org/949559

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
