### PR TITLE
dev-util/rt-tests: Fix build with glibc-2.41

### DIFF
--- a/dev-util/rt-tests/files/rt-tests-2.8-glibc.patch
+++ b/dev-util/rt-tests/files/rt-tests-2.8-glibc.patch
@@ -1,0 +1,55 @@
+From 280e198c39d1b17d0491d7c4e7afda97ae6c8e6f Mon Sep 17 00:00:00 2001
+From: Yaakov Selkowitz <yselkowi@redhat.com>
+Date: Wed, 29 Jan 2025 16:46:11 -0500
+Subject: [PATCH] Fix rt-tests build with glibc-2.41
+
+The sched_*attr APIs were added to glibc
+https://sourceware.org/git/?p=glibc.git;a=commit;h=21571ca0d70302909cf72707b2a7736cf12190a0
+
+This fixes the build conflict in rt-tests with glibc-2.4
+
+Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>
+Signed-off-by: John Kacur <jkacur@redhat.com>
+---
+ src/include/rt-sched.h | 2 ++
+ src/lib/rt-sched.c     | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/include/rt-sched.h b/src/include/rt-sched.h
+index 80171c76e0ee..dfd7f45f51cc 100644
+--- a/src/include/rt-sched.h
++++ b/src/include/rt-sched.h
+@@ -42,6 +42,7 @@
+ #define __NR_sched_getattr		275
+ #endif
+ 
++#if ! __GLIBC_PREREQ(2, 41)
+ struct sched_attr {
+ 	uint32_t size;
+ 	uint32_t sched_policy;
+@@ -67,5 +68,6 @@ int sched_getattr(pid_t pid,
+ 		  struct sched_attr *attr,
+ 		  unsigned int size,
+ 		  unsigned int flags);
++#endif
+ 
+ #endif /* __RT_SCHED_H__ */
+diff --git a/src/lib/rt-sched.c b/src/lib/rt-sched.c
+index 8023bc70c473..2500abde26e4 100644
+--- a/src/lib/rt-sched.c
++++ b/src/lib/rt-sched.c
+@@ -14,6 +14,7 @@
+ 
+ #include "rt-sched.h"
+ 
++#if ! __GLIBC_PREREQ(2, 41)
+ int sched_setattr(pid_t pid,
+ 		  const struct sched_attr *attr,
+ 		  unsigned int flags)
+@@ -28,3 +29,4 @@ int sched_getattr(pid_t pid,
+ {
+ 	return syscall(__NR_sched_getattr, pid, attr, size, flags);
+ }
++#endif
+-- 
+2.47.1

--- a/dev-util/rt-tests/rt-tests-2.8.ebuild
+++ b/dev-util/rt-tests/rt-tests-2.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,10 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 DEPEND="${PYTHON_DEPS}
 	sys-process/numactl"
 RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-glibc.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Fix build with glibc-2.41. Thanks.

See https://lore.kernel.org/linux-rt-users/5325ef50-b73b-1571-f937-df44718b1e1e@redhat.com/T/#mf2d08fb5fe9c502ac160b315717840d08ab6a0b3

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
