### PR TITLE
sys-apps/bat: fix build with libgit2 1.9.0

### DIFF
--- a/sys-apps/bat/bat-0.25.0.ebuild
+++ b/sys-apps/bat/bat-0.25.0.ebuild
@@ -243,6 +243,14 @@ DOCS=( README.md CHANGELOG.md doc/alternatives.md )
 
 QA_FLAGS_IGNORED="usr/bin/${PN}"
 
+src_prepare() {
+	default
+
+	# libgit2-sys unnecessarily(?) requests <libgit2-1.9.0, bump to 2 for now
+	sed -e '/range_version/s/1\.9\.0/2/' \
+		-i "${ECARGO_VENDOR}"/libgit2-sys-0.17.0+1.8.1/build.rs || die
+}
+
 src_configure() {
 	export RUSTONIG_SYSTEM_LIBONIG=1
 	export LIBGIT2_NO_VENDOR=1


### PR DESCRIPTION
Missed this in the bump since I have sys-apps/eza pinning it currently.

Closes: https://bugs.gentoo.org/949505
Closes: https://bugs.gentoo.org/949536

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
