### PR TITLE
kde-plasma/plasma-browser-integration: Add missing include to fix llvm build

### DIFF
--- a/kde-plasma/plasma-browser-integration/files/plasma-browser-integration-6.3.0-fix-missing-include.patch
+++ b/kde-plasma/plasma-browser-integration/files/plasma-browser-integration-6.3.0-fix-missing-include.patch
@@ -1,0 +1,27 @@
+From 11f5d91860d3f3392dd454298068b6757f5fb98a Mon Sep 17 00:00:00 2001
+From: Jami Kettunen <jami.kettunen@protonmail.com>
+Date: Tue, 11 Feb 2025 22:50:10 +0200
+Subject: [PATCH] Add missing include for flatpak-integrator plugin
+
+flatpak-integrator/plugin.cpp:160:13: error: use of undeclared identifier 'close'
+  160 |             close(dirfd);
+      |             ^
+---
+ flatpak-integrator/plugin.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/flatpak-integrator/plugin.cpp b/flatpak-integrator/plugin.cpp
+index 27f064cc..e6d59033 100644
+--- a/flatpak-integrator/plugin.cpp
++++ b/flatpak-integrator/plugin.cpp
+@@ -3,6 +3,7 @@
+ 
+ #include <fcntl.h>
+ #include <sys/stat.h>
++#include <unistd.h>
+ 
+ #include <QDBusConnection>
+ #include <QDBusConnectionInterface>
+-- 
+GitLab
+

--- a/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.3.0.ebuild
+++ b/kde-plasma/plasma-browser-integration/plasma-browser-integration-6.3.0.ebuild
@@ -36,6 +36,10 @@ DEPEND="${RDEPEND}
 	>=kde-frameworks/krunner-${KFMIN}:6
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-6.3.0-fix-missing-include.patch" # https://invent.kde.org/plasma/plasma-browser-integration/-/merge_requests/142
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DMOZILLA_DIR="${EPREFIX}/usr/$(get_libdir)/mozilla"


### PR DESCRIPTION
kde-plasma/plasma-browser-integration-6.3.0 fails to build with llvm due to a missing `#include <unistd.h>`. There's an upstream MR open with the fix, so this change pulls in the patch until a new upstream release is made.

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
