### PR TITLE
sys-devel/smatch: Do not install cgcc wrapper

### DIFF
--- a/sys-devel/smatch/smatch-1.72-r2.ebuild
+++ b/sys-devel/smatch/smatch-1.72-r2.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://repo.or.cz/w/smatch.git/snapshot/${PV}.tar.gz -> ${P}.tar.gz
 		mirror://gentoo/${P}.tar.gz"
 	# Update on bumps
-	S="${WORKDIR}"/${P}-2b596bf
+	S="${WORKDIR}"/${P}-7f4b936
 
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86"
 fi
@@ -29,9 +29,10 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
-	"${FILESDIR}/${PN}-1.72-C23.patch"
-	"${FILESDIR}/${PN}-1.72-function-prototype.patch"
-)
+	"${FILESDIR}/${P}-C23.patch"
+	"${FILESDIR}/${P}-function-prototype.patch"
+	"${FILESDIR}/${P}-make-deps.patch"
+	)
 
 src_prepare() {
 	default
@@ -66,8 +67,8 @@ src_test() {
 
 src_install() {
 	# default install target installs a lot of sparse cruft
-	dobin smatch cgcc
+	dobin smatch
 	insinto /usr/share/smatch/smatch_data
 	doins smatch_data/*
-	dodoc FAQ Documentation/smatch.txt
+	dodoc FAQ Documentation/smatch.rst
 }

--- a/sys-devel/smatch/smatch-1.73-r1.ebuild
+++ b/sys-devel/smatch/smatch-1.73-r1.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://repo.or.cz/w/smatch.git/snapshot/${PV}.tar.gz -> ${P}.tar.gz
 		mirror://gentoo/${P}.tar.gz"
 	# Update on bumps
-	S="${WORKDIR}"/${P}-7f4b936
+	S="${WORKDIR}"/${P}-2b596bf
 
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86"
 fi
@@ -29,10 +29,9 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
-	"${FILESDIR}/${P}-C23.patch"
-	"${FILESDIR}/${P}-function-prototype.patch"
-	"${FILESDIR}/${P}-make-deps.patch"
-	)
+	"${FILESDIR}/${PN}-1.72-C23.patch"
+	"${FILESDIR}/${PN}-1.72-function-prototype.patch"
+)
 
 src_prepare() {
 	default
@@ -67,8 +66,8 @@ src_test() {
 
 src_install() {
 	# default install target installs a lot of sparse cruft
-	dobin smatch cgcc
+	dobin smatch
 	insinto /usr/share/smatch/smatch_data
 	doins smatch_data/*
-	dodoc FAQ Documentation/smatch.rst
+	dodoc FAQ Documentation/smatch.txt
 }


### PR DESCRIPTION
It belongs to sparse. Fixes file collision.

Closes: https://bugs.gentoo.org/949623

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
