### PR TITLE
net-analyzer/ospd-openvas: fix tests.messaging.test_mqtt.MQTTDaemonTestCase adding a delay

### DIFF
--- a/net-analyzer/ospd-openvas/files/ospd-openvas-add-delay-in-mqtt-test.patch
+++ b/net-analyzer/ospd-openvas/files/ospd-openvas-add-delay-in-mqtt-test.patch
@@ -1,0 +1,33 @@
+# Fix: mqtt test
+# Closes #934153
+# Upstream https://github.com/greenbone/ospd-openvas/pull/1033/commits/f968bcc540c22dad89a2ee3bdfc6384b97b6fa0f
+
+--- a/tests/messaging/test_mqtt.py
++++ b/tests/messaging/test_mqtt.py
+@@ -3,6 +3,7 @@
+ #
+ # SPDX-License-Identifier: AGPL-3.0-or-later
+ 
++import time
+ from datetime import datetime
+ from uuid import UUID
+ 
+@@ -87,12 +88,15 @@ class MQTTDaemonTestCase(TestCase):
+         daemon = MQTTDaemon(client)
+ 
+     def test_run(self):
+-        client = mock.MagicMock()
+-
++        client = mock.MagicMock(side_effect=1)
+         daemon = MQTTDaemon(client)
++        t_ini = time.time()
+ 
+         daemon.run()
++        # In some systems the spawn of the thread can take longer than expected.
++        # Therefore, we wait until the thread is spawned or times out.
++        while len(client.mock_calls) == 0 and time.time() - t_ini < 10:
++            time.sleep(1)
+ 
+         client.connect.assert_called_with()
+-
+         client.loop_start.assert_called_with()

--- a/net-analyzer/ospd-openvas/ospd-openvas-22.7.1-r2.ebuild
+++ b/net-analyzer/ospd-openvas/ospd-openvas-22.7.1-r2.ebuild
@@ -41,6 +41,10 @@ RDEPEND="
 	notus? ( >=net-analyzer/notus-scanner-22.4 )
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-add-delay-in-mqtt-test.patch" #934153
+)
+
 distutils_enable_tests unittest
 
 python_compile() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/934153

<!-- Please put the pull request description above -->
This test [    def test_run(self):](https://github.com/greenbone/ospd-openvas/blob/cf29b79990e531820ad8a15241610f24ab2cbcf3/tests/messaging/test_mqtt.py#L89) sometimes fails because client.loop_start.assert_called_with() is called before daemon is started.
Adding a delay seems to fix the issue.
I have reported it in an upstream PR https://github.com/greenbone/ospd-openvas/pull/1026

---
- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.