### PR TITLE
net-misc/zssh: remove noop configure option

### DIFF
--- a/net-misc/zssh/zssh-1.5c-r3.ebuild
+++ b/net-misc/zssh/zssh-1.5c-r3.ebuild
@@ -39,9 +39,7 @@ src_prepare() {
 
 src_configure() {
 	tc-export AR CC RANLIB
-	#actually, nls isn't supported in this software, but in bundled lrzsz
 	econf \
-		$(use_enable nls) \
 		$(use_enable readline)
 }
 


### PR DESCRIPTION
USE=nls is provided by lrzsz, originally by bundled version, in our package - by conditional use dependency on net-dialup/lrzsz

Closes: https://bugs.gentoo.org/949569

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
