### PR TITLE
app-i18n/jfbterm: update EAPI 7 -> 8, fix home URI, port to C23

### DIFF
--- a/app-i18n/jfbterm/files/jfbterm-0.4.7-fonts.patch
+++ b/app-i18n/jfbterm/files/jfbterm-0.4.7-fonts.patch
@@ -1,0 +1,15 @@
+Use portage machinery instead of package makefiles to install fonts
+This does fc-cache, unlike before
+https://bugs.gentoo.org/835793
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -22,9 +22,7 @@
+ 
+ install-exec-hook:
+ 	chown root:utmp $(DESTDIR)$(bindir)/jfbterm
+-	chmod ug+s $(DESTDIR)$(bindir)/jfbterm
+ 
+ install-data-local:
+ 	$(INSTALL_DATA) $(srcdir)/$(JFBTERM_CONFIG_FILE) $(DESTDIR)$(sysconfdir)/$(JFBTERM_CONFIG_FILE)
+-	$(INSTALL_DATA) $(srcdir)/fonts/*.pcf.gz $(DESTDIR)$(datadir)/fonts/jfbterm
+ 

--- a/app-i18n/jfbterm/files/jfbterm-0.4.7-gettimeoftheday.patch
+++ b/app-i18n/jfbterm/files/jfbterm-0.4.7-gettimeoftheday.patch
@@ -1,0 +1,43 @@
+Man 5 utmp has instructions how to replace time with gettimeofday in utmp.
+Use them.
+https://bugs.gentoo.org/919295
+--- a/term.c
++++ b/term.c
+@@ -248,6 +248,7 @@
+ 	struct utmp	utmp;
+ 	struct passwd	*pw;
+ 	char	*tn;
++	struct timeval	tv;
+ 
+ 	pw = getpwuid(util_getuid());
+ 	tn = rindex(p->name, '/') + 1;
+@@ -262,7 +263,9 @@
+ 	    tn = p->name + 5;
+ 	strncpy(utmp.ut_line, tn, sizeof(utmp.ut_line));
+ 	strncpy(utmp.ut_user, pw->pw_name, sizeof(utmp.ut_user));
+-	time(&(utmp.ut_time));
++	gettimeofday(&tv, NULL);
++	utmp.ut_tv.tv_sec = tv.tv_sec;
++	utmp.ut_tv.tv_usec = tv.tv_usec;
+ 	pututline(&utmp);
+ 	endutent();
+ }
+@@ -271,6 +274,7 @@
+ {
+ 	struct utmp	utmp, *utp;
+ 	char	*tn;
++	struct timeval	tv;
+ 
+ 	tn = rindex(p->name, '/') + 4;
+ 	memset((char *)&utmp, 0, sizeof(utmp));
+@@ -281,7 +285,9 @@
+ 	utp->ut_type = DEAD_PROCESS;
+ 	memset(utp->ut_user, 0, sizeof(utmp.ut_user));
+ 	utp->ut_type = DEAD_PROCESS;
+-	time(&(utp->ut_time));
++	gettimeofday(&tv, NULL);
++	utp->ut_tv.tv_sec = tv.tv_sec;
++	utp->ut_tv.tv_usec = tv.tv_usec;
+ 	pututline(utp);
+ 	endutent();
+ }

--- a/app-i18n/jfbterm/jfbterm-0.4.7-r5.ebuild
+++ b/app-i18n/jfbterm/jfbterm-0.4.7-r5.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools font
+
+DESCRIPTION="The J Framebuffer Terminal/Multilingual Enhancement with UTF-8 support"
+HOMEPAGE="https://osdn.net/projects/jfbterm/"
+SRC_URI="mirror://sourceforge.jp/${PN}/13501/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="debug"
+
+# ncurses is runtime-onlu dependency, because program provides it's own terminfo
+# gzip needed for unpacking font at runtime
+RDEPEND="media-fonts/font-misc-misc
+	media-fonts/intlfonts
+	media-fonts/unifont
+	sys-libs/ncurses
+	app-alternatives/gzip"
+
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-sigchld-debian.patch
+	"${FILESDIR}"/${PN}-no-kernel-headers.patch
+	"${FILESDIR}"/${PN}-gentoo.patch
+	"${FILESDIR}"/${PN}-wrong-inline-gcc5.patch
+	"${FILESDIR}"/${PN}-automake-1.13.patch
+	"${FILESDIR}"/"${P}"-fonts.patch
+	"${FILESDIR}"/"${P}"-gettimeoftheday.patch
+)
+
+FONT_S="${S}/fonts"
+FONT_SUFFIX="pcf.gz"
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable debug)
+}
+
+src_install() {
+	dodir /etc
+	default
+
+	mv "${ED}"/etc/${PN}.conf{.sample,} || die
+
+	font_src_install
+
+	doman ${PN}.{1,conf.5}
+
+	# install example config files
+	docinto examples
+	dodoc ${PN}.conf.sample*
+	docompress -x /usr/share/doc/${PF}/examples
+}


### PR DESCRIPTION
Changes call to time() to call to gettimeofday() according to utmp man page
Removes font installation from makefile and delegates to portage machinery so font cache gets updated

Bug: https://bugs.gentoo.org/835793
Closes: https://bugs.gentoo.org/919295

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
