### PR TITLE
app-crypt/hashalot: update EAPI 7 -> 8, fix implicit decl in configure

### DIFF
--- a/app-crypt/hashalot/hashalot-0.3-r3.ebuild
+++ b/app-crypt/hashalot/hashalot-0.3-r3.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Reads a passphrase and prints a hash"
+HOMEPAGE="https://www.paranoiacs.org/~sluskyb/"
+SRC_URI="https://www.paranoiacs.org/~sluskyb/hacks/hashalot/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+
+src_prepare() {
+	default
+
+	# https://bugs.gentoo.org/900132
+	eautoreconf
+}


### PR DESCRIPTION
Autoreconf replaces bad tests with good.

Closes: https://bugs.gentoo.org/900132

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
