### PR TITLE
media-libs/libifp: update EAPI 7 -> 8, C23 and musl fixes

### DIFF
--- a/media-libs/libifp/files/libifp-1.0.0.2-c23.patch
+++ b/media-libs/libifp/files/libifp-1.0.0.2-c23.patch
@@ -1,0 +1,25 @@
+Fix incompatible function pointer types
+https://bugs.gentoo.org/880943
+--- a/src/ifp_os_libusb.c	2025-02-13 17:01:02.998513717 +0400
++++ b/src/ifp_os_libusb.c	2025-02-13 17:06:29.903489348 +0400
+@@ -20,8 +20,8 @@
+ 	char * ob, int max_o, const char * ib, int max_i)
+ {
+ 	int i=0, e=0;
+-	char const * ibb = (char const *)ib;
++	char * ibb = (char *) ib; //strip const qualifier for iconv
+ 	char * obb = (char *)ob;
+ 	size_t i_n = max_i;
+ 	size_t o_n = max_o;
+ 	iconv_t ICONV;
+--- a/src/userfile.c	2025-02-13 17:01:02.998513717 +0400
++++ b/src/userfile.c	2025-02-13 17:03:31.117230875 +0400
+@@ -947,7 +947,7 @@
+ 	return i;
+ }
+ 
+-int file_compare_fts(const FTSENT * const*p1, const FTSENT * const*p2)
++int file_compare_fts(const FTSENT const **p1, const FTSENT const **p2)
+ {
+ 	if (p1 == NULL) { ifp_err("p1 shouldn't be NULL"); return 0; }
+ 	if (p2 == NULL) { ifp_err("p2 shouldn't be NULL"); return 0; }

--- a/media-libs/libifp/files/libifp-1.0.0.2-configure.patch
+++ b/media-libs/libifp/files/libifp-1.0.0.2-configure.patch
@@ -1,0 +1,50 @@
+Fix implicit declaration to autoconf.
+Introduce dependency on pkgconf to deal with hardcoded paths in CFLAGS
+https://bugs.gentoo.org/899824
+--- a/configure.in
++++ b/configure.ac
+@@ -1,9 +1,9 @@
+-AC_INIT(configure.in)
++AC_INIT
++AC_CONFIG_SRCDIR([configure.ac])
+ 
+ #The automake documentation says this is a no-no, but I don't understand
+ #what the alternative is.
+ #Commented out until I can find out what the portable alternative is.
+-CFLAGS="-g -O2 -Wall -W -Wno-unused-parameter"
+ ##CFLAGS="-g -O2 -Wall -W"
+ 
+ AM_INIT_AUTOMAKE(libifp, 1.0.0.2)
+@@ -12,6 +12,7 @@
+ AC_PROG_LIBTOOL
+ AC_C_BIGENDIAN
+ AC_SUBST(LIBTOOL_DEPS)
++PKG_PROG_PKG_CONFIG
+ 
+ dnl AC_DEFINE(IFP_AUTOCONF)
+ 
+@@ -22,10 +23,14 @@
+ AC_MSG_CHECKING([libusb])
+ AC_ARG_WITH(libusb,
+ 	AC_HELP_STRING([--with-libusb=PATH],[libusb path (default /usr)]),
+-	ac_libusb=$enableval, ac_libusb=no)
++	ac_libusb=$withval, ac_libusb=no)
+ if test "x${ac_libusb}" != "xno" ; then
+ 		case ${with_libusb} in
+ 			"" | "yes" | "YES")
++				PKG_CHECK_MODULES([LIBUSB],[libusb],,[AC_MSG_ERROR([Cannot detect libusb])])
++				CFLAGS+=" $LIBUSB_CFLAGS"
++				CPPFLAGS+=" $LIBUSB_CFLAGS"
++				LDFLAGS+=" $LIBUSB_LDFLAGS"
+ 				;;
+ 			"no" | "NO")
+ 				use_libusb=false
+@@ -93,7 +98,7 @@
+ AC_MSG_CHECKING([kernel source code])
+ AC_ARG_WITH(kmodule,
+     AC_HELP_STRING([--with-kmodule=to/kernel/src], [build as linux kernel module [[default=no]]]),
+-    ac_kmodule=$enableval, ac_kmodule=no)
++    ac_kmodule=$withval, ac_kmodule=no)
+ if test "x$ac_kmodule" != "xno" ; then
+ 	#echo "enableval is $enableval, with_kmodule is $with_kmodule"
+ 	if test "x$with_kmodule" = "xyes" ; then

--- a/media-libs/libifp/libifp-1.0.0.2-r2.ebuild
+++ b/media-libs/libifp/libifp-1.0.0.2-r2.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="General-purpose library for iRiver's iFP portable audio players"
+HOMEPAGE="https://ifp-driver.sourceforge.net/libifp/"
+SRC_URI="https://downloads.sourceforge.net/ifp-driver/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~x86"
+IUSE="doc examples static-libs"
+
+RDEPEND="virtual/libusb:0"
+DEPEND="${RDEPEND}
+	doc? ( >=app-text/doxygen-1.3.7 )
+	elibc_musl? ( sys-libs/fts-standalone:= )"
+BDEPEND="${DEPEND}
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-configure.patch"
+	"${FILESDIR}/${P}-c23.patch"
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	use doc || export have_doxygen=no
+	use elibc_musl && append-ldflags -lfts # 713650
+	econf \
+		$(use_enable static-libs static) \
+		$(use_enable examples) \
+		--with-libusb \
+		--without-kmodule
+}
+
+src_test() { :; } # hardware dependant wrt #318597
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	find "${D}" -name '*.la' -exec rm -f {} + || die
+
+	# clean /usr/bin after installation
+	# by moving examples to examples dir
+	if use examples; then
+	    insinto /usr/share/${PN}/examples
+	    doins "${S}"/examples/simple.c "${S}"/examples/ifpline.c
+	    mv "${D}"/usr/bin/{simple,ifpline} "${D}"/usr/share/${PN}/examples || die
+	else
+	    rm -f "${D}"/usr/bin/{simple,ifpline} || die
+	fi
+
+	use doc && dodoc README ChangeLog TODO
+}


### PR DESCRIPTION
Fix missing dependency on musl system by adding conditional DEPEND and ldflag
Fix implicit declarations in configure by fixing configure.ac, introducing dependency to pkgconfig in process, as original configure.ac uses hardcoded paths, changing variable names following changes in current versions of autotools, then eautoreconf fixes remaining problems. Finally, fix pointer type mismatch - by making function signature correct and by explicitly stripping const qualifier from a pointer passed to iconf

Closes: https://bugs.gentoo.org/713650
Closes: https://bugs.gentoo.org/880943
Closes: https://bugs.gentoo.org/899824

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
