### PR TITLE
media-libs/libggiwmh: update EAPI 7 -> 8, fix impl decls in configure

### DIFF
--- a/media-libs/libggiwmh/libggiwmh-0.3.2-r2.ebuild
+++ b/media-libs/libggiwmh/libggiwmh-0.3.2-r2.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Window manager hints extensions for libggi"
+HOMEPAGE="https://ibiblio.org/ggicore/packages/libggiwmh.html"
+SRC_URI="https://downloads.sourceforge.net/ggi/${P}.src.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="X"
+
+RDEPEND=">=media-libs/libggi-2.2.2
+	X? (
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86dga
+		x11-libs/libXxf86vm
+	)"
+DEPEND="${RDEPEND}"
+
+DOCS=( ChangeLog README doc/libggiwmh{,-functions,-libraries}.txt )
+
+src_prepare() {
+	default
+
+	# https://bugs.gentoo.org/899822
+	rm acinclude.m4 || die #it's not regenerated and breaks libggi check
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable X x) \
+		$(use_with X x) \
+		--disable-static
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Autoreconf, but non-regenerated acinclude.m4 needs to be removed

Closes: https://bugs.gentoo.org/899822

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
