### PR TITLE
app-accessibility/emacspeak-ss: add missing includes

### DIFF
--- a/app-accessibility/emacspeak-ss/emacspeak-ss-1.9.1-r2.ebuild
+++ b/app-accessibility/emacspeak-ss/emacspeak-ss-1.9.1-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Adds support for several speech synthesizers to emacspeak"
+HOMEPAGE="http://leb.net/blinux/"
+SRC_URI="http://leb.net/pub/blinux/emacspeak/blinux/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND=">=app-accessibility/emacspeak-18"
+
+PATCHES=(
+	"${FILESDIR}"/gentoo-apollo-fix.patch
+	"${FILESDIR}"/"${P}"-missing-includes.patch
+)
+
+src_prepare() {
+	default
+	tc-export CC
+}
+
+src_install() {
+	emake \
+		prefix="${ED}"/usr \
+		man1dir="${ED}"/usr/share/man/man1 \
+		install
+	dodoc CREDITS ChangeLog OtherSynthesizers TODO TROUBLESHOOTING README*
+}

--- a/app-accessibility/emacspeak-ss/files/emacspeak-ss-1.9.1-missing-includes.patch
+++ b/app-accessibility/emacspeak-ss/files/emacspeak-ss-1.9.1-missing-includes.patch
@@ -1,0 +1,13 @@
+Add missing includes for implicitly declared functions
+https://bugs.gentoo.org/875479
+--- a/ping-apollo.c	2025-02-14 00:18:28.905559670 +0400
++++ b/ping-apollo.c	2025-02-14 00:19:59.617012294 +0400
+@@ -9,6 +9,8 @@
+ #include <sys/time.h>
+ #include <unistd.h>
+ #include <linux/serial.h>
++#include <stdlib.h>
++#include <string.h>
+ 
+ #define DEFAULT_DEVICE "/dev/ttyS0"
+ #define MAXCHARS 128


### PR DESCRIPTION
Fixes implicit function declarations

Closes: https://bugs.gentoo.org/875479

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
