### PR TITLE
media-libs/libggimisc: update EAPI 7 -> 8, fix impl. decls in configure

### DIFF
--- a/media-libs/libggimisc/libggimisc-2.2.2-r2.ebuild
+++ b/media-libs/libggimisc/libggimisc-2.2.2-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Adds support for some special graphical target features"
+HOMEPAGE="https://ibiblio.org/ggicore/packages/libggimisc.html"
+SRC_URI="https://downloads.sourceforge.net/ggi/${P}.src.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="fbcon svga"
+
+RDEPEND=">=media-libs/libggi-2.2.2
+	svga? ( media-libs/svgalib )"
+DEPEND="${RDEPEND}"
+
+DOCS=( ChangeLog README TODO doc/ggimisc.txt doc/libggimisc{,-functions,-libraries}.txt
+	doc/retrace.txt )
+
+src_prepare() {
+	default
+
+	rm -f acinclude.m4 || die
+	eautoreconf
+}
+
+src_configure() {
+	econf --disable-x --without-x \
+		$(use_enable svga svgalib) \
+		$(use_enable fbcon fbdev)
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	elog "X extension for ${PN} has been temporarily disabled for this release."
+}


### PR DESCRIPTION
Autoreconf with removal of acinclude.m4

Closes: https://bugs.gentoo.org/899820

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
