### PR TITLE
media-libs/libggigcp: update EAPI 7 -> 8, fix impl. decls in configure

### DIFF
--- a/media-libs/libggigcp/libggigcp-1.0.2-r2.ebuild
+++ b/media-libs/libggigcp/libggigcp-1.0.2-r2.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Libggi extension for advanced color and palette handling"
+HOMEPAGE="https://ibiblio.org/ggicore/packages/libggigcp.html"
+SRC_URI="https://downloads.sourceforge.net/ggi/${P}.src.tar.bz2"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=media-libs/libggi-2.2.2"
+DEPEND="${RDEPEND}"
+
+DOCS=( ChangeLog README doc/TODO doc/libggigcp{,-functions,-libraries,-structures}.txt
+	doc/colors{,2}.faq )
+
+src_prepare() {
+	default
+
+	rm -f acinclude.m4 || die
+	eautoreconf
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Autoreconf with removal of acinclude.m4

Closes: https://bugs.gentoo.org/899818

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
