### PR TITLE
x11-plugins/wmmaiload: update EAPI 7 -> 8, fix C23 build

### DIFF
--- a/x11-plugins/wmmaiload/files/meson.build
+++ b/x11-plugins/wmmaiload/files/meson.build
@@ -1,0 +1,77 @@
+project('wmmaiload', 'c', version: '2.3.0')
+
+add_project_arguments(
+    '-DHAVE_THREADS',
+    '-DHAVE_IMAP',
+    '-DHAVE_MAILDIR',
+    '-DHAVE_MBOX',
+    '-DHAVE_MH',
+    '-DHAVE_POP3',
+    '-DHAVE_SSL',
+    '-DHAVE_SELECT',
+    '-DHAVE_STRING_H',
+    '-DHAVE_STRINGS_H',
+    '-DHAVE_UNISTD_H',
+    language: 'c',
+)
+
+# Originally, this was generated and regenerated
+# by a set of shell functions embedded into makefile
+# replacing with sane defaults
+
+add_project_arguments(
+    '-DVERSION="2.3.0"',
+    '-DAUTHORS="Thomas Nemeth"',
+    '-DOSTYPE="linux"',
+    '-DBUILD=""',
+    language: 'c',
+)
+
+threads_dep = dependency('threads')
+ssl = dependency('openssl')
+xext = dependency('xext')
+xpm = dependency('xpm')
+gtk = dependency('gtk+-2.0')
+x11 = dependency('X11')
+
+wmmaiload_sources = [
+    'wmmaiload/checkthread.c',
+    'wmmaiload/dockapp.c',
+    'wmmaiload/imapclient.c',
+    'wmmaiload/main.c',
+    'wmmaiload/options.c',
+    'wmmaiload/pop3client.c',
+    'wmmaiload/ssl.c',
+]
+
+wmmaiload_include = include_directories('wmmaiload')
+
+wmmaiload = executable(
+    'wmmaiload',
+    wmmaiload_sources,
+    include_directories: wmmaiload_include,
+    dependencies: [threads_dep, ssl, xext, xpm],
+    install: true,
+    c_args: ['-DPACKAGE="WMMaiLoad"', '-DPROGRAM="wmmaiload"'],
+)
+
+wmmail_conf_sources = [
+    'wmmaiload-config/actions.c',
+    'wmmaiload-config/dialogs.c',
+    'wmmaiload-config/main.c',
+    'wmmaiload-config/mainwindow.c',
+    'wmmaiload-config/popedit.c',
+    'wmmaiload-config/tools.c',
+]
+
+wmmail_conf_include = include_directories('wmmaiload-config')
+
+wmmail_conf = executable(
+    'wmmaiload-config',
+    wmmail_conf_sources,
+    dependencies: [gtk, x11],
+    include_directories: wmmail_conf_include,
+    c_args: ['-DPACKAGE="WMMaiLoad-Config"', '-DPROGRAM="wmmaiload-config"'],
+    install: true,
+)
+

--- a/x11-plugins/wmmaiload/files/wmmaiload-2.3.0-c23.patch
+++ b/x11-plugins/wmmaiload/files/wmmaiload-2.3.0-c23.patch
@@ -1,0 +1,34 @@
+diff --git a/wmmaiload/dockapp.c b/wmmaiload/dockapp.c
+index f29ec9c..ee659a4 100644
+--- a/wmmaiload/dockapp.c
++++ b/wmmaiload/dockapp.c
+@@ -27,6 +27,7 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <stdlib.h>
+ 
+ #define WINDOWED_SIZE_W 64
+ #define WINDOWED_SIZE_H 64
+diff --git a/wmmaiload/main.c b/wmmaiload/main.c
+index a3d0b52..78ed1bb 100644
+--- a/wmmaiload/main.c
++++ b/wmmaiload/main.c
+@@ -138,7 +138,7 @@ static void mbox_add(MailBox **list, const char *value);
+ static BoxType getboxtype(const char *t);
+ static void free_mbox(MailBox **list);
+ static int nb_mbox(MailBox *list);
+-static void check_cfg_values();
++static void check_cfg_values(Bool wait);
+ static void replace_box_list(MailBox *replace);
+ 
+ 
+@@ -167,7 +167,7 @@ int main(int argc, char **argv)
+ #if DEBUG_LEVEL>0
+         printf("arguments parsed.\n");
+ #endif
+-        check_cfg_values();
++        check_cfg_values(False);
+         /* Load default configuration */
+         if (! config_file)
+         {

--- a/x11-plugins/wmmaiload/wmmaiload-2.3.0-r3.ebuild
+++ b/x11-plugins/wmmaiload/wmmaiload-2.3.0-r3.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit toolchain-funcs
+
+DESCRIPTION="dockapp that monitors one or more mailboxes"
+HOMEPAGE="http://tnemeth.free.fr/projets/dockapps.html"
+SRC_URI="http://tnemeth.free.fr/projets/programmes/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/gtk+:2
+	x11-libs/libXpm
+	dev-libs/openssl"
+
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.1-checkthread.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-ssl.patch
+	"${FILESDIR}"/${P}-c23.patch
+)
+
+src_configure() {
+	# The ./configure script is not autoconf based, therefore don't use econf:
+	./configure -p /usr || die
+}
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		CPP="$(tc-getCPP)" \
+		CFLAGS="${CFLAGS}" \
+		DEBUG_LDFLAGS="" \
+		LDFLAGS="${LDFLAGS}" \
+		DEBUG_CFLAGS=""
+}
+
+src_install() {
+	dobin ${PN}/${PN} ${PN}-config/${PN}-config
+	doman doc/*.1
+	dodoc AUTHORS ChangeLog FAQ NEWS README THANKS TODO doc/sample.${PN}rc
+}

--- a/x11-plugins/wmmaiload/wmmaiload-2.3.0-r3.ebuild
+++ b/x11-plugins/wmmaiload/wmmaiload-2.3.0-r3.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit toolchain-funcs
+inherit meson
 
 DESCRIPTION="dockapp that monitors one or more mailboxes"
 HOMEPAGE="http://tnemeth.free.fr/projets/dockapps.html"
@@ -18,7 +18,6 @@ RDEPEND="x11-libs/gtk+:2
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.1-checkthread.patch
 	"${FILESDIR}"/${P}-fno-common.patch
@@ -26,23 +25,17 @@ PATCHES=(
 	"${FILESDIR}"/${P}-c23.patch
 )
 
-src_configure() {
-	# The ./configure script is not autoconf based, therefore don't use econf:
-	./configure -p /usr || die
-}
+src_prepare() {
+	default
 
-src_compile() {
-	emake \
-		CC="$(tc-getCC)" \
-		CPP="$(tc-getCPP)" \
-		CFLAGS="${CFLAGS}" \
-		DEBUG_LDFLAGS="" \
-		LDFLAGS="${LDFLAGS}" \
-		DEBUG_CFLAGS=""
+	cp "${FILESDIR}"/meson.build . || die "No new build file"
+	rm -f wmmaiload/config.h && touch wmmaiload/config.h || die "Can't remove stale config"
+	rm -f wmmaiload-config/config.h && touch wmmaiload-config/config.h || die "Can't remove stale config"
 }
 
 src_install() {
-	dobin ${PN}/${PN} ${PN}-config/${PN}-config
+	meson_install
+
 	doman doc/*.1
 	dodoc AUTHORS ChangeLog FAQ NEWS README THANKS TODO doc/sample.${PN}rc
 }


### PR DESCRIPTION
see explanation below, due to reworking of the commit

Closes: https://bugs.gentoo.org/943914
Closes: https://bugs.gentoo.org/921310
Closes: https://bugs.gentoo.org/875470

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
