### PR TITLE
sys-fs/f2fs-tools: fix build with C23

### DIFF
--- a/sys-fs/f2fs-tools/f2fs-tools-1.16.0-r2.ebuild
+++ b/sys-fs/f2fs-tools/f2fs-tools-1.16.0-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Tools for Flash-Friendly File System (F2FS)"
+HOMEPAGE="https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/about/"
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/${PN}.git"
+	EGIT_BRANCH="dev"
+else
+	SRC_URI="https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/${PN}.git/snapshot/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~x86"
+fi
+
+LICENSE="GPL-2"
+SLOT="0/10"
+IUSE="lz4 lzo selinux"
+
+RDEPEND="
+	lz4? ( app-arch/lz4:= )
+	lzo? ( dev-libs/lzo:2 )
+	sys-apps/util-linux
+	selinux? ( sys-libs/libselinux )
+	elibc_musl? ( sys-libs/queue-standalone )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-musl-1.2.4-lfs.patch
+	"${FILESDIR}"/${P}-c23.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/863896
+	# Sent an email to linux-f2fs-devel@ but it hasn't been accepted yet...
+	filter-lto
+
+	local myconf=(
+		# This is required to install to /sbin, bug #481110
+		--bindir="${EPREFIX}"/sbin
+		$(use_with lz4)
+		$(use_with lzo lzo2)
+		$(use_with selinux)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+	find "${ED}" -name "*.la" -delete || die
+}

--- a/sys-fs/f2fs-tools/files/f2fs-tools-1.16.0-c23.patch
+++ b/sys-fs/f2fs-tools/files/f2fs-tools-1.16.0-c23.patch
@@ -1,0 +1,41 @@
+https://bugs.gentoo.org/944297
+https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/commit/?id=6617d15a660becc23825007ab3fc2d270b5b250f
+
+From 6617d15a660becc23825007ab3fc2d270b5b250f Mon Sep 17 00:00:00 2001
+From: Jaegeuk Kim <jaegeuk@kernel.org>
+Date: Thu, 24 Oct 2024 20:33:38 +0000
+Subject: f2fs-tools: use stdbool.h instead of bool
+
+The existing bool definition is broken for c23, where bool is now a keyword.
+
+Signed-off-by: Elliott Hughes <enh@google.com>
+Signed-off-by: Jaegeuk Kim <jaegeuk@kernel.org>
+---
+ include/f2fs_fs.h | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/include/f2fs_fs.h b/include/f2fs_fs.h
+index 9534da9..0cb9228 100644
+--- a/include/f2fs_fs.h
++++ b/include/f2fs_fs.h
+@@ -28,6 +28,7 @@
+ #include <stddef.h>
+ #include <string.h>
+ #include <time.h>
++#include <stdbool.h>
+ 
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+@@ -119,9 +120,6 @@ typedef uint16_t	u16;
+ typedef uint8_t		u8;
+ typedef u32		block_t;
+ typedef u32		nid_t;
+-#ifndef bool
+-typedef u8		bool;
+-#endif
+ typedef unsigned long	pgoff_t;
+ typedef unsigned short	umode_t;
+ 
+-- 
+cgit 1.2.3-korg
+


### PR DESCRIPTION
Add upstream patch

Closes: https://bugs.gentoo.org/944297

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
