### PR TITLE
net-analyzer/p0f: port to C23, remove USE=ipv6

### DIFF
--- a/net-analyzer/p0f/files/p0f-3.09_beta-build.patch
+++ b/net-analyzer/p0f/files/p0f-3.09_beta-build.patch
@@ -1,0 +1,66 @@
+Fixes build with C99/c23 compilers by including a patch from
+arcctgx@poczta.onet.pl at https://bugs.gentoo.org/881143#c8
+Folds all seds into a patch
+https://bugs.gentoo.org/881143
+--- a/build.sh
++++ b/build.sh
+@@ -16,11 +16,11 @@
+ BASIC_CFLAGS="-Wall -Wno-format -I/usr/local/include/ \
+               -I/opt/local/include/ -DVERSION=\"$VERSION\" $CFLAGS"
+ 
+ BASIC_LDFLAGS="-L/usr/local/lib/ -L/opt/local/lib $LDFLAGS"
+ 
+-USE_CFLAGS="-fstack-protector-all -fPIE -D_FORTIFY_SOURCE=2 -g -ggdb \
++USE_CFLAGS="-fstack-protector-all -fPIE -D_FORTIFY_SOURCE=2  \
+             $BASIC_CFLAGS"
+ 
+ USE_LDFLAGS="-Wl,-z,relro -pie $BASIC_LDFLAGS"
+ 
+ if [ "$OSTYPE" = "cygwin" ]; then
+@@ -79,12 +79,12 @@
+   exit 0
+ 
+ elif [ "$1" = "all" -o "$1" = "" ]; then
+ 
+   echo "[+] Configuring production build."
+-  BASIC_CFLAGS="$BASIC_CFLAGS -O3"
+-  USE_CFLAGS="$USE_CFLAGS -O3"
++  BASIC_CFLAGS="$BASIC_CFLAGS"
++  USE_CFLAGS="$USE_CFLAGS"
+ 
+ elif [ "$1" = "debug" ]; then
+ 
+   echo "[+] Configuring debug build."
+   BASIC_CFLAGS="$BASIC_CFLAGS -DDEBUG_BUILD=1"
+@@ -195,11 +195,11 @@
+ 
+ echo -n "[*] Checking if memory alignment is required... "
+ 
+ rm -f "$TMP" "$TMP.c" "$TMP.log" || exit 1
+ 
+-echo -e "#include \"types.h\"\nvolatile u8 tmp[6]; int main() { printf(\"%d\x5cn\", *(u32*)(tmp+1)); return 0; }" >"$TMP.c" || exit 1
++echo -e "#include <stdio.h>\n#include \"types.h\"\nvolatile u8 tmp[6]; int main() { printf(\"%d\x5cn\", *(u32*)(tmp+1)); return 0; }" >"$TMP.c" || exit 1
+ $CC $USE_CFLAGS $USE_LDFLAGS "$TMP.c" -o "$TMP" &>"$TMP.log"
+ 
+ if [ ! -x "$TMP" ]; then
+ 
+   echo "FAIL"
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -5,13 +5,13 @@
+ # Copyright (C) 2012 by Michal Zalewski <lcamtuf@coredump.cx>
+ #
+ # Distributed under the terms and conditions of GNU LGPL.
+ #
+ 
+-CC      = gcc
+-CFLAGS  = -g -ggdb -Wall -Wno-format -funsigned-char
+-LDFLAGS =
++CC      ?= gcc
++CFLAGS  +=  -Wall -Wno-format -funsigned-char
++LDFLAGS +=
+ TARGETS = p0f-client p0f-sendsyn p0f-sendsyn6
+ 
+ all: $(TARGETS)
+ 
+ clean:

--- a/net-analyzer/p0f/p0f-3.09_beta-r2.ebuild
+++ b/net-analyzer/p0f/p0f-3.09_beta-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+MY_P=${P/_beta/b}
+
+DESCRIPTION="A tool to perform passive OS detection based on SYN packets"
+HOMEPAGE="https://lcamtuf.coredump.cx/p0f3/"
+SRC_URI="https://lcamtuf.coredump.cx/p0f3/releases/${MY_P}.tgz"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="debug"
+
+RDEPEND="net-libs/libpcap"
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-build.patch" )
+
+src_prepare() {
+	default
+
+	sed -i -e "/FP_FILE/s:p0f.fp:${EPREFIX}/etc/&:" config.h || die
+}
+
+src_compile() {
+	tc-export CC
+
+	edo ./build.sh $(use debug && echo debug)
+
+	emake -C tools p0f-client p0f-sendsyn p0f-sendsyn6
+}
+
+src_test() {
+	./p0f -L || die # check that program starts and can print current interfaces
+}
+
+src_install() {
+	dosbin p0f tools/p0f-{client,sendsyn}
+	use ipv6 && dosbin tools/p0f-sendsyn6
+
+	insinto /etc
+	doins p0f.fp
+
+	dodoc docs/{ChangeLog,README,TODO,*.txt} tools/README-TOOLS
+}


### PR DESCRIPTION
Folds multiple sed incantations into one patch, also adds minimal test. C23 fix is from attachment to the bug, and folded into main patch. USE=ipv6 enabled a build of `p0f-sendsyn6` utility, build it always.

Closes: https://bugs.gentoo.org/881143

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
