### PR TITLE
net-analyzer/xprobe: update EAPI 7 -> 8, fix impl decls in configure, C23

### DIFF
--- a/net-analyzer/xprobe/files/xprobe-0.3-clang.patch
+++ b/net-analyzer/xprobe/files/xprobe-0.3-clang.patch
@@ -1,0 +1,16 @@
+Clang: ISO C++17 does not allow register storage class specifier
+https://bugs.gentoo.org/897838
+--- a/libs-external/USI++/src/misc.cc
++++ b/libs-external/USI++/src/misc.cc
+@@ -18,9 +18,9 @@
+ in_cksum (unsigned short *ptr, int nbytes, bool may_pad)
+ {
+ 
+-  register long sum;		/* assumes long == 32 bits */
++  long sum;		/* assumes long == 32 bits */
+   u_short oddbyte;
+-  register u_short answer;	/* assumes u_short == 16 bits */
++  u_short answer;	/* assumes u_short == 16 bits */
+ 
+ 
+   /* For psuedo-headers: odd len's require

--- a/net-analyzer/xprobe/files/xprobe-0.3-demangle-output.patch
+++ b/net-analyzer/xprobe/files/xprobe-0.3-demangle-output.patch
@@ -1,0 +1,156 @@
+https://github.com/dschwen/xprobe2/commit/1a8c68bc904bb1e971ec456aaff0879933a80e23
+https://bugs.gentoo.org/910424
+
+From 1a8c68bc904bb1e971ec456aaff0879933a80e23 Mon Sep 17 00:00:00 2001
+From: Daniel Schwen <daniel@schwen.de>
+Date: Mon, 22 Mar 2021 14:28:25 -0600
+Subject: [PATCH] Fix garbled output (#1)
+
+--- a/src/os_matrix.cc
++++ b/src/os_matrix.cc
+@@ -42,12 +42,12 @@ OS_Name::OS_Name(void) {
+  *******************
+  * returns FAIL is the OS already exist. os_id otherwise.
+  */
+- 
++
+ 
+ int OS_Name::add_os(string &os_name) {
+ 
+     if (find_os(os_name) != FAIL) return FAIL; /* exist */
+-    
++
+     osid_name.insert(pair<int, string>(id_count, os_name));
+     return (id_count++);
+ }
+@@ -58,7 +58,7 @@ int OS_Name::add_os(string &os_name) {
+  *******************
+  * returns FAIL is the OS does not exist. os_id otherwise.
+  */
+- 
++
+ 
+ int OS_Name::find_os(string &os_name) {
+     map <int, string>::iterator osid_i;
+@@ -76,7 +76,7 @@ int OS_Name::find_os(string &os_name) {
+  *******************
+  * for debugging _ONLY_
+  */
+- 
++
+ 
+ void OS_Name::list_oses(void) {
+     map <int, string>::iterator osid_i;
+@@ -94,18 +94,18 @@ void OS_Name::list_oses(void) {
+  *******************
+  * for debugging _ONLY_
+  */
+- 
+ 
+ 
+-const string OS_Name::osid2str(int id) {
++
++const string & OS_Name::osid2str(int id) {
+     map <int, string>::iterator osid_i = osid_name.find(id);
+     if (osid_i != osid_name.end()) return ((*osid_i).second);
+     return ("BUG, PLEASE REPORT! :-)");
+ }
+-    
++
+ /*
+  * OS_Vector stuff:
+- */        
++ */
+ OS_Vector::OS_Vector(int new_os_id) {
+     os_id = new_os_id;
+     total = 0;
+@@ -148,18 +148,18 @@ int OS_Matrix::find_os_id(int os_id) {
+         if (os_id == osid_vec[i].get_os_id()) return i;
+     return -1;
+ }
+-        
++
+ void OS_Matrix::add_result(int test_id, int os_id, int score, int times) {
+     int i;
+ 
+-    xprobe_debug(XPROBE_DEBUG_OSMATRIX, "test_id: %i os_id: %i score: %i\n", test_id, os_id, score); 
++    xprobe_debug(XPROBE_DEBUG_OSMATRIX, "test_id: %i os_id: %i score: %i\n", test_id, os_id, score);
+ 
+     if (find_os_id(os_id) == -1) /* if doesn't exist. we insert it
+                                       * first */
+         osid_vec.push_back(OS_Vector(os_id));
+ 
+     i = find_os_id(os_id);
+-	while (times-- > 0) {			
++	while (times-- > 0) {
+ 	    osid_vec[i].add_result(test_id, score);
+ 	}
+ }
+@@ -173,7 +173,7 @@ int OS_Matrix::get_score(int os_id) {
+ 
+ int OS_Matrix::get_max_score(int os_id) {
+ 	int i = find_os_id(os_id);
+-	
++
+     //return (xp_loaded_mods * XPROBE_MATCH_YES);
+ 	return (osid_vec[i].get_number_of_keywords() * XPROBE_MATCH_YES);
+ 
+@@ -181,12 +181,12 @@ int OS_Matrix::get_max_score(int os_id) {
+ 
+ int OS_Matrix::get_prcnt_score(int os_id) {
+ 
+-    if (get_score(os_id) < 0) return 0;	
++    if (get_score(os_id) < 0) return 0;
+     return get_score(os_id) * 100/get_max_score(os_id);
+ 
+ }
+ 
+-int OS_Matrix::get_top(int num) { 
++int OS_Matrix::get_top(int num) {
+ 
+     sort(osid_vec.begin(), osid_vec.end(), os_vector_compare);
+ 
+@@ -194,5 +194,4 @@ int OS_Matrix::get_top(int num) {
+         return osid_vec[num].get_os_id();
+ 
+     return 0; /* out of range */
+-} 
+-
++}
+--- a/src/os_matrix.h
++++ b/src/os_matrix.h
+@@ -44,9 +44,9 @@ class OS_Name {
+         int id_count;
+     public:
+         OS_Name(void);
+-        const string osid2str(int);
++        const string & osid2str(int);
+         const char *osid2char(int id) {
+-             string s = osid2str(id);
++             const string & s = osid2str(id);
+              return (s.c_str());
+         }
+         int add_os(string &os_name);
+@@ -54,7 +54,7 @@ class OS_Name {
+         void list_oses(void);
+         int get_osnum(void) { return id_count; }
+ };
+-               
++
+ 
+ class OS_Vector {
+ 
+@@ -79,7 +79,7 @@ class OS_Matrix {
+         vector <OS_Vector> osid_vec;
+         int xp_loaded_mods;
+         int find_os_id(int);
+-    
++
+     public:
+         OS_Matrix(int);
+         virtual ~OS_Matrix(void);
+@@ -96,4 +96,3 @@ class OS_Matrix {
+ };
+ 
+ #endif /* INTERFACE_H */
+-            

--- a/net-analyzer/xprobe/files/xprobe-0.3-makefiles.patch
+++ b/net-analyzer/xprobe/files/xprobe-0.3-makefiles.patch
@@ -1,0 +1,99 @@
+Add explicit dependency between program and library
+Fixes break with MAKEOPTS="-j1 --shuffle=3854825862" and other shuffle
+Also folds sed commands from ebuild and patches configure; running
+autoreconf breaks build
+https://bugs.gentoo.org/882675
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -47,7 +47,7 @@
+ 
+ all: lib xprobe2
+ 
+-xprobe2: $(OBJS) modules
++xprobe2: $(OBJS) modules lib
+ 	$(CXX) $(CFLAGS) $(OBJS) $(MODOBJS) -o $@ $(LDFLAGS) $(LIBS)
+ 	strip $@    
+ 
+--- a/libs-external/USI++/src/Makefile.in
++++ b/libs-external/USI++/src/Makefile.in
+@@ -15,7 +15,7 @@
+ 	clear
+ 
+ usi++:icmp.o datalink.o ip.o misc.o udp.o tcp.o TX_IP.o Layer2.o arp.o
+-	ar cr libusi++.a *.o
++	$(AR) cr libusi++.a *.o
+ #	ld *.o -Bshareable -o libusi++.so
+ 	$(RANLIB) libusi++.a
+ 	rm -f *.o
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -49,7 +49,7 @@
+ 
+ xprobe2: $(OBJS) modules lib
+ 	$(CXX) $(CFLAGS) $(OBJS) $(MODOBJS) -o $@ $(LDFLAGS) $(LIBS)
+-	strip $@    
++	true $@    
+ 
+ modules:
+ 	cd xpmodules; ${MAKE}    
+--- a/src/xplib/Makefile.in
++++ b/src/xplib/Makefile.in
+@@ -44,7 +44,7 @@
+ all: libxplib.a
+ 
+ libxplib.a: $(OBJS)
+-	ar cr libxplib.a *.o
++	$(AR) cr libxplib.a *.o
+ 	$(RANLIB) libxplib.a
+ 
+  .c.o: $(INCLUDES)
+--- a/src/xpmodules/alive_probe/Makefile.in
++++ b/src/xpmodules/alive_probe/Makefile.in
+@@ -42,7 +42,7 @@
+ all: alive_probe.a
+ 
+ alive_probe.a: icmp_ping.o tcp_ping.o udp_ping.o ttl_module portscan_module
+-	ar cr alive_probe.a *.o ttl_calc/*.o portscanner/*.o
++	$(AR) cr alive_probe.a *.o ttl_calc/*.o portscanner/*.o
+ 	$(RANLIB) alive_probe.a
+ 
+ icmp_ping.o: icmp_ping.cc
+--- a/src/xpmodules/os_probe/Makefile.in
++++ b/src/xpmodules/os_probe/Makefile.in
+@@ -43,7 +43,7 @@
+ 
+ os_probe.a: icmp_port_unreach_mod icmp_echo_id_mod icmp_timestamp_mod \
+ icmp_inforeq_mod icmp_addrmask_mod tcp_handshake_mod tcp_rst_mod smb_mod snmp_mod
+-	ar cr os_probe.a icmp_port_unreach/*.o icmp_echo_id/*.o icmp_timestamp/*.o \
++	$(AR) cr os_probe.a icmp_port_unreach/*.o icmp_echo_id/*.o icmp_timestamp/*.o \
+     icmp_inforeq/*.o icmp_addrmask/*.o tcp_handshake/*.o tcp_rst/*.o smb/*.o snmp/*.o
+ 	$(RANLIB) os_probe.a
+ 
+--- b/configure
++++ a/configure
+@@ -2252,6 +2252,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ $ac_declaration
++#include <cstdlib>
+ int
+ main ()
+ {
+@@ -2613,6 +2614,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ $ac_declaration
++#include <cstdlib>
+ int
+ main ()
+ {
+--- a/libs-external/USI++/src/configure	2025-02-15 16:41:20.320574540 +0400
++++ b/libs-external/USI++/src/configure	2025-02-15 16:42:29.463212487 +0400
+@@ -3499,6 +3499,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlibh>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/net-analyzer/xprobe/xprobe-0.3-r2.ebuild
+++ b/net-analyzer/xprobe/xprobe-0.3-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P=${PN}2-${PV}
+
+DESCRIPTION="Active OS fingerprinting tool - this is Xprobe2"
+HOMEPAGE="http://sys-security.com/blog/xprobe2"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.tar.gz"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="net-libs/libpcap"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-cxx11.patch
+	"${FILESDIR}"/${P}-gcc-12.patch
+	"${FILESDIR}"/${P}-makefiles.patch
+	"${FILESDIR}"/${P}-demangle-output.patch
+	"${FILESDIR}"/${P}-clang.patch
+)
+
+src_prepare() {
+	default
+
+	tc-export AR
+}
+
+src_install() {
+	default
+
+	dodoc AUTHORS CHANGELOG CREDITS README TODO docs/*.{txt,pdf}
+}


### PR DESCRIPTION
Ensures that package compiles and runs with clang-17+ and gcc-15+
Folds seds into patch. Fixes configure by patching includes - running autoreconf breaks the build.
Adds with attribution a patch to fix a bug where pointer to string wasn't dereferenced and mangled output.
Also fixes build dependency graph so shuffle or high job number succeed

Closes: https://bugs.gentoo.org/910424
Closes: https://bugs.gentoo.org/897838
Closes: https://bugs.gentoo.org/882675
Closes: https://bugs.gentoo.org/900044

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
