### PR TITLE
games-board/gnushogi: update EAPI 7 -> 8, fix build errors

### DIFF
--- a/games-board/gnushogi/files/gnushogi-1.4.1-makefile.patch
+++ b/games-board/gnushogi/files/gnushogi-1.4.1-makefile.patch
@@ -1,0 +1,72 @@
+Fix for the build system.
+Allows propagating errors upwards, replaces sometimes dubious
+if well-meaning seds from ebuild
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -44,19 +44,19 @@
+ #
+ 
+ gnushogi_compile:
+-	-cd $(GNUSHOGIDIR) && $(MAKE) $(PROGNAME)
++	$(MAKE) -C $(GNUSHOGIDIR) $(PROGNAME)
+ 
+ pat2inc:
+-	-cd $(GNUSHOGIDIR) && $(MAKE) pat2inc
++	$(MAKE) -C $(GNUSHOGIDIR) pat2inc
+ 
+ sizetest:
+-	-cd $(GNUSHOGIDIR) && $(MAKE) sizetest
++	$(MAKE) -C $(GNUSHOGIDIR) sizetest
+ 
+ xshogi_compile:
+-	-cd $(XSHOGIDIR) && $(MAKE)
++	$(MAKE) -C $(XSHOGIDIR)
+ 
+-bbk:
++bbk: gnushogi_compile pat2inc sizetest
+-	-cd $(GNUSHOGIDIR) && $(MAKE) $(PROGNAME).bbk
++	$(MAKE) -C $(GNUSHOGIDIR) $(PROGNAME).bbk
+ 
+ 
+ #
+@@ -73,10 +73,10 @@
+ install: gnushogi_install @XSHOGIINSTALL@
+ 
+ gnushogi_install:
+-	-cd $(GNUSHOGIDIR) && $(MAKE) install
++	$(MAKE) -C $(GNUSHOGIDIR) install
+ 
+ xshogi_install: $(XSHOGIDIR)/xshogi
+-	-cd $(XSHOGIDIR) && $(MAKE) install
++	$(MAKE) -C $(XSHOGIDIR) install
+ 
+ 
+ 
+@@ -87,13 +87,13 @@
+ clean: gnushogi_clean @XSHOGICLEAN@ doc_clean
+ 
+ gnushogi_clean:
+-	cd $(GNUSHOGIDIR) && $(MAKE) clean
++	$(MAKE) -C $(GNUSHOGIDIR) clean
+ 
+ xshogi_clean:
+-	cd $(XSHOGIDIR) && $(MAKE) clean
++	$(MAKE) -C $(XSHOGIDIR) clean
+ 
+ doc_clean:
+-	cd $(BUILDROOT)/doc && $(MAKE) clean
++	$(MAKE) -C $(BUILDROOT)/doc clean
+ 
+ 
+ #
+--- a/gnushogi/Makefile.in
++++ b//gnushogi/Makefile.in
+@@ -51,7 +51,7 @@
+ 
+ # Where the language description, the book, and the 
+ # persistent hashtable live.
+-LIBDIR  =   $(prefix)/lib/$(PROGNAME)
++LIBDIR  =   @libdir@
+ 
+ # Where the man page goes.
+ MANDIR  = $(prefix)/man/man6 

--- a/games-board/gnushogi/files/gnushogi-1.4.1-xshogi-parser.patch
+++ b/games-board/gnushogi/files/gnushogi-1.4.1-xshogi-parser.patch
@@ -1,0 +1,25 @@
+Fix compilation with modern C: add correct function declarations
+https://bugs.gentoo.org/883893
+https://bugs.gentoo.org/930372
+https://bugs.gentoo.org/932280
+--- a/xshogi/parser.y
++++ b/xshogi/parser.y
+@@ -70,7 +70,9 @@
+                   
+ enum { False, True };
+ 
+-static void yyerror();
++static void yyerror(char *);
++extern int yyparse (void);
++extern int yylex (void);
+            
+ static ShogiMove move_type;
+ static int  from_x, from_y, to_x, to_y;
+@@ -88,6 +90,7 @@
+ extern void SendToProgram(char *message, FILE *fp);
+ extern void MakeMove(ShogiMove *move_type, int from_x, int from_y, 
+                      int to_x, int to_y);
++extern void DisplayMessage(char *message, int toRemotePlayer);
+ 
+ %}
+ 

--- a/games-board/gnushogi/gnushogi-1.4.1-r2.ebuild
+++ b/games-board/gnushogi/gnushogi-1.4.1-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit desktop
 
@@ -22,18 +22,11 @@ BDEPEND="
 	>=sys-devel/bison-1.34
 	app-alternatives/lex"
 
-PATCHES=( "${FILESDIR}"/${PN}-1.4.1-fno-common.patch )
-
-src_prepare() {
-	default
-
-	sed -i \
-		-e '/^bbk:/s/$/ gnushogi_compile pat2inc sizetest/' \
-		Makefile.in || die
-	sed -i \
-		-e "/^LIBDIR/s:=.*:=\"$(get_libdir)\":" \
-		gnushogi/Makefile.in || die
-}
+PATCHES=(
+	"${FILESDIR}"/"${P}-fno-common.patch"
+	"${FILESDIR}"/"${P}-makefile.patch"
+	"${FILESDIR}"/"${P}-xshogi-parser.patch"
+)
 
 src_configure() {
 	econf \


### PR DESCRIPTION
Massages Makefile.in into fail-early form, fixes generated parser by adding missing function declarations.

Closes: https://bugs.gentoo.org/932280
Closes: https://bugs.gentoo.org/930372
Closes: https://bugs.gentoo.org/883893

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
