### PR TITLE
net-analyzer/p0f: Remove USE=ipv6 from install phase too

### DIFF
--- a/net-analyzer/p0f/p0f-3.09_beta-r2.ebuild
+++ b/net-analyzer/p0f/p0f-3.09_beta-r2.ebuild
@@ -41,8 +41,7 @@ src_test() {
 }
 
 src_install() {
-	dosbin p0f tools/p0f-{client,sendsyn}
-	use ipv6 && dosbin tools/p0f-sendsyn6
+	dosbin p0f tools/p0f-{client,sendsyn,sendsyn6}
 
 	insinto /etc
 	doins p0f.fp


### PR DESCRIPTION
Completes previous removal of USE=ipv6. Fixes merging.

Closes: https://bugs.gentoo.org/949816

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
