### PR TITLE
sys-process/atop: Restrict C version to gnu17

### DIFF
--- a/sys-process/atop/atop-2.11.0-r1.ebuild
+++ b/sys-process/atop/atop-2.11.0-r1.ebuild
@@ -51,6 +51,7 @@ src_prepare() {
 
 	if use modules ; then
 		cd "${WORKDIR}"/${NETATOP_P} || die
+		eapply "${FILESDIR}/netatop-3.2.2-strict-prototype.patch"
 
 		sed \
 			-e "s#\`uname -r\`#${KV_FULL}#g" \

--- a/sys-process/atop/atop-2.11.0-r1.ebuild
+++ b/sys-process/atop/atop-2.11.0-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Check on bumps of atop
+# https://www.atoptool.nl/downloadnetatop.php
+NETATOP_VER=3.2.2
+
+# Controls 'netatop' kernel module
+MODULES_OPTIONAL_IUSE="modules"
+NETATOP_P=netatop-${NETATOP_VER}
+NETATOP_S="${WORKDIR}"/${NETATOP_P}
+
+inherit linux-mod-r1 systemd toolchain-funcs flag-o-matic
+
+DESCRIPTION="Resource-specific view of processes"
+HOMEPAGE="https://www.atoptool.nl/ https://github.com/Atoptool/atop"
+SRC_URI="https://github.com/Atoptool/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI+=" modules? ( https://www.atoptool.nl/download/${NETATOP_P}.tar.gz )"
+
+# Module is GPL-2 as well
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+
+RDEPEND="
+	dev-libs/glib
+	sys-libs/ncurses:=
+	sys-libs/zlib
+	>=sys-process/acct-6.6.4-r1
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.11.0-build.patch
+	"${FILESDIR}"/${PN}-2.11.0-respect-opt.patch
+)
+
+pkg_pretend() {
+	if use kernel_linux ; then
+		CONFIG_CHECK="~BSD_PROCESS_ACCT"
+		check_extra_config
+	fi
+}
+
+src_prepare() {
+	append-cflags -std=gnu17 # bug 945250
+	default
+
+	if use modules ; then
+		cd "${WORKDIR}"/${NETATOP_P} || die
+
+		sed \
+			-e "s#\`uname -r\`#${KV_FULL}#g" \
+			-e "s#\$(shell uname -r)#${KV_FULL}#g" \
+			-i Makefile || die
+
+		grep -rq "uname -r" && die "found uname calls"
+
+		cd "${S}" || die
+	fi
+
+	tc-export CC PKG_CONFIG
+
+	# bug #191926
+	sed -i 's: root : :' atop.cronsysv || die
+
+	# Prefixify
+	sed -i "s:/\(usr\|etc\|var\):${EPREFIX}/\1:g" Makefile || die
+}
+
+src_compile() {
+	default
+
+	local modlist=( "netatop=:../${NETATOP_P}::netatop.ko" )
+	linux-mod-r1_src_compile
+
+	if use modules ; then
+		# Don't let the Makefile try to build the module for us
+		emake -C "${NETATOP_S}" netatopd
+	fi
+}
+
+src_install() {
+	linux-mod-r1_src_install
+
+	if use modules ; then
+		dosbin "${NETATOP_S}"/netatopd
+		doman "${NETATOP_S}"/man/*
+
+		systemd_dounit "${NETATOP_S}"/netatop.service
+
+		newinitd "${NETATOP_S}"/netatop.rc netatop
+	fi
+
+	emake DESTDIR="${D}" genericinstall
+
+	# useless -${PV} copies ?
+	rm "${ED}"/usr/bin/atop*-${PV} || die
+
+	newinitd atop.rc.openrc ${PN}
+	newinitd atopacct.rc.openrc atopacct
+
+	systemd_dounit "${S}"/${PN}.service
+	systemd_dounit "${S}"/atopacct.service
+
+	dodoc atop.cronsysv AUTHORS README
+
+	exeinto /usr/share/${PN}
+	doexe ${PN}.daily
+
+	insinto /etc/default
+	newins ${PN}{.default,}
+
+	keepdir /var/log/${PN}
+}

--- a/sys-process/atop/files/netatop-3.2.2-strict-prototype.patch
+++ b/sys-process/atop/files/netatop-3.2.2-strict-prototype.patch
@@ -1,0 +1,77 @@
+Fix for strict prototypes error: declarations are fine,
+definitions are missing void
+https://bugs.gentoo.org/949835
+--- a/netatop.c	2024-06-01 15:19:08.000000000 +0400
++++ b/netatop.c	2025-02-16 15:48:07.094848633 +0400
+@@ -1053,7 +1053,7 @@
+ ** can be found at the head
+ */
+ static void
+-gctaskexit()
++gctaskexit(void)
+ {
+ 	unsigned long	flags;
+ 	struct taskinfo	*tip;
+@@ -1087,7 +1087,7 @@
+ ** cleanup sockinfo structures that are connected to finished processes
+ */
+ static void
+-gcsockinfo()
++gcsockinfo(void)
+ {
+ 	int		i;
+ 	struct sockinfo	*sip, *sipsave;
+@@ -1300,7 +1300,7 @@
+ ** remove taskinfo structures of finished tasks from hash list
+ */
+ static void
+-gctaskinfo()
++gctaskinfo(void)
+ {
+ 	int		i;
+ 	struct taskinfo	*tip, *tipsave;
+@@ -1376,7 +1376,7 @@
+ ** remove all sockinfo structs
+ */
+ static void
+-wipesockinfo()
++wipesockinfo(void)
+ {
+ 	struct sockinfo	*sip, *sipsave;
+ 	int 		i;
+@@ -1404,7 +1404,7 @@
+ ** remove all taskinfo structs from hash list
+ */
+ static void
+-wipetaskinfo()
++wipetaskinfo(void)
+ {
+ 	struct taskinfo	*tip, *tipsave;
+ 	int 		i;
+@@ -1432,7 +1432,7 @@
+ ** remove all taskinfo structs from exit list
+ */
+ static void
+-wipetaskexit()
++wipetaskexit(void)
+ {
+ 	gctaskexit();
+ }
+@@ -1768,7 +1768,7 @@
+ ** called when module loaded
+ */
+ int
+-init_module()
++init_module(void)
+ {
+ 	int i;
+ 
+@@ -1869,7 +1869,7 @@
+ ** called when module unloaded
+ */
+ void
+-cleanup_module()
++cleanup_module(void)
+ {
+ 	/*
+  	** tell kernel daemon to stop


### PR DESCRIPTION
Heavily uses C polymorphism that GCC-15 disallows. Best if fixed upstream

Bug: https://bugs.gentoo.org/945250

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
