### PR TITLE
net-analyzer/iplog: Fix bad patch

### DIFF
--- a/net-analyzer/iplog/files/iplog-2.2.3-C23.patch
+++ b/net-analyzer/iplog/files/iplog-2.2.3-C23.patch
@@ -2,11 +2,10 @@ https://bugs.gentoo.org/945194 - guard bool for modern compilers
 https://bugs.gentoo.org/712644 - type aliaces for musl
 --- a/src/iplog.h
 +++ b/src/iplog.h
-@@ -21,6 +21,9 @@
+@@ -21,6 +21,8 @@
  #ifndef __IPLOG_H
  #define __IPLOG_H
  
-+#define _GNU_SOURCE 1
 +#include <sys/types.h> /* for u_* types */
 +
  #ifndef HAVE_IPADDR_T
@@ -22,15 +21,22 @@ https://bugs.gentoo.org/712644 - type aliaces for musl
  
  #ifdef HAVE_PATHS_H
  #	include <paths.h>
-C23 and GNU-15 compatibility, explicitly cast sockaddr
---- a/src/iplog_tcp.c
-+++ b/src/iplog_tcp.c
-@@ -144,7 +144,7 @@
+Explicitly cast sockaddr_in to sockaddr, always correct thing to do in this situation.
+--- a/src/iplog_tcp.c	2025-02-16 22:16:15.486203469 +0400
++++ b/src/iplog_tcp.c	2025-02-16 22:16:58.045309444 +0400
+@@ -142,14 +142,11 @@
+ 		fn_sin.sin_port = tcp->th_sport;
+ 		fn_sin.sin_addr.s_addr = ip->ip_src.s_addr;
  
  		ret = sendto(raw_sock, (char *) xip,
  				sizeof(struct ip) + sizeof(struct tcphdr), 0,
 -#if !defined(__GLIBC__) || (__GLIBC__ < 2)
-+#if !defined(__GLIBC__) || (__GLIBC__ < 2) || (__STDC_VERSION__ > 201710L)
- 				(struct sockaddr *)
- #endif
- 				&fn_sin,
+-				(struct sockaddr *)
+-#endif
+-				&fn_sin,
++				(struct sockaddr *)&fn_sin,
+ 				sizeof(struct sockaddr_in));
+ 
+ 		if (ret == -1)
+ 			IDEBUG(("[%s:%d] sendto: %s", __FILE__, __LINE__, strerror(errno)));
+ 


### PR DESCRIPTION
Cast sockaddr_in* to sockaddr* unconditionally, it's always right thing to do in this place both in musl and in glibc context. Fixes build failure with gcc-14 without -stc=gnu23 passed to it.
Remove remains of fixes for -std=c23, gnu extensions are always enabled in all contexts we care about.

Closes: https://bugs.gentoo.org/949571

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
