### PR TITLE
dev-lang/rust: must depend on dev-lang/gcc[cxx]

### DIFF
--- a/dev-lang/rust/rust-1.71.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.71.1-r101.ebuild
@@ -63,7 +63,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.74.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.74.1-r101.ebuild
@@ -69,7 +69,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.75.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.75.0-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.76.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.76.0-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.77.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.77.1-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.78.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.78.0-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.79.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.79.0-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.80.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.80.1-r101.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.81.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.81.0-r101.ebuild
@@ -65,7 +65,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.82.0-r102.ebuild
+++ b/dev-lang/rust/rust-1.82.0-r102.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.83.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.83.0-r2.ebuild
@@ -64,7 +64,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.84.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.0-r1.ebuild
@@ -65,7 +65,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (

--- a/dev-lang/rust/rust-1.84.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.1-r1.ebuild
@@ -65,7 +65,7 @@ LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
 BDEPEND="${PYTHON_DEPS}
 	app-eselect/eselect-rust
 	|| (
-		>=sys-devel/gcc-4.7
+		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
 	!system-llvm? (


### PR DESCRIPTION
Found while compiling with a fresh crossdev installation.
Without that, the build fails with the following error:

    [profiler_builtins 0.0.0] cargo::rerun-if-env-changed=LLVM_PROFILER_RT_LIB
    [profiler_builtins 0.0.0] cargo::rerun-if-env-changed=RUST_COMPILER_RT_FOR_PROFILER
    [profiler_builtins 0.0.0] cargo::rerun-if-changed=/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/lib/profile
    [profiler_builtins 0.0.0] cargo::rerun-if-changed=/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/include
    [profiler_builtins 0.0.0] TARGET = Some("i686-unknown-linux-gnu")
    [profiler_builtins 0.0.0] OPT_LEVEL = Some("3")
    [profiler_builtins 0.0.0] HOST = Some("x86_64-unknown-linux-gnu")
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CC_i686-unknown-linux-gnu
    [profiler_builtins 0.0.0] CC_i686-unknown-linux-gnu = None
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CC_i686_unknown_linux_gnu
    [profiler_builtins 0.0.0] CC_i686_unknown_linux_gnu = Some("i686-pc-linux-musl-gcc")
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
    [profiler_builtins 0.0.0] CRATE_CC_NO_DEFAULTS = None
    [profiler_builtins 0.0.0] DEBUG = Some("false")
    [profiler_builtins 0.0.0] CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CFLAGS_i686-unknown-linux-gnu
    [profiler_builtins 0.0.0] CFLAGS_i686-unknown-linux-gnu = None
    [profiler_builtins 0.0.0] cargo:rerun-if-env-changed=CFLAGS_i686_unknown_linux_gnu
    [profiler_builtins 0.0.0] CFLAGS_i686_unknown_linux_gnu = Some("-ffunction-sections -fdata-sections -fPIC -m32 -march=i686")
    [profiler_builtins 0.0.0] cargo:warning=i686-pc-linux-musl-gcc: error: /usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/lib/profile/InstrProfiling
    Runtime.cpp: C++ compiler not installed on this system
    [profiler_builtins 0.0.0]
    [profiler_builtins 0.0.0]
    [profiler_builtins 0.0.0] error occurred: Command "i686-pc-linux-musl-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m32" "-march=i686" "-I" "/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/include" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m32" "-march=i686" "-fno-builtin" "-fomit-frame-pointer" "-fvisibility=hidden" "-DVISIBILITY_HIDDEN" "-DCOMPILER_RT_HAS_UNAME=1" "-DCOMPILER_RT_HAS_FCNTL_LCK=1" "-DCOMPILER_RT_HAS_ATOMICS=1" "-o" "/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/build/x86_64-unknown-linux-gnu/stage1-std/i686-unknown-linux-gnu/release/build/profiler_builtins-acc5b54be66bd911/out/79fe831ac9526f6c-InstrProfilingRuntime.o" "-c" "/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/lib/profile/InstrProfilingRuntime.cpp" with args i686-pc-linux-musl-gcc did not execute successfully (status code exit status: 1).
    [profiler_builtins 0.0.0]
    [profiler_builtins 0.0.0]
    The following warnings were emitted during compilation:
    
    warning: profiler_builtins@0.0.0: i686-pc-linux-musl-gcc: error: /usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/src/llvm-project/compiler-rt/lib/profile/InstrProfilingRuntime.cpp: C++ compiler not installed on this system
    
    error: failed to run custom build command for `profiler_builtins v0.0.0 (/usr/i686-pc-linux-musl/tmp/portage/dev-lang/rust-1.82.0-r102/work/rustc-1.82.0-src/library/profiler_builtins)`
    note: To improve backtraces for build dependencies, set the CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
