### PR TITLE
app-text/xournalpp: add gtksourceview dependency

### DIFF
--- a/app-text/xournalpp/xournalpp-1.2.3-r1.ebuild
+++ b/app-text/xournalpp/xournalpp-1.2.3-r1.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/xournalpp/xournalpp.git"
 else
 	SRC_URI="https://github.com/xournalpp/xournalpp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tgz"
-	KEYWORDS="~amd64 ~ppc64"
+	KEYWORDS="amd64 ~ppc64"
 fi
 
 DESCRIPTION="Handwriting notetaking software with PDF annotation support"
@@ -33,6 +33,7 @@ COMMON_DEPEND="
 	>=media-libs/libsndfile-1.0.25
 	sys-libs/zlib:=
 	>=x11-libs/gtk+-3.18.9:3
+	>=x11-libs/gtksourceview-4.0
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}"

--- a/app-text/xournalpp/xournalpp-1.2.5-r1.ebuild
+++ b/app-text/xournalpp/xournalpp-1.2.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/xournalpp/xournalpp.git"
 else
 	SRC_URI="https://github.com/xournalpp/xournalpp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tgz"
-	KEYWORDS="amd64 ~ppc64"
+	KEYWORDS="~amd64 ~ppc64"
 fi
 
 DESCRIPTION="Handwriting notetaking software with PDF annotation support"
@@ -33,6 +33,7 @@ COMMON_DEPEND="
 	>=media-libs/libsndfile-1.0.25
 	sys-libs/zlib:=
 	>=x11-libs/gtk+-3.18.9:3
+	>=x11-libs/gtksourceview-4.0
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}"


### PR DESCRIPTION
When opened, Xournalpp complained that there was no `libgtksourceview` in my system. That dependency was missing in the ebuild. 
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.


