### PR TITLE
dev-debug/pwndbg: fix dependencies according to upstream requirements

### DIFF
--- a/dev-debug/pwndbg/pwndbg-20250120-r1.ebuild
+++ b/dev-debug/pwndbg/pwndbg-20250120-r1.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 		>=dev-python/typing-extensions-4.12.0[${PYTHON_USEDEP}]
 		>=dev-util/pwntools-4.13.1[${PYTHON_USEDEP}]
 		>=dev-util/ROPgadget-7.3[${PYTHON_USEDEP}]
-		>=dev-util/unicorn-2.0.1[python,${PYTHON_USEDEP}]
+		>=dev-util/unicorn-2.1.1[python,${PYTHON_USEDEP}]
 	')
 "
 

--- a/dev-debug/pwndbg/pwndbg-99999999.ebuild
+++ b/dev-debug/pwndbg/pwndbg-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,7 +38,7 @@ RDEPEND="
 		>=dev-python/typing-extensions-4.6.1[${PYTHON_USEDEP}]
 		>=dev-util/pwntools-4.11.0[${PYTHON_USEDEP}]
 		>=dev-util/ROPgadget-7.2[${PYTHON_USEDEP}]
-		>=dev-util/unicorn-2.0.1[python,${PYTHON_USEDEP}]
+		>=dev-util/unicorn-2.1.1[python,${PYTHON_USEDEP}]
 	')
 "
 


### PR DESCRIPTION
fix dependencies

Upstream requires most recent version of `dev-util/unicorn`, although older version still work.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
