### PR TITLE
app-editors/helix: Add ARM64 support

### DIFF
--- a/app-editors/helix/helix-25.01.ebuild
+++ b/app-editors/helix/helix-25.01.ebuild
@@ -311,7 +311,7 @@ LICENSE+="
 	ZLIB
 "
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="amd64 arm64"
 IUSE="+grammar"
 
 RDEPEND="dev-vcs/git"


### PR DESCRIPTION
Tested on Snapdragon X Elite, works without any other changes.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
