### PR TITLE
www-apps/radicale: add optional library as test dep

### DIFF
--- a/www-apps/radicale/radicale-3.4.1.ebuild
+++ b/www-apps/radicale/radicale-3.4.1.ebuild
@@ -32,6 +32,7 @@ RDEPEND="
 
 BDEPEND="
 	test? (
+		dev-python/bcrypt[${PYTHON_USEDEP}]
 		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/waitress[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
We moved dev-python/bcrypt from RDEPEND to optfeature, however for the test suite it remains madatory. So add it to BDEPEND when test is set.


Closes: https://bugs.gentoo.org/949850

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
