### PR TITLE
net-misc/vmpsd: update EAPI 7 -> 8, port to C23

### DIFF
--- a/net-misc/vmpsd/files/vmpsd-1.4-C23.patch
+++ b/net-misc/vmpsd/files/vmpsd-1.4-C23.patch
@@ -1,0 +1,159 @@
+Fix compilation with -std=gnu23: missing function decls,
+wrong prototypes, old-style prototypes, incorrect function
+pointer types.
+https://bugs.gentoo.org/887249
+https://bugs.gentoo.org/883125
+--- a/daemon.c
++++ b/daemon.c
+@@ -40,14 +40,11 @@
+ 
+ #endif
+ 
+ }
+ 
+-void daemon_start(ignsigcld)
+-
+-	int	ignsigcld;	
+-
++void daemon_start(int ignsigcld)
+ {
+ 	register int	childpid;
+ 
+ #ifdef  VMPS_CHECK_BSD
+ 	int	fd;
+--- a/data.c
++++ b/data.c
+@@ -5,10 +5,12 @@
+ #include <string.h>
+ 
+ #include "data.h"
+ #include "log.h"
+ 
++extern void parse_error(const char *token); // from parser.c
++
+ void 	*macs = NULL;
+ void 	*vlans = NULL;
+ void	*ports = NULL;
+ void 	*vlan_groups = NULL;
+ void 	*port_groups = NULL;
+@@ -35,13 +37,14 @@
+ 	exit(1);
+ }
+ 
+ void *xfree(void *p) {
+ 
+-	if (p == NULL) return;
++	if (p == NULL) return NULL;
+ 	vmps_log(DEBUG|SYSTEM, "FREE: %x",p);
+ 	free(p);
++	return NULL;
+ }
+ 
+ /* --------------------------------------------------------------------------- */
+ 
+ int compare_mac(const void *pa, const void *pb) {
+--- a/external.c
++++ b/external.c
+@@ -20,11 +20,11 @@
+ pid_t	external_pid = 0;
+ 
+ int	tocli[2];
+ int	fromcli[2];
+ 
+-RETSIGTYPE sig_term()
++RETSIGTYPE sig_term(int)
+ {
+ 
+ 	vmps_log(SYSTEM|INFO, "Terminating external program (%d).", external_pid);
+ 	if ( kill(external_pid, SIGTERM) < 0 ) {
+ 		vmps_log(SYSTEM|FATAL, "Cannot send TERM signal to external program (%s).", strerror(errno));
+@@ -33,21 +33,21 @@
+ 
+ 	vmps_log(SYSTEM|INFO, "VMPSD TERMINATING.");
+ 	exit(0);
+ }
+ 
+-RETSIGTYPE sig_child_e()
++RETSIGTYPE sig_child_e(int)
+ {
+         int     pid;
+         int     status;
+ 
+         pid = wait3(&status, WNOHANG, (struct rusage *) 0);
+ 	vmps_log(SYSTEM|INFO, "VMPSD EXITING (external program terminating prematurely)[%d].",pid);
+ 	exit(1);
+ }
+ 
+-int spawn_external()
++int spawn_external(void)
+ {
+ 
+ 	pid_t	chpid;
+ 
+ 	signal(SIGCHLD, sig_child_e);
+--- a/external.h
++++ b/external.h
+@@ -6,7 +6,8 @@
+ extern char 	external_prog[256];
+ extern pid_t	external_pid;
+ 
+ int get_vlan_external(VQP_REQUEST *r, char *vlan_name);
+ void do_request_external(int sock, VQP_REQUEST *r );
++int spawn_external(void);
+ 
+ #endif
+--- a/vmpsd.c
++++ b/vmpsd.c
+@@ -11,10 +11,13 @@
+ 
+ #include "vqp.h"
+ #include "log.h"
+ #include "external.h"
+ 
++extern void parse_db_file(const char *fname); //from parse.c
++extern void daemon_start(int ignsigcld); //from daemon.c
++
+ struct in_addr	bind_address; 
+ unsigned int	port_number = 1589;
+ char    	db_fname[256];
+ int		default_behaviour = 0;
+ 
+@@ -93,11 +96,11 @@
+ 	printf("\t                 0x0004 - vqp\n");
+ 	printf("\t-p port    port to listen on (1589)\n");
+ 	printf("\n");
+ }
+ 
+-RETSIGTYPE handle_sighup() {
++RETSIGTYPE handle_sighup(int,  siginfo_t *, void *) {
+ 
+ 	if ( external_logic ) return;
+ 	vmps_log(PARSER|INFO, "RECEIVED SIGHUP. Re-reading config file");
+ 	drop_data();
+ 	parse_db_file(db_fname);
+--- a/vqp.c
++++ b/vqp.c
+@@ -3,10 +3,11 @@
+ #include <string.h>
+ #include <netdb.h>
+ 
+ #include "log.h"
+ #include "data.h"
++#include "snmp.h"
+ #include "vqp.h"
+ #include "external.h"
+ 
+ int get_request(int sock, VQP_REQUEST *r)
+ {
+--- a/vqp.h
++++ b/vqp.h
+@@ -50,7 +50,9 @@
+ extern int      default_behaviour;
+ 
+ int get_request(int sock, VQP_REQUEST *r);
+ void print_request(VQP_REQUEST *r);
+ void do_request(int sock, VQP_REQUEST *r );
++int send_response(int sock, u_char action, VQP_REQUEST *r, char *vlan_name);
++void print_action(VQP_REQUEST *r, char *str, char *vlan_name);
+ 
+ #endif

--- a/net-misc/vmpsd/files/vmpsd-1.4-missing-includes.patch
+++ b/net-misc/vmpsd/files/vmpsd-1.4-missing-includes.patch
@@ -1,0 +1,80 @@
+From:  Jocelyn Mayer <l_indien@mailmagic.fr>
+Patches missing includes and other C99 compilation errors
+https://bugs.gentoo.org/887249
+--- a/daemon.c	2005-12-29 16:32:02.000000000 +0100
++++ b/daemon.c	2019-06-07 09:50:06.839448716 +0200
+@@ -2,10 +2,14 @@
+ 
+ #include "log.h"
+ 
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <signal.h>
++#include <sys/types.h>
+ #include <sys/param.h>
++#include <sys/stat.h>
+ #include <sys/wait.h>
++#include <unistd.h>
+ #include <errno.h>
+ 
+ #ifdef	SETPGRP_VOID
+@@ -38,7 +42,7 @@ RETSIGTYPE sig_child()
+ 
+ }
+ 
+-daemon_start(ignsigcld)
++void daemon_start(ignsigcld)
+ 
+ 	int	ignsigcld;	
+ 
+--- a/data.c	2004-07-08 22:58:20.000000000 +0200
++++ b/data.c	2019-06-07 09:46:32.896814247 +0200
+@@ -2,7 +2,7 @@
+ 
+ #include <stdlib.h>
+ #include <search.h>
+-#include <stdlib.h>
++#include <string.h>
+ 
+ #include "data.h"
+ #include "log.h"
+--- a/external.c	2004-11-10 14:10:04.000000000 +0100
++++ b/external.c	2019-06-07 09:42:38.903931334 +0200
+@@ -1,5 +1,7 @@
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <signal.h>
++#include <string.h>
+ #include <sys/param.h>
+ #include <sys/wait.h>
+ #include <sys/types.h>
+--- a/parser.c	2004-07-08 15:57:30.000000000 +0200
++++ b/parser.c	2019-06-07 09:41:00.534719377 +0200
+@@ -1,5 +1,6 @@
+ #include "config.h"
+ 
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <string.h>
+--- a/vmpsd.c	2019-06-07 09:28:33.013509568 +0200
++++ b/vmpsd.c	2019-06-07 09:44:38.800408508 +0200
+@@ -1,7 +1,9 @@
+ #include "config.h"
+ 
+ #include <stdlib.h>
++#include <stdio.h>
+ #include <signal.h>
++#include <string.h>
+ 
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+--- a/vqp.c	2019-06-07 09:28:33.085510455 +0200
++++ b/vqp.c	2019-06-07 09:41:48.839314511 +0200
+@@ -1,5 +1,6 @@
+ #include "config.h"
+ 
++#include <string.h>
+ #include <netdb.h>
+ 
+ #include "log.h"

--- a/net-misc/vmpsd/vmpsd-1.4-r1.ebuild
+++ b/net-misc/vmpsd/vmpsd-1.4-r1.ebuild
@@ -1,13 +1,14 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
 DESCRIPTION="An open-source VLAN management system"
-HOMEPAGE="http://vmps.sourceforge.net"
+HOMEPAGE="https://vmps.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/vmps/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -18,17 +19,16 @@ DEPEND="
 	${RDEPEND}
 	dev-libs/openssl"
 
-S="${WORKDIR}/${PN}"
-
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.4-snmp-support.patch
 	"${FILESDIR}"/${PN}-1.3-64bit.patch
-	"${FILESDIR}"/${PN}-1.4-Wreturn-type.patch
+	"${FILESDIR}"/${PN}-1.4-missing-includes.patch
+	"${FILESDIR}"/${PN}-1.4-C23.patch
 )
 
 src_prepare() {
 	default
-	mv configure.{in,ac} || die
+
 	eautoreconf
 }
 


### PR DESCRIPTION
Incorporates patch from the bugzilla and bugs that bitrotten since: more missing declarations, wrong declarations, missing includes.

Haven't checked if it fixes musl build - net-analyzer/net-snmp is a dependency and it fails on musl.

As -r0 was also `testing`, I dropped it and put -r1 instead.

Closes: https://bugs.gentoo.org/887249
Closes: https://bugs.gentoo.org/883125

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
