### PR TITLE
dev-lang/rust: remove REQUIRED_USE for x86

### DIFF
--- a/dev-lang/rust/rust-1.82.0-r102.ebuild
+++ b/dev-lang/rust/rust-1.82.0-r102.ebuild
@@ -105,7 +105,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	rust-analyzer? ( rust-src )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
-	x86? ( cpu_flags_x86_sse2 )
 "
 
 # we don't use cmake.eclass, but can get a warning

--- a/dev-lang/rust/rust-1.83.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.83.0-r2.ebuild
@@ -105,7 +105,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	rust-analyzer? ( rust-src )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
-	x86? ( cpu_flags_x86_sse2 )
 "
 
 # we don't use cmake.eclass, but can get a warning

--- a/dev-lang/rust/rust-1.84.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.0-r1.ebuild
@@ -106,7 +106,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	rust-analyzer? ( rust-src )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
-	x86? ( cpu_flags_x86_sse2 )
 "
 
 # we don't use cmake.eclass, but can get a warning

--- a/dev-lang/rust/rust-1.84.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.1-r1.ebuild
@@ -106,7 +106,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	rust-analyzer? ( rust-src )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
-	x86? ( cpu_flags_x86_sse2 )
 "
 
 # we don't use cmake.eclass, but can get a warning


### PR DESCRIPTION
This fix was included in

https://github.com/gentoo/gentoo/pull/38792

but it was clobbered by further version bumps.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
