### PR TITLE
net-misc/nx: add x11-apps/xkbcomp as RDEPEND

### DIFF
--- a/net-misc/nx/nx-3.5.99.27-r1.ebuild
+++ b/net-misc/nx/nx-3.5.99.27-r1.ebuild
@@ -18,6 +18,7 @@ RDEPEND="dev-libs/libxml2
 	media-libs/libjpeg-turbo:*
 	>=media-libs/libpng-1.2.8:0=
 	>=sys-libs/zlib-1.2.3
+	x11-apps/xkbcomp
 	x11-libs/libX11
 	x11-libs/libXcomposite
 	x11-libs/libXdamage


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/687816
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
