### PR TITLE
sci-chemistry/molmol: Consolidate patches, remove seds, pin C to gnu17

### DIFF
--- a/sci-chemistry/molmol/files/molmol-2k_p2-transform-makefiles.patch
+++ b/sci-chemistry/molmol/files/molmol-2k_p2-transform-makefiles.patch
@@ -1,0 +1,40 @@
+Transformed multiple seds to this patch. `MOLMOLHOME` is the runtime variable
+that depends on knowledge of paths that I didn't think of how to correctly
+pass beyond editing it with sed. For everything else, it is here and changed
+to work correctly with build system.
+Rolled up sed transformations were to made build system non-parallel,
+fix environmental variables, remove sleep and add use right shell and
+build dependencies in startup script.
+--- a/makedef.lnx
++++ b/makedef.lnx
+@@ -11,12 +11,12 @@
+ 
+ XINCL   = -I/usr/X11R6/include
+ 
+-CC=gcc
++CC ?= gcc
+ MCPPFLAGS =
+-MCFLAGS =-pipe -O3 -ffast-math -march=i686 -mcpu=i686
++MCFLAGS := $(CFLAGS)
+ 
+ RANLIB   = /bin/true
+-WAIT     = sleep 2
++WAIT     = sleep 0
+ SHELL    = /bin/sh
+ CPP      = /lib/cpp
+ 
+--- a/molmol
++++ b/molmol
+@@ -1,9 +1,10 @@
+-#!/bin/ksh
++#!/bin/sh
+ #
+ # startup script for MOLMOL
+ #
+ 
+-MOLMOLHOME=/opt/group/MOLMOL
++MOLMOLHOME=/;
++MOLMOLDEV="Motif/OpenGL"
+ export MOLMOLHOME
+ export MOLMOLDEV
+ 

--- a/sci-chemistry/molmol/molmol-2k_p2-r10.ebuild
+++ b/sci-chemistry/molmol/molmol-2k_p2-r10.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit desktop toolchain-funcs flag-o-matic
+
+MY_PV="${PV/_p/.}.0"
+MY_P="${PN}-${MY_PV}"
+
+DESCRIPTION="Publication-quality molecular visualization package"
+
+# Original page dead
+#HOMEPAGE="http://hugin.ethz.ch/wuthrich/software/molmol/index.html"
+HOMEPAGE="
+	http://www.csb.yale.edu/userguides/graphics/molmol/molmol_descrip.html
+	http://pjf.net/science/molmol.html
+"
+SRC_URI="
+	ftp://ftp.mol.biol.ethz.ch/software/MOLMOL/unix-gzip/${MY_P}-src.tar.gz
+	ftp://ftp.mol.biol.ethz.ch/software/MOLMOL/unix-gzip/${MY_P}-doc.tar.gz
+	https://dev.gentoo.org/~soap/distfiles/${PN}-patches.tbz2
+	https://dev.gentoo.org/~pacho/${PN}/${PN}_256.png
+"
+S="${WORKDIR}"
+
+LICENSE="molmol"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+
+RDEPEND="
+	|| (
+		(
+			media-libs/mesa[X(+)]
+			x11-libs/libGLw
+		)
+		media-libs/mesa[motif(-),X(+)]
+	)
+	media-libs/libjpeg-turbo:=
+	media-libs/libpng:=
+	media-libs/tiff:=
+	sys-libs/zlib
+	virtual/glu
+	x11-libs/libXpm
+	x11-libs/motif:0
+	x11-apps/xdpyinfo
+	media-fonts/font-adobe-100dpi
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc14-fix.patch
+	# Patch from http://pjf.net/science/molmol.html, where src.rpm is provided
+	"${WORKDIR}"/patches/pjf_RH9_molmol2k2.diff
+	"${WORKDIR}"/patches/ldflags.patch
+	"${WORKDIR}"/patches/opengl.patch
+	"${WORKDIR}"/patches/cast.patch
+	# patch from fink
+	# fixes numerous bad bracings and hopefully the OGL bug 429974
+	"${WORKDIR}"/patches/${P}-fink.patch
+	"${WORKDIR}"/patches/wild.patch
+
+	"${FILESDIR}"/${P}-transform-makefiles.patch
+)
+
+pkg_setup() {
+	MMDIR="/usr/$(get_libdir)/molmol"
+}
+
+src_prepare() {
+	default
+	eapply -p0 "${WORKDIR}"/patches/libpng15.patch
+	rm -rf tiff*
+
+	sed \
+		-e "s|^MOLMOLHOME.*|MOLMOLHOME=${EPREFIX}/${MMDIR}|" \
+		-i "${S}"/molmol || die
+
+	ln -s makedef.lnx "${S}"/makedef || die
+
+	# Parallel build fails (#880621) and cannot be disabled by MAKEOPTS
+	# (#880621, #941488).
+	find . -name Makefile -exec sed -i -e "1i .NOTPARALLEL:" {} + || die
+
+	# https://bugs.gentoo.org/944200
+	# uses C polymorphism. Can't be trivially patched
+	append-cflags -std=gnu17
+	tc-export AR CC
+}
+
+src_install() {
+	dobin molmol
+
+	exeinto ${MMDIR}
+	doexe src/main/molmol
+	insinto ${MMDIR}
+	doins -r auxil help macros man setup tips
+
+	make_desktop_entry "${PN}" MOLMOL
+	newicon "${DISTDIR}/${PN}_256.png" "${PN}.png"
+
+	einstalldocs
+	dodoc HISTORY
+}


### PR DESCRIPTION
This uses C polymorphism with function pointers without signature. Fixing that without major re-engineering would be problematic. Five sed expressions are consolidated into patch, re-engineeded when needed, eg. for CC and MCFLAGS.
Where possible, patches are moved from eapply inside src_prepare to PATCHES variable, order of preparations is changed for better understanding.

Closes: https://bugs.gentoo.org/944200

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
