### PR TITLE
dev-python/versioningit: add RDEPEND to dev-vcs/git

### DIFF
--- a/dev-python/versioningit/versioningit-3.1.2-r1.ebuild
+++ b/dev-python/versioningit/versioningit-3.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,6 +23,7 @@ RDEPEND="
 	$(python_gen_cond_dep '
 		<dev-python/tomli-3[${PYTHON_USEDEP}]
 	' 3.10)
+	dev-vcs/git
 "
 BDEPEND="
 	test? (


### PR DESCRIPTION
Python module calls git binary at runtime. See
https://bugs.gentoo.org/949873.

Closes: https://bugs.gentoo.org/949873

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
