### PR TITLE
sys-apps/accountsservice: add vala support

### DIFF
--- a/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
+++ b/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 PYTHON_COMPAT=( python3_{10..13} )
-inherit meson python-any-r1 systemd
+inherit meson python-any-r1 systemd vala
 
 DESCRIPTION="D-Bus interfaces for querying and manipulating user account information"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/AccountsService/"
@@ -13,7 +13,7 @@ LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~loong ppc ppc64 ~riscv ~sparc x86"
 
-IUSE="doc elogind gtk-doc +introspection selinux systemd test"
+IUSE="doc elogind gtk-doc +introspection selinux systemd test vala"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="^^ ( elogind systemd )"
 
@@ -42,6 +42,7 @@ BDEPEND="
 		dev-util/gtk-doc
 		app-text/docbook-xml-dtd:4.3
 	)
+	vala? ( $(vala_depend) )
 	test? (
 		$(python_gen_any_dep '
 			dev-python/python-dbusmock[${PYTHON_USEDEP}]
@@ -68,6 +69,12 @@ python_check_deps() {
 	fi
 }
 
+src_prepare() {
+	default
+
+	use vala && vala_setup
+}
+
 src_configure() {
 	# No option to disable tests
 	if ! use test; then
@@ -82,7 +89,7 @@ src_configure() {
 		$(meson_use introspection)
 		$(meson_use doc docbook)
 		$(meson_use gtk-doc gtk_doc)
-		-Dvapi=false
+		$(meson_use vala vapi)
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
The ebuild has `-Dvapi=false`, this commit will change that to use the vala useflag, thus allowing it to be build with vala support so other packages can ask for this with vala build support.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
