### PR TITLE
app-shells/mksh: apply upstream patch to fix fgrep deprecation

### DIFF
--- a/app-shells/mksh/files/mksh-59c-fgrep.patch
+++ b/app-shells/mksh/files/mksh-59c-fgrep.patch
@@ -1,0 +1,60 @@
+From 94229c3fdb6bb3afcc6fbecf4b2e521a9d485dd1 Mon Sep 17 00:00:00 2001
+From: tg <tg@mirbsd.org>
+Date: Tue, 27 Jul 2021 19:17:14 +0000
+Subject: [PATCH] =?UTF-8?q?we=20may=20have=20neither=20fgrep=20nor=20grep?=
+ =?UTF-8?q?=20-F=20(scosysv=20has=20only=20the=20former=E2=80=A6)?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ Build.sh | 6 +++---
+ check.t  | 8 ++++----
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Build.sh b/Build.sh
+index dc98dfa2..08d368d2 100644
+--- a/Build.sh
++++ b/Build.sh
+@@ -1413,7 +1413,7 @@ tcc)
+ 	;;
+ tendra)
+ 	vv '|' "$CC $CFLAGS $CPPFLAGS $LDFLAGS $NOWARN $LIBS -V 2>&1 | \
+-	    grep -F -i -e version -e release"
++	    grep -i -e version -e release"
+ 	;;
+ ucode)
+ 	vv '|' "$CC $CFLAGS $CPPFLAGS $LDFLAGS $NOWARN $LIBS -V"
+@@ -2688,7 +2688,7 @@ cat >test.sh <<-EOF
+ 		args[\${#args[*]}]=\$TMPDIR
+ 	fi
+ 	print Testing mksh for conformance:
+-	grep -F -e 'KSH R' -e Mir''OS: "\$sflag" | sed '/KSH/s/^./&           /'
++	grep -e 'KSH R' -e Mir''OS: "\$sflag" | sed '/KSH/s/^./&           /'
+ 	print "This shell is actually:\\n\\t\$KSH_VERSION"
+ 	print 'test.sh built for mksh $dstversion'
+ 	cstr='\$os = defined \$^O ? \$^O : "unknown";'
+diff --git a/check.t b/check.t
+index 0d9d50c4..bfe116f0 100644
+--- a/check.t
++++ b/check.t
+@@ -6726,7 +6726,7 @@ stdin:
+ 		echo FNORD-7
+ 		typeset -
+ 		echo FNORD-8
+-	} | fgrep FNORD
++	} | grep FNORD
+ 	fnord=(42 23)
+ 	typeset -p fnord
+ 	echo FNORD-9
+@@ -8723,8 +8723,8 @@ stdin:
+ 	(echo x; exit 12) | (cat; exit 23) | (cat; exit 42)
+ 	echo 5 $? , $PIPESTATUS , ${PIPESTATUS[0]} , ${PIPESTATUS[1]} , ${PIPESTATUS[2]} , ${PIPESTATUS[3]} .
+ 	echo 6 ${PIPESTATUS[0]} .
+-	set | fgrep PIPESTATUS
+-	echo 8 $(set | fgrep PIPESTATUS) .
++	set | grep PIPESTATUS
++	echo 8 $(set | grep PIPESTATUS) .
+ expected-stdout:
+ 	1 0 .
+ 	2 0 .

--- a/app-shells/mksh/mksh-59c.ebuild
+++ b/app-shells/mksh/mksh-59c.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -38,6 +38,10 @@ DEPEND="
 		sys-apps/ed
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}/mksh-59c-fgrep.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/949882

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
