### PR TITLE
media-video/xvattr: Fix build

### DIFF
--- a/media-video/xvattr/files/xvattr-1.3-conflicting-types.patch
+++ b/media-video/xvattr/files/xvattr-1.3-conflicting-types.patch
@@ -1,0 +1,42 @@
+Fix incompatible pointers, GTK style
+Also, remove non-POSIX getopt declaration that conflitcts
+with musl
+https://bugs.gentoo.org/919367
+https://bugs.gentoo.org/945292
+--- a/gxvattr.c
++++ b/gxvattr.c
+@@ -256,7 +256,7 @@
+         label = gtk_label_new (xvattr[k].name);
+         if (!strcmp(xvattr[k].name, "XV_COLORKEY")) {
+           manipulator = gtk_color_selection_new();
+-          set_color_widget(manipulator, cur_val);
++          set_color_widget(GTK_OBJECT(manipulator), cur_val);
+           property->controller = (GtkObject *) manipulator;
+           property->set_widget = set_color_widget;
+           if (xvattr[k].flags & XvSettable) {
+@@ -269,7 +269,7 @@
+ 	           xvattr[k].max_value == 1) {
+ 	  // boolean value, use check button
+ 	  manipulator = gtk_check_button_new();
+-	  set_bool_widget(manipulator, cur_val);
++	  set_bool_widget(GTK_OBJECT(manipulator), cur_val);
+           property->controller = (GtkObject *) manipulator;
+           property->set_widget = set_bool_widget;
+           if (xvattr[k].flags & XvSettable) {
+--- a/getopt.h
++++ b/getopt.h
+@@ -138,14 +138,7 @@
+    `getopt'.  */
+ 
+ #if (defined __STDC__ && __STDC__) || defined __cplusplus
+-# ifdef __GNU_LIBRARY__
+-/* Many other libraries have conflicting prototypes for getopt, with
+-   differences in the consts, in stdlib.h.  To avoid compilation
+-   errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
+-# else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
+-# endif /* __GNU_LIBRARY__ */
+ 
+ # ifndef __need_getopt
+ extern int getopt_long (int __argc, char *const *__argv, const char *__shortopts,

--- a/media-video/xvattr/xvattr-1.3-r4.ebuild
+++ b/media-video/xvattr/xvattr-1.3-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,6 +26,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${P}-gtk.patch
 	"${FILESDIR}"/${P}-pod-encoding.patch
+	"${FILESDIR}"/${P}-conflicting-types.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Corrects incompatible pointer types by casting GTK-style. Also removes fallback definition of getopt, leaving only POSIX one, because it is present both on glibc and musl systems

Closes: https://bugs.gentoo.org/945292
Closes: https://bugs.gentoo.org/919367

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
