### PR TITLE
sci-geosciences/grass: fix addpredict use

### DIFF
--- a/sci-geosciences/grass/grass-8.3.2-r1.ebuild
+++ b/sci-geosciences/grass/grass-8.3.2-r1.ebuild
@@ -156,16 +156,24 @@ src_prepare() {
 	eend $?
 
 	# For testsuite, see https://bugs.gentoo.org/show_bug.cgi?id=500580#c3
+	local ati_cards mesa_cards nvidia_cards render_cards
 	shopt -s nullglob
-	local mesa_cards=$(echo -n /dev/dri/card* /dev/dri/render* | sed 's/ /:/g')
-	if test -n "${mesa_cards}"; then
-		addpredict "${mesa_cards}"
-	fi
-	local ati_cards=$(echo -n /dev/ati/card* | sed 's/ /:/g')
-	if test -n "${ati_cards}"; then
-		addpredict "${ati_cards}"
-	fi
-	shopt -u nullglob
+	ati_cards=$(echo -n /dev/ati/card*)
+	for card in "${ati_cards[@]}"; do
+		addpredict "${card}"
+	done
+	mesa_cards=$(echo -n /dev/dri/card*)
+	for card in "${mesa_cards[@]}"; do
+		addpredict "${card}"
+	done
+	nvidia_cards=$(echo -n /dev/nvidia*)
+	for card in "${nvidia_cards[@]}"; do
+		addpredict "${card}"
+	done
+	render_cards=$(echo -n /dev/dri/renderD128*)
+	for card in "${render_cards[@]}"; do
+		addpredict "${card}"
+	done
 	addpredict /dev/nvidiactl
 }
 

--- a/sci-geosciences/grass/grass-8.4.0.ebuild
+++ b/sci-geosciences/grass/grass-8.4.0.ebuild
@@ -156,16 +156,24 @@ src_prepare() {
 	eend $?
 
 	# For testsuite, see https://bugs.gentoo.org/show_bug.cgi?id=500580#c3
+	local ati_cards mesa_cards nvidia_cards render_cards
 	shopt -s nullglob
-	local mesa_cards=$(echo -n /dev/dri/card* /dev/dri/render* | sed 's/ /:/g')
-	if test -n "${mesa_cards}"; then
-		addpredict "${mesa_cards}"
-	fi
-	local ati_cards=$(echo -n /dev/ati/card* | sed 's/ /:/g')
-	if test -n "${ati_cards}"; then
-		addpredict "${ati_cards}"
-	fi
-	shopt -u nullglob
+	ati_cards=$(echo -n /dev/ati/card*)
+	for card in "${ati_cards[@]}"; do
+		addpredict "${card}"
+	done
+	mesa_cards=$(echo -n /dev/dri/card*)
+	for card in "${mesa_cards[@]}"; do
+		addpredict "${card}"
+	done
+	nvidia_cards=$(echo -n /dev/nvidia*)
+	for card in "${nvidia_cards[@]}"; do
+		addpredict "${card}"
+	done
+	render_cards=$(echo -n /dev/dri/renderD128*)
+	for card in "${render_cards[@]}"; do
+		addpredict "${card}"
+	done
 	addpredict /dev/nvidiactl
 }
 

--- a/sci-geosciences/grass/grass-8.4.1_rc1.ebuild
+++ b/sci-geosciences/grass/grass-8.4.1_rc1.ebuild
@@ -156,16 +156,24 @@ src_prepare() {
 	eend $?
 
 	# For testsuite, see https://bugs.gentoo.org/show_bug.cgi?id=500580#c3
+	local ati_cards mesa_cards nvidia_cards render_cards
 	shopt -s nullglob
-	local mesa_cards=$(echo -n /dev/dri/card* /dev/dri/render* | sed 's/ /:/g')
-	if test -n "${mesa_cards}"; then
-		addpredict "${mesa_cards}"
-	fi
-	local ati_cards=$(echo -n /dev/ati/card* | sed 's/ /:/g')
-	if test -n "${ati_cards}"; then
-		addpredict "${ati_cards}"
-	fi
-	shopt -u nullglob
+	ati_cards=$(echo -n /dev/ati/card*)
+	for card in "${ati_cards[@]}"; do
+		addpredict "${card}"
+	done
+	mesa_cards=$(echo -n /dev/dri/card*)
+	for card in "${mesa_cards[@]}"; do
+		addpredict "${card}"
+	done
+	nvidia_cards=$(echo -n /dev/nvidia*)
+	for card in "${nvidia_cards[@]}"; do
+		addpredict "${card}"
+	done
+	render_cards=$(echo -n /dev/dri/renderD128*)
+	for card in "${render_cards[@]}"; do
+		addpredict "${card}"
+	done
 	addpredict /dev/nvidiactl
 }
 

--- a/sci-geosciences/grass/grass-9999.ebuild
+++ b/sci-geosciences/grass/grass-9999.ebuild
@@ -151,16 +151,24 @@ src_prepare() {
 	eend $?
 
 	# For testsuite, see https://bugs.gentoo.org/show_bug.cgi?id=500580#c3
+	local ati_cards mesa_cards nvidia_cards render_cards
 	shopt -s nullglob
-	local mesa_cards=$(echo -n /dev/dri/card* /dev/dri/render* | sed 's/ /:/g')
-	if test -n "${mesa_cards}"; then
-		addpredict "${mesa_cards}"
-	fi
-	local ati_cards=$(echo -n /dev/ati/card* | sed 's/ /:/g')
-	if test -n "${ati_cards}"; then
-		addpredict "${ati_cards}"
-	fi
-	shopt -u nullglob
+	ati_cards=$(echo -n /dev/ati/card*)
+	for card in "${ati_cards[@]}"; do
+		addpredict "${card}"
+	done
+	mesa_cards=$(echo -n /dev/dri/card*)
+	for card in "${mesa_cards[@]}"; do
+		addpredict "${card}"
+	done
+	nvidia_cards=$(echo -n /dev/nvidia*)
+	for card in "${nvidia_cards[@]}"; do
+		addpredict "${card}"
+	done
+	render_cards=$(echo -n /dev/dri/renderD128*)
+	for card in "${render_cards[@]}"; do
+		addpredict "${card}"
+	done
 	addpredict /dev/nvidiactl
 }
 


### PR DESCRIPTION
Newer Portage bans use of colons in addpredict calls.

Closes: https://bugs.gentoo.org/948968

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
