### PR TITLE
dev-python/shiboken6: adjust to toolchain-funcs change

### DIFF
--- a/dev-python/shiboken6/shiboken6-6.8.1-r1.ebuild
+++ b/dev-python/shiboken6/shiboken6-6.8.1-r1.ebuild
@@ -32,7 +32,7 @@ S="${WORKDIR}/${MY_P}/sources/shiboken6"
 # arbitrarily relicensed. (TODO)
 LICENSE="|| ( GPL-2 GPL-3+ LGPL-3 ) GPL-3"
 SLOT="6/${PV}"
-KEYWORDS="amd64 ~arm arm64 ~loong ~ppc64 ~riscv ~x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv ~x86"
 IUSE="+docstrings numpy test vulkan"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -82,11 +82,11 @@ src_prepare() {
 			ApiExtractor/clangparser/compilersupport.cpp || die
 	fi
 
-	local clangver="$(CPP=clang clang-major-version)"
+	local clangver="$(CC=clang clang-major-version)"
 
 	# Clang 15 and older used the full version as a directory name.
 	if [[ ${clangver} -lt 16 ]]; then
-		clangver="$(CPP=clang clang-fullversion)"
+		clangver="$(CC=clang clang-fullversion)"
 	fi
 
 	# Shiboken6 assumes the "/usr/lib/clang/${CLANG_NEWEST_VERSION}/include/"

--- a/dev-python/shiboken6/shiboken6-6.8.1.1-r1.ebuild
+++ b/dev-python/shiboken6/shiboken6-6.8.1.1-r1.ebuild
@@ -32,7 +32,7 @@ S="${WORKDIR}/${MY_P}/sources/shiboken6"
 # arbitrarily relicensed. (TODO)
 LICENSE="|| ( GPL-2 GPL-3+ LGPL-3 ) GPL-3"
 SLOT="6/${PV}"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="amd64 ~arm arm64 ~loong ~ppc64 ~riscv ~x86"
 IUSE="+docstrings numpy test vulkan"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -82,11 +82,11 @@ src_prepare() {
 			ApiExtractor/clangparser/compilersupport.cpp || die
 	fi
 
-	local clangver="$(CPP=clang clang-major-version)"
+	local clangver="$(CC=clang clang-major-version)"
 
 	# Clang 15 and older used the full version as a directory name.
 	if [[ ${clangver} -lt 16 ]]; then
-		clangver="$(CPP=clang clang-fullversion)"
+		clangver="$(CC=clang clang-fullversion)"
 	fi
 
 	# Shiboken6 assumes the "/usr/lib/clang/${CLANG_NEWEST_VERSION}/include/"


### PR DESCRIPTION
Needs a revbump as this causes breakage in dev-python/pyside build.

https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=a1e7d1e7a213a08d6acc94d6b10628259ba49517

@Nowa-Ammerlaan @floppym 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
