### PR TITLE
dev-libs/libgit2-glib: fix compatibility with libgit2-1.8.0+

### DIFF
--- a/dev-libs/libgit2-glib/files/libgit2-glib-1.2.0-fix-macro.patch
+++ b/dev-libs/libgit2-glib/files/libgit2-glib-1.2.0-fix-macro.patch
@@ -1,0 +1,26 @@
+From a95f38cba3e440bb4b418691af60dc9c209ed9ce Mon Sep 17 00:00:00 2001
+From: Antoine Jacoutot <ajacoutot@gnome.org>
+Date: Thu, 2 Jan 2025 14:03:41 +0100
+Subject: [PATCH] Fix definition of GGIT_MICRO_VERSION.
+
+Signed-off-by: Antoine Jacoutot <ajacoutot@gnome.org>
+---
+ libgit2-glib/ggit-version.h.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgit2-glib/ggit-version.h.in b/libgit2-glib/ggit-version.h.in
+index 4b25185..642271b 100644
+--- a/libgit2-glib/ggit-version.h.in
++++ b/libgit2-glib/ggit-version.h.in
+@@ -35,7 +35,7 @@
+  *
+  * libgit2-glib micro version component (e.g. 3 if %GGIT_VERSION is 1.2.3)
+  */
+-#define GGIT_MINOR_VERSION (@MICRO_VERSION@)
++#define GGIT_MICRO_VERSION (@MICRO_VERSION@)
+ 
+ #define GGIT_ENCODE_VERSION(major,minor,micro) \
+         ((major) << 24 | (minor) << 16 | (micro) << 8)
+-- 
+GitLab
+

--- a/dev-libs/libgit2-glib/files/libgit2-glib-1.2.0-libgit2-1.8.0+.patch
+++ b/dev-libs/libgit2-glib/files/libgit2-glib-1.2.0-libgit2-1.8.0+.patch
@@ -1,0 +1,493 @@
+From 9c3002bd2f1594901e7d8c2c0edc5c7ce30a9a76 Mon Sep 17 00:00:00 2001
+From: Alberto Fanjul <albertofanjul@gmail.com>
+Date: Mon, 3 Feb 2025 23:46:24 +0100
+Subject: [PATCH] Compatibility changes for libgit2 >=1.8.0
+
+---
+ libgit2-glib/ggit-clone-options.c        |  7 ++-
+ libgit2-glib/ggit-cred-ssh-interactive.c |  2 +-
+ libgit2-glib/ggit-remote-callbacks.c     |  6 +-
+ libgit2-glib/ggit-types-18.h             | 77 +++++++++++++++++++++++
+ libgit2-glib/ggit-types-19.h             | 79 ++++++++++++++++++++++++
+ libgit2-glib/ggit-types-pre18.h          | 75 ++++++++++++++++++++++
+ libgit2-glib/ggit-types.c                |  7 +++
+ libgit2-glib/ggit-types.h                | 58 +++--------------
+ libgit2-glib/meson.build                 |  8 +++
+ meson.build                              |  6 ++
+ 10 files changed, 270 insertions(+), 55 deletions(-)
+ create mode 100644 libgit2-glib/ggit-types-18.h
+ create mode 100644 libgit2-glib/ggit-types-19.h
+ create mode 100644 libgit2-glib/ggit-types-pre18.h
+
+diff --git a/libgit2-glib/ggit-clone-options.c b/libgit2-glib/ggit-clone-options.c
+index b47fdb1..70bac69 100644
+--- a/libgit2-glib/ggit-clone-options.c
++++ b/libgit2-glib/ggit-clone-options.c
+@@ -19,6 +19,9 @@
+  */
+ 
+ #include <git2.h>
++#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8)
++#include <git2/sys/errors.h>
++#endif
+ #include <gio/gio.h>
+ 
+ #include "ggit-clone-options.h"
+@@ -149,7 +152,7 @@ create_repository_wrapper (git_repository **out,
+ 
+ 	if (error != NULL)
+ 	{
+-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
++#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+ 		git_error_set_str (GIT_ERROR, error->message);
+ #else
+ 		giterr_set_str (GIT_ERROR, error->message);
+@@ -191,7 +194,7 @@ create_remote_wrapper (git_remote     **out,
+ 
+ 	if (error)
+ 	{
+-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
++#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+ 		git_error_set_str (GIT_ERROR, error->message);
+ #else
+ 		giterr_set_str (GIT_ERROR, error->message);
+diff --git a/libgit2-glib/ggit-cred-ssh-interactive.c b/libgit2-glib/ggit-cred-ssh-interactive.c
+index 4f60f8b..0bdca95 100644
+--- a/libgit2-glib/ggit-cred-ssh-interactive.c
++++ b/libgit2-glib/ggit-cred-ssh-interactive.c
+@@ -191,7 +191,7 @@ callback_wrapper (const char                            *name,
+ 	{
+ 		gchar *text;
+ 
+-		text = g_strndup (prompts[i].text, prompts[i].length);
++		text = g_strndup ((const gchar *)prompts[i].text, prompts[i].length);
+ 
+ 		wprompts[i] = ggit_cred_ssh_interactive_prompt_new (wname,
+ 		                                                    winstruction,
+diff --git a/libgit2-glib/ggit-remote-callbacks.c b/libgit2-glib/ggit-remote-callbacks.c
+index a1e7b7d..e8b9f62 100644
+--- a/libgit2-glib/ggit-remote-callbacks.c
++++ b/libgit2-glib/ggit-remote-callbacks.c
+@@ -18,6 +18,10 @@
+  * along with libgit2-glib. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <git2.h>
++#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8)
++#include <git2/sys/errors.h>
++#endif
+ #include "ggit-remote-callbacks.h"
+ #include "ggit-cred.h"
+ #include "ggit-transfer-progress.h"
+@@ -160,7 +164,7 @@ credentials_wrap (git_cred     **cred,
+ 		{
+ 			if (error)
+ 			{
+-#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
++#if (LIBGIT2_VER_MAJOR > 0 && LIBGIT2_VER_MINOR < 8) || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 28)
+ 				git_error_set_str (GIT_ERROR, error->message);
+ #else
+ 				giterr_set_str (GIT_ERROR, error->message);
+diff --git a/libgit2-glib/ggit-types-18.h b/libgit2-glib/ggit-types-18.h
+new file mode 100644
+index 0000000..7ee43f0
+--- /dev/null
++++ b/libgit2-glib/ggit-types-18.h
+@@ -0,0 +1,77 @@
++/*
++ * ggit-types-18.h
++ * This file is part of libgit2-glib
++ *
++ * Copyright (C) 2025 - Alberto Fanjul
++ *
++ * libgit2-glib is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * libgit2-glib is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with libgit2-glib. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef __GGIT_TYPES_18_H__
++#define __GGIT_TYPES_18_H__
++
++/**
++ * GgitConfigLevel:
++ * @GGIT_CONFIG_LEVEL_PROGRAMDATA: System-wide on Windows, for compatibility with portable git.
++ * @GGIT_CONFIG_LEVEL_SYSTEM: System-wide configuration file.
++ * @GGIT_CONFIG_LEVEL_XDG: XDG compatible configuration file (.config/git/config).
++ * @GGIT_CONFIG_LEVEL_GLOBAL: User-specific configuration file, also called Global configuration file.
++ * @GGIT_CONFIG_LEVEL_LOCAL: Repository specific configuration file.
++ * @GIT_CONFIG_LEVEL_WORKTREE: Worktree specific configuration file; $GIT_DIR/config.worktree
++ * @GGIT_CONFIG_LEVEL_APP: Application specific configuration file; freely defined by applications.
++ * @GGIT_CONFIG_LEVEL_HIGHEST: Represents the highest level of a config file.
++ *
++ * Priority level of a config file.
++ * These priority levels correspond to the natural escalation logic
++ * (from higher to lower) when searching for config entries in git.git.
++ */
++typedef enum
++{
++	GGIT_CONFIG_LEVEL_PROGRAMDATA = 1,
++	GGIT_CONFIG_LEVEL_SYSTEM      = 2,
++	GGIT_CONFIG_LEVEL_XDG         = 3,
++	GGIT_CONFIG_LEVEL_GLOBAL      = 4,
++ 	GGIT_CONFIG_LEVEL_LOCAL       = 5,
++	GGIT_CONFIG_LEVEL_WORKTREE    = 6,
++	GGIT_CONFIG_LEVEL_APP         = 7,
++	GGIT_CONFIG_LEVEL_HIGHEST     = -1
++} GgitConfigLevel;
++
++typedef enum
++{
++	GGIT_CHECKOUT_NONE                    = 0,
++	GGIT_CHECKOUT_SAFE                    = (1u << 0),
++	GGIT_CHECKOUT_FORCE                   = (1u << 1),
++	GGIT_CHECKOUT_RECREATE_MISSING        = (1u << 2),
++	GGIT_CHECKOUT_ALLOW_CONFLICTS         = (1u << 4),
++	GGIT_CHECKOUT_REMOVE_UNTRACKED        = (1u << 5),
++	GGIT_CHECKOUT_REMOVE_IGNORED          = (1u << 6),
++	GGIT_CHECKOUT_UPDATE_ONLY             = (1u << 7),
++	GGIT_CHECKOUT_DONT_UPDATE_INDEX       = (1u << 8),
++	GGIT_CHECKOUT_NO_REFRESH              = (1u << 9),
++	GGIT_CHECKOUT_SKIP_UNMERGED           = (1u << 10),
++	GGIT_CHECKOUT_USE_OURS                = (1u << 11),
++	GGIT_CHECKOUT_USE_THEIRS              = (1u << 12),
++	GGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH  = (1u << 13),
++	GGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES = (1u << 18),
++	GGIT_CHECKOUT_DONT_OVERWRITE_IGNORED  = (1u << 19),
++	GGIT_CHECKOUT_CONFLICT_STYLE_MERGE    = (1u << 20),
++	GGIT_CHECKOUT_CONFLICT_STYLE_DIFF3    = (1u << 21),
++	GGIT_CHECKOUT_DONT_REMOVE_EXISTING    = (1u << 22),
++	GGIT_CHECKOUT_DONT_WRITE_INDEX        = (1u << 23),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES       = (1u << 16),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1u << 17)
++} GgitCheckoutStrategy;
++
++#endif /* __GGIT_TYPES_18_H__ */
+diff --git a/libgit2-glib/ggit-types-19.h b/libgit2-glib/ggit-types-19.h
+new file mode 100644
+index 0000000..cda8cb1
+--- /dev/null
++++ b/libgit2-glib/ggit-types-19.h
+@@ -0,0 +1,79 @@
++/*
++ * ggit-types-19.h
++ * This file is part of libgit2-glib
++ *
++ * Copyright (C) 2025 - Alberto Fanjul
++ *
++ * libgit2-glib is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * libgit2-glib is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with libgit2-glib. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef __GGIT_TYPES_19_H__
++#define __GGIT_TYPES_19_H__
++
++/**
++ * GgitConfigLevel:
++ * @GGIT_CONFIG_LEVEL_PROGRAMDATA: System-wide on Windows, for compatibility with portable git.
++ * @GGIT_CONFIG_LEVEL_SYSTEM: System-wide configuration file.
++ * @GGIT_CONFIG_LEVEL_XDG: XDG compatible configuration file (.config/git/config).
++ * @GGIT_CONFIG_LEVEL_GLOBAL: User-specific configuration file, also called Global configuration file.
++ * @GGIT_CONFIG_LEVEL_LOCAL: Repository specific configuration file.
++ * @GIT_CONFIG_LEVEL_WORKTREE: Worktree specific configuration file; $GIT_DIR/config.worktree
++ * @GGIT_CONFIG_LEVEL_APP: Application specific configuration file; freely defined by applications.
++ * @GGIT_CONFIG_LEVEL_HIGHEST: Represents the highest level of a config file.
++ *
++ * Priority level of a config file.
++ * These priority levels correspond to the natural escalation logic
++ * (from higher to lower) when searching for config entries in git.git.
++ */
++typedef enum
++{
++	GGIT_CONFIG_LEVEL_PROGRAMDATA = 1,
++	GGIT_CONFIG_LEVEL_SYSTEM      = 2,
++	GGIT_CONFIG_LEVEL_XDG         = 3,
++	GGIT_CONFIG_LEVEL_GLOBAL      = 4,
++ 	GGIT_CONFIG_LEVEL_LOCAL       = 5,
++	GGIT_CONFIG_LEVEL_WORKTREE    = 6,
++	GGIT_CONFIG_LEVEL_APP         = 7,
++	GGIT_CONFIG_LEVEL_HIGHEST     = -1
++} GgitConfigLevel;
++
++typedef enum
++{
++	GGIT_CHECKOUT_SAFE                    = 0,
++	GGIT_CHECKOUT_FORCE                   = (1u << 1),
++	GGIT_CHECKOUT_RECREATE_MISSING        = (1u << 2),
++	GGIT_CHECKOUT_ALLOW_CONFLICTS         = (1u << 4),
++	GGIT_CHECKOUT_REMOVE_UNTRACKED        = (1u << 5),
++	GGIT_CHECKOUT_REMOVE_IGNORED          = (1u << 6),
++	GGIT_CHECKOUT_UPDATE_ONLY             = (1u << 7),
++	GGIT_CHECKOUT_DONT_UPDATE_INDEX       = (1u << 8),
++	GGIT_CHECKOUT_NO_REFRESH              = (1u << 9),
++	GGIT_CHECKOUT_SKIP_UNMERGED           = (1u << 10),
++	GGIT_CHECKOUT_USE_OURS                = (1u << 11),
++	GGIT_CHECKOUT_USE_THEIRS              = (1u << 12),
++	GGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH  = (1u << 13),
++	GGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES = (1u << 18),
++	GGIT_CHECKOUT_DONT_OVERWRITE_IGNORED  = (1u << 19),
++	GGIT_CHECKOUT_CONFLICT_STYLE_MERGE    = (1u << 20),
++	GGIT_CHECKOUT_CONFLICT_STYLE_DIFF3    = (1u << 21),
++	GGIT_CHECKOUT_DONT_REMOVE_EXISTING    = (1u << 22),
++	GGIT_CHECKOUT_DONT_WRITE_INDEX        = (1u << 23),
++	GGIT_CHECKOUT_DRY_RUN                 = (1u << 24),
++	GGIT_CHECKOUT_CONFLICT_STYLE_ZDIFF3   = (1u << 25),
++	GGIT_CHECKOUT_NONE                    = (1u << 30),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES       = (1u << 16),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1u << 17)
++} GgitCheckoutStrategy;
++
++#endif /* __GGIT_TYPES_19_H__ */
+diff --git a/libgit2-glib/ggit-types-pre18.h b/libgit2-glib/ggit-types-pre18.h
+new file mode 100644
+index 0000000..91da10e
+--- /dev/null
++++ b/libgit2-glib/ggit-types-pre18.h
+@@ -0,0 +1,75 @@
++/*
++ * ggit-types-pre18.h
++ * This file is part of libgit2-glib
++ *
++ * Copyright (C) 2025 - Alberto Fanjul
++ *
++ * libgit2-glib is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * libgit2-glib is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with libgit2-glib. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef __GGIT_TYPES_PRE18_H__
++#define __GGIT_TYPES_PRE18_H__
++
++/**
++ * GgitConfigLevel:
++ * @GGIT_CONFIG_LEVEL_PROGRAMDATA: System-wide on Windows, for compatibility with portable git.
++ * @GGIT_CONFIG_LEVEL_SYSTEM: System-wide configuration file.
++ * @GGIT_CONFIG_LEVEL_XDG: XDG compatible configuration file (.config/git/config).
++ * @GGIT_CONFIG_LEVEL_GLOBAL: User-specific configuration file, also called Global configuration file.
++ * @GGIT_CONFIG_LEVEL_LOCAL: Repository specific configuration file.
++ * @GGIT_CONFIG_LEVEL_APP: Application specific configuration file; freely defined by applications.
++ * @GGIT_CONFIG_LEVEL_HIGHEST: Represents the highest level of a config file.
++ *
++ * Priority level of a config file.
++ * These priority levels correspond to the natural escalation logic
++ * (from higher to lower) when searching for config entries in git.git.
++ */
++typedef enum
++{
++	GGIT_CONFIG_LEVEL_PROGRAMDATA = 1,
++	GGIT_CONFIG_LEVEL_SYSTEM      = 2,
++	GGIT_CONFIG_LEVEL_XDG         = 3,
++	GGIT_CONFIG_LEVEL_GLOBAL      = 4,
++ 	GGIT_CONFIG_LEVEL_LOCAL       = 5,
++	GGIT_CONFIG_LEVEL_APP         = 6,
++	GGIT_CONFIG_LEVEL_HIGHEST     = -1
++} GgitConfigLevel;
++
++typedef enum
++{
++	GGIT_CHECKOUT_NONE                    = 0,
++	GGIT_CHECKOUT_SAFE                    = (1u << 0),
++	GGIT_CHECKOUT_FORCE                   = (1u << 1),
++	GGIT_CHECKOUT_RECREATE_MISSING        = (1u << 2),
++	GGIT_CHECKOUT_ALLOW_CONFLICTS         = (1u << 4),
++	GGIT_CHECKOUT_REMOVE_UNTRACKED        = (1u << 5),
++	GGIT_CHECKOUT_REMOVE_IGNORED          = (1u << 6),
++	GGIT_CHECKOUT_UPDATE_ONLY             = (1u << 7),
++	GGIT_CHECKOUT_DONT_UPDATE_INDEX       = (1u << 8),
++	GGIT_CHECKOUT_NO_REFRESH              = (1u << 9),
++	GGIT_CHECKOUT_SKIP_UNMERGED           = (1u << 10),
++	GGIT_CHECKOUT_USE_OURS                = (1u << 11),
++	GGIT_CHECKOUT_USE_THEIRS              = (1u << 12),
++	GGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH  = (1u << 13),
++	GGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES = (1u << 18),
++	GGIT_CHECKOUT_DONT_OVERWRITE_IGNORED  = (1u << 19),
++	GGIT_CHECKOUT_CONFLICT_STYLE_MERGE    = (1u << 20),
++	GGIT_CHECKOUT_CONFLICT_STYLE_DIFF3    = (1u << 21),
++	GGIT_CHECKOUT_DONT_REMOVE_EXISTING    = (1u << 22),
++	GGIT_CHECKOUT_DONT_WRITE_INDEX        = (1u << 23),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES       = (1u << 16),
++	GGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1u << 17)
++} GgitCheckoutStrategy;
++
++#endif /* __GGIT_TYPES_PRE18_H__ */
+diff --git a/libgit2-glib/ggit-types.c b/libgit2-glib/ggit-types.c
+index df8ed6e..3129d63 100644
+--- a/libgit2-glib/ggit-types.c
++++ b/libgit2-glib/ggit-types.c
+@@ -42,6 +42,9 @@ ASSERT_ENUM (GGIT_CONFIG_LEVEL_SYSTEM, GIT_CONFIG_LEVEL_SYSTEM);
+ ASSERT_ENUM (GGIT_CONFIG_LEVEL_XDG, GIT_CONFIG_LEVEL_XDG);
+ ASSERT_ENUM (GGIT_CONFIG_LEVEL_GLOBAL, GIT_CONFIG_LEVEL_GLOBAL);
+ ASSERT_ENUM (GGIT_CONFIG_LEVEL_LOCAL, GIT_CONFIG_LEVEL_LOCAL);
++#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8)
++ASSERT_ENUM (GGIT_CONFIG_LEVEL_WORKTREE, GIT_CONFIG_LEVEL_WORKTREE);
++#endif
+ ASSERT_ENUM (GGIT_CONFIG_LEVEL_APP, GIT_CONFIG_LEVEL_APP);
+ ASSERT_ENUM (GGIT_CONFIG_LEVEL_HIGHEST, GIT_CONFIG_HIGHEST_LEVEL);
+ 
+@@ -270,6 +273,10 @@ ASSERT_ENUM (GGIT_CHECKOUT_CONFLICT_STYLE_MERGE,    GIT_CHECKOUT_CONFLICT_STYLE_
+ ASSERT_ENUM (GGIT_CHECKOUT_CONFLICT_STYLE_DIFF3,    GIT_CHECKOUT_CONFLICT_STYLE_DIFF3);
+ ASSERT_ENUM (GGIT_CHECKOUT_DONT_REMOVE_EXISTING,    GIT_CHECKOUT_DONT_REMOVE_EXISTING);
+ ASSERT_ENUM (GGIT_CHECKOUT_DONT_WRITE_INDEX,        GIT_CHECKOUT_DONT_WRITE_INDEX);
++#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 9)
++ASSERT_ENUM (GGIT_CHECKOUT_DRY_RUN,                 GIT_CHECKOUT_DRY_RUN);
++ASSERT_ENUM (GGIT_CHECKOUT_CONFLICT_STYLE_ZDIFF3,   GIT_CHECKOUT_CONFLICT_STYLE_ZDIFF3);
++#endif
+ ASSERT_ENUM (GGIT_CHECKOUT_UPDATE_SUBMODULES,       GIT_CHECKOUT_UPDATE_SUBMODULES);
+ ASSERT_ENUM (GGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED, GIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED);
+ 
+diff --git a/libgit2-glib/ggit-types.h b/libgit2-glib/ggit-types.h
+index 7e28975..47d26ca 100644
+--- a/libgit2-glib/ggit-types.h
++++ b/libgit2-glib/ggit-types.h
+@@ -22,6 +22,13 @@
+ #define __GGIT_TYPES_H__
+ 
+ #include <glib.h>
++#if LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 9)
++#include "ggit-types-19.h"
++#elif LIBGIT2_VER_MAJOR > 1 || (LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8)
++#include "ggit-types-18.h"
++#else
++#include "ggit-types-pre18.h"
++#endif
+ 
+ G_BEGIN_DECLS
+ 
+@@ -334,31 +341,6 @@ typedef enum
+ 	GGIT_BLAME_TRACK_COPIES_SAME_FILE = 1 << 0
+ } GgitBlameFlags;
+ 
+-/**
+- * GgitConfigLevel:
+- * @GGIT_CONFIG_LEVEL_PROGRAMDATA: System-wide on Windows, for compatibility with portable git.
+- * @GGIT_CONFIG_LEVEL_SYSTEM: System-wide configuration file.
+- * @GGIT_CONFIG_LEVEL_XDG: XDG compatible configuration file (.config/git/config).
+- * @GGIT_CONFIG_LEVEL_GLOBAL: User-specific configuration file, also called Global configuration file.
+- * @GGIT_CONFIG_LEVEL_LOCAL: Repository specific configuration file.
+- * @GGIT_CONFIG_LEVEL_APP: Application specific configuration file; freely defined by applications.
+- * @GGIT_CONFIG_LEVEL_HIGHEST: Represents the highest level of a config file.
+- *
+- * Priority level of a config file.
+- * These priority levels correspond to the natural escalation logic
+- * (from higher to lower) when searching for config entries in git.git.
+- */
+-typedef enum
+-{
+-	GGIT_CONFIG_LEVEL_PROGRAMDATA = 1,
+-	GGIT_CONFIG_LEVEL_SYSTEM      = 2,
+-	GGIT_CONFIG_LEVEL_XDG         = 3,
+-	GGIT_CONFIG_LEVEL_GLOBAL      = 4,
+-	GGIT_CONFIG_LEVEL_LOCAL       = 5,
+-	GGIT_CONFIG_LEVEL_APP         = 6,
+-	GGIT_CONFIG_LEVEL_HIGHEST     = -1
+-} GgitConfigLevel;
+-
+ /**
+  * GgitCreateFlags:
+  * @GGIT_CREATE_NONE: attempt to create.
+@@ -987,32 +969,6 @@ typedef enum
+ 	GGIT_PACKBUILDER_STAGE_DELTAFICATION  = 1
+ } GgitPackbuilderStage;
+ 
+-typedef enum
+-{
+-	GGIT_CHECKOUT_NONE                    = 0,
+-	GGIT_CHECKOUT_SAFE                    = (1u << 0),
+-	GGIT_CHECKOUT_FORCE                   = (1u << 1),
+-	GGIT_CHECKOUT_RECREATE_MISSING        = (1u << 2),
+-	GGIT_CHECKOUT_ALLOW_CONFLICTS         = (1u << 4),
+-	GGIT_CHECKOUT_REMOVE_UNTRACKED        = (1u << 5),
+-	GGIT_CHECKOUT_REMOVE_IGNORED          = (1u << 6),
+-	GGIT_CHECKOUT_UPDATE_ONLY             = (1u << 7),
+-	GGIT_CHECKOUT_DONT_UPDATE_INDEX       = (1u << 8),
+-	GGIT_CHECKOUT_NO_REFRESH              = (1u << 9),
+-	GGIT_CHECKOUT_SKIP_UNMERGED           = (1u << 10),
+-	GGIT_CHECKOUT_USE_OURS                = (1u << 11),
+-	GGIT_CHECKOUT_USE_THEIRS              = (1u << 12),
+-	GGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH  = (1u << 13),
+-	GGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES = (1u << 18),
+-	GGIT_CHECKOUT_DONT_OVERWRITE_IGNORED  = (1u << 19),
+-	GGIT_CHECKOUT_CONFLICT_STYLE_MERGE    = (1u << 20),
+-	GGIT_CHECKOUT_CONFLICT_STYLE_DIFF3    = (1u << 21),
+-	GGIT_CHECKOUT_DONT_REMOVE_EXISTING    = (1u << 22),
+-	GGIT_CHECKOUT_DONT_WRITE_INDEX        = (1u << 23),
+-	GGIT_CHECKOUT_UPDATE_SUBMODULES       = (1u << 16),
+-	GGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1u << 17)
+-} GgitCheckoutStrategy;
+-
+ typedef enum {
+ 	GGIT_CHECKOUT_NOTIFY_NONE      = 0,
+ 	GGIT_CHECKOUT_NOTIFY_CONFLICT  = (1u << 0),
+diff --git a/libgit2-glib/meson.build b/libgit2-glib/meson.build
+index 94bc4f0..e4ea9ea 100644
+--- a/libgit2-glib/meson.build
++++ b/libgit2-glib/meson.build
+@@ -12,6 +12,13 @@ ggit_version_h = configure_file(
+         install: true,
+   configuration: version_data)
+ 
++ggit_types_18_h = 'ggit-types-pre18.h'
++if libgit2_version_19_or_more
++  ggit_types_18_h = 'ggit-types-19.h'
++elif libgit2_version_18_or_more
++  ggit_types_18_h = 'ggit-types-18.h'
++endif
++
+ headers = [
+   'ggit-annotated-commit.h',
+   'ggit-blame.h',
+@@ -80,6 +87,7 @@ headers = [
+   'ggit-tree-builder.h',
+   'ggit-tree-entry.h',
+   'ggit-types.h',
++  ggit_types_18_h,
+   ggit_version_h,
+ ]
+ 
+diff --git a/meson.build b/meson.build
+index e54a8b4..da1c8ef 100644
+--- a/meson.build
++++ b/meson.build
+@@ -127,6 +127,12 @@ gobject_dep = dependency('gobject-2.0', version: '>=' + glib_req)
+ gio_dep = dependency('gio-2.0', version: '>=' + glib_req)
+ 
+ libgit2_dep = dependency('libgit2', version: '>= 0.25.0')
++libgit2_version = libgit2_dep.version().split('.')
++libgit2_version_major = libgit2_version[0].to_int()
++libgit2_version_minor = libgit2_version[1].to_int()
++libgit2_version_micro = libgit2_version[2].to_int()
++libgit2_version_18_or_more = libgit2_version_major > 1 or (libgit2_version_major == 1 and libgit2_version_minor >= 8)
++libgit2_version_19_or_more = libgit2_version_major > 1 or (libgit2_version_major == 1 and libgit2_version_minor >= 9)
+ 
+ # XXX: Not nice, but probably our best option
+ enable_gir = get_option('introspection') and find_program('g-ir-scanner', required: false).found()
+-- 
+GitLab
+

--- a/dev-libs/libgit2-glib/libgit2-glib-1.2.0-r3.ebuild
+++ b/dev-libs/libgit2-glib/libgit2-glib-1.2.0-r3.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit gnome.org meson python-r1 vala xdg
+
+DESCRIPTION="Git library for GLib"
+HOMEPAGE="https://wiki.gnome.org/Projects/Libgit2-glib"
+
+LICENSE="LGPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="gtk-doc python +ssh +vala"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	>=dev-libs/gobject-introspection-1.54:=
+	>=dev-libs/glib-2.44.0:2
+	>=dev-libs/libgit2-0.26.0:=[ssh?]
+	python? (
+		${PYTHON_DEPS}
+		dev-python/pygobject:3[${PYTHON_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	virtual/pkgconfig
+	gtk-doc? ( dev-util/gi-docgen )
+	vala? ( $(vala_depend) )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.0-fix-macro.patch
+	"${FILESDIR}"/${PN}-1.2.0-libgit2-1.8.0+.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e '/meson_python_compile.py/d' meson.build || die
+}
+
+src_configure() {
+	local emesonargs=(
+		$(meson_use gtk-doc gtk_doc)
+		-Dintrospection=true
+		-Dpython=false # we install python scripts manually
+		$(meson_use ssh)
+		$(meson_use vala vapi)
+	)
+
+	use vala && vala_setup
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use python ; then
+		python_moduleinto gi.overrides
+		python_foreach_impl python_domodule libgit2-glib/Ggit.py
+	fi
+}


### PR DESCRIPTION
Fix build with libgit-1.9.0 using upstream patches.

Closes: https://bugs.gentoo.org/947165

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

-> SizeViolation: 'files/libgit2-glib-1.2.0-libgit2-1.8.0+.patch' exceeds 20.0 KiB in size; 20.2 KiB total
but I cannot really fix that myself from what I remember of the handbook.
Other issues pre-exist.

Please note that all boxes must be checked for the pull request to be merged.
