### PR TITLE
gnome-base/gnome: bump meta ebuilds to 47.3-ish

### DIFF
--- a/gnome-base/gnome-core-apps/gnome-core-apps-47.3.ebuild
+++ b/gnome-base/gnome-core-apps/gnome-core-apps-47.3.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Sub-meta package for the core applications integrated with GNOME"
+HOMEPAGE="https://www.gnome.org/"
+S="${WORKDIR}"
+
+LICENSE="metapackage"
+SLOT="3.0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="+bluetooth cups"
+
+# gnome-color-manager min version enforced here due to control-center pulling it in
+# glib-networking min version enforced as multiple other deps here rely on it (e.g. via libsoup)
+# TODO: Replace eog with loupe
+RDEPEND="
+	>=gnome-base/gnome-core-libs-${PV}[cups?]
+
+	>=gnome-base/gnome-session-47.0.1
+	>=gnome-base/gnome-settings-daemon-47.2[cups?]
+	>=gnome-base/gnome-control-center-47.3[cups?]
+	>=gnome-extra/gnome-color-manager-3.36.0
+
+	>=app-crypt/gcr-3.41.1:0
+	>=app-crypt/gcr-4.3.0:4
+	>=gnome-base/nautilus-47.1
+	>=gnome-base/gnome-keyring-46.2
+	>=gnome-extra/evolution-data-server-3.54.3
+	>=net-libs/glib-networking-2.80.1
+
+	|| (
+		>=app-editors/gnome-text-editor-47.2
+		>=app-editors/gedit-46.2
+	)
+	>=app-text/evince-46.3.1
+	>=gnome-extra/gnome-contacts-47.1.1
+	>=media-gfx/eog-47.0
+	>=media-video/totem-43.1
+	|| (
+		>=x11-terms/gnome-terminal-3.54.3
+		>=gui-apps/gnome-console-47.1
+	)
+
+	>=gnome-extra/gnome-user-docs-47.2
+	>=gnome-extra/yelp-42.2
+
+	>=x11-themes/adwaita-icon-theme-47.0
+
+	bluetooth? ( >=net-wireless/gnome-bluetooth-47.1 )
+"
+DEPEND=""
+BDEPEND=""

--- a/gnome-base/gnome-core-libs/gnome-core-libs-47.3.ebuild
+++ b/gnome-base/gnome-core-libs/gnome-core-libs-47.3.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Sub-meta package for the core libraries of GNOME"
+HOMEPAGE="https://www.gnome.org/"
+S="${WORKDIR}"
+
+LICENSE="metapackage"
+SLOT="3.0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="cups python"
+
+# Note to developers:
+# This is a wrapper for the core libraries used by GNOME
+RDEPEND="
+	>=dev-libs/glib-2.82.4:2
+	>=x11-libs/gdk-pixbuf-2.42.12:2
+	>=x11-libs/pango-1.54.0
+	>=x11-libs/gtk+-3.24.42:3[cups?]
+	>=gui-libs/gtk-4.16.12:4[cups?]
+	>=gui-libs/libadwaita-1.6.2:1
+	>=app-accessibility/at-spi2-core-2.54.1:2
+	>=gnome-base/librsvg-2.58.5
+	>=gnome-base/gnome-desktop-44.1:4
+
+	>=gnome-base/gvfs-1.56.1
+	>=gnome-base/dconf-0.40.0
+
+	>=media-libs/gstreamer-1.24.11:1.0
+	>=media-libs/gst-plugins-base-1.24.11:1.0
+	>=media-libs/gst-plugins-good-1.24.11:1.0
+
+	python? ( >=dev-python/pygobject-3.50.0:3 )
+"
+DEPEND=""
+BDEPEND=""

--- a/gnome-base/gnome-extra-apps/gnome-extra-apps-47.3.ebuild
+++ b/gnome-base/gnome-extra-apps/gnome-extra-apps-47.3.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Sub-meta package for the applications of GNOME"
+HOMEPAGE="https://www.gnome.org/"
+S=${WORKDIR}
+
+LICENSE="metapackage"
+SLOT="3.0"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="+games share +shotwell +tracker"
+
+# Note to developers:
+# This is a wrapper for the extra apps integrated with GNOME
+# Keep pkg order within a USE flag as upstream releng versions file
+# TODO: Should we keep these here: file-roller, nautilus-sendto, gnome-photos?
+# TODO: Add gnome-remote-desktop as replacement for vino that was removed from meta in 3.36?
+# TODO: Replace cheese with Snapshot once we have it packaged
+# TODO: Replace tracker-miners by localsearch when it is packaged
+RDEPEND="
+	>=gnome-base/gnome-core-libs-${PV}
+
+	>=sys-apps/baobab-47.0
+	>=media-video/cheese-44.1
+	>=www-client/epiphany-47.2
+	>=app-arch/file-roller-44.4
+	>=gnome-extra/gnome-calculator-47.1
+	>=gnome-extra/gnome-calendar-47.0
+	>=gnome-extra/gnome-characters-47.0
+	>=sys-apps/gnome-disk-utility-46.1
+	>=media-gfx/gnome-font-viewer-47.0
+	>=gnome-extra/gnome-system-monitor-47.0
+	>=gnome-extra/gnome-weather-47.0
+	>=gnome-extra/sushi-46.0
+
+	>=gnome-base/dconf-editor-45.0.1
+	>=mail-client/evolution-3.54.3
+	>=gnome-extra/gnome-tweaks-46.1
+	>=gnome-extra/nautilus-sendto-3.8.6
+	>=app-crypt/seahorse-47.0.1
+
+	games? (
+		>=games-puzzle/five-or-more-3.32.3
+		>=games-board/four-in-a-row-3.38.1
+		>=games-board/gnome-chess-47.0
+		>=games-puzzle/gnome-klotski-3.38.2
+		>=games-board/gnome-mahjongg-47.0
+		>=games-board/gnome-mines-40.1
+		>=games-arcade/gnome-nibbles-4.1.0
+		>=games-arcade/gnome-robots-40.0
+		>=games-puzzle/gnome-sudoku-47.1.1
+		>=games-puzzle/gnome-taquin-3.38.1
+		>=games-puzzle/gnome-tetravex-3.38.2
+		>=games-puzzle/hitori-44.0
+		>=games-board/iagno-3.38.1
+		>=games-puzzle/lightsoff-46.0
+		>=games-puzzle/quadrapassel-40.2
+		>=games-puzzle/swell-foop-46.0
+		>=games-board/tali-40.9
+	)
+	share? ( >=gnome-extra/gnome-user-share-43.0 )
+	shotwell? ( >=media-gfx/shotwell-0.32.10 )
+	tracker? (
+		>=app-misc/tracker-3.6.0
+		>=app-misc/tracker-miners-3.6.2
+		>=media-gfx/gnome-photos-44.0
+		>=media-sound/gnome-music-47.1
+	)
+"
+DEPEND=""
+BDEPEND=""

--- a/gnome-base/gnome-extra-apps/gnome-extra-apps-47.3.ebuild
+++ b/gnome-base/gnome-extra-apps/gnome-extra-apps-47.3.ebuild
@@ -15,7 +15,7 @@ IUSE="+games share +shotwell +tracker"
 # Note to developers:
 # This is a wrapper for the extra apps integrated with GNOME
 # Keep pkg order within a USE flag as upstream releng versions file
-# TODO: Should we keep these here: file-roller, nautilus-sendto, gnome-photos?
+# TODO: Should we keep these here: file-roller, gnome-photos?
 # TODO: Add gnome-remote-desktop as replacement for vino that was removed from meta in 3.36?
 # TODO: Replace cheese with Snapshot once we have it packaged
 # TODO: Replace tracker-miners by localsearch when it is packaged
@@ -38,7 +38,6 @@ RDEPEND="
 	>=gnome-base/dconf-editor-45.0.1
 	>=mail-client/evolution-3.54.3
 	>=gnome-extra/gnome-tweaks-46.1
-	>=gnome-extra/nautilus-sendto-3.8.6
 	>=app-crypt/seahorse-47.0.1
 
 	games? (

--- a/gnome-base/gnome-light/gnome-light-47.3.ebuild
+++ b/gnome-base/gnome-light/gnome-light-47.3.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+P_RELEASE="$(ver_cut 1).0"
+
+DESCRIPTION="Meta package for GNOME-Light, merge this package to install"
+HOMEPAGE="https://www.gnome.org/"
+S="${WORKDIR}"
+
+LICENSE="metapackage"
+SLOT="2.0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+IUSE="cups +gnome-shell"
+
+# XXX: Note to developers:
+# This is a wrapper for the 'light' GNOME 3 desktop, and should only consist of
+# the bare minimum of libs/apps needed. It is basically gnome-base/gnome without
+# any apps, but shouldn't be used by users unless they know what they are doing.
+# cantarell minimum version is ensured here as gnome-shell depends on it.
+RDEPEND="
+	>=gnome-base/gnome-core-libs-${PV}[cups?]
+
+	>=gnome-base/gnome-session-47.0.1
+	>=gnome-base/gnome-settings-daemon-47.2[cups?]
+	>=gnome-base/gnome-control-center-47.3[cups?]
+
+	>=gnome-base/nautilus-47.1
+
+	gnome-shell? (
+		>=x11-wm/mutter-47.4
+		>=dev-libs/gjs-1.78.1
+		>=gnome-base/gnome-shell-47.3
+		>=media-fonts/cantarell-0.303.1
+	)
+
+	>=x11-themes/adwaita-icon-theme-${P_RELEASE}
+	>=x11-themes/gnome-backgrounds-${P_RELEASE}
+
+	|| (
+		>=x11-terms/gnome-terminal-3.54.3
+		>=gui-apps/gnome-console-47.1
+	)
+"
+DEPEND=""
+PDEPEND=">=gnome-base/gvfs-1.56.1"
+BDEPEND=""
+
+pkg_pretend() {
+	if ! use gnome-shell; then
+		# Users probably want to use gnome-flashback, e16, sawfish, etc
+		ewarn "You're not installing GNOME Shell"
+		ewarn "You will have to install and manage a window manager by yourself"
+	fi
+}
+
+pkg_postinst() {
+	# Remember people where to find our project information
+	elog "Please remember to look at https://wiki.gentoo.org/wiki/Project:GNOME"
+	elog "for information about the project and documentation."
+}

--- a/gnome-base/gnome-light/gnome-light-47.3.ebuild
+++ b/gnome-base/gnome-light/gnome-light-47.3.ebuild
@@ -7,7 +7,7 @@ P_RELEASE="$(ver_cut 1).0"
 
 DESCRIPTION="Meta package for GNOME-Light, merge this package to install"
 HOMEPAGE="https://www.gnome.org/"
-S="${WORKDIR}"
+S=${WORKDIR}
 
 LICENSE="metapackage"
 SLOT="2.0"
@@ -57,7 +57,7 @@ pkg_pretend() {
 }
 
 pkg_postinst() {
-	# Remember people where to find our project information
+	# Remind people where to find our project information
 	elog "Please remember to look at https://wiki.gentoo.org/wiki/Project:GNOME"
 	elog "for information about the project and documentation."
 }

--- a/gnome-base/gnome/gnome-47.3.ebuild
+++ b/gnome-base/gnome/gnome-47.3.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Meta package for GNOME, merge this package to install"
+HOMEPAGE="https://www.gnome.org/"
+S=${WORKDIR}
+
+LICENSE="metapackage"
+SLOT="2.0" # Cannot be installed at the same time as gnome-2
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+
+IUSE="accessibility +bluetooth +classic cups +extras"
+
+# TODO: check accessibility completeness
+RDEPEND="
+	>=gnome-base/gnome-core-libs-${PV}[cups?]
+	>=gnome-base/gnome-core-apps-${PV}[cups?,bluetooth?]
+
+	>=gnome-base/gdm-47.0
+
+	>=x11-wm/mutter-47.4
+	>=gnome-base/gnome-shell-47.3
+	>=media-fonts/cantarell-0.303.1
+
+	>=x11-themes/gnome-backgrounds-47.0
+	x11-themes/sound-theme-freedesktop
+
+	accessibility? (
+		>=app-accessibility/at-spi2-core-2.54.0
+		>=app-accessibility/orca-47.3
+		>=gnome-extra/mousetweaks-3.32.0
+	)
+	classic? ( >=gnome-extra/gnome-shell-extensions-47.3 )
+	extras? ( >=gnome-base/gnome-extra-apps-${PV} )
+"
+PDEPEND=">=gnome-base/gvfs-1.56.1[udisks]"
+
+DEPEND=""
+BDEPEND=""
+
+pkg_postinst() {
+	# Remind people where to find our project information
+	elog "Please remember to look at https://wiki.gentoo.org/wiki/Project:GNOME"
+	elog "for information about the project and documentation."
+}


### PR DESCRIPTION
Gnome releng did some changes post 47.2 release and stopped producing easy to crawl lists of packages. Nevertheless, did to libgit2-glib dependency issues that stopped portage from resolving properly world updates (probably for fractal + gitg + git-absorb), I had to find a way to reduce the amount of packages to update that could cause trouble. I wanted to update gnome but found out the meta ebuilds hadn't been updated in a while. Here are bumps of the meta ebuilds with versions as close as possible to what Gnome published for 47.3. Since 47.4 is due in less that 2 weeks, I figured it would be good enough for now.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
