### PR TITLE
net-dialup/linux-atm: fix build on musl, C23

### DIFF
--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-c99-musl.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-c99-musl.patch
@@ -1,0 +1,113 @@
+Author: NHOrus <jy6x2b32pie9@yahoo.com>
+Bug: https://bugs.gentoo.org/897842
+Enabling the system extension that gate some POSIX features
+and fixing missing includes, 32/64 bit confusion, standard
+atexit function instead of non-standard, and function signature
+--- a/configure.in
++++ b/configure.in
+@@ -34,6 +34,7 @@ dnl We have some special PERL scripts wh
+ AC_PATH_PROG(PERL, perl)
+ AC_SUBST(PERL)
+ 
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ dnl Check for needed header files
+ AC_CHECK_HEADER(asm/errno.h, ,
+--- a/src/lib/unix.c
++++ b/src/lib/unix.c
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+--- a/src/sigd/policy.c
++++ b/src/sigd/policy.c
+@@ -8,6 +8,7 @@
+ 
+ #include <atm.h>
+ #include <atmd.h>
++#include <string.h>
+ 
+ #include "proto.h" /* for "pretty" */
+ #include "policy.h"
+--- a/src/sigd/kernel.c
++++ b/src/sigd/kernel.c
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <assert.h>
++#include <string.h>
+ 
+ #include <atm.h>
+ #include <linux/atmsvc.h>
+--- a/src/sigd/atmsigd.c
++++ b/src/sigd/atmsigd.c
+@@ -283,12 +283,12 @@ static void setup_signals(void)
+ /* ------------------------------- main ...  ------------------------------- */
+ 
+ 
+-static void trace_on_exit(int status,void *dummy)
++static void trace_on_exit(void)
+ {
+     char path[PATH_MAX+1];
+     FILE *file;
+ 
+-    if (!status) return;
++//    if (!status) return;
+     if (!dump_dir) file = stderr;
+     else {
+ 	sprintf(path,"atmsigd.%d.trace.exit",getpid());
+@@ -517,7 +517,7 @@ int main(int argc,char **argv)
+ 	    exit(0);
+ 	}
+     }
+-    (void) on_exit(trace_on_exit,NULL);
++    (void) atexit(trace_on_exit);
+     poll_loop();
+     close_all();
+     for (sig = entities; sig; sig = sig->next) stop_saal(&sig->saal);
+--- a/src/led/address.c
++++ b/src/led/address.c
+@@ -33,6 +33,7 @@
+ #include <sys/ioctl.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <string.h>
+ 
+ #include <atm.h>
+ #include <linux/atmdev.h>
+--- a/src/led/conn.c
++++ b/src/led/conn.c
+@@ -405,7 +405,7 @@ Conn_t *accept_conn(Conn_t *conn)
+ {
+         Conn_t *new;
+         struct sockaddr_atmsvc addr;
+-        size_t len;
++        socklen_t len;
+         int fd;
+         char buff[MAX_ATM_ADDR_LEN+1];
+ 
+--- a/src/led/display.c
++++ b/src/led/display.c
+@@ -6,6 +6,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <atm.h>
+ #include <atmd.h>
+ 
+--- a/src/mpoad/io.c
++++ b/src/mpoad/io.c
+@@ -16,7 +16,7 @@
+ #include <syscall.h>
+ #include <linux/poll.h>
+ #define SYS_poll 168
+-_syscall3(int,poll,struct pollfd *,ufds,unsigned int,nfds,int,timeout);
++int _syscall3(int, int poll,struct pollfd *,int ufds,unsigned int,int nfds,int,int timeout);
+ #endif
+ #include <atm.h>
+ #include <linux/types.h>

--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-fix-booleans.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-fix-booleans.patch
@@ -1,0 +1,42 @@
+Correct for building with C23, rename `bool` struct member
+https://bugs.gentoo.org/949721
+--- a/src/lane/load.c
++++ b/src/lane/load.c
+@@ -498,8 +498,8 @@
+ 	break;
+       case BOOLEAN:
+ 	Debug_unit(&load_unit, "Variable is boolean: %s", 
+-		   g_return.bool==BL_TRUE?"True":"False");
+-	set_var_bool(curr_unit, varname, g_return.bool);
++		   g_return.boolval==BL_TRUE?"True":"False");
++	set_var_bool(curr_unit, varname, g_return.boolval);
+ 	break;
+       case INTEGER:
+ 	Debug_unit(&load_unit, "Variable is integer: %d", g_return.intti);
+--- a/src/lane/load_lex.h
++++ b/src/lane/load_lex.h
+@@ -24,7 +24,7 @@
+ #define END 0
+ 
+ typedef struct {
+-  Bool_t bool;
++  Bool_t boolval;
+   int intti;
+   AtmAddr_t *atmaddress;
+   LaneDestination_t *destaddr;
+--- a/src/lane/load_lex.l
++++ b/src/lane/load_lex.l
+@@ -44,11 +44,11 @@
+ 		 return ATMADDRESS;
+ 	        }
+ True	|
+-true		{g_return.bool = BL_TRUE;
++true		{g_return.boolval = BL_TRUE;
+ 		 return BOOLEAN;
+ 		}	
+ False	|
+-false		{g_return.bool = BL_FALSE;
++false		{g_return.boolval = BL_FALSE;
+ 		 return BOOLEAN;
+ 		}
+ \#.*		{}

--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-fix-formatting.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-fix-formatting.patch
@@ -1,0 +1,192 @@
+Changes cherry-picked from
+https://sources.debian.org/patches/linux-atm/1:2.5.1-7/misc/
+https://sources.debian.org/patches/linux-atm/1:2.5.1-7/linux-atm-2.5.2-c99-musl.patch/
+to fix -Werror=format
+Also all changes I did on second pass for printing size_t and friends
+https://bugs.gentoo.org/949721
+--- a/src/ilmid/asn1/asn_int.c
++++ b/src/ilmid/asn1/asn_int.c
+@@ -185,7 +185,7 @@ FILE* f _AND_
+ AsnInt* v _AND_
+ unsigned short int indent)
+ {
+-    fprintf(f,"%d", *v);
++    fprintf(f,"%ld", *v);
+ } 
+ 
+ 
+--- a/src/ilmid/asn1/asn_oid.c
++++ b/src/ilmid/asn1/asn_oid.c
+@@ -127,7 +127,7 @@ unsigned short int indent)
+     if (firstArcNum > 2)
+         firstArcNum = 2;
+ 
+-    fprintf(f,"%u %u", firstArcNum, arcNum - (firstArcNum * 40));
++    fprintf(f,"%d %lu", firstArcNum, arcNum - (firstArcNum * 40));
+ 
+     for (; i < v->octetLen ; )
+     {
+@@ -136,7 +136,7 @@ unsigned short int indent)
+ 
+         arcNum = (arcNum << 7) + (v->octs[i] & 0x7f);
+         i++;
+-        fprintf(f," %u", arcNum);
++        fprintf(f," %lu", arcNum);
+     }
+     fprintf(f,"}");
+ 
+--- a/src/lib/ans.c
++++ b/src/lib/ans.c
+@@ -41,7 +41,7 @@
+ static int ans(const char *text,int wanted,void *result,int res_len)
+ {
+     unsigned char answer[MAX_ANSWER];
+-    unsigned char name[MAX_NAME];
++    char name[MAX_NAME];
+     unsigned char *pos,*data,*found;
+     int answer_len,name_len,data_len,found_len;
+     int questions,answers;
+--- a/src/test/ttcp.c
++++ b/src/test/ttcp.c
+@@ -664,7 +664,7 @@ int no_check = 0;
+     exit(0);
+ 
+   usage:
+-    fprintf(stderr, Usage);
++    fprintf(stderr, "%s", Usage);
+     exit(1);
+ }
+ 
+Further changes are novel and fix size_t formatting
+--- a/src/arpd/atmarp.c
++++ b/src/arpd/atmarp.c
+@@ -67,7 +67,7 @@
+     }
+     if (req->type == art_query) return query_result(&reply);
+     if (len != sizeof(int)) {
+-	fprintf(stderr,"bad read: %d != %d\n",len,sizeof(int));
++	fprintf(stderr,"bad read: %d != %zu\n",len,sizeof(int));
+ 	exit(1);
+     }
+     if (*(int *) &reply < 0) {
+--- a/src/ilmid/asn1/asn_int.c
++++ b/src/ilmid/asn1/asn_int.c
+@@ -370,5 +370,5 @@
+ UAsnInt* v _AND_
+ unsigned short int indent)
+ {
+-    fprintf(f,"%u", *v);
++    fprintf(f,"%lu", *v);
+ } 
+--- a/src/lane/mem_lecs.c
++++ b/src/lane/mem_lecs.c
+@@ -77,7 +77,7 @@
+     free(tmp->start);
+     free(tmp);
+   } else {
+-    printf("Trying to free memory by %s, allocated by %s, size %d\n",
++    printf("Trying to free memory by %s, allocated by %s, size %zu\n",
+ 	   unit, tmp->unit, tmp->size);
+   }
+ }
+@@ -89,6 +89,6 @@
+ 
+   printf("Dumping memory allocation\n");
+   for (tmp=memlist;tmp;tmp=tmp->next)
+-    printf("%s : %d bytes from %p\n", tmp->unit, tmp->size, tmp->start);
++    printf("%s : %zu bytes from %p\n", tmp->unit, tmp->size, tmp->start);
+   printf("-------------------------\n");
+ }
+--- a/src/maint/atmaddr.c
++++ b/src/maint/atmaddr.c
+@@ -97,7 +97,7 @@
+     }
+     if (cmd != ATM_GETADDR) return 0;
+     if (req.length % sizeof(*addr)) {
+-	fprintf(stderr,"internal error: len %d %% %d\n",req.length,
++	fprintf(stderr,"internal error: len %d %% %zu\n",req.length,
+ 	  sizeof(*addr));
+ 	return 1;
+     }
+--- a/src/maint/atmtcp.c
++++ b/src/maint/atmtcp.c
+@@ -579,7 +579,7 @@
+ 	exit(1);
+     }
+     if (wrote != sizeof(stream)) {
+-	fprintf(stderr,"short write (%d < %d)\n",wrote,sizeof(stream));
++	fprintf(stderr,"short write (%d < %zu)\n",wrote,sizeof(stream));
+ 	exit(1);
+     }
+     wrote = write(fd,data,size);
+--- a/src/mpoad/lecs.c
++++ b/src/mpoad/lecs.c
+@@ -157,7 +157,7 @@
+                 /* Sampo-Add: end */
+         }
+         if (end_of_tlvs - tlvs != 0)
+-                printf("mpcd: lecs.c: get_reply: ignoring %d bytes of trailing TLV carbage\n",
++                printf("mpcd: lecs.c: get_reply: ignoring %ld bytes of trailing TLV carbage\n",
+                        end_of_tlvs - tlvs);
+         return 1;
+ }
+--- a/src/switch/swc.c
++++ b/src/switch/swc.c
+@@ -28,7 +28,7 @@
+ 	exit(1);
+     }
+     if (size != sizeof(*msg)) {
+-	fprintf(stderr,"bad write: %d != %d\n",size,sizeof(*msg));
++	fprintf(stderr,"bad write: %d != %zu\n",size,sizeof(*msg));
+ 	exit(1);
+     }
+     size = read(s,msg,sizeof(*msg));
+@@ -37,7 +37,7 @@
+ 	exit(1);
+     }
+     if (size != sizeof(*msg)) {
+-	fprintf(stderr,"bad read: %d != %d\n",size,sizeof(*msg));
++	fprintf(stderr,"bad read: %d != %zu\n",size,sizeof(*msg));
+ 	exit(1);
+     }
+ }
+--- a/src/test/isp.c
++++ b/src/test/isp.c
+@@ -37,7 +37,7 @@
+     wrote = write(sock,msg,sizeof(*msg));
+     if (wrote == sizeof(*msg)) return;
+     if (wrote < 0) perror("write");
+-    else fprintf(stderr,"bad write: %d != %d\n",wrote,sizeof(*msg));
++    else fprintf(stderr,"bad write: %d != %zu\n",wrote,sizeof(*msg));
+     exit(1);
+ }
+ 
+@@ -49,7 +49,7 @@
+     got = read(sock,msg,sizeof(*msg));
+     if (got == sizeof(*msg)) return;
+     if (got < 0) perror("read");
+-    else fprintf(stderr,"bad read: %d != %d\n",got,sizeof(*msg));
++    else fprintf(stderr,"bad read: %d != %zu\n",got,sizeof(*msg));
+     exit(1);
+ }
+ 
+--- a/src/test/window.c
++++ b/src/test/window.c
+@@ -180,7 +180,7 @@
+        /* Get a reply */
+        size = read(s2, buffer2, REPLY_SIZE);
+        if (size != REPLY_SIZE) {
+-	 fprintf(stderr,"Received reply of length %d, should be %d.\n",
++	 fprintf(stderr,"Received reply of length %zd, should be %d.\n",
+ 		 size,REPLY_SIZE);
+        }
+ #endif
+@@ -264,7 +264,7 @@
+ 	 }
+ 
+        } else {
+-	 fprintf(stderr,"Received message of length %d, should be %d.\n",
++	 fprintf(stderr,"Received message of length %zd, should be %d.\n",
+ 		 size,PINGPONG_SIZE);
+        }
+      }

--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-remove-bad-define.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-remove-bad-define.patch
@@ -1,0 +1,31 @@
+previously was sed -i '/#define _LINUX_NETDEVICE_H/d' src/arpd/*.c in ebuild
+--- a/src/arpd/arp.c
++++ b/src/arpd/arp.c
+@@ -15,7 +15,6 @@
+ #include <sys/types.h>
+ #include <sys/socket.h> /* for linux/if_arp.h */
+ #include <netinet/in.h> /* for ntohs, etc. */
+-#define _LINUX_NETDEVICE_H /* very crude hack for glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ #include <linux/if_ether.h>
+--- a/src/arpd/io.c
++++ b/src/arpd/io.c
+@@ -21,7 +21,6 @@
+ #include <atm.h>
+ #include <linux/atmclip.h> /* for CLIP_DEFAULT_IDLETIMER */
+ #include <linux/atmarp.h>
+-#define _LINUX_NETDEVICE_H /* glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ 
+--- a/src/arpd/itf.c
++++ b/src/arpd/itf.c
+@@ -12,7 +12,6 @@
+ #include <sys/types.h>
+ #include <linux/atmclip.h>
+ #include <sys/socket.h>
+-#define _LINUX_NETDEVICE_H /* glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ 

--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-socklen-types.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-socklen-types.patch
@@ -1,0 +1,182 @@
+Correct type used for all calls to socket-related business,
+so the won't throw errors.
+https://bugs.gentoo.org/949721
+--- a/src/arpd/io.c
++++ b/src/arpd/io.c
+@@ -276,7 +276,8 @@
+     struct atm_qos qos;
+     ENTRY *entry;
+     VCC *vcc;
+-    int fd,len,size,error;
++    int fd,error;
++    socklen_t len,size;
+ 
+     len = sizeof(addr);
+     if ((fd = accept(incoming,(struct sockaddr *) &addr,&len)) < 0) {
+@@ -613,7 +614,8 @@
+ 
+ int get_local(int fd,struct sockaddr_atmsvc *addr)
+ {
+-    int length,result;
++    int result;
++    socklen_t length;
+ 
+     length = sizeof(struct sockaddr_atmsvc);
+     result = getsockname(fd,(struct sockaddr *) addr,&length);
+--- a/src/arpd/table.c
++++ b/src/arpd/table.c
+@@ -101,7 +101,8 @@
+     char addr_buf[MAX_ATM_ADDR_LEN+1];
+     char qos_buf[MAX_ATM_QOS_LEN+1];
+     struct atm_qos qos;
+-    int size,sndbuf;
++    int sndbuf;
++    socklen_t size;
+ 
+     size = sizeof(addr);
+     if (getpeername(vcc->fd,(struct sockaddr *) &addr,&size) < 0) {
+--- a/src/include/atmd.h
++++ b/src/include/atmd.h
+@@ -104,7 +104,7 @@
+ typedef struct {
+     int	s;			/* socket */
+     struct sockaddr_un addr;	/* reply address */
+-    int size;			/* address size */
++    socklen_t size;			/* address size */
+ } UN_CTX;
+ 
+ 
+--- a/src/lane/connect_bus.c
++++ b/src/lane/connect_bus.c
+@@ -170,7 +170,8 @@
+ data_handler(const Event_t *event, void *funcdata)
+ {
+   Conn_t *tmp, *newconn;
+-  int fd, nbytes;
++  int fd;
++  socklen_t nbytes;
+   static char buffer[BUFSIZE];
+   struct sockaddr_atmsvc addr;
+ 
+--- a/src/lane/connect.c
++++ b/src/lane/connect.c
+@@ -258,7 +258,8 @@
+ data_handler(const Event_t *event, void *funcdata)
+ {
+   Conn_t *tmp, *newconn;
+-  int fd, nbytes;
++  int fd;
++  socklen_t nbytes;
+   static char buffer[BUFSIZE];
+   LaneControl_t *ctmp;
+   struct sockaddr_atmsvc addr;
+--- a/src/lane/lane_atm.c
++++ b/src/lane/lane_atm.c
+@@ -138,7 +138,7 @@
+   struct atm_blli blli;
+   struct atm_qos qos;
+   int fd, ret;
+-  int len = sizeof(address);
++  socklen_t len = sizeof(address);
+   
+   fd = socket(PF_ATMSVC, SOCK_DGRAM, 0);
+   if (fd <0) {
+--- a/src/lane/lecs.c
++++ b/src/lane/lecs.c
+@@ -119,7 +119,7 @@
+   int just_dump=0;
+   fd_set fds;
+   struct sockaddr_atmsvc client;
+-  int len;
++  socklen_t len;
+   unsigned char buffer[P_SIZE];
+ 
+   while(i!=-1) {
+--- a/src/lib/sdu2cell.c
++++ b/src/lib/sdu2cell.c
+@@ -15,7 +15,8 @@
+ {
+     struct atm_qos qos;
+     int trailer,total,cells;
+-    int size,i;
++    int i;
++    socklen_t size;
+ 
+     size = sizeof(qos);
+     if (getsockopt(s,SOL_AAL,SO_ATMQOS,&qos,&size) < 0) return -1;
+--- a/src/lib/unix.c
++++ b/src/lib/unix.c
+@@ -64,7 +64,7 @@
+ int un_recv_connect(int s,void *buf,int size)
+ {
+     struct sockaddr_un addr;
+-    int addr_size;
++    socklen_t addr_size;
+     int len;
+ 
+     addr_size = sizeof(addr);
+--- a/src/maint/atmtcp.c
++++ b/src/maint/atmtcp.c
+@@ -817,7 +817,8 @@
+ 	}
+ 	else if (!strcmp(ARG,"listen") ||
+ 	  (do_background = !strcmp(ARG,"listen-bg"))) {
+-	    int fd,port,addr_len;
++	    int fd,port;
++	    socklen_t addr_len;
+ 	    int *fd2 = alloc_t(int);
+ 
+ 	    if ((fd = socket(PF_INET,SOCK_STREAM,0)) < 0) {
+--- a/src/mpoad/io.c
++++ b/src/mpoad/io.c
+@@ -521,7 +521,8 @@
+ static int accept_conn(int slot)
+ {
+         struct sockaddr_atmsvc sa;
+-        int i, new_fd, sa_len;
++        int i, new_fd;
++        socklen_t sa_len;
+ 
+         sa_len = sizeof(sa);
+         new_fd = accept(fds[slot].fd, (struct sockaddr *)&sa, &sa_len);
+--- a/src/sigd/io.c
++++ b/src/sigd/io.c
+@@ -355,7 +355,7 @@
+     error = 0;
+     if (bind(s,(struct sockaddr *) &addr,sizeof(addr)) < 0) error = errno;
+     else {
+-	int size;
++	socklen_t size;
+ 
+ 	size = sizeof(addr);
+ 	if (getsockname(s,(struct sockaddr *) &addr,&size) < 0)
+--- a/src/test/ttcp.c
++++ b/src/test/ttcp.c
+@@ -92,7 +92,8 @@
+ struct sockaddr_atmsvc satm;
+ struct atm_qos qos;
+ 
+-int domain, fromlen;
++int domain;
++socklen_t fromlen;
+ int fd;				/* fd of network socket */
+ 
+ int buflen = 8 * 1024;		/* length of buffer */
+@@ -466,7 +467,7 @@
+ 	    
+ 	    {
+ 		struct sockaddr_atmsvc peer;
+-		int peerlen = sizeof(peer);
++		socklen_t peerlen = sizeof(peer);
+ 		if (getpeername(fd, (struct sockaddr *) &peer, 
+ 				&peerlen) < 0) {
+ 		    err("getpeername");
+@@ -498,7 +499,7 @@
+     /* set socket buffer size */
+ #if defined(SO_SNDBUF) || defined(SO_RCVBUF)
+     if (sockbufsize) {
+-	int len;
++	socklen_t len;
+ 
+ 	if (trans) {
+ 	    /* set send socket buffer if we are transmitting */    

--- a/net-dialup/linux-atm/linux-atm-2.5.2-r2.ebuild
+++ b/net-dialup/linux-atm/linux-atm-2.5.2-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info
+
+DESCRIPTION="Tools for ATM"
+HOMEPAGE="https://linux-atm.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+EYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+BDEPEND="sys-devel/bison"
+
+RESTRICT="test"
+
+CONFIG_CHECK="~ATM"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-headers.patch
+	"${FILESDIR}"/${P}-linux-5.2-SIOCGSTAMP.patch
+	"${FILESDIR}"/${P}-linux-headers-5.19.patch
+	"${FILESDIR}"/${P}-c99-musl.patch
+	"${FILESDIR}"/${P}-remove-bad-define.patch
+	"${FILESDIR}"/${P}-fix-booleans.patch
+	"${FILESDIR}"/${P}-socklen-types.patch
+	"${FILESDIR}"/${P}-fix-formatting.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-flags -fno-strict-aliasing
+	export YACC=bison
+	econf
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+	dodoc doc/README* doc/atm*
+}


### PR DESCRIPTION
As usual, wrong defines, missing includes, need for gnu extensions, `int` instead of `socklen_t`, `Bool_t bool`, weird fixes for buggy and outdated system libraries.

Closes: https://bugs.gentoo.org/897842
Closes: https://bugs.gentoo.org/949721
Closes: https://bugs.gentoo.org/712860

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
