### PR TITLE
net-analyzer/fragroute: update EAPI 7 -> 8, fix build problem

### DIFF
--- a/net-analyzer/fragroute/files/fragroute-1.2.6-missing-includes.patch
+++ b/net-analyzer/fragroute/files/fragroute-1.2.6-missing-includes.patch
@@ -1,0 +1,34 @@
+Add missing includes needed for compilation, including ones in sed
+command in previous ebuild.
+https://bugs.gentoo.org/945195
+Remove terrible hack in bget.h for ancient compilers. I wonder why they forgotten
+to put AC_C_PROTOTYPES in configure.ac... But that macro is dead and unsupported.
+--- a/bget.h
++++ b/bget.h
+@@ -4,13 +4,7 @@
+ 
+ */
+ 
+-#ifndef _
+-#ifdef PROTOTYPES
+ #define  _(x)  x		      /* If compiler knows prototypes */
+-#else
+-#define  _(x)  ()                     /* It it doesn't */
+-#endif /* PROTOTYPES */
+-#endif
+ 
+-typedef long bufsize;
++typedef size_t bufsize;
+ void	bpool	    _((void *buffer, bufsize len));
+
+sed -i -e "/#define IPUTIL_H/a#include <stdio.h>\n#include <stdint.h>" iputil.h || die
+--- a/iputil.h
++++ b/iputil.h
+@@ -1,5 +1,7 @@
+ #ifndef IPUTIL_H
+ #define IPUTIL_H
++#include <stdio.h>
++#include <stdint.h>
+ 
+ ssize_t inet_add_option(uint16_t eth_type, void *buf, size_t len,
+                 int proto, const void *optbuf, size_t optlen);

--- a/net-analyzer/fragroute/fragroute-1.2.6-r5.ebuild
+++ b/net-analyzer/fragroute/fragroute-1.2.6-r5.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+MY_P="${P}-ipv6"
+
+inherit autotools
+
+DESCRIPTION="Testing of network intrusion detection systems, firewalls and TCP/IP stacks"
+HOMEPAGE="https://github.com/stsi/fragroute-ipv6"
+SRC_URI="https://fragroute-ipv6.googlecode.com/files/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+RDEPEND="
+	>=dev-libs/libdnet-1.14-r1
+	dev-libs/libevent:=
+	net-libs/libpcap
+	dev-libs/libbsd
+
+"
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="
+	app-alternatives/awk
+"
+DOCS=( INSTALL README TODO )
+PATCHES=(
+	"${FILESDIR}"/${P}-libdir.patch
+	"${FILESDIR}"/${P}-pcap_open.patch
+	"${FILESDIR}"/${P}-missing-includes.patch
+)
+
+src_prepare() {
+	default
+
+	# Remove broken and old files, autotools will regen needed files
+	rm *.m4 acconfig.h missing Makefile.in || die
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		DNETINC='' \
+		DNETLIB=-ldnet \
+		EVENTINC='' \
+		EVENTLIB=-levent \
+		PCAPINC='' \
+		PCAPLIB=-lpcap
+}


### PR DESCRIPTION
Fail-deadly workaround for ancient compilers that was depricated and always failed.

Bug: https://bugs.gentoo.org/880843
Closes: https://bugs.gentoo.org/945195

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
