### PR TITLE
sys-firmware/edk2: add loong support

### DIFF
--- a/app-emulation/virt-firmware/virt-firmware-24.11.ebuild
+++ b/app-emulation/virt-firmware/virt-firmware-24.11.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~riscv ~x86"
 
 RDEPEND="
 	dev-python/cryptography[${PYTHON_USEDEP}]

--- a/sys-firmware/edk2/edk2-202411.ebuild
+++ b/sys-firmware/edk2/edk2-202411.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_REQ_USE="sqlite"
 PYTHON_COMPAT=( python3_{12..13} )
 
-inherit edo prefix python-any-r1 readme.gentoo-r1 secureboot toolchain-funcs
+inherit edo flag-o-matic prefix python-any-r1 readme.gentoo-r1 secureboot toolchain-funcs
 
 DESCRIPTION="TianoCore EDK II UEFI firmware for virtual machines"
 HOMEPAGE="https://github.com/tianocore/edk2"
@@ -64,6 +64,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-202411-werror.patch"
+	"${FILESDIR}/${PN}-202411-gcc15.patch"
 	"${FILESDIR}/${PN}-202411-loong.patch"
 	"${FILESDIR}/${PN}-202408-binutils-2.41-textrels.patch"
 )

--- a/sys-firmware/edk2/edk2-202411.ebuild
+++ b/sys-firmware/edk2/edk2-202411.ebuild
@@ -48,7 +48,7 @@ SRC_URI="
 S="${WORKDIR}/${PN}-${PN}-stable${PV}"
 LICENSE="BSD-2 MIT"
 SLOT="0"
-KEYWORDS="-* ~amd64 arm64 ~riscv"
+KEYWORDS="-* ~amd64 arm64 ~loong ~riscv"
 
 BDEPEND="
 	${PYTHON_DEPS}

--- a/sys-firmware/edk2/files/descriptors/50-edk2-loongarch64-qcow2-nosb.json
+++ b/sys-firmware/edk2/files/descriptors/50-edk2-loongarch64-qcow2-nosb.json
@@ -1,0 +1,33 @@
+{
+    "description": "UEFI for LoongArch VMs",
+    "interface-types": [
+        "uefi"
+    ],
+    "mapping": {
+        "device": "flash",
+        "mode" : "split",
+        "executable": {
+            "filename": "/usr/share/edk2/LoongArchVirtQemu/QEMU_EFI.fd",
+            "format": "raw"
+        },
+        "nvram-template": {
+            "filename": "/usr/share/edk2/LoongArchVirtQemu/QEMU_VARS.fd",
+            "format": "raw"
+        }
+    },
+    "targets": [
+        {
+            "architecture": "loongarch64",
+            "machines": [
+                "virt",
+                "virt-*"
+            ]
+        }
+    ],
+    "features": [
+
+    ],
+    "tags": [
+
+    ]
+}

--- a/sys-firmware/edk2/files/edk2-202411-gcc15.patch
+++ b/sys-firmware/edk2/files/edk2-202411-gcc15.patch
@@ -1,0 +1,32 @@
+https://github.com/tianocore/edk2/commit/e063f8b8a53861043b9872cc35b08a3dc03b0942
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Mon, 20 Jan 2025 09:40:31 +0100
+Subject: [PATCH] BaseTools/Pccts: set C standard
+
+The prehistoric code base doesn't build with ISO C23.  Set the C
+standard to C11 (for both clang and gcc) so it continues to build with
+gcc 15 (which uses C23 by default).
+
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
++++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
+@@ -169,7 +169,7 @@ ANTLR=${BIN_DIR}/antlr
+ DLG=${BIN_DIR}/dlg
+ OBJ_EXT=o
+ OUT_OBJ = -o
+-CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN $(COTHER) -DZZLEXBUFSIZE=65536
++CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN $(COTHER) -DZZLEXBUFSIZE=65536 -std=gnu11
+ CPPFLAGS=
+ #
+ # SGI Users, use this CFLAGS
+--- a/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
++++ b/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
+@@ -123,7 +123,7 @@ endif
+ COPT=-O
+ ANTLR=${BIN_DIR}/antlr
+ DLG=${BIN_DIR}/dlg
+-CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN -DZZLEXBUFSIZE=65536
++CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN -DZZLEXBUFSIZE=65536 -std=gnu11
+ CPPFLAGS=
+ OBJ_EXT=o
+ OUT_OBJ = -o

--- a/sys-firmware/edk2/files/edk2-202411-loong.patch
+++ b/sys-firmware/edk2/files/edk2-202411-loong.patch
@@ -1,0 +1,33 @@
+https://github.com/tianocore/edk2/commit/b8f3199595d23c29433528a5207a6aa9fb368d44
+From: Chao Li <lichao@loongson.cn>
+Date: Tue, 17 Dec 2024 18:05:45 +0800
+Subject: [PATCH] OvmfPkg/LoongArch: Enabling some base libraries
+
+BaseCryptLib, RngLib, IntrinsicLib and OpensslLib are enabled by default
+on LoongArch VM, since some APPs or OS require them.
+
+Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
+Cc: Jiewen Yao <jiewen.yao@intel.com>
+Cc: Gerd Hoffmann <kraxel@redhat.com>
+Signed-off-by: Chao Li <lichao@loongson.cn>
+--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
++++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+@@ -156,6 +156,18 @@
+   FileExplorerLib                  | MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
+   ImagePropertiesRecordLib         | MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+ 
++  #
++  # CryptoPkg libraries needed by multiple firmware features
++  #
++  IntrinsicLib                     | CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
++!if $(NETWORK_TLS_ENABLE) == TRUE
++  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLib.inf
++!else
++  OpensslLib                       | CryptoPkg/Library/OpensslLib/OpensslLibCrypto.inf
++!endif
++  BaseCryptLib                     | CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
++  RngLib                           | MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
++
+ !if $(HTTP_BOOT_ENABLE) == TRUE
+   HttpLib                          | MdeModulePkg/Library/DxeHttpLib/DxeHttpLib.inf
+ !endif


### PR DESCRIPTION
Tested with both QEMU KVM and TCG.

EDK2 currently fails to build with `gcc:15` due to the bumped default C standard, but works fine with `gcc:14`. And TLS support have to be disabled for `loong` right now due to mis-handled FPU exception; both problems are going to be reported and handled upstream.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
