### PR TITLE
net-libs/xdp-tools: forcing ld.bfd is no longer necessary

### DIFF
--- a/net-libs/xdp-tools/xdp-tools-1.5.2.ebuild
+++ b/net-libs/xdp-tools/xdp-tools-1.5.2.ebuild
@@ -51,9 +51,6 @@ src_configure() {
 	# filter LDFLAGS some more: #916591
 	filter-ldflags -Wl,--{icf,lto}*
 
-	# force ld.bfd: #916591
-	tc-ld-force-bfd
-
 	export CC="$(tc-getCC)"
 	export PREFIX="${EPREFIX}/usr"
 	export LIBDIR="${PREFIX}/$(get_libdir)"


### PR DESCRIPTION
1.5.0 improved its portability and no longer uses the linker directly.

Bug: https://bugs.gentoo.org/916591
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
