### PR TITLE
llvm-core/flang: adjust for the split of the flang-rt tree

### DIFF
--- a/llvm-core/flang/flang-21.0.0.9999.ebuild
+++ b/llvm-core/flang/flang-21.0.0.9999.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	)
 "
 
-LLVM_COMPONENTS=( flang cmake )
+LLVM_COMPONENTS=( flang flang-rt cmake )
 LLVM_TEST_COMPONENTS=( clang/test/Driver mlir/test/lib )
 llvm.org_set_globals
 


### PR DESCRIPTION
Flang's runtime has moved to it's own tree in the llvm monorepo.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
