### PR TITLE
sys-process/btop: add USE=gpu

### DIFF
--- a/sys-process/btop/btop-1.4.0.ebuild
+++ b/sys-process/btop/btop-1.4.0.ebuild
@@ -14,6 +14,7 @@ SRC_URI="
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv x86"
+IUSE="+gpu"
 
 BDEPEND="
 	app-text/lowdown
@@ -35,7 +36,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBTOP_GPU=true
+		-DBTOP_GPU=$(usex gpu)
 		-DBTOP_RSMI_STATIC=false
 		-DBTOP_STATIC=false
 		# These settings can be controlled in make.conf CFLAGS/CXXFLAGS
@@ -50,6 +51,8 @@ src_configure() {
 pkg_postinst() {
 	xdg_pkg_postinst
 
-	optfeature "GPU monitoring support (Radeon GPUs)" dev-util/rocm-smi
-	optfeature "GPU monitoring support (NVIDIA GPUs)" x11-drivers/nvidia-drivers
+	if use gpu; then
+		optfeature "GPU monitoring support (Radeon GPUs)" dev-util/rocm-smi
+		optfeature "GPU monitoring support (NVIDIA GPUs)" x11-drivers/nvidia-drivers
+	fi
 }

--- a/sys-process/btop/metadata.xml
+++ b/sys-process/btop/metadata.xml
@@ -13,4 +13,7 @@
 		<remote-id type="github">aristocratos/btop</remote-id>
 		<bugs-to>https://github.com/aristocratos/btop/issues</bugs-to>
 	</upstream>
+	<use>
+		<flag name="gpu">Enable or disable optional GPU support.</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Add ability to disable potentially unused GPU monitoring 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
