### PR TITLE
dev-util/geany-plugins: Fix automagic enabling of tests and gcc-15 test failure

### DIFF
--- a/dev-util/geany-plugins/files/geany-plugins-2.0-gcc15-r1.patch
+++ b/dev-util/geany-plugins/files/geany-plugins-2.0-gcc15-r1.patch
@@ -25,3 +25,19 @@
  }
  
  /* loads @filename in @kf and return %FALSE if failed, emitting a warning
+# https://github.com/geany/geany-plugins/commit/109ad6e6a2cfa31deb33ebfcef838ba337ff208f
+--- a/geanyprj/src/unittests.c
++++ b/geanyprj/src/unittests.c
+@@ -25,12 +25,6 @@ file_teardown(void)
+ 	system("rm -rf test_list_dir");
+ }
+ 
+-gboolean
+-true(G_GNUC_UNUSED const gchar * arg)
+-{
+-	return TRUE;
+-}
+-
+ START_TEST(test_get_file_list)
+ {
+ 	GSList *files = get_file_list("test_list_dir", NULL, NULL, NULL);

--- a/dev-util/geany-plugins/geany-plugins-2.0-r2.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-2.0-r2.ebuild
@@ -15,10 +15,12 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
-IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope webhelper workbench"
+IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope test webhelper workbench"
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
 
-DEPEND="
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="
 	dev-libs/glib:2
 	>=dev-util/geany-2.0
 	x11-libs/gtk+:3
@@ -38,7 +40,10 @@ DEPEND="
 	webhelper? ( net-libs/webkit-gtk:4.1 )
 	workbench? ( dev-libs/libgit2:= )
 "
-RDEPEND="${DEPEND}
+DEPEND="${COMMON_DEPEND}
+	test? ( dev-libs/check )
+"
+RDEPEND="${COMMON_DEPEND}
 	scope? ( dev-debug/gdb )
 "
 BDEPEND="virtual/pkgconfig
@@ -57,6 +62,9 @@ pkg_setup() {
 
 src_prepare() {
 	default
+	if ! use test; then
+		sed -i "s:gp_have_unittests=yes:gp_have_unittests=no:" build/unittests.m4 || die
+	fi
 	eautoreconf
 }
 

--- a/dev-util/geany-plugins/geany-plugins-2.0-r2.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-2.0-r2.ebuild
@@ -47,7 +47,7 @@ BDEPEND="virtual/pkgconfig
 
 PATCHES=(
 	"${FILESDIR}/${P}-gcc14.patch"
-	"${FILESDIR}/${P}-gcc15.patch"
+	"${FILESDIR}/${P}-gcc15-r1.patch"
 	"${FILESDIR}/${P}-webkit2gtk-4.1.patch"
 )
 


### PR DESCRIPTION
Add an existing upstream commit for gcc-15 test failure

Closes: https://bugs.gentoo.org/950007

Tests were being automagically enabled by the presence of dev-libs/check.

The changes here are only related to tests, hence no bump.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
