### PR TITLE
dev-lang/rust: fix experimental targets check

### DIFF
--- a/dev-lang/rust/rust-1.74.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.74.1-r101.ebuild
@@ -44,8 +44,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.74.1/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -56,12 +60,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -304,13 +305,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -322,7 +323,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.75.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.75.0-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.75.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -270,13 +271,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -288,7 +289,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.76.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.76.0-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.76.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -269,13 +270,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -287,7 +288,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.77.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.77.1-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.77.1/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -268,13 +269,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -286,7 +287,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.78.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.78.0-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.78.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -268,13 +269,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -285,7 +286,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.79.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.79.0-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.79.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -268,13 +269,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -285,7 +286,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.80.1-r101.ebuild
+++ b/dev-lang/rust/rust-1.80.1-r101.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.80.1/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -267,13 +268,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -284,7 +285,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.81.0-r101.ebuild
+++ b/dev-lang/rust/rust-1.81.0-r101.ebuild
@@ -40,8 +40,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.81.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -52,12 +56,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -271,13 +272,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -288,7 +289,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.82.0-r102.ebuild
+++ b/dev-lang/rust/rust-1.82.0-r102.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.82.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -279,13 +280,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -296,7 +297,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.83.0-r2.ebuild
+++ b/dev-lang/rust/rust-1.83.0-r2.ebuild
@@ -39,8 +39,12 @@ ALL_LLVM_TARGETS=( AArch64 AMDGPU ARC ARM AVR BPF CSKY DirectX Hexagon Lanai
 ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+# https://github.com/rust-lang/llvm-project/blob/rustc-1.83.0/llvm/CMakeLists.txt
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -51,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -279,13 +280,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -296,7 +297,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.84.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.1-r1.ebuild
@@ -40,8 +40,11 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 # https://github.com/rust-lang/llvm-project/blob/rustc-1.84.0/llvm/CMakeLists.txt
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -52,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -279,13 +279,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -298,7 +298,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.85.0.ebuild
+++ b/dev-lang/rust/rust-1.85.0.ebuild
@@ -61,7 +61,11 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 # https://github.com/rust-lang/llvm-project/blob/rustc-1.84.0/llvm/CMakeLists.txt
-ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
@@ -77,6 +81,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -346,13 +353,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	local build_channel
@@ -378,7 +385,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-1.86.0_beta20250218.ebuild
+++ b/dev-lang/rust/rust-1.86.0_beta20250218.ebuild
@@ -62,7 +62,11 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 # https://github.com/rust-lang/llvm-project/blob/rustc-1.84.0/llvm/CMakeLists.txt
-ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
@@ -78,6 +82,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -348,13 +355,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	local build_channel
@@ -380,7 +387,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -61,7 +61,11 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 # https://github.com/rust-lang/llvm-project/blob/rustc-1.84.0/llvm/CMakeLists.txt
-ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV%%_*}" # Beta releases get to share the same SLOT as the eventual stable
@@ -77,6 +81,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -346,13 +353,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	local build_channel
@@ -378,7 +385,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632


### PR DESCRIPTION
1. target in ALL_LLVM_TARGETS has prefix llvm_targets_, so check in last commit failed always.
2. using associate array for the test of experimental target's existence

Fixes: ff8e2b548c258e60463b1df0224beda29c7aacec

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
