### PR TITLE
media-sound/gimmix: update EAPI 7 -> 8, fix build

### DIFF
--- a/media-sound/gimmix/files/gimmix-0.5.7.2-fix-headers.patch
+++ b/media-sound/gimmix/files/gimmix-0.5.7.2-fix-headers.patch
@@ -1,0 +1,22 @@
+Fix headers for USE="lyrics -cover -taglib"
+Add missing dependency, include guard
+https://bugs.gentoo.org/919181
+--- a/src/gimmix-lyrics.h
++++ b/src/gimmix-lyrics.h
+@@ -4,6 +4,7 @@
+ #define GIMMIX_LYRICS_H
+ 
+ #include "gimmix-core.h"
++#include "gimmix-metadata.h"
+ #include "gimmix.h"
+ #include "wejpconfig.h"
+ #include <gtk/gtk.h>
+--- a/src/gimmix-metadata.h
++++ b/src/gimmix-metadata.h
+@@ -1,5 +1,5 @@
+ #ifndef GIMMIX_METADATA_H
+-#define GIMMIX_METADAT_H
++#define GIMMIX_METADATA_H
+ 
+ #include "gimmix-core.h"
+ #include "gimmix.h"

--- a/media-sound/gimmix/gimmix-0.5.7.2-r2.ebuild
+++ b/media-sound/gimmix/gimmix-0.5.7.2-r2.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools xdg
+
+DESCRIPTION="a graphical music player daemon (MPD) client using GTK+2"
+HOMEPAGE="https://launchpad.net/gimmix"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="cover lyrics taglib"
+
+RDEPEND="
+	media-libs/libmpd:=
+	gnome-base/libglade:=
+	x11-libs/gtk+:2
+	cover? (
+		net-libs/libnxml:=
+		net-misc/curl:=
+	)
+	lyrics? (
+		net-libs/libnxml:=
+		net-misc/curl:=
+	)
+	taglib? ( media-libs/taglib:= )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	dev-util/intltool"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5.7.1-curl-headers.patch
+	"${FILESDIR}"/${PN}-0.5.7.2-format-security.patch
+	"${FILESDIR}"/${PN}-0.5.7.2-QA-desktop-file.patch
+	"${FILESDIR}"/${PN}-0.5.7.2-fno-common.patch
+	"${FILESDIR}"/${PN}-0.5.7.2-fix-headers.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable cover) \
+		$(use_enable lyrics) \
+		$(use_enable taglib tageditor)
+}


### PR DESCRIPTION
It depends upon deprecated dependency libglade. Upstream is dead.

Closes: https://bugs.gentoo.org/919181

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
