### PR TITLE
media-libs/zxing-cpp: add missing test dependency and force find_package

### DIFF
--- a/media-libs/zxing-cpp/zxing-cpp-2.2.1-r1.ebuild
+++ b/media-libs/zxing-cpp/zxing-cpp-2.2.1-r1.ebuild
@@ -21,6 +21,7 @@ RESTRICT="!test? ( test )"
 DEPEND="
 	test? (
 		dev-cpp/gtest
+		dev-libs/libfmt
 		dev-libs/stb
 	)
 "
@@ -43,6 +44,7 @@ src_configure() {
 		-DBUILD_EXAMPLES=OFF # nothing is installed
 		-DBUILD_BLACKBOX_TESTS=$(usex test)
 		-DBUILD_UNIT_TESTS=$(usex test)
+		-DBUILD_DEPENDENCIES=LOCAL # force find_package as REQUIRED
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/950106
Fixes: d5c62bd26e15d585d1516010cdbde0d809fd5ae8

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
