### PR TITLE
dev-build/cmake: allow upstream behavior for FindBLAS

### DIFF
--- a/dev-build/cmake/cmake-3.31.5-r1.ebuild
+++ b/dev-build/cmake/cmake-3.31.5-r1.ebuild
@@ -47,7 +47,7 @@ else
 			https://github.com/Kitware/CMake/releases/download/v$(ver_cut 1-3)/${MY_P}-SHA-256.txt.asc
 		)"
 
-		KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+		KEYWORDS="~alpha ~amd64 arm arm64 hppa ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 
 		BDEPEND="verify-sig? ( >=sec-keys/openpgp-keys-bradking-20240902 )"
 	fi

--- a/dev-build/cmake/files/cmake-3.27.0_rc1-0003-Prefer-pkgconfig-in-FindBLAS.patch
+++ b/dev-build/cmake/files/cmake-3.27.0_rc1-0003-Prefer-pkgconfig-in-FindBLAS.patch
@@ -1,31 +1,28 @@
-From 9bc75325cc38962ecdd4a3ebd67ce34ea8162a45 Mon Sep 17 00:00:00 2001
-From: Lars Wendler <polynomial-c@gentoo.org>
-Date: Thu, 13 Feb 2020 13:12:45 +0100
-Subject: [PATCH 3/6] Prefer pkgconfig in FindBLAS
-
+diff --git a/Modules/FindBLAS.cmake b/Modules/FindBLAS.cmake
+index 6d60c9d86a..b6664dfe26 100644
 --- a/Modules/FindBLAS.cmake
 +++ b/Modules/FindBLAS.cmake
-@@ -7,6 +7,10 @@ FindBLAS
+@@ -7,6 +7,11 @@ FindBLAS
  
  Find Basic Linear Algebra Subprograms (BLAS) library
  
 +Version modified for Gentoo Linux.
 +If a valid PkgConfig configuration is found, this overrides and cancels
-+all further checks.
++all further checks. The upstream behavior can be restored by defining
++GENTOO_REMOVE_CMAKE_BLAS_HACK
 +
  This module finds an installed Fortran library that implements the
  `BLAS linear-algebra interface`_.
  
-@@ -276,6 +280,9 @@ function(_add_blas_target)
+@@ -281,6 +286,11 @@ function(_add_blas_target)
    endif()
  endfunction()
  
 +# first, try PkgConfig
-+set(BLA_PREFER_PKGCONFIG ON)
++if(NOT DEFINED GENTOO_REMOVE_CMAKE_BLAS_HACK)
++  set(BLA_PREFER_PKGCONFIG ON)
++endif()
 +
  if(CMAKE_Fortran_COMPILER_LOADED)
    include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranFunctionExists.cmake)
  else()
--- 
-2.41.0
-


### PR DESCRIPTION
Hi. Gentoo patches cmake's FindBLAS changing the upstream behavior, which sometimes breaks builds and takes time for investigation. The corresponding bug has been open for 4.5 years: https://bugs.gentoo.org/736547

This patch allows restoring the upstream behavior of FindBLAS by defining `GENTOO_REMOVE_CMAKE_BLAS_HACK`. This is quite ugly, but it is easy and less ugly than what we have right now.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
