### PR TITLE
net-wireless/wepattack: fix build failure with C23

### DIFF
--- a/net-wireless/wepattack/files/wepattack-0.1.3-seds.patch
+++ b/net-wireless/wepattack/files/wepattack-0.1.3-seds.patch
@@ -1,0 +1,48 @@
+Transform seds from Makefile into patch. Were:
+	sed -i \
+		-e "/^CFLAGS=/s:=:=${CFLAGS} :" \
+		-e 's:-fno-for-scope::g' \
+		-e "/^CC=/s:gcc:$(tc-getCC):" \
+		-e "/^LD=/s:gcc:$(tc-getCC):" \
+		-e 's:log.o\\:log.o \\:' \
+		src/Makefile || die
+	sed -i \
+		-e "s/wordfile:/-wordlist=/" \
+		run/wepattack_word || die
+https://bugs.gentoo.org/711032
+--- a/run/wepattack_word
++++ b/run/wepattack_word
+@@ -28,7 +28,7 @@
+ 
+ if test -f $JOHNDIR/john; then
+ 
+-	$JOHNDIR/john -wordfile:$WORDLIST -rules -stdout:13\
++	$JOHNDIR/john --wordlist=$WORDLIST -rules -stdout:13\
+  	| wepattack -f $1
+ 	exit 0;
+ else
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -2,11 +2,10 @@
+ # 15-10-2002 Dominik Blunk and Alain Girardet
+ #
+ #
+-CC=gcc
+-LD=gcc
++LD=${CC}
+ #
+ # CFLAGS
+-CFLAGS=-fno-for-scope -c -D__LINUX_WLAN__ -D__I386__
++CFLAGS += -c -D__LINUX_WLAN__ -D__I386__
+ #
+ #
+ # LDFLAGS
+@@ -21,7 +21,7 @@
+ INSTDIR=/usr/bin
+ 
+ wepattack: 	wepattack.o rc4.o wepfilter.o log.o modes.o misc.o verify.o keygen.o
+-	$(LD) $(LDFLAGS) -o $@ wepattack.o rc4.o wepfilter.o log.o\
++	$(LD) $(LDFLAGS) -o $@ wepattack.o rc4.o wepfilter.o log.o \
+ 	modes.o misc.o verify.o keygen.o $(LIBS)
+ 
+ wepattack.o:	wepattack.c wepattack.h

--- a/net-wireless/wepattack/files/wepattack-0.1.3-signals.patch
+++ b/net-wireless/wepattack/files/wepattack-0.1.3-signals.patch
@@ -1,0 +1,13 @@
+Fix signature for signal handler
+https://bugs.gentoo.org/944166
+--- a/src/wepattack.c
++++ b/src/wepattack.c
+@@ -216,7 +216,7 @@
+ //
+ // signal handler for ctrl+c
+ //
+-void sigint() {
++void sigint(int) {
+ 
+ 	printf("\nAborting... writing result to '%s'\n", logfile);
+ 

--- a/net-wireless/wepattack/wepattack-0.1.3-r7.ebuild
+++ b/net-wireless/wepattack/wepattack-0.1.3-r7.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P="WepAttack-${PV}"
+DESCRIPTION="WLAN tool for breaking 802.11 WEP keys"
+HOMEPAGE="https://wepattack.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/wepattack/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="john"
+
+DEPEND="
+	dev-libs/openssl:=
+	net-libs/libpcap
+	sys-libs/zlib
+"
+RDEPEND="
+	${DEPEND}
+	john? (
+		|| (
+			app-crypt/johntheripper
+			app-crypt/johntheripper-jumbo
+		)
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-filter-mac-address.patch
+	"${FILESDIR}"/${P}-missed-string.h-warnings-fix.patch
+	"${FILESDIR}"/${P}-modern-c.patch
+	"${FILESDIR}"/${P}-seds.patch
+	"${FILESDIR}"/${P}-signals.patch
+)
+
+src_compile() {
+	tc-export CC
+	emake -C src
+}
+
+src_test() {
+	src/wepattack || die "Program can't start"
+}
+
+src_install() {
+	dodoc README
+	dobin src/wepattack
+
+	if use john; then
+		dosbin run/wepattack_{inc,word}
+		insinto /etc
+		doins "${FILESDIR}"/wepattack.conf
+	fi
+}


### PR DESCRIPTION
Seds in ebuild transformed into patch in the process.

Closes: https://bugs.gentoo.org/944166
Closes: https://bugs.gentoo.org/711032

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
