### PR TITLE
sci-mathematics/prover9: Port to C99, fix parallel build.

### DIFF
--- a/sci-mathematics/prover9/files/LADR-2009-11A-c99.patch
+++ b/sci-mathematics/prover9/files/LADR-2009-11A-c99.patch
@@ -1,0 +1,25 @@
+Explicitly declare int values as ints.
+https://bugs.gentoo.org/886597
+https://bugs.gentoo.org/871261
+--- a/mace4.src/msearch.c
++++ b/mace4.src/msearch.c
+@@ -847,7 +847,7 @@
+  *************/
+ 
+ static
+-int next_domain_size(n)
++int next_domain_size(int n)
+ {
+   int top = (parm(Opt->end_size) == -1 ? INT_MAX : parm(Opt->end_size));
+       
+--- a/mace4.src/select.c
++++ b/mace4.src/select.c
+@@ -233,7 +233,7 @@
+  *
+  *************/
+ 
+-int select_concentric_band(min_id, max_id, max_constrained)
++int select_concentric_band(int min_id, int max_id, int max_constrained)
+ {
+   int max = -1;
+   int id_of_max = -1;

--- a/sci-mathematics/prover9/files/LADR-2009-11A-stable-ordering.patch
+++ b/sci-mathematics/prover9/files/LADR-2009-11A-stable-ordering.patch
@@ -1,0 +1,91 @@
+Do not call clean in the middle of build. We start with clean tree, we build
+stuff with all the same flags, every time, we don't remove files from under
+make while it's in the process of building things with large jobs number
+or with shuffle.
+Pipe CFLAGS (and, transitively, LDFLAGS) to last place where they were missing
+https://bugs.gentoo.org/881475
+https://bugs.gentoo.org/911554
+https://bugs.gentoo.org/887409
+https://bugs.gentoo.org/728030
+--- a/ladr/Makefile
++++ b/ladr/Makefile
+@@ -36,7 +36,7 @@
+           $(INFE_OBJ) $(MODL_OBJ) $(MISC_OBJ)
+ 
+ libladr.la: $(OBJECTS)
+-	libtool --tag=CC --mode=link $(CC) -shared -rpath /usr/lib -version-info 4:0:0 -o libladr.la $(OBJECTS) -lm
++	libtool --tag=CC --mode=link $(CC) $(CFLAGS) -shared -rpath /usr/lib -version-info 4:0:0 -o libladr.la $(OBJECTS) -lm
+ 
+ %.lo: %.c
+ 	libtool --tag=CC --mode=compile $(CC) -c $(CFLAGS) $(XFLAGS) -o $@ $<
+--- a/apps.src/Makefile
++++ b/apps.src/Makefile
+@@ -13,7 +13,7 @@
+ 
+ PROGRAMS = latfilter olfilter clausefilter idfilter renamer unfast clausetester rewriter isofilter0 isofilter isofilter2 dprofiles interpfilter upper-covers miniscope interpformat prooftrans mirror-flip perm3 sigtest directproof test_clause_eval test_complex complex gen_trc_defs
+ 
+-all: ladr apps install realclean
++all: ladr apps install
+ 
+ ladr:
+ 	cd ../ladr && $(MAKE) libladr.la
+@@ -24,7 +24,7 @@
+ realclean:
+ 	libtool --tag=CC --mode=clean /bin/rm -f *.o $(PROGRAMS)
+ 
+-install:
++install: apps
+ 	libtool --tag=CC --mode=install /bin/cp $(PROGRAMS) `pwd`/../bin
+ 
+ tags:
+--- a/mace4.src/Makefile
++++ b/mace4.src/Makefile
+@@ -27,7 +27,6 @@
+ 
+ ladr:
+ 	cd ../ladr && $(MAKE) libladr.la
+-	$(MAKE) clean
+ 
+ mace4: libmace4.a mace4.o $(OBJECTS)
+ 	libtool --tag=CC --mode=link $(CC) $(CFLAGS) -o mace4 mace4.o libmace4.a ../ladr/libladr.la
+@@ -42,5 +42,5 @@
+ realclean:
+ 	libtool --tag=CC --mode=clean /bin/rm -f *.o *.a mace4
+ 
+-install:
++install: mace4
+ 	libtool --tag=CC --mode=install /bin/cp mace4 `pwd`/../bin
+--- a/provers.src/Makefile
++++ b/provers.src/Makefile
+@@ -28,19 +28,17 @@
+ 
+ ##############################################################################
+ 
+-all: libs $(PROGRAMS) install clean
++all: libs $(PROGRAMS) install
+ 
+ libs: ladr libmace4
+ 
+ ladr libladr:
+ 	cd ../ladr && $(MAKE) libladr
+-	$(MAKE) clean
+ 
+ libmace libmace4:
+ 	cd ../mace4.src && $(MAKE) libmace4
+-	$(MAKE) clean
+ 
+-install:
++install: libs $(PROGRAMS)
+ 	libtool --tag=CC --mode=install /bin/cp -p $(PROGRAMS) `pwd`/../bin
+ 
+ clean:
+--- a/test.src/Makefile
++++ b/test.src/Makefile
+@@ -16,7 +16,6 @@
+ all: ladr apps
+ 
+ ladr:
+-	make clean
+ 	cd ../ladr && $(MAKE) libladr.la
+ 
+ clean:

--- a/sci-mathematics/prover9/prover9-2009.11a-r2.ebuild
+++ b/sci-mathematics/prover9/prover9-2009.11a-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,6 +26,8 @@ IUSE="examples"
 PATCHES=(
 	"${WORKDIR}/${MY_PN}-2009-11A-makefile.patch"
 	"${FILESDIR}/${MY_PN}-2009-11A-manpages.patch"
+	"${FILESDIR}/${MY_PN}-2009-11A-c99.patch"
+	"${FILESDIR}/${MY_PN}-2009-11A-stable-ordering.patch"
 )
 
 src_prepare() {
@@ -33,16 +35,15 @@ src_prepare() {
 
 	sed -e "/^CC =/s:gcc:$(tc-getCC):g" -i */Makefile || die
 
-	export MAKEOPTS+=" -j1 "
 	tc-export AR CC
 }
 
 src_compile() {
-	emake CFLAGS="${CFLAGS} ${LDFLAGS}" -j1 all
+	emake CFLAGS="${CFLAGS} ${LDFLAGS}" all
 }
 
 src_test() {
-	LD_LIBRARY_PATH="${S}/ladr/.libs/" emake -j1 test1 test2 test3
+	LD_LIBRARY_PATH="${S}/ladr/.libs/" emake test1 test2 test3
 }
 
 src_install() {


### PR DESCRIPTION
Add ints to implicitly-declared function parameters that are actually ints Remove all the cleans that were scattered around makefiles. They are useful for development only and only hinder packaged build. Pipe CFLAG to last place it's needed to be used, for linking a library.

Closes: https://bugs.gentoo.org/728030
Closes: https://bugs.gentoo.org/871261
Closes: https://bugs.gentoo.org/881475
Closes: https://bugs.gentoo.org/886597
Closes: https://bugs.gentoo.org/887409
Closes: https://bugs.gentoo.org/911554

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
