### PR TITLE
net-vpn/tailscale: add dependency on nftables

### DIFF
--- a/net-vpn/tailscale/tailscale-1.80.1-r1.ebuild
+++ b/net-vpn/tailscale/tailscale-1.80.1-r1.ebuild
@@ -23,7 +23,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 
 CONFIG_CHECK="~TUN"
 
-RDEPEND="net-firewall/iptables"
+RDEPEND="|| ( net-firewall/iptables net-firewall/nftables )"
 BDEPEND=">=dev-lang/go-1.22"
 
 RESTRICT="test"


### PR DESCRIPTION
tailscale supports iptables and nftables so it should depend on either of them

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
