### PR TITLE
sci-biology/yass: Fix build with USE=lowmem

### DIFF
--- a/sci-biology/yass/files/yass-1.14-lowmem-define.patch
+++ b/sci-biology/yass/files/yass-1.14-lowmem-define.patch
@@ -1,0 +1,13 @@
+Add missing function definition to hash.c
+Whole hash.c is used only if USE=lowmem is enabled.
+https://bugs.gentoo.org/919215
+--- a/src/hash.h
++++ b/src/hash.h
+@@ -57,6 +57,7 @@
+   
+ }Table_hash;
+ 
++long int hashVerifie (Table_hash *table, char *mess,long int diag);
+ 
+ /*
+  *

--- a/sci-biology/yass/yass-1.14-r4.ebuild
+++ b/sci-biology/yass/yass-1.14-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="lowmem threads"
 
-PATCHES=( "${FILESDIR}"/${PV}-as-needed.patch )
+PATCHES=(
+	"${FILESDIR}"/${PV}-as-needed.patch
+	"${FILESDIR}"/${P}-lowmem-define.patch
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Add missing declaration to the lowmem-only header.

Closes: https://bugs.gentoo.org/919215

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
