### PR TITLE
dev-util/gengetopt: del unary_function fix c17

### DIFF
--- a/dev-util/gengetopt/files/gengetopt-2.23.1-fix-c17.patch
+++ b/dev-util/gengetopt/files/gengetopt-2.23.1-fix-c17.patch
@@ -1,0 +1,21 @@
+unary_function removed in C++17. It can just be deleted.
+--- a/src/gm_utils.h
++++ b/src/gm_utils.h
+@@ -117,7 +117,7 @@
+  * Function object to print something into a stream (to be used with for_each)
+  */
+ template<class T>
+-struct print_f : public std::unary_function<T, void>
++struct print_f
+ {
+     print_f(std::ostream& out, const string &s = ", ") : os(out), sep(s) {}
+     void operator() (T x) { os << x << sep; }
+@@ -129,7 +129,7 @@
+  * Function object to print a pair into two streams (to be used with for_each)
+  */
+ template<class T>
+-struct pair_print_f : public std::unary_function<T, void>
++struct pair_print_f
+ {
+     pair_print_f(std::ostream& out1, std::ostream& out2, const string &s = ", ") :
+         os1(out1), os2(out2), sep(s) {}

--- a/dev-util/gengetopt/gengetopt-2.23-r1.ebuild
+++ b/dev-util/gengetopt/gengetopt-2.23-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,6 +17,7 @@ BDEPEND="sys-apps/texinfo"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.22.6-docdirs.patch
+	"${FILESDIR}"/${PN}-2.23.1-fix-c17.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
unary_function removed in C++17. It can just be deleted.
no revbump

Closes: https://bugs.gentoo.org/913636

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
