### PR TITLE
sys-devel/smatch: Do not install cgcc wrapper in live ebuild

### DIFF
--- a/sys-devel/smatch/smatch-9999.ebuild
+++ b/sys-devel/smatch/smatch-9999.ebuild
@@ -62,7 +62,7 @@ src_test() {
 
 src_install() {
 	# default install target installs a lot of sparse cruft
-	dobin smatch cgcc
+	dobin smatch
 	insinto /usr/share/smatch/smatch_data
 	doins smatch_data/*
 	dodoc FAQ Documentation/smatch.rst


### PR DESCRIPTION
It still belongs to sparse.

Closes: https://bugs.gentoo.org/950232

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
