### PR TITLE
x11-plugins/wmcms: update EAPI 7 -> 8, port to C99

### DIFF
--- a/x11-plugins/wmcms/files/wmcms-0.3.5-c99.patch
+++ b/x11-plugins/wmcms/files/wmcms-0.3.5-c99.patch
@@ -1,0 +1,51 @@
+Fix C099 bugs - correct types of static values,
+inclyde correct headers.
+Fold seds from old ebuild.
+Remove CC and CFLAGS from Makefile - toolchain provides
+https://bugs.gentoo.org/874483
+https://bugs.gentoo.org/919218
+--- a/Makefile	2025-02-24 22:58:37.620418861 +0400
++++ b/Makefile	2025-02-24 22:59:58.108959699 +0400
+@@ -1,7 +1,5 @@
+-CC	=	gcc
+ LIBS	=	-lXext -lX11 -L/usr/X11R6/lib -lXpm -ldockapp
+ SRCS	=	wmcms.c
+-CFLAGS	=	-g -O2
+ 
+ all: wmcms
+ 
+@@ -9,7 +7,7 @@
+ 	rm -f wmcms
+ 	
+ wmcms : $(SRCS) wmcms.xpm
+-		$(CC) $(CFLAGS) $(SRCS) $(INC) -o wmcms $(LIBS)
++		$(CC) $(CFLAGS) $(SRCS) $(INC) ${LDFLAGS} -o wmcms $(LIBS)
+ 
+ install : all
+ 		install -c -s wmcms /usr/local/bin
+diff '--color=auto' -ru wmcms-0.3.5.old/wmcms.c wmcms-0.3.5/wmcms.c
+--- wmcms-0.3.5.old/wmcms.c	2025-02-24 22:58:37.620418861 +0400
++++ wmcms-0.3.5/wmcms.c	2025-02-24 22:59:37.916610009 +0400
+@@ -18,9 +18,10 @@
+ 
+ #include <stdio.h>
+ #include <unistd.h>
+-#include <dockapp.h>
++#include <string.h>
++#include <libdockapp/dockapp.h>
+ #include "state_linux_2.6.h"
+ #include "state_linux_2.4.h"
+ #include "wmcms.xpm"
+ 
+ char *displayName = "";
+@@ -133,8 +144,8 @@
+ }
+ int main (int argc, char **argv)
+ {
+-  static unsigned b_width = 64;
+-  static unsigned b_height = 137;
++  static unsigned short b_width = 64;
++  static unsigned short b_height = 137;
+ 
+   int cpu_total;
+   int old_cpu_user;

--- a/x11-plugins/wmcms/wmcms-0.3.5-r5.ebuild
+++ b/x11-plugins/wmcms/wmcms-0.3.5-r5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -17,19 +17,12 @@ DEPEND=">=x11-libs/libdockapp-0.7:="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-s4t4n.patch
+	"${FILESDIR}"/${P}-c99.patch
 )
 
-src_prepare() {
-	default
-
-	# Respect LDFLAGS, see bug #335031
-	sed -e 's/ -o wmcms/ ${LDFLAGS} -o wmcms/' -i Makefile || die
-
-	sed -e 's#<dockapp.h>#<libdockapp/dockapp.h>#' -i *.c || die
-}
-
 src_compile() {
-	emake CFLAGS="${CFLAGS}" CC="$(tc-getCC)"
+	tc-export CC
+	default
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/874483
Closes: https://bugs.gentoo.org/919218

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
