### PR TITLE
sci-libs/opencascade: Mask ffmpeg use-flag as it's 4.x only

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,14 @@
 
 # New entries go on top.
 
+# Paul Zander <negril.nx+gentoo@gmail.com> (2025-02-24)
+# Only builds with ffmpeg-4.x, upstream has no timeline to fix it.
+# https://tracker.dev.opencascade.org/view.php?id=32871
+# Fringe usage only to play audio. Which most consumers (freecad, vtk)
+# don't do. Mask so the unsuspecting user with ffmpeg in global USE isn't
+# restricted to ancient ffmpeg.
+sci-libs/opencascade ffmpeg
+
 # Sam James <sam@gentoo.org> (2025-02-21)
 # Mask for older GTK to phase in enabling Vulkan for users (and avoid a surprise
 # for stable users, as Vulkan is enabled by default on desktop profiles).


### PR DESCRIPTION
Only builds with ffmpeg-4.x, upstream has no timeline to fix it. Fringe usage only to play audio. Which most consumers (freecad, vtk) don't do. Mask so the unsuspecting user with ffmpeg in global USE isn't restricted to ancient ffmpeg.

See-Also: https://tracker.dev.opencascade.org/view.php?id=32871

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
