### PR TITLE
dev-libs/libtpms: Fix nvram_offsets test on 32-bit platforms

### DIFF
--- a/dev-libs/libtpms/files/libtpms-0.10.0-tpm2-Add-padding-to-OBJECT-for-32bit-targets.patch
+++ b/dev-libs/libtpms/files/libtpms-0.10.0-tpm2-Add-padding-to-OBJECT-for-32bit-targets.patch
@@ -1,0 +1,32 @@
+Bug: https://bugs.gentoo.org/948139
+
+From 095a085b6f447551110e09b2013c6a21c2a29f2d Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Fri, 15 Nov 2024 08:07:23 -0500
+Subject: [PATCH] tpm2: Add padding to OBJECT for 32bit targets
+
+The nvram_offsets test fails on 32bit targets due to an unexpected size
+of an OBJECT. This was due to missing padding.
+
+Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
+---
+ src/tpm2/Global.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/tpm2/Global.h b/src/tpm2/Global.h
+index 910b940..c4d7176 100644
+--- a/src/tpm2/Global.h
++++ b/src/tpm2/Global.h
+@@ -265,6 +265,9 @@ typedef struct OBJECT
+     // this field carries additional metadata
+     // needed to derive the proof value for
+     // the object.
++#if __LONG_WIDTH__ == 32
++    UINT8               _pad1[4]; /* 32 bit targets need padding */
++#endif
+ 
+     // libtpms added: SEED_COMPAT_LEVEL to use for deriving child keys
+     SEED_COMPAT_LEVEL   seedCompatLevel;
+-- 
+2.45.3
+

--- a/dev-libs/libtpms/libtpms-0.10.0-r1.ebuild
+++ b/dev-libs/libtpms/libtpms-0.10.0-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools eapi9-ver
+
+DESCRIPTION="Library providing software emulation of a TPM"
+HOMEPAGE="https://github.com/stefanberger/libtpms"
+SRC_URI="https://github.com/stefanberger/libtpms/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+
+DEPEND="dev-libs/openssl:="
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.10.0-Remove-WError.patch"
+	"${FILESDIR}/${PN}-0.10.0-tpm2-Add-padding-to-OBJECT-for-32bit-targets.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# --disable-hardening because it just sets what our toolchain
+	# already does. If the user wants to disable that in their *FLAGS,
+	# or via USE on toolchain packages, honour that.
+	econf \
+		--with-openssl \
+		--disable-hardening
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	if ver_replacing -lt 0.8.0; then
+		elog "Versions of libtpms prior to 0.8.0 generate weaker than expected TPM 2.0 RSA"
+		elog "keys due to a flawed key creation algorithm. Because fixing this would render"
+		elog "existing sealed data inaccessible, to use the corrected algorithm, the old"
+		elog "TPM state file must be deleted and a new TPM state file created. Data still"
+		elog "sealed using the old state file will be permanently inaccessible. For the"
+		elog "details see https://github.com/stefanberger/libtpms/issues/183"
+	fi
+}


### PR DESCRIPTION
Although this only to fix a failed test, the patch does change the ABI of "typedef struct OBJECT" adding 4 bytes of padding to the end on 32-bit architectures. I cannot prove this change is limited to fixing the failed test and that it doesn't break/fix something else on 32-bit architectures.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
