### PR TITLE
app-text/sword: EAPI 8, add test utils, force compliance w/ useflags

### DIFF
--- a/app-text/sword/files/sword-1.9.0-cflags.patch
+++ b/app-text/sword/files/sword-1.9.0-cflags.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -174,10 +174,10 @@
+ ELSE(MSVC)
+ 	SET(CMAKE_C_FLAGS_DEBUG            "-g3 -Wall -O0 ${CMAKE_C_FLAGS}")
+ 	SET(CMAKE_C_FLAGS_RELEASE          "-O3 ${CMAKE_C_FLAGS}")
+-	SET(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O3 -g ${CMAKE_C_FLAGS}")
++	SET(CMAKE_C_FLAGS_RELWITHDEBINFO   "${CMAKE_C_FLAGS}")
+ 	SET(CMAKE_CXX_FLAGS_DEBUG          "-g3 -Wall -O0 ${CMAKE_CXX_FLAGS}")
+ 	SET(CMAKE_CXX_FLAGS_RELEASE        "-O3 ${CMAKE_CXX_FLAGS}")
+-	SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g ${CMAKE_CXX_FLAGS}")
++	SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS}")
+ ENDIF(MSVC)
+ ##############################################################################################
+ # Setting libraries and includes

--- a/app-text/sword/metadata.xml
+++ b/app-text/sword/metadata.xml
@@ -9,5 +9,6 @@ societies to write new Bible software more quickly and easily.
 	</longdescription>
 	<use>
 		<flag name="clucene">Use <pkg>dev-cpp/clucene</pkg> for lucene search support</flag>
+		<flag name="utils">CLI (diatheke) and conversion utilities for bible documents in SWORD supported formats</flag>
 	</use>
 </pkgmetadata>

--- a/app-text/sword/sword-1.9.0-r2.ebuild
+++ b/app-text/sword/sword-1.9.0-r2.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Library for Bible reading software"
+HOMEPAGE="https://www.crosswire.org/sword/"
+SRC_URI="https://www.crosswire.org/ftpmirror/pub/${PN}/source/v${PV%.*}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-macos"
+IUSE="clucene curl icu test utils"
+REQUIRED_USE="test? ( curl icu utils )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-arch/bzip2
+	app-arch/xz-utils
+	sys-libs/zlib
+	curl? ( net-misc/curl )
+	icu? ( dev-libs/icu:= )
+	clucene? ( dev-cpp/clucene:1 )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.9.0-cflags.patch
+)
+
+DOCS=( AUTHORS CODINGSTYLE ChangeLog README examples/ samples/ )
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_SKIP_RPATH="ON"
+		# default is shared and static
+		-DLIBSWORD_LIBRARY_TYPE="Shared"
+		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
+		-DSYSCONF_INSTALL_DIR="${EPREFIX}/etc"
+		-DSWORD_BUILD_TESTS=$(usex test)
+		-DSWORD_BUILD_UTILS=$(usev !utils No)
+		-DSWORD_NO_CLUCENE=$(usev !clucene Yes)
+		-DWITH_CLUCENE=$(usex clucene)
+		-DSWORD_NO_CURL=$(usev !curl Yes)
+		-DWITH_CURL=$(usex curl)
+		-DSWORD_NO_ICU=$(usev !icu Yes)
+		-DWITH_ICU=$(usex icu)
+		-DWITH_ZLIB=1
+	)
+
+	cmake_src_configure
+}
+
+src_test() {
+	local -x LD_LIBRARY_PATH="${BUILD_DIR}"
+	cmake_src_test
+}


### PR DESCRIPTION
update EAPI 7 -> 8

useflags:
add test
add utils (previously enabled by default, rdep breakout checked)
rm doc (no bdep, small size)
rm debug (no action)

cmakeargs:
force compliance with useflags (SWORD_NO_*)
rm rpath

add patch to respect user's CFLAGS

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
