### PR TITLE
sys-libs/libxcrypt: avoid using pkg-config for headers-only

### DIFF
--- a/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.36-r3.ebuild
@@ -138,9 +138,11 @@ src_configure() {
 	fi
 
 	if use headers-only; then
-		# Nothing is compiled here which would affect the headers for the target.
-		# So forcing CC is sane.
+		# Nothing is compiled which would affect the headers, so we set
+		# CC and PKG_CONFIG to ensure configure passes without defaulting
+		# to the unprefixed host variants e.g. "pkg-config"
 		local -x CC="$(tc-getBUILD_CC)"
+		local -x PKG_CONFIG="false"
 	fi
 
 	# Avoid possible "illegal instruction" errors with gold

--- a/sys-libs/libxcrypt/libxcrypt-4.4.38.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.38.ebuild
@@ -138,9 +138,11 @@ src_configure() {
 	fi
 
 	if use headers-only; then
-		# Nothing is compiled here which would affect the headers for the target.
-		# So forcing CC is sane.
+		# Nothing is compiled which would affect the headers, so we set
+		# CC and PKG_CONFIG to ensure configure passes without defaulting
+		# to the unprefixed host variants e.g. "pkg-config"
 		local -x CC="$(tc-getBUILD_CC)"
+		local -x PKG_CONFIG="false"
 	fi
 
 	# Doesn't work with LTO: bug #852917.

--- a/sys-libs/libxcrypt/metadata.xml
+++ b/sys-libs/libxcrypt/metadata.xml
@@ -13,7 +13,7 @@
 	<use>
 		<flag name="compat">Build with compatibility interfaces for other crypt implementations</flag>
 		<flag name="system">Install as system libcrypt.so rather than to an alternate directory (will collide with <pkg>sys-libs/glibc</pkg>'s version)</flag>
-		<flag name="headers-only">Build and install only the headers.</flag>
+		<flag name="headers-only">Build and install only the headers. This is mostly useful for toolchain bootstrapping, to avoid circular deps.</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">besser82/libxcrypt</remote-id>


### PR DESCRIPTION
    sys-libs/libxcrypt: avoid using pkg-config for headers-only
    
    When setting USE=headers-only, nothing gets built, and
    just some static files get installed: the two (x)crypt.h
    headers alongside the /usr/share/doc files. The usefulness
    of this is mostly for early compiler bootstrapping, to
    break circular deps like:
    compiler-rt -> libxcrypt -> complier-rt
    
    There is no need to have a working pkg-config, the env var
    PKG_CONFIG is empty, there might not even be any setup for
    cross-*/pkgconf and the configure step will likely end up
    calling the host pkg-config (which will fail my profile
    sanity checks).
    
    So we set to a known no-op value just for USE=headers-only
    leaving all the non-headers builds to pick the correct
    variant as before.
    
    Closes: https://bugs.gentoo.org/950273
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>


    sys-devel/libxcrypt: clarify the intended use of USE=headers-only
    
    Closes: https://bugs.gentoo.org/950273
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
