### PR TITLE
dev-lang/rust: Enable dynamic linking by default for musl targets

### DIFF
--- a/dev-lang/rust/files/1.85.0-musl-dynamic-linking.patch
+++ b/dev-lang/rust/files/1.85.0-musl-dynamic-linking.patch
@@ -1,0 +1,271 @@
+From be965af5421e55c0032a989b220bc0da005d2272 Mon Sep 17 00:00:00 2001
+From: Michal Rostecki <vadorovsky@protonmail.com>
+Date: Tue, 25 Feb 2025 16:24:21 +0100
+Subject: [PATCH] Enable dynamic linking by default for musl
+
+---
+ .../src/spec/targets/aarch64_unknown_linux_musl.rs             | 3 ---
+ .../src/spec/targets/arm_unknown_linux_musleabi.rs             | 3 +--
+ .../src/spec/targets/arm_unknown_linux_musleabihf.rs           | 3 +--
+ .../src/spec/targets/armv5te_unknown_linux_musleabi.rs         | 3 +--
+ .../src/spec/targets/armv7_unknown_linux_musleabi.rs           | 3 +--
+ .../src/spec/targets/armv7_unknown_linux_musleabihf.rs         | 3 +--
+ .../rustc_target/src/spec/targets/i586_unknown_linux_musl.rs   | 2 --
+ .../rustc_target/src/spec/targets/i686_unknown_linux_musl.rs   | 2 --
+ .../src/spec/targets/mips64_unknown_linux_muslabi64.rs         | 3 +--
+ .../src/spec/targets/mips64el_unknown_linux_muslabi64.rs       | 2 --
+ .../src/spec/targets/powerpc64_unknown_linux_musl.rs           | 2 --
+ .../src/spec/targets/powerpc64le_unknown_linux_musl.rs         | 2 --
+ .../src/spec/targets/powerpc_unknown_linux_musl.rs             | 2 --
+ .../src/spec/targets/powerpc_unknown_linux_muslspe.rs          | 2 --
+ .../src/spec/targets/riscv32gc_unknown_linux_musl.rs           | 3 +--
+ .../rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs  | 2 --
+ .../src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs   | 3 +--
+ .../rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs | 2 --
+ 18 files changed, 8 insertions(+), 37 deletions(-)
+
+diff --git a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
+index 4fefdfa5c5e..bb65048a56d 100644
+--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
+@@ -12,9 +12,6 @@ pub(crate) fn target() -> Target {
+         | SanitizerSet::MEMORY
+         | SanitizerSet::THREAD;
+ 
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+-
+     Target {
+         llvm_target: "aarch64-unknown-linux-musl".into(),
+         metadata: crate::spec::TargetMetadata {
+diff --git a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs
+index 26241dd0bd4..cab79e2bf7d 100644
+--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs
++++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabi.rs
+@@ -20,8 +20,7 @@ pub(crate) fn target() -> Target {
+             features: "+strict-align,+v6".into(),
+             max_atomic_width: Some(64),
+             mcount: "\u{1}mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
+index 4bbde7667b9..c5f6c180a95 100644
+--- a/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
++++ b/compiler/rustc_target/src/spec/targets/arm_unknown_linux_musleabihf.rs
+@@ -20,8 +20,7 @@ pub(crate) fn target() -> Target {
+             features: "+strict-align,+v6,+vfp2,-d32".into(),
+             max_atomic_width: Some(64),
+             mcount: "\u{1}mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs
+index 62619546891..680dafe6943 100644
+--- a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs
++++ b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_musleabi.rs
+@@ -20,8 +20,7 @@ pub(crate) fn target() -> Target {
+             max_atomic_width: Some(32),
+             mcount: "\u{1}mcount".into(),
+             has_thumb_interworking: true,
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs
+index 0436e0d8df4..e862b28ca92 100644
+--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs
++++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabi.rs
+@@ -24,8 +24,7 @@ pub(crate) fn target() -> Target {
+             features: "+v7,+thumb2,+soft-float,-neon".into(),
+             max_atomic_width: Some(64),
+             mcount: "\u{1}mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+index 22e49f2f1b0..acb7c99cdaf 100644
+--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
++++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+@@ -23,8 +23,7 @@ pub(crate) fn target() -> Target {
+             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
+             max_atomic_width: Some(64),
+             mcount: "\u{1}mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/i586_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/i586_unknown_linux_musl.rs
+index 8ad93496f3a..623422a89ea 100644
+--- a/compiler/rustc_target/src/spec/targets/i586_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/i586_unknown_linux_musl.rs
+@@ -4,7 +4,5 @@ pub(crate) fn target() -> Target {
+     let mut base = super::i686_unknown_linux_musl::target();
+     base.cpu = "pentium".into();
+     base.llvm_target = "i586-unknown-linux-musl".into();
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+     base
+ }
+diff --git a/compiler/rustc_target/src/spec/targets/i686_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/i686_unknown_linux_musl.rs
+index 6ba87c732b7..b805b80b85b 100644
+--- a/compiler/rustc_target/src/spec/targets/i686_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/i686_unknown_linux_musl.rs
+@@ -6,8 +6,6 @@ pub(crate) fn target() -> Target {
+     base.max_atomic_width = Some(64);
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32", "-Wl,-melf_i386"]);
+     base.stack_probes = StackProbeType::Inline;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     // The unwinder used by i686-unknown-linux-musl, the LLVM libunwind
+     // implementation, apparently relies on frame pointers existing... somehow.
+diff --git a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
+index 32f5c79d653..9a25fe773fb 100644
+--- a/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
++++ b/compiler/rustc_target/src/spec/targets/mips64_unknown_linux_muslabi64.rs
+@@ -22,8 +22,7 @@ pub(crate) fn target() -> Target {
+             abi: "abi64".into(),
+             endian: Endian::Big,
+             mcount: "_mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
+index 5e7c37fd46c..4f50e8b7033 100644
+--- a/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
++++ b/compiler/rustc_target/src/spec/targets/mips64el_unknown_linux_muslabi64.rs
+@@ -5,8 +5,6 @@ pub(crate) fn target() -> Target {
+     base.cpu = "mips64r2".into();
+     base.features = "+mips64r2".into();
+     base.max_atomic_width = Some(64);
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+     Target {
+         // LLVM doesn't recognize "muslabi64" yet.
+         llvm_target: "mips64el-unknown-linux-musl".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+index a54b17c87a7..a964f417799 100644
+--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+@@ -7,8 +7,6 @@ pub(crate) fn target() -> Target {
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
+     base.max_atomic_width = Some(64);
+     base.stack_probes = StackProbeType::Inline;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "powerpc64-unknown-linux-musl".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+index f763c37f535..d0335506f16 100644
+--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+@@ -6,8 +6,6 @@ pub(crate) fn target() -> Target {
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
+     base.max_atomic_width = Some(64);
+     base.stack_probes = StackProbeType::Inline;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "powerpc64le-unknown-linux-musl".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_musl.rs
+index 0cd0ea96ad3..5372a83e29a 100644
+--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_musl.rs
+@@ -6,8 +6,6 @@ pub(crate) fn target() -> Target {
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
+     base.max_atomic_width = Some(32);
+     base.stack_probes = StackProbeType::Inline;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "powerpc-unknown-linux-musl".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+index b86c3c2e8e0..2305db81c5e 100644
+--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
++++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+@@ -6,8 +6,6 @@ pub(crate) fn target() -> Target {
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-mspe"]);
+     base.max_atomic_width = Some(32);
+     base.stack_probes = StackProbeType::Inline;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "powerpc-unknown-linux-muslspe".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
+index a07429bb0c5..cf2d7669a8a 100644
+--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
+@@ -23,8 +23,7 @@ pub(crate) fn target() -> Target {
+             llvm_abiname: "ilp32d".into(),
+             max_atomic_width: Some(32),
+             supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
+index fbe8c48eca7..7a78004927b 100644
+--- a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
+@@ -12,8 +12,6 @@ pub(crate) fn target() -> Target {
+     base.stack_probes = StackProbeType::Inline;
+     base.supported_sanitizers =
+         SanitizerSet::ADDRESS | SanitizerSet::LEAK | SanitizerSet::MEMORY | SanitizerSet::THREAD;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "s390x-unknown-linux-musl".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs b/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs
+index 1149b6d16eb..e1e060c211d 100644
+--- a/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs
++++ b/compiler/rustc_target/src/spec/targets/thumbv7neon_unknown_linux_musleabihf.rs
+@@ -27,8 +27,7 @@ pub(crate) fn target() -> Target {
+             features: "+v7,+thumb-mode,+thumb2,+vfp3,+neon".into(),
+             max_atomic_width: Some(64),
+             mcount: "\u{1}mcount".into(),
+-            // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-            crt_static_default: true,
++            crt_static_default: false,
+             ..base::linux_musl::opts()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs
+index 8dcdc5be8a9..8be0f335db9 100644
+--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs
++++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_musl.rs
+@@ -14,8 +14,6 @@ pub(crate) fn target() -> Target {
+         | SanitizerSet::MEMORY
+         | SanitizerSet::THREAD;
+     base.supports_xray = true;
+-    // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
+-    base.crt_static_default = true;
+ 
+     Target {
+         llvm_target: "x86_64-unknown-linux-musl".into(),
+-- 
+2.45.3
+

--- a/dev-lang/rust/rust-1.85.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.85.0-r1.ebuild
@@ -3,12 +3,12 @@
 
 EAPI=8
 
-LLVM_COMPAT=( 20 )
+LLVM_COMPAT=( 19 )
 PYTHON_COMPAT=( python3_{10..13} )
 
 RUST_MAX_VER=${PV%%_*}
 if [[ ${PV} == *9999* ]]; then
-	RUST_MIN_VER="1.86.0" # Update this as new `beta` releases come out.
+	RUST_MIN_VER="1.85.0" # Update this as new `beta` releases come out.
 elif [[ ${PV} == *beta* ]]; then
 	# Enforce that `beta` is built from `stable`.
 	# While uncommon it is possible for feature changes within `beta` to result

--- a/dev-lang/rust/rust-1.86.0_beta20250218-r1.ebuild
+++ b/dev-lang/rust/rust-1.86.0_beta20250218-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-LLVM_COMPAT=( 20 )
+LLVM_COMPAT=( 19 )
 PYTHON_COMPAT=( python3_{10..13} )
 
 RUST_MAX_VER=${PV%%_*}
@@ -14,7 +14,7 @@ elif [[ ${PV} == *beta* ]]; then
 	# While uncommon it is possible for feature changes within `beta` to result
 	# in an older snapshot being unable to build a newer one without modifying the sources.
 	# 'stable' releases should always be able to build a beta snapshot so just use those.
-	RUST_MAX_VER="$(ver_cut 1).$(($(ver_cut 2) - 1)).1"
+	RUST_MAX_VER="$(ver_cut 1).$(($(ver_cut 2) - 1)).0"
 	RUST_MIN_VER="$(ver_cut 1).$(($(ver_cut 2) - 1)).0"
 else
 	RUST_MIN_VER="$(ver_cut 1).$(($(ver_cut 2) - 1)).0"
@@ -39,6 +39,7 @@ elif [[ ${PV} == *beta* ]]; then
 	SRC_URI="https://static.rust-lang.org/dist/${BETA_SNAPSHOT}/rustc-beta-src.tar.xz -> rustc-${PV}-src.tar.xz
 		verify-sig? ( https://static.rust-lang.org/dist/${BETA_SNAPSHOT}/rustc-beta-src.tar.xz.asc
 			-> rustc-${PV}-src.tar.xz.asc )
+		https://github.com/rust-lang/rust/pull/137020.patch -> ${P}-vendor-in-install-phase.patch
 	"
 	S="${WORKDIR}/${MY_P}-src"
 else
@@ -165,6 +166,7 @@ RESTRICT="test"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 PATCHES=(
+	"${DISTDIR}"/${P}-vendor-in-install-phase.patch
 	"${FILESDIR}"/1.85.0-cross-compile-libz.patch
 	"${FILESDIR}"/1.85.0-musl-dynamic-linking.patch
 	"${FILESDIR}"/1.67.0-doc-wasm.patch
@@ -216,7 +218,12 @@ src_unpack() {
 			directory = "vendor"
 		_EOF_
 	else
-		verify-sig_src_unpack
+		# Until upstream merge this patch we can't use the default verify-sig_src_unpack
+		if use verify-sig; then
+			verify-sig_verify_detached "${DISTDIR}/rustc-${PV}-src.tar.xz" \
+				"${DISTDIR}/rustc-${PV}-src.tar.xz.asc"
+		fi
+		default_src_unpack
 	fi
 }
 


### PR DESCRIPTION
We already have a similar patch for versions before 1.85.0. Change rust-lang/rust@9c37c14aa245, which got released in 1.85.0,  made us think that such a patch is not needed anymore, but that's not true. Upstream didn't fix the existing individual targets yet.

Bug: https://bugs.gentoo.org/950275

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
