### PR TITLE
app-misc/ddcutil: fix build error with clang 19

### DIFF
--- a/app-misc/ddcutil/ddcutil-2.1.4.ebuild
+++ b/app-misc/ddcutil/ddcutil-2.1.4.ebuild
@@ -1,18 +1,18 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 # Check for bumps & cleanup with app-misc/ddcui
 
-inherit autotools linux-info udev
+inherit autotools flag-o-matic linux-info udev
 
 DESCRIPTION="Program for querying and changing monitor settings"
 HOMEPAGE="https://www.ddcutil.com/"
 SRC_URI="https://github.com/rockowitz/ddcutil/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-SLOT="0/5"
 LICENSE="GPL-2"
+SLOT="0/5"
 KEYWORDS="amd64 arm arm64 ~loong ~ppc ppc64 ~riscv ~sparc x86"
 IUSE="drm usb-monitor user-permissions video_cards_nvidia X"
 REQUIRED_USE="drm? ( X )"
@@ -43,6 +43,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.4.1-no-werror.patch
+	"${FILESDIR}"/${PN}-2.1.4-fix-clang.patch
 )
 
 pkg_pretend() {
@@ -65,6 +66,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# too many error on -Wcompound-token-split-by-macro by clang
+	append-cflags $(test-flags-CC -Wno-compound-token-split-by-macro)
+
 	local myeconfargs=(
 		# FAILS: doxyfile: No such file or directory
 		# $(use_enable doc doxygen)

--- a/app-misc/ddcutil/files/ddcutil-1.4.1-no-werror.patch
+++ b/app-misc/ddcutil/files/ddcutil-1.4.1-no-werror.patch
@@ -19,7 +19,7 @@ index c12f15c..27d2124 100644
  dnl AC_MSG_NOTICE([DBG = |$DBG|])
 
 -AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, [test "x$ddcutil_version_suffix" != "x"] )
-+AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, [test 0])
++AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, [test 1 -eq 0])
 
  AS_IF( [test 0$DBG -ne 0],
     AC_MSG_NOTICE([debug messages enabled]),

--- a/app-misc/ddcutil/files/ddcutil-2.1.4-fix-clang.patch
+++ b/app-misc/ddcutil/files/ddcutil-2.1.4-fix-clang.patch
@@ -1,0 +1,57 @@
+https://github.com/rockowitz/ddcutil/pull/502
+
+From d6eeb92f0e537aba415b6abc28fe157626a7bef7 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Tue, 25 Feb 2025 22:24:23 +0800
+Subject: [PATCH] fix error reported by clang 19
+
+1. query_sysenv_i2c.c: error: variable 'busct' set but not used [-Werror,-Wunused-but-set-variable]
+2. i2c_strategy_dispatcher.c: error: expression which evaluates to zero treated as a null pointer
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+---
+ src/app_sysenv/query_sysenv_i2c.c | 3 ---
+ src/i2c/i2c_strategy_dispatcher.c | 4 ++--
+ 2 files changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/src/app_sysenv/query_sysenv_i2c.c b/src/app_sysenv/query_sysenv_i2c.c
+index 55f3424a..290b704b 100644
+--- a/src/app_sysenv/query_sysenv_i2c.c
++++ b/src/app_sysenv/query_sysenv_i2c.c
+@@ -275,11 +275,8 @@ void test_edid_read_variants(Env_Accumulator * accum) {
+    rpt_title("Testing EDID read alternatives...",depth);
+    sysenv_rpt_current_time(NULL, d1);
+ 
+-   int  busct = 0;
+-
+    for (int busno=0; busno < I2C_BUS_MAX; busno++) {
+       if (i2c_device_exists(busno)) {
+-         busct++;
+          rpt_nl();
+          rpt_vstring(d1, "Examining device /dev/i2c-%d...", busno);
+ 
+diff --git a/src/i2c/i2c_strategy_dispatcher.c b/src/i2c/i2c_strategy_dispatcher.c
+index ee435e6d..d6026526 100644
+--- a/src/i2c/i2c_strategy_dispatcher.c
++++ b/src/i2c/i2c_strategy_dispatcher.c
+@@ -188,7 +188,7 @@ Status_Errno_DDC invoke_i2c_writer(
+                  hexstring_t(bytes_to_write, bytect));
+ 
+    // n. prior to gcc 11, declaration cannot immediately follow label
+-   I2C_IO_Strategy * strategy = I2C_IO_STRATEGY_NOT_SET;
++   I2C_IO_Strategy * strategy = NULL;
+ retry:
+    strategy = i2c_get_io_strategy();
+    DBGTRC_NOPREFIX(debug, TRACE_GROUP, "strategy = %s", strategy->strategy_name);
+@@ -235,7 +235,7 @@ Status_Errno_DDC invoke_i2c_reader(
+                    readbuf);
+ 
+      // n. prior to gcc 11, declaration cannot immediately follow label
+-     I2C_IO_Strategy * strategy = I2C_IO_STRATEGY_NOT_SET;
++     I2C_IO_Strategy * strategy = NULL;
+ retry:
+      strategy = i2c_get_io_strategy();
+      DBGTRC_NOPREFIX(debug, TRACE_GROUP, "strategy = %s", strategy->strategy_name);
+-- 
+2.45.2
+


### PR DESCRIPTION
1. 'test STRING' equivalent to '-n STRING' which is True if the length of string is non-zero, so 'test 0' always success. Both 'test ""' and 'test 1 -eq 0' are ok, but the later is more intuitive.
2. too many error on Wcompound-token-split-by-macro, so disable this warning as a workaround.
3. fix two error reported by clang 19, patch submitted to upstream.

Closes: https://bugs.gentoo.org/928969
Closes: https://bugs.gentoo.org/929096

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
