### PR TITLE
app-text/talkfilters: update EAPI 7 -> 8, fix build on musl, license

### DIFF
--- a/app-text/talkfilters/files/talkfilters-2.3.8-string.patch
+++ b/app-text/talkfilters/files/talkfilters-2.3.8-string.patch
@@ -1,0 +1,12 @@
+Missing headers for strcmp, fixes build on musl
+https://bugs.gentoo.org/894712
+--- a/getopt.c
++++ b/getopt.c
+@@ -39,6 +39,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C

--- a/app-text/talkfilters/talkfilters-2.3.8-r2.ebuild
+++ b/app-text/talkfilters/talkfilters-2.3.8-r2.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Convert ordinary English text into text that mimics a stereotyped dialect"
+HOMEPAGE="https://www.hyperrealm.com/talkfilters/talkfilters.html"
+SRC_URI="https://www.hyperrealm.com/talkfilters/packages/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~mips ~ppc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-format-security.patch
+	"${FILESDIR}"/${P}-string.patch
+)
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894712
Closes: https://bugs.gentoo.org/880305

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
