### PR TITLE
sys-boot/plymouth: update EAPI 7 -> 8, fix musl build, QA issues

### DIFF
--- a/sys-boot/plymouth/files/plymouth-22.02.122-has_rpmatch.patch
+++ b/sys-boot/plymouth/files/plymouth-22.02.122-has_rpmatch.patch
@@ -1,0 +1,16 @@
+Use C23 __has_include to add correct include on musl. Was compiler extension
+before C23, works on clang/gcc versions we care about.
+https://bugs.gentoo.org/898564
+--- a/src/libply/ply-command-parser.c	2025-02-26 14:05:33.417781845 +0000
++++ b/src/libply/ply-command-parser.c	2025-02-26 14:09:10.068476721 +0000
+@@ -29,6 +29,10 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++#if __has_include(<rpmatch.h>)
++#include <rpmatch.h>
++#endif
++
+ #include "ply-buffer.h"
+ #include "ply-list.h"
+ #include "ply-utils.h"

--- a/sys-boot/plymouth/plymouth-22.02.122-r4.ebuild
+++ b/sys-boot/plymouth/plymouth-22.02.122-r4.ebuild
@@ -1,0 +1,122 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic autotools readme.gentoo-r1 systemd
+
+DESCRIPTION="Graphical boot animation (splash) and logger"
+HOMEPAGE="https://gitlab.freedesktop.org/plymouth/plymouth"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/plymouth/plymouth"
+else
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+SRC_URI="https://dev.gentoo.org/~aidecoe/distfiles/${CATEGORY}/${PN}/gentoo-logo.png"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="debug +drm +gtk +pango selinux +split-usr static-libs +udev"
+
+CDEPEND="
+	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
+	gtk? (
+		dev-libs/glib:2
+		x11-libs/cairo
+		>=x11-libs/gtk+-3.14:3[X]
+	)
+	pango? (
+		x11-libs/cairo
+		>=x11-libs/pango-1.21[X]
+	)
+"
+DEPEND="${CDEPEND}
+	elibc_musl? ( sys-libs/rpmatch-standalone )
+	pango? ( x11-base/xorg-proto )
+	app-text/docbook-xsl-stylesheets
+	dev-libs/libxslt
+	virtual/pkgconfig
+"
+# Block due bug #383067
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-plymouthd )
+	udev? ( virtual/udev )
+"
+
+DOC_CONTENTS="
+	Follow the following instructions to set up Plymouth:\n
+	https://wiki.gentoo.org/wiki/Plymouth#Configuration
+"
+
+PATCHES=(
+	"${FILESDIR}"/0.9.3-glibc-sysmacros.patch
+	"${FILESDIR}"/${P}-glibc-2.36.patch
+	"${FILESDIR}"/${P}-has_rpmatch.patch
+)
+
+src_prepare() {
+	use elibc_musl && append-ldflags -lrpmatch
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		--with-system-root-install=no
+		--localstatedir=/var
+		--without-rhgb-compat-link
+		--enable-documentation
+		--enable-systemd-integration
+		--with-systemdunitdir="$(systemd_get_systemunitdir)"
+		$(use_enable !static-libs shared)
+		$(use_enable static-libs static)
+		$(use_enable debug tracing)
+		$(use_enable drm)
+		$(use_enable gtk)
+		$(use_enable pango)
+		$(use_with udev)
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/plymouth
+	newins "${DISTDIR}"/gentoo-logo.png bizcom.png
+
+	if use split-usr ; then
+		# Install compatibility symlinks as some rdeps hardcode the paths
+		dosym ../usr/bin/plymouth /bin/plymouth
+		dosym ../usr/sbin/plymouth-set-default-theme /sbin/plymouth-set-default-theme
+		dosym ../usr/sbin/plymouthd /sbin/plymouthd
+	fi
+
+	readme.gentoo_create_doc
+
+	# directories needed to keep runtime state
+	# https://bugs.gentoo.org/925430
+	keepdir "${D}"/var/spool/plymouth "{D}"/var/lib/plymouth
+	# looks like make install create /var/run/plymouth
+	# this is not needed for systemd, same should hold for openrc
+	# so remove
+	rm -rf "${D}"/var/run
+	# https://bugs.gentoo.org/839081
+	find "${D}" -name '*.la' -delete || die
+
+	# fix broken symlink
+	dosym ../../bizcom.png /usr/share/plymouth/themes/spinfinity/header-image.png
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+	if ! has_version "sys-kernel/dracut"; then
+		ewarn "If you want initramfs builder with plymouth support, please emerge"
+		ewarn "sys-kernel/dracut."
+	fi
+}


### PR DESCRIPTION
Use C23/compiler extension to conditionally include right header. Clean up *.la files.
Keep empty directories, they are needed for runtime services. Fix is only for 22.02.122, not 24.004.60 or live.

Closes: https://bugs.gentoo.org/839081
Closes: https://bugs.gentoo.org/925430
Closes: https://bugs.gentoo.org/921110
Closes: https://bugs.gentoo.org/898564

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
