### PR TITLE
media-libs/tiff: fix race condition in tests

### DIFF
--- a/media-libs/tiff/files/tiff-4.7.0-fix-test-race.patch
+++ b/media-libs/tiff/files/tiff-4.7.0-fix-test-race.patch
@@ -1,0 +1,30 @@
+https://gitlab.com/libtiff/libtiff/-/merge_requests/701
+https://bugs.gentoo.org/943020
+
+From efadbbd8746d2c6c8129438716e2c1e8aeecafdb Mon Sep 17 00:00:00 2001
+From: Gabi Falk <gabifalk@gmx.com>
+Date: Wed, 26 Feb 2025 14:00:00 +0000
+Subject: [PATCH] test: Fix race condition in
+ {tiffcrop,tiffcp}-32bpp-None-jpeg.sh tests
+
+These tests used the same output path, which could cause failures
+when run in parallel.  These were the only tests with a conflicting
+outfile= parameter.
+
+Link: https://bugs.gentoo.org/943020
+---
+ test/tiffcrop-32bpp-None-jpeg.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/tiffcrop-32bpp-None-jpeg.sh b/test/tiffcrop-32bpp-None-jpeg.sh
+index 9b0d1f5f..4a47f6ed 100755
+--- a/test/tiffcrop-32bpp-None-jpeg.sh
++++ b/test/tiffcrop-32bpp-None-jpeg.sh
+@@ -2,6 +2,6 @@
+ # Generated file, master is Makefile.am
+ . ${srcdir:-.}/common.sh
+ infile="$srcdir/images/32bpp-None-jpeg.tiff"
+-outfile="o-tiffcp-32bpp-None-jpeg-YCbCr.tiff"
++outfile="o-tiffcrop-32bpp-None-jpeg-YCbCr.tiff"
+ f_test_convert "${TIFFCROP} -c jpeg" $infile $outfile
+ f_tiffinfo_validate $outfile

--- a/media-libs/tiff/tiff-4.7.0-r1.ebuild
+++ b/media-libs/tiff/tiff-4.7.0-r1.ebuild
@@ -50,6 +50,8 @@ MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/tiffconf.h
 )
 
+PATCHES=( "${FILESDIR}"/${P}-fix-test-race.patch ) # bug#943020
+
 src_prepare() {
 	default
 

--- a/media-libs/tiff/tiff-4.7.0.ebuild
+++ b/media-libs/tiff/tiff-4.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -44,6 +44,8 @@ BDEPEND="verify-sig? ( sec-keys/openpgp-keys-evenrouault )"
 MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/tiffconf.h
 )
+
+PATCHES=( "${FILESDIR}"/${P}-fix-test-race.patch ) # bug#943020
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/943020

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
