### PR TITLE
dev-libs/libspt: update EAPI 7 -> 8, fix gettimeofday usage

### DIFF
--- a/dev-libs/libspt/files/libspt-1.1-timeval-in-utmp.patch
+++ b/dev-libs/libspt/files/libspt-1.1-timeval-in-utmp.patch
@@ -1,0 +1,17 @@
+Switch to canonic handling of timeval possibly embedded in
+struct utmp, see manpage.
+https://bugs.gentoo.org/943014
+--- a/sptagent.c
++++ b/sptagent.c
+@@ -1033,7 +1033,10 @@
+ {
+ #ifdef HAVE_UTMP_UT_TV
+ #ifdef HAVE_GETTIMEOFDAY
+-    gettimeofday(&utptr->ut_tv, NULL);
++    struct timeval tv;
++    gettimeofday(&tv, NULL);
++    utptr->ut_tv.tv_sec = tv.tv_sec;
++    utptr->ut_tv.tv_usec = tv.tv_usec;
+ #else
+     utptr->ut_tv.tv_sec = time(NULL);
+     utptr->ut_tv.ut_usec = 0;

--- a/dev-libs/libspt/libspt-1.1-r5.ebuild
+++ b/dev-libs/libspt/libspt-1.1-r5.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library for handling root privilege"
+HOMEPAGE="http://www.j10n.org/libspt/"
+SRC_URI="http://www.j10n.org/${PN}/${P}.tar.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="suid"
+RESTRICT="test"
+
+RDEPEND="net-libs/libtirpc"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-gentoo.patch"
+	"${FILESDIR}/${PN}-glibc-2.30.patch"
+	"${FILESDIR}/${PN}-rpc.patch"
+	"${FILESDIR}/${PN}-gettimeofday.patch"
+	"${FILESDIR}/${P}-timeval-in-utmp.patch"
+)
+
+src_prepare() {
+	rm aclocal.m4
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--with-libtirpc
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${ED}" -name '*.la' -delete || die
+
+	if use suid; then
+		fperms 4755 /usr/libexec/sptagent
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/943014

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
