### PR TITLE
media-libs/libfpx: fix build with clang 19

### DIFF
--- a/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
+++ b/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -37,6 +37,11 @@ src_configure() {
 	# Do not trust for LTO either
 	append-flags -fno-strict-aliasing
 	filter-lto
+
+	# https://bugs.gentoo.org/896246
+	# already fixed by upstream but the patch is too large, waiting for new releases
+	# https://github.com/ImageMagick/libfpx/commit/5f340b0a490450b40302cc9948c7dfac60d40041
+	append-cxxflags -std=gnu++14
 
 	append-ldflags -Wl,--no-undefined
 	econf \


### PR DESCRIPTION
patch from upstream

Closes: https://bugs.gentoo.org/896246

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
