### PR TITLE
sci-physics/fastjet-contrib: fix dependency on plugins

### DIFF
--- a/sci-physics/fastjet-contrib/fastjet-contrib-1.100-r1.ebuild
+++ b/sci-physics/fastjet-contrib/fastjet-contrib-1.100-r1.ebuild
@@ -17,7 +17,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
 
-DEPEND=">=sci-physics/fastjet-3.4.1"
+DEPEND=">=sci-physics/fastjet-3.4.1[plugins]"
 RDEPEND="${DEPEND}"
 
 PATCHES=(

--- a/sci-physics/fastjet-contrib/fastjet-contrib-1.101-r1.ebuild
+++ b/sci-physics/fastjet-contrib/fastjet-contrib-1.101-r1.ebuild
@@ -17,7 +17,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
 
-DEPEND=">=sci-physics/fastjet-3.4.1"
+DEPEND=">=sci-physics/fastjet-3.4.1[plugins]"
 RDEPEND="${DEPEND}"
 
 PATCHES=(

--- a/sci-physics/fastjet-contrib/fastjet-contrib-9999.ebuild
+++ b/sci-physics/fastjet-contrib/fastjet-contrib-9999.ebuild
@@ -16,7 +16,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS=""
 
-DEPEND=">=sci-physics/fastjet-3.4.1"
+DEPEND=">=sci-physics/fastjet-3.4.1[plugins]"
 RDEPEND="${DEPEND}"
 
 PATCHES=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/950330