### PR TITLE
app-misc/ddcutil: fix build with USE=-X, don't install a removed udev rule

### DIFF
--- a/app-misc/ddcutil/ddcutil-2.2.0.ebuild
+++ b/app-misc/ddcutil/ddcutil-2.2.0.ebuild
@@ -31,7 +31,6 @@ RDEPEND="
 	)
 	user-permissions? (
 		acct-group/i2c
-		usb-monitor? ( acct-group/video )
 	)
 	X? (
 		x11-libs/libXrandr
@@ -86,9 +85,6 @@ src_install() {
 	default
 	if use user-permissions; then
 		udev_dorules data/usr/lib/udev/rules.d/60-ddcutil-i2c.rules
-		if use usb-monitor; then
-			udev_dorules data/usr/lib/udev/rules.d/60-ddcutil-usb.rules
-		fi
 	fi
 }
 
@@ -99,14 +95,6 @@ pkg_postinst() {
 		einfo "Restart the computer or reload the i2c-dev module to activate"
 		einfo "the new udev rule."
 		einfo "For more information read: http://www.ddcutil.com/i2c_permissions/"
-
-		if use usb-monitor; then
-			einfo "To allow non-root users access to USB monitors, add those users"
-			einfo "to the video group: usermod -aG video user"
-			einfo "Restart the computer, reload the hiddev and hidraw modules, or replug"
-			einfo "the monitor to activate the new udev rule."
-			einfo "For more information read: http://www.ddcutil.com/usb/"
-		fi
 
 		udev_reload
 	fi

--- a/app-misc/ddcutil/ddcutil-2.2.0.ebuild
+++ b/app-misc/ddcutil/ddcutil-2.2.0.ebuild
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.4.1-no-werror.patch
 	"${FILESDIR}"/${PN}-2.1.4-fix-clang.patch
 	"${FILESDIR}"/${P}-fix-clang.patch
+	"${FILESDIR}"/${P}-fix-build-without-X.patch
 )
 
 pkg_pretend() {

--- a/app-misc/ddcutil/files/ddcutil-2.2.0-fix-build-without-X.patch
+++ b/app-misc/ddcutil/files/ddcutil-2.2.0-fix-build-without-X.patch
@@ -1,0 +1,280 @@
+https://github.com/rockowitz/ddcutil/issues/504
+https://bugs.gentoo.org/950320
+
+From a35d1dc432d4dd419e4874b37c62d23f3ae70469 Mon Sep 17 00:00:00 2001
+From: "Sanford Rockowitz (/shared/home/rock/dot_gitconfig)"
+ <rockowitz@minsoft.com>
+Date: Thu, 27 Feb 2025 09:28:14 -0500
+Subject: [PATCH] build with configure option --disable-x11
+
+eliminates watch-mode XEVENT
+
+addresses issue #504
+---
+ src/base/parms.h                 |  6 +++++-
+ src/cmdline/cmd_parser_goption.c | 12 ++++++++++++
+ src/dw/Makefile.am               | 10 ++++++++--
+ src/dw/dw_common.c               |  2 ++
+ src/dw/dw_main.c                 | 14 ++++++++++++++
+ src/dw/dw_poll.c                 |  4 ++++
+ src/dw/dw_services.c             |  4 ++++
+ 7 files changed, 49 insertions(+), 3 deletions(-)
+
+diff --git a/src/base/parms.h b/src/base/parms.h
+index 3a8fbdd5..fcfac321 100644
+--- a/src/base/parms.h
++++ b/src/base/parms.h
+@@ -3,7 +3,7 @@
+  *  System configuration and tuning
+  */
+ 
+-// Copyright (C) 2014-2024 Sanford Rockowitz <rockowitz@minsoft.com>
++// Copyright (C) 2014-2025 Sanford Rockowitz <rockowitz@minsoft.com>
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ 
+ #ifndef PARMS_H_
+@@ -109,7 +109,11 @@
+ #define DEFAULT_DDCUTIL_SYSLOG_LEVEL DDCA_SYSLOG_WARNING
+ #define DEFAULT_LIBDDCUTIL_SYSLOG_LEVEL DDCA_SYSLOG_NOTICE
+ 
++#ifdef USE_X11
+ #define DEFAULT_WATCH_MODE Watch_Mode_Dynamic
++#else
++#define DEFAULT_WATCH_MODE Watch_Mode_Poll
++#endif
+ 
+ //
+ // Asynchronous Initialization
+diff --git a/src/cmdline/cmd_parser_goption.c b/src/cmdline/cmd_parser_goption.c
+index 27973d9b..b6ae37b7 100644
+--- a/src/cmdline/cmd_parser_goption.c
++++ b/src/cmdline/cmd_parser_goption.c
+@@ -508,8 +508,10 @@ static bool parse_watch_mode(
+ 
+       if (     is_abbrev(v2, "POLL", 3))
+          parsed_cmd->watch_mode = Watch_Mode_Poll;
++#ifdef USE_X11
+       else if (is_abbrev(v2, "XEVENT", 3))
+          parsed_cmd->watch_mode = Watch_Mode_Xevent;
++#endif
+    // else if (is_abbrev(v2, "UDEV", 3))
+    //    parsed_cmd->watch_mode = Watch_Mode_Udev;
+       else if (is_abbrev(v2, "DYNAMIC", 3))
+@@ -1026,9 +1028,15 @@ parse_command(
+    case Watch_Mode_Udev:     default_watch_mode_keyword = "UDEV";    break;
+    }
+    char watch_mode_expl[80];
++#ifdef USE_X11
+    g_snprintf(watch_mode_expl, 80, "DYNAMIC|XEVENT|POLL, default: %s", default_watch_mode_keyword);
++#else
++   g_snprintf(watch_mode_expl, 80, "DYNAMIC|POLL, default: %s", default_watch_mode_keyword);
++#endif
+    gboolean enable_watch_displays = true;
++#ifdef USE_X11
+    gint     xevent_watch_loop_millis_work = DEFAULT_XEVENT_WATCH_LOOP_MILLISEC;
++#endif
+    gint     poll_watch_loop_millis_work = DEFAULT_POLL_WATCH_LOOP_MILLISEC;
+ 
+    gboolean f1_flag         = false;
+@@ -1288,8 +1296,10 @@ parse_command(
+                       G_OPTION_ARG_NONE, &disable_api_flag, "Completely disable API", NULL },
+       {"watch-mode", '\0', G_OPTION_FLAG_HIDDEN,
+                            G_OPTION_ARG_STRING, &watch_mode_work, "How to watch for display changes",  watch_mode_expl},
++#ifdef USE_X11
+       {"xevent-watch-loop-millisec", '\0', G_OPTION_FLAG_HIDDEN,
+                            G_OPTION_ARG_INT, &xevent_watch_loop_millis_work, "Loop delay for mode XEVENT", "milliseconds"},
++#endif
+       {"poll-watch-loop-millisec", '\0', G_OPTION_FLAG_HIDDEN,
+                            G_OPTION_ARG_INT, &poll_watch_loop_millis_work, "Loop delay for mode POLL", "milliseconds"},
+ #ifdef ENABLE_USB
+@@ -2054,6 +2064,7 @@ parse_command(
+       }
+    }
+ 
++#ifdef USE_X11
+    if (xevent_watch_loop_millis_work <= 0) {
+       EMIT_PARSER_ERROR(errmsgs,
+             "--xevent-watch-loop-millisec not a positive number: %d", xevent_watch_loop_millis_work);
+@@ -2061,6 +2072,7 @@ parse_command(
+    }
+    else
+       parsed_cmd->xevent_watch_loop_millisec = (uint16_t) xevent_watch_loop_millis_work;
++#endif
+ 
+    if (poll_watch_loop_millis_work <= 0) {
+       EMIT_PARSER_ERROR(errmsgs,
+diff --git a/src/dw/Makefile.am b/src/dw/Makefile.am
+index 0327f1af..063beef4 100644
+--- a/src/dw/Makefile.am
++++ b/src/dw/Makefile.am
+@@ -27,8 +27,14 @@ libdw_la_SOURCES += \
+   dw_dref.c \
+   dw_udev.c \
+   dw_recheck.c \
+-  dw_services.c \
+-  dw_xevent.c
++  dw_services.c
++endif
++
++if ENABLE_UDEV_COND
++if USE_X11_COND
++libdw_la_SOURCES += \
++  dw_xevent.c 
++endif
+ endif
+ 
+ # Rename to "all=local" for development 
+diff --git a/src/dw/dw_common.c b/src/dw/dw_common.c
+index 62f87226..29c4ff75 100644
+--- a/src/dw/dw_common.c
++++ b/src/dw/dw_common.c
+@@ -59,7 +59,9 @@
+ 
+ #include "dw_status_events.h"
+ #include "dw_dref.h"
++#ifdef USE_X11
+ #include "dw_xevent.h"
++#endif
+ 
+ #include "dw_common.h"
+ 
+diff --git a/src/dw/dw_main.c b/src/dw/dw_main.c
+index 996d6f95..d3218c89 100644
+--- a/src/dw/dw_main.c
++++ b/src/dw/dw_main.c
+@@ -46,7 +46,9 @@
+ #include "dw_udev.h"
+ #include "dw_recheck.h"
+ #include "dw_poll.h"
++#ifdef USE_X11
+ #include "dw_xevent.h"
++#endif
+ 
+ #include "dw_main.h"
+ 
+@@ -79,8 +81,10 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+    DBGTRC_STARTING(debug, TRACE_GROUP, "initial_mode=%s xev_data_loc=%p", watch_mode_name(initial_mode), xev_data_loc);
+ 
+    DDC_Watch_Mode resolved_watch_mode = Watch_Mode_Poll;
++#ifdef USE_X11
+    XEvent_Data * xevdata = NULL;
+    *xev_data_loc = NULL;
++#endif
+ 
+ #ifndef ENABLE_UDEV
+    if (initial_mode == Watch_Mode_Udev)
+@@ -89,6 +93,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+ 
+    if (initial_mode == Watch_Mode_Dynamic) {
+       resolved_watch_mode = Watch_Mode_Poll;    // always works, may be slow
++#ifdef USE_X11
+       char * xdg_session_type = getenv("XDG_SESSION_TYPE");
+       DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "XDG_SESSION_TYPE=|%s|", xdg_session_type);
+       if (xdg_session_type &&         // can xdg_session_type ever not be set
+@@ -111,6 +116,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+       // sysfs_fully_reliable = is_sysfs_reliable();
+       // if (!sysfs_fully_reliable)
+       //    dw_watch_mode = Watch_Mode_Poll;
++#endif
+    }
+    else {
+       resolved_watch_mode = initial_mode;
+@@ -124,6 +130,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+    }
+ #endif
+ 
++#ifdef USE_X11
+    if (resolved_watch_mode == Watch_Mode_Xevent) {
+       xevdata  = dw_init_xevent_screen_change_notification();
+       // *xev_data_loc  = ddc_init_xevent_screen_change_notification();
+@@ -132,15 +139,18 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+          MSG_W_SYSLOG(DDCA_SYSLOG_WARNING, "X11 RANDR api unavailable. Switching to Watch_Mode_Poll");
+       }
+    }
++#endif
+ 
+    // DBG( "xevdata=%p, watch_mode = %s", xevdata, dw_watch_mode_name(resolved_watch_mode));
+ 
++#ifdef USE_X11
+    *xev_data_loc = xevdata;
+    // ASSERT_IFF(resolved_watch_mode == Watch_Mode_Xevent, xevdata);
+    ASSERT_IFF(resolved_watch_mode == Watch_Mode_Xevent, *xev_data_loc);
+    if (*xev_data_loc && IS_DBGTRC(debug, DDCA_TRC_NONE)) {
+       dw_dbgrpt_xevent_data(*xev_data_loc,  0);
+    }
++#endif
+    DBGTRC_DONE(debug, TRACE_GROUP, "resolved_watch_mode: %s. *xev_data_loc: %p",
+          watch_mode_name(resolved_watch_mode),  *xev_data_loc);
+    return resolved_watch_mode;
+@@ -278,6 +288,7 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
+    if (watch_thread) {
+       DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "resolved_watch_mode = %s",
+                                             watch_mode_name(global_wdd->watch_mode));
++#ifdef USE_X11
+       if (global_wdd->watch_mode == Watch_Mode_Xevent) {
+          if (terminate_using_x11_event) {   // for testing, does not currently work
+             dw_send_x11_termination_message(global_wdd->evdata);
+@@ -290,6 +301,9 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
+       else {
+          terminate_watch_thread = true;  // signal watch thread to terminate
+       }
++#else
++      terminate_watch_thread = true;
++#endif
+ 
+       // DBGTRC_NOPREFIX(debug, TRACE_GROUP, "Waiting %d millisec for watch thread to terminate...", 4000);
+       // usleep(4000*1000);  // greater than the sleep in watch_displays_using_poll()
+diff --git a/src/dw/dw_poll.c b/src/dw/dw_poll.c
+index 677a6ce6..336b5c92 100644
+--- a/src/dw/dw_poll.c
++++ b/src/dw/dw_poll.c
+@@ -62,7 +62,9 @@
+ #include "dw_dref.h"
+ #include "dw_recheck.h"
+ #include "dw_status_events.h"
++#ifdef USE_X11
+ #include "dw_xevent.h"
++#endif
+ 
+ #include "dw_poll.h"
+ 
+@@ -276,6 +278,7 @@ gpointer dw_watch_display_connections(gpointer data) {
+          continue;
+       dw_terminate_if_invalid_thread_or_process(cur_pid, cur_tid);
+ 
++#ifdef USE_X11
+       if (wdd->watch_mode == Watch_Mode_Xevent) {
+          if (terminate_using_x11_event) {
+             bool event_found = dw_next_X11_event_of_interest(wdd->evdata);
+@@ -295,6 +298,7 @@ gpointer dw_watch_display_connections(gpointer data) {
+                continue;
+          }
+       }
++#endif
+ 
+       DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "locking process_event_mutex");
+       g_mutex_lock(&process_event_mutex);
+diff --git a/src/dw/dw_services.c b/src/dw/dw_services.c
+index 75601879..93085e00 100644
+--- a/src/dw/dw_services.c
++++ b/src/dw/dw_services.c
+@@ -15,7 +15,9 @@
+ #include "dw/dw_recheck.h"
+ #include "dw/dw_status_events.h"
+ #include "dw/dw_udev.h"
++#ifdef USE_X11
+ #include "dw/dw_xevent.h"
++#endif
+ 
+ #include "dw_services.h"
+ 
+@@ -31,7 +33,9 @@ void init_dw_services() {
+    init_dw_poll();
+    init_dw_recheck();
+    init_dw_udev();
++#ifdef USE_X11
+    init_dw_xevent();
++#endif
+ 
+    DBGMSF(debug, "Done");
+ }


### PR DESCRIPTION
Upstream added a feature [1] that uses X11 API unconditionally which broke
building with USE=-X. The patch [2] changes it, so support for this feature
is enabled only if ddcutil is built with X support.

Remove installation of udev rule file that was dropped upstream [3].
Also remove dependency on acct-group/video because it's no longer
mentioned in the usb udev rule that still exists [4].


[1] https://github.com/rockowitz/ddcutil/commit/6bf1062d
[2] https://github.com/rockowitz/ddcutil/commit/a35d1dc
[3] https://github.com/rockowitz/ddcutil/commit/0938023
[4] https://github.com/rockowitz/ddcutil/commit/e906c51

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
