### PR TITLE
sci-libs/qfits: update EAPI 7 -> 8, add missing includes

### DIFF
--- a/sci-libs/qfits/files/qfits-6.2.0-includes.patch
+++ b/sci-libs/qfits/files/qfits-6.2.0-includes.patch
@@ -1,0 +1,32 @@
+Missing includes in main library and in tests
+https://bugs.gentoo.org/886463
+--- a/main/dtfits.c
++++ b/main/dtfits.c
+@@ -33,6 +33,7 @@
+ #include <string.h>
+ 
+ #include "qfits_table.h"
++#include "qfits_tools.h"
+ 
+ /*-----------------------------------------------------------------------------
+                                    Define
+--- a/main/qextract.c
++++ b/main/qextract.c
+@@ -32,6 +32,7 @@
+ #include "qfits_table.h" 
+ #include "qfits_image.h" 
+ #include "qfits_rw.h" 
++#include "qfits_tools.h"
+ 
+ /*-----------------------------------------------------------------------------
+                                Function prototypes
+--- a/test/test_pixio.c
++++ b/test/test_pixio.c
+@@ -41,6 +41,7 @@
+ 
+ #include "qfits_header.h"
+ #include "qfits_image.h"
++#include "qfits_rw.h"
+ #include "qfits_md5.h"
+ #include "qfits_memory.h"
+ 

--- a/sci-libs/qfits/files/qfits-6.2.0-m4.patch
+++ b/sci-libs/qfits/files/qfits-6.2.0-m4.patch
@@ -1,0 +1,36 @@
+Missing system inlude in self-defined autoconf tests
+https://bugs.gentoo.org/908483
+--- a/m4macros/eso.m4
++++ b/m4macros/eso.m4
+@@ -252,6 +252,7 @@
+                        AC_RUN_IFELSE([
+ #include <stdio.h>
+ #include <stdarg.h>
++#include <stdlib.h>
+ 
+ int
+ doit(char * s, ...)
+@@ -701,6 +702,7 @@
+                    [
+                        AC_RUN_IFELSE([
+ #include <stdarg.h>
++#include <stdlib.h>
+ 
+ void f(int i, ...)
+ {
+@@ -733,6 +735,7 @@
+                    [
+                        AC_RUN_IFELSE([
+ #include <stdarg.h>
++#include <stdlib.h>
+ 
+ void f(int i, ...)
+ {
+@@ -784,6 +787,7 @@
+                    [
+                        AC_RUN_IFELSE([
+ #include <stdarg.h>
++#include <stdlib.h>
+ 
+ void f(int i, ...)
+ {

--- a/sci-libs/qfits/qfits-6.2.0-r1.ebuild
+++ b/sci-libs/qfits/qfits-6.2.0-r1.ebuild
@@ -1,10 +1,12 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit autotools
 
 DESCRIPTION="ESO stand-alone C library offering easy access to FITS files"
-HOMEPAGE="http://www.eso.org/projects/aot/qfits/"
+HOMEPAGE="https://www.eso.org/sci/software/eclipse/qfits/"
 SRC_URI="ftp://ftp.hq.eso.org/pub/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -12,10 +14,18 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
-PATCHES=( "${FILESDIR}"/${P}-{ttest,open}.patch )
+PATCHES=(
+	"${FILESDIR}/${P}-ttest.patch"
+	"${FILESDIR}/${P}-open.patch"
+	"${FILESDIR}/${P}-includes.patch"
+	"${FILESDIR}/${P}-m4.patch"
+)
 
-src_configure() {
-	econf --disable-static
+src_prepare() {
+	default
+
+	# https://bugs.gentoo.org/908483
+	eautoreconf
 }
 
 src_install() {


### PR DESCRIPTION
Update home page, add missing includes in tests, main library and custom m4 scripts for configure.

Closes: https://bugs.gentoo.org/908483
Closes: https://bugs.gentoo.org/886463

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
