### PR TITLE
cargo.eclass: Enable dynamic linking by default

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -745,10 +745,15 @@ cargo_env() {
 	# The default linker is "cc" so override by setting linker to CC in the
 	# RUSTFLAGS. The given linker cannot include any arguments, so split these
 	# into link-args along with LDFLAGS.
+	#
+	# Rust defaults to static linking (-C target-feature=+crt-static) on musl
+	# targets. We already patch dev-lang/rust to always prefer dynamic linking,
+	# but to ensure that behavior with dev-lang/rust-bin, set the opposite option
+	# (-C target-feature=-crt-static) in RUSTFLAGS.
 	local -x CARGO_BUILD_TARGET=$(rust_abi)
 	local TRIPLE=${CARGO_BUILD_TARGET//-/_}
 	local TRIPLE=${TRIPLE^^} LD_A=( $(tc-getCC) ${LDFLAGS} )
-	local -Ix CARGO_TARGET_"${TRIPLE}"_RUSTFLAGS+=" -C strip=none -C linker=${LD_A[0]}"
+	local -Ix CARGO_TARGET_"${TRIPLE}"_RUSTFLAGS+=" -C strip=none -C linker=${LD_A[0]} -C target-feature=-crt-static"
 	[[ ${#LD_A[@]} -gt 1 ]] && local CARGO_TARGET_"${TRIPLE}"_RUSTFLAGS+="$(printf -- ' -C link-arg=%s' "${LD_A[@]:1}")"
 	local CARGO_TARGET_"${TRIPLE}"_RUSTFLAGS+=" ${RUSTFLAGS}"
 


### PR DESCRIPTION
Rust defaults to static linking (`-C target-feature=+crt-static`) on musl targets. We already patch dev-lang/rust to always prefer dynamic linking, but to ensure that behavior with dev-lang/rust-bin, set the opposite option (`-C target-feature=-crt-static`) in RUSTFLAGS.

Bug: https://bugs.gentoo.org/940722

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
