### PR TITLE
net-misc/taptap: add missing include

### DIFF
--- a/net-misc/taptap/files/taptap-1.0-missing-include.patch
+++ b/net-misc/taptap/files/taptap-1.0-missing-include.patch
@@ -1,0 +1,12 @@
+Add missing include
+https://bugs.gentoo.org/919058
+--- a/taptap.c
++++ b/taptap.c
+@@ -35,6 +35,7 @@
+ #include <unistd.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ #ifndef __NetBSD__
+ #include <linux/if.h>
+ #include <linux/if_tun.h>

--- a/net-misc/taptap/taptap-1.0-r2.ebuild
+++ b/net-misc/taptap/taptap-1.0-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit edo toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Program to link two /dev/net/tun to form virtual ethernet"
 HOMEPAGE="https://grumpf.hope-2000.org/"
@@ -13,15 +13,16 @@ S="${WORKDIR}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~sparc ~x86"
+PATCHES=( "${FILESDIR}/${P}-missing-include.patch" )
 
 src_unpack() {
-	cp "${DISTDIR}"/${P}.c ${P}.c || die
+	cp "${DISTDIR}/${P}.c" "${PN}.c" || die
 }
 
 src_compile() {
-	edo $(tc-getCC) ${CFLAGS} ${LDFLAGS} -o ${PN} ${P}.c
+	emake CC="$(tc-getCC)" "${PN}"
 }
 
 src_install() {
-	dobin ${PN}
+	dobin "${PN}"
 }


### PR DESCRIPTION
Changed build process to lean more on portage infrastructure with implicit emake rules instead of explicit edo that may be missing compile or link flags.

Closes: https://bugs.gentoo.org/919877
Closes: https://bugs.gentoo.org/919058

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
