### PR TITLE
sci-libs/cfitsio: port to C23

### DIFF
--- a/sci-libs/cfitsio/cfitsio-4.5.0-r1.ebuild
+++ b/sci-libs/cfitsio/cfitsio-4.5.0-r1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib fortran-2
+
+DESCRIPTION="C and Fortran library for manipulating FITS files"
+HOMEPAGE="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html"
+SRC_URI="https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/${P}.tar.gz"
+
+LICENSE="ISC"
+SLOT="0/10-r1"
+KEYWORDS="~alpha ~amd64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="bzip2 curl test tools"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	app-alternatives/yacc
+	app-alternatives/lex
+"
+RDEPEND="
+	sys-libs/zlib[${MULTILIB_USEDEP}]
+	bzip2? ( app-arch/bzip2[${MULTILIB_USEDEP}] )
+	curl? ( net-misc/curl[${MULTILIB_USEDEP}] )
+"
+# Bug #803350
+DEPEND="
+	${RDEPEND}
+	<dev-lang/cfortran-20110621
+"
+
+PATCHES=( "${FILESDIR}/${P}-rename-nullptr.patch" )
+
+pkg_setup() {
+	fortran-2_pkg_setup
+}
+
+src_prepare() {
+	cmake_src_prepare
+
+	# fix libdir
+	sed -e 's:lib/::' -i CMakeLists.txt || die
+
+	# Avoid internal cfortran
+	rm cfortran.h || die
+}
+
+multilib_src_configure() {
+	local libdir=$(get_libdir)
+	local mycmakeargs=(
+		# used for .pc file
+		-DLIB_SUFFIX=${libdir#lib}
+
+		-DUSE_BZIP2=$(usex bzip2)
+		-DUSE_CURL=$(usex curl)
+		-DUSE_PTHREADS=ON
+		# just appending CFLAGS
+		-DUSE_SSE2=OFF
+		-DUSE_SSSE3=OFF
+
+		-DTESTS=$(usex test)
+		-DUTILS=$(multilib_native_usex tools)
+	)
+	cmake_src_configure
+}
+
+multilib_src_install_all() {
+	dodoc README.md docs/*.pdf
+
+	docinto examples
+	dodoc utilities/{cookbook.{c,f},testprog.c,testf77.f,speed.c,smem.c}
+}

--- a/sci-libs/cfitsio/files/cfitsio-4.5.0-rename-nullptr.patch
+++ b/sci-libs/cfitsio/files/cfitsio-4.5.0-rename-nullptr.patch
@@ -1,0 +1,51 @@
+Nullptr is reserved keyword in C23. Rename to something that describes usage better
+https://bugs.gentoo.org/944747
+--- a/putcol.c
++++ b/putcol.c
+@@ -1226,7 +1226,7 @@
+     long rept, rowrept, width, tnull, naxes[9] = {1,1,1,1,1,1,1,1,1}, groups;
+     double zeros = 0.;
+     char message[FLEN_ERRMSG], keyname[FLEN_KEYWORD], nullstr[FLEN_VALUE];
+-    char **stringptr, *nullptr, *cptr;
++    char **stringptr, *ptr_to_null, *cptr;
+ 
+     if (*status > 0)
+         return(*status);
+@@ -2081,24 +2081,24 @@
+           {
+             stringptr = cols[jj].array;
+             dataptr = stringptr + 1;
+-            nullptr = *stringptr;
++            ptr_to_null = *stringptr;
+             nbytes = 2;
+           }
+           else
+           {
+             dataptr = (char *) cols[jj].array + col[jj].nullsize;
+-            nullptr = (char *) cols[jj].array;
++            ptr_to_null = (char *) cols[jj].array;
+             nbytes = col[jj].nullsize;
+           }
+ 
+-          if (memcmp(nullptr, &zeros, nbytes) ) 
++          if (memcmp(ptr_to_null, &zeros, nbytes) ) 
+           {
+             /* null value flag not zero; must check for and write nulls */
+             if (hdutype == IMAGE_HDU)   
+             {
+                 if (ffppn(cols[jj].fptr, cols[jj].datatype, 
+                       felement, cols[jj].repeat * ntodo, dataptr,
+-                      nullptr, &tstatus) > 0)
++                      ptr_to_null, &tstatus) > 0)
+                 break;
+             }
+             else
+@@ -2113,7 +2113,7 @@
+ 
+                 if (ffpcn(cols[jj].fptr, cols[jj].datatype, cols[jj].colnum, frow,
+                       felement, cols[jj].repeat * ntodo, dataptr,
+-                      nullptr, &tstatus) > 0)
++                      ptr_to_null, &tstatus) > 0)
+                 break;
+             }
+           }


### PR DESCRIPTION
Rename nullptr to ptr_to_null, as it points to null in string, not is pointer that is null.

Also adds missing dependency on fortran

Closes: https://bugs.gentoo.org/943959
Closes: https://bugs.gentoo.org/944747

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
