### PR TITLE
media-sound/rcenter: update EAPI 7 -> 8, port to C23, add rudimentary test

### DIFF
--- a/media-sound/rcenter/files/rcenter-0.6.2-pthread-pointer-type.patch
+++ b/media-sound/rcenter/files/rcenter-0.6.2-pthread-pointer-type.patch
@@ -1,0 +1,15 @@
+Give a type and a name to a function parameter that will continue to be ignored
+As NULL is passed as an argument to pthread_create's callback in only place where timerloop
+is used, this invention of a name due to C23 does nothing and argument is never used.
+https://bugs.gentoo.org/944365
+--- a/lowlevel.c
++++ b/lowlevel.c
+@@ -44,7 +44,7 @@
+ static int timerpipe[2];
+ static int quitpipe[2];
+ 
+-static void *timerloop()
++static void *timerloop(void * nothing)
+ {
+     int n;
+     int status;

--- a/media-sound/rcenter/rcenter-0.6.2-r1.ebuild
+++ b/media-sound/rcenter/rcenter-0.6.2-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Rcenter - A program to control the EMU10K Remote Control"
+HOMEPAGE="http://rooster.stanford.edu/~ben/projects/rcenter.php"
+SRC_URI="http://rooster.stanford.edu/~ben/projects/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+#-sparc: emu10k1 doesn't get recognized on sparc hardware
+KEYWORDS="~amd64 -sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-Wimplicit-function-declaration.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-pthread-pointer-type.patch
+)
+
+src_configure() {
+	tc-export CC
+}
+
+src_test() {
+	"${S}"/rcenter -h || die
+}
+
+src_install() {
+	dobin rcenter
+	fperms 755 /usr/bin/rcenter
+
+	insinto /usr/share/rcenter
+	doins -r config
+
+	dodoc HISTORY README
+}
+
+pkg_postinst() {
+	elog "Rcenter Installed  - However You need to setup the scripts"
+	elog "for making remote control commands actually work"
+	elog
+	elog "The Skel scripts can be copied from ${EROOT}/usr/share/rcenter/config to <user>/.rcenter"
+	elog "Where <user> is a person who will use rcenter"
+	elog "Remeber to use emu-config -i to turn on the remote"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/944365

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
