### PR TITLE
app-misc/ddcutil: fix patch for USE=-X

### DIFF
--- a/app-misc/ddcutil/files/ddcutil-2.2.0-fix-build-without-X.patch
+++ b/app-misc/ddcutil/files/ddcutil-2.2.0-fix-build-without-X.patch
@@ -10,15 +10,17 @@ Subject: [PATCH] build with configure option --disable-x11
 eliminates watch-mode XEVENT
 
 addresses issue #504
+
 ---
  src/base/parms.h                 |  6 +++++-
  src/cmdline/cmd_parser_goption.c | 12 ++++++++++++
  src/dw/Makefile.am               | 10 ++++++++--
- src/dw/dw_common.c               |  2 ++
- src/dw/dw_main.c                 | 14 ++++++++++++++
- src/dw/dw_poll.c                 |  4 ++++
+ src/dw/dw_common.c               |  4 ++++
+ src/dw/dw_common.h               |  6 +++++-
+ src/dw/dw_main.c                 | 31 ++++++++++++++++++++++++++++++-
+ src/dw/dw_poll.c                 |  6 ++++++
  src/dw/dw_services.c             |  4 ++++
- 7 files changed, 49 insertions(+), 3 deletions(-)
+ 8 files changed, 74 insertions(+), 5 deletions(-)
 
 diff --git a/src/base/parms.h b/src/base/parms.h
 index 3a8fbdd5..fcfac321 100644
@@ -125,7 +127,7 @@ index 0327f1af..063beef4 100644
  
  # Rename to "all=local" for development 
 diff --git a/src/dw/dw_common.c b/src/dw/dw_common.c
-index 62f87226..29c4ff75 100644
+index 62f87226..ddb456e3 100644
 --- a/src/dw/dw_common.c
 +++ b/src/dw/dw_common.c
 @@ -59,7 +59,9 @@
@@ -138,8 +140,45 @@ index 62f87226..29c4ff75 100644
  
  #include "dw_common.h"
  
+@@ -132,7 +134,9 @@ void dw_free_watch_displays_data(Watch_Displays_Data * wdd) {
+    if (wdd) {
+       assert( memcmp(wdd->marker, WATCH_DISPLAYS_DATA_MARKER, 4) == 0 );
+       wdd->marker[3] = 'x';
++#ifdef USE_X11
+       free(wdd->evdata);
++#endif
+       free(wdd);
+    }
+ }
+diff --git a/src/dw/dw_common.h b/src/dw/dw_common.h
+index bd310923..e12ca63e 100644
+--- a/src/dw/dw_common.h
++++ b/src/dw/dw_common.h
+@@ -14,7 +14,9 @@
+ 
+ #include "base/displays.h"
+ 
++#ifdef USE_X11
+ #include "dw_xevent.h"
++#endif
+ 
+ extern uint16_t   initial_stabilization_millisec;
+ extern uint16_t   stabilization_poll_millisec;
+@@ -40,9 +42,11 @@ typedef struct {
+    pid_t                    main_process_id;
+    pid_t                    main_thread_id;
+    DDCA_Display_Event_Class event_classes;
+-   DDC_Watch_Mode          watch_mode;
++   DDC_Watch_Mode           watch_mode;
+    int                      watch_loop_millisec;
++#ifdef USE_X11
+    XEvent_Data *            evdata;
++#endif
+   } Watch_Displays_Data;
+ 
+ void dw_free_watch_displays_data(Watch_Displays_Data * wdd);
 diff --git a/src/dw/dw_main.c b/src/dw/dw_main.c
-index 996d6f95..d3218c89 100644
+index 996d6f95..c5e098cb 100644
 --- a/src/dw/dw_main.c
 +++ b/src/dw/dw_main.c
 @@ -46,7 +46,9 @@
@@ -152,7 +191,20 @@ index 996d6f95..d3218c89 100644
  
  #include "dw_main.h"
  
-@@ -79,8 +81,10 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+@@ -65,7 +67,12 @@ static DDCA_Display_Event_Class active_watch_displays_classes = DDCA_EVENT_CLASS
+ static Watch_Displays_Data * global_wdd;     // needed to pass to dw_stop_watch_displays()
+ 
+ 
++// ***
++// Iftesting out resolve_watch_mode() if X11 is not defined is a quick and dirty hack.
++// It relies on the fact that currently the only mode other than XEVENT is POLL
++// ***
+ 
++#ifdef USE_X11
+ /** Determines the actual watch mode to be used
+  *
+  *  @param  initial_mode  mode requested
+@@ -79,8 +86,10 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
     DBGTRC_STARTING(debug, TRACE_GROUP, "initial_mode=%s xev_data_loc=%p", watch_mode_name(initial_mode), xev_data_loc);
  
     DDC_Watch_Mode resolved_watch_mode = Watch_Mode_Poll;
@@ -163,7 +215,7 @@ index 996d6f95..d3218c89 100644
  
  #ifndef ENABLE_UDEV
     if (initial_mode == Watch_Mode_Udev)
-@@ -89,6 +93,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+@@ -89,6 +98,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
  
     if (initial_mode == Watch_Mode_Dynamic) {
        resolved_watch_mode = Watch_Mode_Poll;    // always works, may be slow
@@ -171,7 +223,7 @@ index 996d6f95..d3218c89 100644
        char * xdg_session_type = getenv("XDG_SESSION_TYPE");
        DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "XDG_SESSION_TYPE=|%s|", xdg_session_type);
        if (xdg_session_type &&         // can xdg_session_type ever not be set
-@@ -111,6 +116,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+@@ -111,6 +121,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
        // sysfs_fully_reliable = is_sysfs_reliable();
        // if (!sysfs_fully_reliable)
        //    dw_watch_mode = Watch_Mode_Poll;
@@ -179,7 +231,7 @@ index 996d6f95..d3218c89 100644
     }
     else {
        resolved_watch_mode = initial_mode;
-@@ -124,6 +130,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+@@ -124,6 +135,7 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
     }
  #endif
  
@@ -187,7 +239,7 @@ index 996d6f95..d3218c89 100644
     if (resolved_watch_mode == Watch_Mode_Xevent) {
        xevdata  = dw_init_xevent_screen_change_notification();
        // *xev_data_loc  = ddc_init_xevent_screen_change_notification();
-@@ -132,15 +139,18 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
+@@ -132,20 +144,23 @@ resolve_watch_mode(DDC_Watch_Mode initial_mode,  XEvent_Data ** xev_data_loc) {
           MSG_W_SYSLOG(DDCA_SYSLOG_WARNING, "X11 RANDR api unavailable. Switching to Watch_Mode_Poll");
        }
     }
@@ -206,7 +258,47 @@ index 996d6f95..d3218c89 100644
     DBGTRC_DONE(debug, TRACE_GROUP, "resolved_watch_mode: %s. *xev_data_loc: %p",
           watch_mode_name(resolved_watch_mode),  *xev_data_loc);
     return resolved_watch_mode;
-@@ -278,6 +288,7 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
+ }
+-
++#endif
+ 
+ /** Starts thread that watches for changes in display connection status.
+  *
+@@ -162,7 +177,9 @@ dw_start_watch_displays(DDCA_Display_Event_Class event_classes) {
+         watch_mode_name(watch_displays_mode), watch_thread, event_classes, SBOOL(all_video_adapters_implement_drm));
+    DBGTRC_NOPREFIX(debug, TRACE_GROUP, "thread_id = %d, traced_function_stack=%p", TID(), traced_function_stack);
+    Error_Info * err = NULL;
++#ifdef USE_X11
+    XEvent_Data * xev_data = NULL;
++#endif
+ 
+    if (!all_video_adapters_implement_drm) {
+       err = ERRINFO_NEW(DDCRC_INVALID_OPERATION, "Requires DRM video drivers");
+@@ -174,8 +191,12 @@ dw_start_watch_displays(DDCA_Display_Event_Class event_classes) {
+       goto bye;
+    }
+ 
++#ifdef USE_X11
+    DDC_Watch_Mode resolved_watch_mode = resolve_watch_mode(watch_displays_mode, &xev_data);
+    ASSERT_IFF(resolved_watch_mode == Watch_Mode_Xevent, xev_data);
++#else
++   DDC_Watch_Mode resolved_watch_mode = Watch_Mode_Poll;
++#endif
+ 
+    int calculated_watch_loop_millisec = dw_calc_watch_loop_millisec(resolved_watch_mode);
+    // DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "calc_watch_loop_millisec() returned %d", calculated_watch_loop_millisec);
+@@ -216,8 +237,10 @@ dw_start_watch_displays(DDCA_Display_Event_Class event_classes) {
+       wdd->event_classes = event_classes;
+       wdd->watch_mode = resolved_watch_mode;
+       wdd->watch_loop_millisec = calculated_watch_loop_millisec;
++#ifdef USE_X11
+       if (xev_data)
+          wdd->evdata = xev_data;
++#endif
+       global_wdd = wdd;
+ 
+ #ifdef CALLBACK_DISPLAYS_THREAD
+@@ -278,6 +301,7 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
     if (watch_thread) {
        DBGTRC_NOPREFIX(debug, DDCA_TRC_NONE, "resolved_watch_mode = %s",
                                              watch_mode_name(global_wdd->watch_mode));
@@ -214,7 +306,7 @@ index 996d6f95..d3218c89 100644
        if (global_wdd->watch_mode == Watch_Mode_Xevent) {
           if (terminate_using_x11_event) {   // for testing, does not currently work
              dw_send_x11_termination_message(global_wdd->evdata);
-@@ -290,6 +301,9 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
+@@ -290,6 +314,9 @@ dw_stop_watch_displays(bool wait, DDCA_Display_Event_Class* enabled_classes_loc)
        else {
           terminate_watch_thread = true;  // signal watch thread to terminate
        }
@@ -224,8 +316,18 @@ index 996d6f95..d3218c89 100644
  
        // DBGTRC_NOPREFIX(debug, TRACE_GROUP, "Waiting %d millisec for watch thread to terminate...", 4000);
        // usleep(4000*1000);  // greater than the sleep in watch_displays_using_poll()
+@@ -433,7 +460,9 @@ void init_dw_main() {
+    RTTI_ADD_FUNC(dw_start_watch_displays);
+    RTTI_ADD_FUNC(dw_stop_watch_displays);
+    RTTI_ADD_FUNC(dw_get_active_watch_classes);
++#ifdef USE_X11
+    RTTI_ADD_FUNC(resolve_watch_mode);
++#endif
+    RTTI_ADD_FUNC(dw_redetect_displays);
+ }
+ 
 diff --git a/src/dw/dw_poll.c b/src/dw/dw_poll.c
-index 677a6ce6..336b5c92 100644
+index 677a6ce6..e1244491 100644
 --- a/src/dw/dw_poll.c
 +++ b/src/dw/dw_poll.c
 @@ -62,7 +62,9 @@
@@ -238,7 +340,18 @@ index 677a6ce6..336b5c92 100644
  
  #include "dw_poll.h"
  
-@@ -276,6 +278,7 @@ gpointer dw_watch_display_connections(gpointer data) {
+@@ -206,8 +208,10 @@ gpointer dw_watch_display_connections(gpointer data) {
+    Watch_Displays_Data * wdd = data;
+    assert(wdd && memcmp(wdd->marker, WATCH_DISPLAYS_DATA_MARKER, 4) == 0);
+    assert(wdd->watch_mode == Watch_Mode_Xevent  || wdd->watch_mode == Watch_Mode_Poll);
++#ifdef USE_X11
+    if (wdd->watch_mode == Watch_Mode_Xevent)
+       assert(wdd->evdata);
++#endif
+    GPtrArray * displays_to_recheck = g_ptr_array_new();
+ 
+    DBGTRC_STARTING(debug, TRACE_GROUP,
+@@ -276,6 +280,7 @@ gpointer dw_watch_display_connections(gpointer data) {
           continue;
        dw_terminate_if_invalid_thread_or_process(cur_pid, cur_tid);
  
@@ -246,7 +359,7 @@ index 677a6ce6..336b5c92 100644
        if (wdd->watch_mode == Watch_Mode_Xevent) {
           if (terminate_using_x11_event) {
              bool event_found = dw_next_X11_event_of_interest(wdd->evdata);
-@@ -295,6 +298,7 @@ gpointer dw_watch_display_connections(gpointer data) {
+@@ -295,6 +300,7 @@ gpointer dw_watch_display_connections(gpointer data) {
                 continue;
           }
        }


### PR DESCRIPTION
Turns out upstream didn't completely solve the issue and ddcutil still failed to build on systems where X was not installed.

Bug: https://bugs.gentoo.org/950320

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
