### PR TITLE
dev-db/influx-cli: fix bash completion collision

### DIFF
--- a/dev-db/influx-cli/influx-cli-2.7.5-r1.ebuild
+++ b/dev-db/influx-cli/influx-cli-2.7.5-r1.ebuild
@@ -24,7 +24,6 @@ src_compile() {
 	emake
 
 	cd bin/$(go env GOOS)/$(go env GOARCH)/ || die
-	./influx completion bash > influx-completion.bash || die
 	./influx completion zsh > influx-completion.zsh || die
 }
 
@@ -32,7 +31,6 @@ src_install() {
 	cd bin/$(go env GOOS)/$(go env GOARCH) || die
 
 	dobin influx
-
-	newbashcomp influx-completion.bash influx
+	# bash ones are provided by bash-completion package
 	newzshcomp influx-completion.zsh _influx
 }


### PR DESCRIPTION

bash completion seems to be provided by a different package, instead of blocking this other pacakge optfeature is used to inform the user of it

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
