### PR TITLE
games-kids/tuxmath: update EAPI 7 -> 8, port to C23

### DIFF
--- a/games-kids/tuxmath/files/tuxmath-2.0.3-c23.patch
+++ b/games-kids/tuxmath/files/tuxmath-2.0.3-c23.patch
@@ -1,0 +1,61 @@
+Remove const qualifier from parameter - better to add it in
+t4k-common library, but that may break other dependencies.
+Also do minimum to transform function that returns 1 on error
+to function that returns nothing. Ideally, we react to error
+somewhere, but see above.
+https://bugs.gentoo.org/925143
+--- a/src/titlescreen.h
++++ b/src/titlescreen.h
+@@ -102,8 +102,8 @@
+ void          TitleScreen(void);
+ int           RenderTitleScreen(void);
+ void          DrawTitleScreen(void);
+-int           HandleTitleScreenEvents(const SDL_Event* evt);
+-int           HandleTitleScreenResSwitch(int new_w, int new_h);
++int           HandleTitleScreenEvents(SDL_Event* evt);
++void          HandleTitleScreenResSwitch(int new_w, int new_h);
+ void          HandleTitleScreenAnimations();
+ void          HandleTitleScreenAnimations_Reset(bool reset);
+ void          ShowMessage(int font_size, const char* str1, const char* str2, const char* str3, const char* str4);
+--- a/src/titlescreen.c
++++ b/src/titlescreen.c
+@@ -140,7 +140,7 @@
+ void update_screen(int* frame);
+ void add_rect(SDL_Rect* src, SDL_Rect* dst);
+ 
+-int handle_easter_egg(const SDL_Event* evt);
++int handle_easter_egg(SDL_Event* evt);
+ 
+ 
+ 
+@@ -406,7 +406,7 @@
+ /* handle titlescreen events (easter egg)
+    this function should be called from event loops
+    return 1 if events require full redraw */
+-int HandleTitleScreenEvents(const SDL_Event* evt)
++int HandleTitleScreenEvents(SDL_Event* evt)
+ {
+     if (evt->type == SDL_KEYDOWN)
+ 	if (evt->key.keysym.sym == SDLK_F10)
+@@ -418,9 +418,10 @@
+ /* handle a resolution switch. Tux et. al. may need to be resized
+    and/or repositioned
+    */
+-int HandleTitleScreenResSwitch(int new_w, int new_h)
++void HandleTitleScreenResSwitch(int new_w, int new_h)
+ {
+-    return RenderTitleScreen();
++    RenderTitleScreen(); //Returns 1 on error. Swallow silently.
++    return;
+ }
+ 
+ /* handle all titlescreen blitting
+@@ -1080,7 +1081,7 @@
+     update->type = 'I';
+ }
+ 
+-int handle_easter_egg(const SDL_Event* evt)
++int handle_easter_egg(SDL_Event* evt)
+ {
+     static int eggtimer = 0;
+     int tuxframe;

--- a/games-kids/tuxmath/tuxmath-2.0.3-r3.ebuild
+++ b/games-kids/tuxmath/tuxmath-2.0.3-r3.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit desktop optfeature
 
@@ -36,6 +36,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-blits-to-tmblits.patch
 	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-c23.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925143

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
