### PR TITLE
games-arcade/bomns: update EAPI 7 -> 8, port to C23, fix Clang build

### DIFF
--- a/games-arcade/bomns/bomns-0.99.2-r2.ebuild
+++ b/games-arcade/bomns/bomns-0.99.2-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools flag-o-matic
 
@@ -23,25 +23,12 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-fpe.patch
+	"${FILESDIR}"/${P}-c23.patch
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 src_prepare() {
 	default
-
-	sed -i \
-		-e "/appicondir/s:\$(prefix):/usr:" \
-		-e "/desktopdir/s:\$(prefix):/usr:" \
-		$(find icons -name Makefile.am) \
-		Makefile.am || die
-
-	sed -i \
-		-e "s:\$*[({]prefix[})]/share:/var/lib/:" \
-		configure.in \
-		graphics/Makefile.am \
-		levels/Makefile.am \
-		sounds/Makefile.am || die
-
-	mv configure.{in,ac} || die
 
 	eautoreconf
 }

--- a/games-arcade/bomns/files/bomns-0.99.2-c23.patch
+++ b/games-arcade/bomns/files/bomns-0.99.2-c23.patch
@@ -1,0 +1,26 @@
+Fix build with C23
+https://bugs.gentoo.org/936565
+diff '--color=auto' -ru bomns-0.99.2.old/src/launcher2/main.c bomns-0.99.2/src/launcher2/main.c
+--- a/src/launcher2/main.c	2025-03-02 16:28:35.646507541 +0400
++++ b/src/launcher2/main.c	2025-03-02 16:29:13.890873033 +0400
+@@ -27,6 +27,7 @@
+ #include <gtk/gtk.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <ctype.h>
+ 
+ #include "main.h"
+ #include "interface.h"
+diff '--color=auto' -ru bomns-0.99.2.old/src/launcher2/main.h bomns-0.99.2/src/launcher2/main.h
+--- a/src/launcher2/main.h	2025-03-02 16:28:35.646507541 +0400
++++ b/src/launcher2/main.h	2025-03-02 16:29:54.746212077 +0400
+@@ -26,7 +26,7 @@
+ void set_defaults();
+ void write_bomns_rc();
+ void load_bomns_rc();
+-void parse_bomns_rc();
++void parse_bomns_rc(const char * cszBuf);
+ 
+ 
+ #endif
+Only in bomns-0.99.2/src/launcher2: main.o

--- a/games-arcade/bomns/files/bomns-0.99.2-clang.patch
+++ b/games-arcade/bomns/files/bomns-0.99.2-clang.patch
@@ -1,0 +1,35 @@
+Static-cast int to Sint16, for clang
+https://bugs.gentoo.org/730794
+--- a/src/bomns.cpp
++++ b/src/bomns.cpp
+@@ -643,7 +643,7 @@
+   int      nDig1  = (int)floor(nNum / 10);
+ 	int      nDig2  =  nNum % 10;
+ 	SDL_Rect rcSrc  = {0, 0, 0, 0};
+-	SDL_Rect rcDest = {nX, nY, 15, 20};
++	SDL_Rect rcDest = {static_cast<Sint16>(nX), static_cast<Sint16>(nY), 15, 20};
+ 
+ 	//three digit num
+   if(nDig0 || bPad)
+--- a/src/level.cpp
++++ b/src/level.cpp
+@@ -163,8 +163,8 @@
+ 
+ bool DrawExplosion(int nX, int nY, SDL_Surface * psdlsDest, int nExplosionState)
+ {
+-	SDL_Rect rcDest = {nX, nY, 10, 10};
+-	SDL_Rect rcSrc  = {(nExplosionState == EXPLOSION_1 ? 90 : (nExplosionState == EXPLOSION_2 ? 150 : 160)), 0, 10, 10};
++	SDL_Rect rcDest = {static_cast<Sint16>(nX), static_cast<Sint16>(nY), 10, 10};
++	SDL_Rect rcSrc  = {static_cast<Sint16>(nExplosionState == EXPLOSION_1 ? 90 : (nExplosionState == EXPLOSION_2 ? 150 : 160)), 0, 10, 10};
+ 	if(SDL_BlitSurface(g_psdlsObjects, &rcSrc, psdlsDest, &rcDest) < 0)
+ 	  return FALSE;
+ 		
+@@ -173,7 +173,7 @@
+ 
+ bool ClearTile(int nX, int nY, SDL_Surface * psdlsDest)
+ {
+-  SDL_Rect rcDest = {nX * 10, nY * 10, 10, 10};
++  SDL_Rect rcDest = {static_cast<Sint16>(nX * 10), static_cast<Sint16>(nY * 10), 10, 10};
+ //  SDL_Rect rcSrc  = {X: 246 - 255}
+   SDL_Rect rcSrc = {246, 0, 10, 10};
+   if(SDL_BlitSurface(g_psdlsObjects, &rcSrc, psdlsDest, &rcDest) < 0)

--- a/games-arcade/bomns/files/bomns-0.99.2-makefile.patch
+++ b/games-arcade/bomns/files/bomns-0.99.2-makefile.patch
@@ -1,0 +1,73 @@
+Were seds:
+sed -i \
+	-e "/appicondir/s:\$(prefix):/usr:" \
+	-e "/desktopdir/s:\$(prefix):/usr:" \
+	$(find icons -name Makefile.am) \
+	Makefile.am || die
+
+sed -i \
+	-e "s:\$*[({]prefix[})]/share:/var/lib/:" \
+	configure.in \
+	graphics/Makefile.am \
+	levels/Makefile.am \
+	sounds/Makefile.am || die
+diff '--color=auto' -ru a/configure.in b/configure.in
+--- a/configure.in	2025-03-02 16:31:36.838786226 +0400
++++ b/configure.in	2025-03-02 16:33:05.229759963 +0400
+@@ -66,7 +66,7 @@
+ then
+   prefix="/usr/local"
+ fi
+-AC_DEFINE_UNQUOTED(DATA_PATH, "${prefix}/share/bomns")
++AC_DEFINE_UNQUOTED(DATA_PATH, "/var/lib/bomns")
+ 
+ 
+ # Do substitutions
+diff '--color=auto' -ru a/graphics/Makefile.am b/graphics/Makefile.am
+--- a/graphics/Makefile.am	2025-03-02 16:31:36.837344972 +0400
++++ b/graphics/Makefile.am	2025-03-02 16:33:05.230008390 +0400
+@@ -10,7 +10,7 @@
+   players.bmp \
+   winscreen.bmp
+ 
+-graphicsdir = $(prefix)/share/bomns/graphics
++graphicsdir = /var/lib/bomns/graphics
+ graphics_DATA = \
+   bomn32.bmp \
+ 	editor_cursor.bmp \
+diff '--color=auto' -ru a/levels/Makefile.am b/levels/Makefile.am
+--- a/levels/Makefile.am	2025-03-02 16:31:36.837084463 +0400
++++ b/levels/Makefile.am	2025-03-02 16:33:05.230101489 +0400
+@@ -4,7 +4,7 @@
+ 	narrow.lvl \
+ 	test.lvl
+ 
+-levelsdir = $(prefix)/share/bomns/levels
++levelsdir = /var/lib/bomns/levels
+ levels_DATA = \
+ 	faceoff.lvl \
+ 	killyou.lvl \
+diff '--color=auto' -ru a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2025-03-02 16:31:36.839799769 +0400
++++ b/Makefile.am	2025-03-02 16:32:27.293524896 +0400
+@@ -9,7 +9,7 @@
+ 					src/launcher2
+ 
+ # installs desktop entry (for menus, &c.)
+-desktopdir = $(prefix)/share/applications
++desktopdir = /usr/share/applications
+ desktop_DATA = bomns.desktop
+ 
+ EXTRA_DIST = TODO \
+diff '--color=auto' -ru a/sounds/Makefile.am b/sounds/Makefile.am
+--- a/sounds/Makefile.am	2025-03-02 16:31:36.836753343 +0400
++++ b/sounds/Makefile.am	2025-03-02 16:33:05.230199687 +0400
+@@ -12,7 +12,7 @@
+   warp.wav \
+   winner.wav
+ 
+-soundsdir = $(prefix)/share/bomns/sounds
++soundsdir = /var/lib/bomns/sounds
+ sounds_DATA = \
+ 	beep.wav \
+   begin1.wav \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/730794
Closes: https://bugs.gentoo.org/936565

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
