### PR TITLE
sci-astronomy/montage: update EAPI 7 -> 8, fix build with GCC-15

### DIFF
--- a/sci-astronomy/montage/files/montage-5.0-c23.patch
+++ b/sci-astronomy/montage/files/montage-5.0-c23.patch
@@ -1,0 +1,34 @@
+Add missing library header, remove unused function
+https://bugs.gentoo.org/920316
+https://bugs.gentoo.org/741080
+--- a/grid/Pegasus/mPresentation.c	2025-03-02 22:04:54.247085465 +0400
++++ b/grid/Pegasus/mPresentation.c	2025-03-02 22:06:57.356329407 +0400
+@@ -14,6 +14,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <strings.h>
++#include <string.h>
+ 
+ #define MAXLEN 20000
+ 
+--- a/lib/src/two_plane_v1.1/initdistdata.c	2025-03-02 22:04:54.227996254 +0400
++++ b/lib/src/two_plane_v1.1/initdistdata.c	2025-03-02 22:06:11.307762628 +0400
+@@ -26,18 +26,6 @@
+   return 0;
+ }
+ 
+-void closefitsfile()
+-{ 
+-  int I_fits_return_status=0;
+-  fits_close_file(ffp_FITS_In, &I_fits_return_status); 
+-  if (I_fits_return_status != 0)
+-  {
+-     fprintf(stderr, "Error closing file\n");
+-     return -1;
+-  }
+-  return 0;
+-}
+-
+ int initdata_byheader(char *fitsheader, DistCoeff *coeff) 
+ {
+   int i, j, m=0, n=0;

--- a/sci-astronomy/montage/montage-5.0-r1.ebuild
+++ b/sci-astronomy/montage/montage-5.0-r1.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+MYPN=Montage
+DESCRIPTION="Toolkit for assembling FITS images into mosaics"
+HOMEPAGE="http://montage.ipac.caltech.edu/"
+SRC_URI="http://montage.ipac.caltech.edu/download/${MYPN}_v${PV}.tar.gz"
+S="${WORKDIR}/${MYPN}"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc mpi"
+
+RDEPEND="
+	media-libs/freetype:2=
+	media-libs/libjpeg-turbo:0=
+	sci-astronomy/wcstools:0=
+	sci-libs/cfitsio:0=
+	mpi? ( virtual/mpi )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.1-fix_format_errors.patch
+	"${FILESDIR}"/${PN}-4.1-initdistdata.patch
+	"${FILESDIR}"/${PN}-5.0-fix_freetype_incude.patch
+	"${FILESDIR}"/${PN}-5.0-c23.patch
+)
+
+src_prepare() {
+	default
+
+	sed -e '/cfitsio/d' \
+		-e '/wcssubs/d' \
+		-e '/jpeg/d' \
+		-e '/freetype/d' \
+		-i lib/src/Makefile || die
+
+	tc-export CC AR
+
+	# bug #708396
+	append-cflags -fcommon -std=gnu17
+
+	find . -name Makefile\* | xargs sed -i \
+		-e "/^CC.*=/s:\(gcc\|cc\):$(tc-getCC):g" \
+		-e "/^CFLAGS.*=/s:-g:${CFLAGS} $($(tc-getPKG_CONFIG) --cflags wcstools):g" \
+		-e "s:-I../../lib/freetype/include :$($(tc-getPKG_CONFIG) --cflags freetype2):g" \
+		-e 's:$(CC) -o:$(CC) $(LDFLAGS) -o:g' \
+		-e "s:-lwcs:$($(tc-getPKG_CONFIG) --libs wcstools):g" \
+		-e "s:-lcfitsio:$($(tc-getPKG_CONFIG) --libs cfitsio):g" \
+		-e 's:-lnsl::g' \
+		-e "s:ar q:$(tc-getAR) q:g"  || die
+
+	if use mpi; then
+		sed -e 's:# MPICC:MPICC:' \
+			-e 's:# BINS:BINS:' \
+			-i Montage/Makefile.* || die
+	fi
+
+	# Handwritten makefile. No parallel build support
+	# bug #888553 #942753
+	MAKEOPTS=-j1
+}
+
+src_install() {
+	dobin bin/*
+	dodoc README* ChangeHistory
+	use doc && dodoc -r man/*
+}


### PR DESCRIPTION
Uses hand-written, badly-recursive Makefile that swallows errors and replaces makefiles of vendored dependencies. Parallel builds exhibit random, unpredictable failures, so they are disabled. Most of Makefiles pass -std=c99, for case where they don't limit C version globally  to C17 with GNU extensions.
Remove an unused function from vendored dependency, add missing include to main component.
Fix deprecated dependency.

Closes: https://bugs.gentoo.org/920316
Bug: https://bugs.gentoo.org/942753
Bug: https://bugs.gentoo.org/888553
Closes: https://bugs.gentoo.org/741080
Bug: https://bugs.gentoo.org/832708

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
