### PR TITLE
net-misc/yt-dlp: add chromium useflag and related depends

### DIFF
--- a/net-misc/yt-dlp/yt-dlp-2025.02.19.ebuild
+++ b/net-misc/yt-dlp/yt-dlp-2025.02.19.ebuild
@@ -6,6 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=hatchling
 PYTHON_COMPAT=( pypy3 pypy3_11 python3_{10..13} )
 inherit bash-completion-r1 distutils-r1 optfeature wrapper
+IUSE="chromium"
 
 DESCRIPTION="youtube-dl fork with additional features and fixes"
 HOMEPAGE="https://github.com/yt-dlp/yt-dlp/"
@@ -23,6 +24,7 @@ KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv x86 ~arm64-macos ~x64-macos"
 
 RDEPEND="
 	dev-python/pycryptodome[${PYTHON_USEDEP}]
+	chromium? ( dev-python/secretstorage )
 	!net-misc/youtube-dl[-yt-dlp(-)]
 "
 

--- a/net-misc/yt-dlp/yt-dlp-9999.ebuild
+++ b/net-misc/yt-dlp/yt-dlp-9999.ebuild
@@ -6,6 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=hatchling
 PYTHON_COMPAT=( pypy3 pypy3_11 python3_{10..13} )
 inherit bash-completion-r1 distutils-r1 git-r3 optfeature wrapper
+IUSE="chromium"
 
 DESCRIPTION="youtube-dl fork with additional features and fixes"
 HOMEPAGE="https://github.com/yt-dlp/yt-dlp/"
@@ -17,6 +18,7 @@ IUSE="man"
 
 RDEPEND="
 	dev-python/pycryptodome[${PYTHON_USEDEP}]
+	chromium? ( dev-python/secretstorage )
 	!net-misc/youtube-dl[-yt-dlp(-)]
 "
 BDEPEND="


### PR DESCRIPTION
Add useflag chromium and depends to decrypt cookies of chromium based browsers

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
