### PR TITLE
dev-qt/qtbase: Patch Qt6Config.cmake to fix cross-compiling other packages

### DIFF
--- a/dev-qt/qtbase/files/qtbase-6.8.2-cross.patch
+++ b/dev-qt/qtbase/files/qtbase-6.8.2-cross.patch
@@ -1,0 +1,37 @@
+When cross-compiling, CMake needs to find the build host's Qt6CoreTools. It
+therefore prepends QT_HOST_PATH, which is /usr, to CMAKE_FIND_ROOT_PATH. The
+problem is that CMAKE_FIND_ROOT_PATH is only a hint, not a definitive
+location. Just below, CMake's find_package is usually told to look in
+/usr/${CHOST}/usr/lib/cmake and /usr/lib/cmake when cross-compiling. Since
+both of these are under /usr, it chooses the former instead of the latter.
+It then ends up trying to execute non-native Qt binaries.
+
+We can avoid this problem by setting CMAKE_FIND_ROOT_PATH to a more precise
+location. All the Qt6 modules are installed under /usr/lib/cmake, represented
+by the __qt_find_package_host_qt_path variable, so we can point it there.
+
+find_package has two modes, module mode and config mode. No mode is
+explicitly chosen in this case, so it tries both. In module mode, it would
+use a module called FindQt6*.cmake, but no such module exists. It is
+therefore safe to assume config mode, which involves the files under
+/usr/lib/cmake.
+
+See the isSameDirectoryOrSubDirectory() call in CMake's
+cmFindCommon::RerootPaths() function for exactly where this goes wrong.
+
+Chewi
+
+https://bugs.gentoo.org/950314
+
+diff -Naur a/cmake/QtConfig.cmake.in b/cmake/QtConfig.cmake.in
+--- a/cmake/QtConfig.cmake.in	2024-11-14 11:02:40.000000000 +0000
++++ b/cmake/QtConfig.cmake.in	2025-03-02 14:29:42.190183608 +0000
+@@ -131,7 +131,7 @@
+         set(__qt_backup_cmake_find_root_path "${CMAKE_FIND_ROOT_PATH}")
+         list(PREPEND CMAKE_PREFIX_PATH "${__qt_find_package_host_qt_path}"
+             ${_qt_additional_host_packages_prefix_paths})
+-        list(PREPEND CMAKE_FIND_ROOT_PATH "${QT_HOST_PATH}"
++        list(PREPEND CMAKE_FIND_ROOT_PATH "${__qt_find_package_host_qt_path}"
+             ${_qt_additional_host_packages_root_paths})
+     endif()
+ 

--- a/dev-qt/qtbase/qtbase-6.8.2-r2.ebuild
+++ b/dev-qt/qtbase/qtbase-6.8.2-r2.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.6.1-forkfd-childstack-size.patch
 	"${FILESDIR}"/${PN}-6.6.3-gcc14-avx512fp16.patch
 	"${FILESDIR}"/${PN}-6.8.0-qcontiguouscache.patch
+	"${FILESDIR}"/${PN}-6.8.2-cross.patch
 	"${FILESDIR}"/${P}-QTBUG-133500.patch
 	"${FILESDIR}"/${P}-QTBUG-133808.patch
 )

--- a/dev-qt/qtbase/qtbase-6.8.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.8.9999.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.6.1-forkfd-childstack-size.patch
 	"${FILESDIR}"/${PN}-6.6.3-gcc14-avx512fp16.patch
 	"${FILESDIR}"/${PN}-6.8.0-qcontiguouscache.patch
+	"${FILESDIR}"/${PN}-6.8.2-cross.patch
 )
 
 src_prepare() {

--- a/dev-qt/qtbase/qtbase-6.9.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.9.9999.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.5.2-no-symlink-check.patch
 	"${FILESDIR}"/${PN}-6.6.1-forkfd-childstack-size.patch
 	"${FILESDIR}"/${PN}-6.6.3-gcc14-avx512fp16.patch
+	"${FILESDIR}"/${PN}-6.8.2-cross.patch
 )
 
 src_prepare() {

--- a/dev-qt/qtbase/qtbase-6.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.9999.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.5.2-no-symlink-check.patch
 	"${FILESDIR}"/${PN}-6.6.1-forkfd-childstack-size.patch
 	"${FILESDIR}"/${PN}-6.6.3-gcc14-avx512fp16.patch
+	"${FILESDIR}"/${PN}-6.8.2-cross.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
When cross-compiling, CMake needs to find the build host's Qt6CoreTools. It therefore prepends `QT_HOST_PATH`, which is `/usr`, to `CMAKE_FIND_ROOT_PATH`. The problem is that `CMAKE_FIND_ROOT_PATH` is only a hint, not a definitive location. Just below, CMake's `find_package` is usually told to look in `/usr/${CHOST}/usr/lib/cmake` and `/usr/lib/cmake` when cross-compiling. Since both of these are under `/usr`, it chooses the former instead of the latter. It then ends up trying to execute non-native Qt binaries.

We can avoid this problem by setting `CMAKE_FIND_ROOT_PATH` to a more precise location. All the Qt6 modules are installed under `/usr/lib/cmake`, represented by the `_qt_find_package_host_qt_path` variable, so we can point it there.

`find_package` has two modes, module mode and config mode. No mode is explicitly chosen in this case, so it tries both. In module mode, it would use a module called FindQt6*.cmake, but no such module exists. It is therefore safe to assume config mode, which involves the files under `/usr/lib/cmake`.

See [the isSameDirectoryOrSubDirectory() call in CMake's cmFindCommon::RerootPaths() function](https://github.com/Kitware/CMake/blob/42755a6d304c3038110dd0b80642e2d089344398/Source/cmFindCommon.cxx#L288-L290) for exactly where this goes wrong.

I have tested this with native builds too, including doing the latest Plasma update.

This would potentially need tweaking for multilib, but we don't support multilib for Qt6.

Perhaps we can upstream this eventually, but I'm not sure whether Qt's CMake files might be located elsewhere in some cases. We should at least give it some soak time here first.

Closes: https://bugs.gentoo.org/950314

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.