### PR TITLE
dev-java/batik: lift dependency to >=virtual/jdk-11:* #950479 | dev-java/rhino: sort variables, explain dependency changes in 1.8.0

### DIFF
--- a/dev-java/batik/batik-1.18-r2.ebuild
+++ b/dev-java/batik/batik-1.18-r2.ebuild
@@ -34,7 +34,7 @@ CP_DEPEND="
 
 DEPEND="
 	${CP_DEPEND}
-	>=virtual/jdk-1.8:*
+	>=virtual/jdk-11:*
 "
 
 RDEPEND="

--- a/dev-java/bsf/bsf-2.4.0-r7.ebuild
+++ b/dev-java/bsf/bsf-2.4.0-r7.ebuild
@@ -29,7 +29,7 @@ CDEPEND="
 	tcl? ( dev-java/jacl:0 )
 "
 DEPEND="${CDEPEND}
-	>=virtual/jdk-1.8:*"
+	>=virtual/jdk-11:*"
 RDEPEND="${CDEPEND}
 	>=virtual/jre-1.8:*"
 

--- a/dev-java/rhino/rhino-1.8.0.ebuild
+++ b/dev-java/rhino/rhino-1.8.0.ebuild
@@ -15,10 +15,18 @@ SRC_URI="https://github.com/mozilla/rhino/archive/Rhino${PV//./_}_Release.tar.gz
 S="${WORKDIR}/rhino-Rhino${PV//./_}_Release"
 
 LICENSE="MPL-1.1 GPL-2"
-KEYWORDS="~amd64 ~arm64 ~ppc64"
 SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
 
-DEPEND=">=virtual/jdk-11:*"
+# error: package jdk.dynalink does not exist
+# error: package jdk.dynalink.linker does not exist
+# error: package jdk.dynalink.linker.support does not exist
+DEPEND=">=virtual/jdk-11"
+
+# rhino/src/main/java/org/mozilla/javascript/Slot.java:29: error: cannot find symbol
+#         var newSlot = new Slot(this);
+#         ^
+#   symbol:   class var
 RDEPEND=">=virtual/jre-11:*"
 
 DOCS=( {CODE_OF_CONDUCT,README,RELEASE-NOTES,RELEASE-STEPS}.md {NOTICE-tools,NOTICE}.txt )


### PR DESCRIPTION
For rhino-1.8.0, dependencies had to be lifted to >=virtual/jdk-11:* and >=virtual/jre-11:*. Using jre-11:* now produces class file version 55.0 instead of 52.0 which leads to bug #950479 and others.

This commit adds comments explaining why the higher java version is needed.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
