### PR TITLE
Fix version information in libsoundtouch

### DIFF
--- a/media-libs/libsoundtouch/files/0001-automake-Fix-version-information.patch
+++ b/media-libs/libsoundtouch/files/0001-automake-Fix-version-information.patch
@@ -1,0 +1,30 @@
+From aef96e29e8aaf747730200a6b08a4f670d022341 Mon Sep 17 00:00:00 2001
+From: Tobias Jakobi <tjakobi@math.uni-bielefeld.de>
+Date: Mon, 3 Mar 2025 11:49:42 +0100
+Subject: [PATCH] automake: Fix version information
+
+During the last version bump the increment of the patch number
+in configure.ac was missed. This results in the pkg-config
+claiming still having 2.3.2 available.
+
+Signed-off-by: Tobias Jakobi <tjakobi@math.uni-bielefeld.de>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 81163b8..51ff2e0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -15,7 +15,7 @@ dnl this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ dnl Place - Suite 330, Boston, MA  02111-1307, USA
+ # Process this file with autoconf to produce a configure script.
+ 
+-AC_INIT([SoundTouch],[2.3.2],[http://www.surina.net/soundtouch])
++AC_INIT([SoundTouch],[2.3.3],[http://www.surina.net/soundtouch])
+ dnl Default to libSoundTouch.so.$LIB_SONAME.0.0
+ LIB_SONAME=1
+ AC_SUBST(LIB_SONAME)
+-- 
+2.45.3
+

--- a/media-libs/libsoundtouch/libsoundtouch-2.3.3-r1.ebuild
+++ b/media-libs/libsoundtouch/libsoundtouch-2.3.3-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic multilib-minimal toolchain-funcs
+
+MY_PN=${PN/lib}
+MY_P=${MY_PN}-${PV}
+DESCRIPTION="Audio processing library for changing tempo, pitch and playback rates"
+HOMEPAGE="https://www.surina.net/soundtouch/ https://codeberg.org/soundtouch/soundtouch"
+SRC_URI="https://www.surina.net/${MY_PN}/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_PN}"
+
+LICENSE="LGPL-2.1"
+# subslot = libSoundTouch.so soname
+SLOT="0/1"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="cpu_flags_x86_sse openmp static-libs"
+
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/0001-automake-Fix-version-information.patch
+)
+
+pkg_pretend() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_prepare() {
+	default
+	sed -i "s:^\(dist_doc_DATA=\)COPYING.TXT :\1:" Makefile.am || die
+
+	if tc-is-clang && use openmp ; then
+		append-libs omp
+	fi
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--enable-shared
+		--disable-integer-samples
+		$(use_enable cpu_flags_x86_sse x86-optimizations)
+		$(use_enable openmp)
+		$(use_enable static-libs static)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_compile() {
+	emake CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}"
+}
+
+multilib_src_install() {
+	emake DESTDIR="${D}" pkgdocdir="${EPREFIX}"/usr/share/doc/${PF}/html install
+}
+
+multilib_src_install_all() {
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Small issue I found when trying to link against libsoundtouc.

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
