### PR TITLE
net-wireless/bluez: fix build with slibtoolize

### DIFF
--- a/net-wireless/bluez/bluez-5.79.ebuild
+++ b/net-wireless/bluez/bluez-5.79.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -76,6 +76,9 @@ PATCHES=(
 
 	# bug #944059
 	"${FILESDIR}"/${P}-c23.patch
+
+	# bug #950467
+	"${FILESDIR}"/${P}-slibtoolize.patch
 )
 
 pkg_setup() {

--- a/net-wireless/bluez/files/bluez-5.79-slibtoolize.patch
+++ b/net-wireless/bluez/files/bluez-5.79-slibtoolize.patch
@@ -1,0 +1,34 @@
+https://web.git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=b71c5327926696223dba0d78f4c9fe36767d16ec
+
+From b71c5327926696223dba0d78f4c9fe36767d16ec Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 3 Mar 2025 16:50:06 -0800
+Subject: configure.ac: check for stdio.h
+
+This fixes a configure failure for readline.h with slibtoolize which
+depends on HAVE_STDIO_H being defined. With GNU libtoolize this check is
+implicit and with slibtoolize it will fail instead.
+
+  error: unknown type name 'FILE'
+
+Since bluez depends on stdio.h itself there is no reason to not check
+for it explicitly.
+
+Gentoo-Issue: https://bugs.gentoo.org/950467
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6a19487f62..32e0a78762 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -70,7 +70,7 @@ AC_CHECK_LIB(pthread, pthread_create, dummy=yes,
+ AC_CHECK_LIB(dl, dlopen, dummy=yes,
+ 			AC_MSG_ERROR(dynamic linking loader is required))
+ 
+-AC_CHECK_HEADERS(string.h linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
++AC_CHECK_HEADERS(stdio.h string.h linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
+ 
+ # basename may be only available in libgen.h with the POSIX behavior,
+ # not desired here


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/950467
Upstream-Commit: https://web.git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=b71c5327926696223dba0d78f4c9fe36767d16ec

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
