### PR TITLE
zig.eclass: prepare for Zig 0.14

### DIFF
--- a/app-eselect/eselect-zig/eselect-zig-1-r1.ebuild
+++ b/app-eselect/eselect-zig/eselect-zig-1-r1.ebuild
@@ -1,18 +1,17 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DESCRIPTION="Manages Zig versions"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+S="${WORKDIR}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
 RDEPEND="app-admin/eselect"
-
-S="${WORKDIR}"
 
 src_install() {
 	insinto /usr/share/eselect/modules/

--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -48,6 +48,7 @@ REQUIRED_USE="
 	!llvm? ( !doc )
 	llvm? ( ${LLVM_REQUIRED_USE} )
 "
+RESTRICT="!llvm? ( test )"
 
 # Used by both "cmake" and "zig" eclasses.
 BUILD_DIR="${WORKDIR}/${P}_build"
@@ -309,7 +310,9 @@ src_test() {
 		fi
 	done
 
-	ZIG_EXE="./stage3/bin/zig" zig_src_test -Dskip-non-native
+	# Run tests with Debug mode by default, like upstream does in CI,
+	# full test suite with other modes is in a sad state right now...
+	ZIG_EXE="./stage3/bin/zig" zig_src_test -Dskip-non-native --release=debug
 
 	ZBS_ARGS=("${args_backup[@]}")
 }

--- a/eclass/zig-utils.eclass
+++ b/eclass/zig-utils.eclass
@@ -493,6 +493,8 @@ zig-utils_find_installation() {
 
 	local zig_supported_versions=(
 		"9999"
+		"0.14.1"
+		"0.14.0"
 		"0.13.1"
 		"0.13.0"
 	)


### PR DESCRIPTION
Just some minor commits while I'm awaiting release.

Tests pass with latest commit, which should match content of 0.14.0, but additional commits might be merged before the release.

Also, I'm heading off to sleep now, so if release is tagged while I'm away, others would be able to bump Zig package in their repositories easily.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
