### PR TITLE
media-libs/imlib2: fix zlib dependency on 1.12.3

### DIFF
--- a/media-libs/imlib2/imlib2-1.12.3-r1.ebuild
+++ b/media-libs/imlib2/imlib2-1.12.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,7 @@ raw +shm static-libs svg +text +tiff +webp zlib"
 
 REQUIRED_USE="shm? ( X )"
 
+# NOTE: zlib is required even if zlib loader is disabled
 RDEPEND="
 	X? (
 		x11-libs/libX11[${MULTILIB_USEDEP}]
@@ -41,7 +42,7 @@ RDEPEND="
 	svg? ( >=gnome-base/librsvg-2.46.0:=[${MULTILIB_USEDEP}] )
 	tiff? ( >=media-libs/tiff-4.0.4:=[${MULTILIB_USEDEP}] )
 	webp? ( media-libs/libwebp:=[${MULTILIB_USEDEP}] )
-	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+	sys-libs/zlib[${MULTILIB_USEDEP}]
 	!<media-plugins/imlib2_loaders-1.10.0
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
since v1.12.3 zlib is a mandatory dependency:
https://git.enlightenment.org/old/legacy-imlib2/commit/f8a45104387184c7ec7e29f9e3164018443d6160

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
