### PR TITLE
app-editors/emacs: add user initd

### DIFF
--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -513,6 +513,11 @@ src_install() {
 	# remove COPYING file (except for etc/COPYING used by describe-copying)
 	rm "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp/COPYING || die
 
+	exeinto /etc/user/init.d
+	sed -e "/command=/s,@EMACS_BIN@,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
+		"${FILESDIR}/emacs.initd" | newexe - ${EMACS_SUFFIX}
+	pipestatus || die
+
 	if use systemd; then
 		insinto /usr/lib/systemd/user
 		sed -e "/^##/d" \

--- a/app-editors/emacs/emacs-30.1.9999.ebuild
+++ b/app-editors/emacs/emacs-30.1.9999.ebuild
@@ -508,6 +508,11 @@ src_install() {
 	# remove COPYING file (except for etc/COPYING used by describe-copying)
 	rm "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp/COPYING || die
 
+	exeinto /etc/user/init.d
+	sed -e "/command=/s,@EMACS_BIN@,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
+		"${FILESDIR}/emacs.initd" | newexe - ${EMACS_SUFFIX}
+	pipestatus || die
+
 	if use systemd; then
 		insinto /usr/lib/systemd/user
 		sed -e "/^##/d" \

--- a/app-editors/emacs/emacs-31.0.9999.ebuild
+++ b/app-editors/emacs/emacs-31.0.9999.ebuild
@@ -508,6 +508,11 @@ src_install() {
 	# remove COPYING file (except for etc/COPYING used by describe-copying)
 	rm "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp/COPYING || die
 
+	exeinto /etc/user/init.d
+	sed -e "/command=/s,@EMACS_BIN@,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
+		"${FILESDIR}/emacs.initd" | newexe - ${EMACS_SUFFIX}
+	pipestatus || die
+
 	if use systemd; then
 		insinto /usr/lib/systemd/user
 		sed -e "/^##/d" \

--- a/app-editors/emacs/files/emacs.initd
+++ b/app-editors/emacs/files/emacs.initd
@@ -1,0 +1,9 @@
+#!/sbin/openrc-run
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+supervisor=supervise-daemon
+description="Emacs text editor"
+
+command="@EMACS_BIN@"
+command_args_foreground="--fg-daemon"


### PR DESCRIPTION
openrc-0.60 now supports user services, similar to systemd --user, allowing users to easily manage daemons. So i'm going around writing basic scripts (often based on the systemd-user units upstream) for some packages.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
