### PR TITLE
dev-cpp/benchmark: fix cmake package config with USE="libpfm"

### DIFF
--- a/dev-cpp/benchmark/benchmark-1.9.1-r1.ebuild
+++ b/dev-cpp/benchmark/benchmark-1.9.1-r1.ebuild
@@ -39,6 +39,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-1.9.0-fix-documentation-installation.patch"
 	"${FILESDIR}/${P}-clock-detection-portability.patch"
+	"${FILESDIR}/${P}-fix-pfm-cmake.patch"
 )
 
 pkg_setup() {

--- a/dev-cpp/benchmark/files/benchmark-1.9.1-fix-pfm-cmake.patch
+++ b/dev-cpp/benchmark/files/benchmark-1.9.1-fix-pfm-cmake.patch
@@ -1,0 +1,36 @@
+https://bugs.gentoo.org/950573
+https://github.com/google/benchmark/pull/1942
+
+From d124c771fe507a8eb5bb37697f8b36a7fde19e27 Mon Sep 17 00:00:00 2001
+From: Alfred Wingate <parona@protonmail.com>
+Date: Wed, 5 Mar 2025 00:16:54 +0200
+Subject: [PATCH] Install FindPFM.cmake for bencmarkConfig.cmake
+
+There is no upstream PFM cmake package config file to use, so this has
+to be installed for the benchmark cmake package config file to work.
+
+Bug: https://bugs.gentoo.org/950573
+See-Also: c2146397ac69e6589a50f6b4fc6a7355669caed5
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -5,6 +5,7 @@ include (CMakeFindDependencyMacro)
+ find_dependency (Threads)
+ 
+ if (@BENCHMARK_ENABLE_LIBPFM@)
++    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+     find_dependency (PFM)
+ endif()
+ 
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -39,6 +39,9 @@ set_property(
+ if (PFM_FOUND)
+   target_link_libraries(benchmark PRIVATE PFM::libpfm)
+   target_compile_definitions(benchmark PRIVATE -DHAVE_LIBPFM)
++  install(
++      FILES "${PROJECT_SOURCE_DIR}/cmake/Modules/FindPFM.cmake"
++      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+ endif()
+ 
+ # pthread affinity, if available


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/950573

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
