### PR TITLE
dev-build/muon: Add missing dev-util/gdbus-codegen test dep

### DIFF
--- a/dev-build/muon/muon-0.4.0.ebuild
+++ b/dev-build/muon/muon-0.4.0.ebuild
@@ -32,6 +32,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="
 	app-text/scdoc
+	test? ( dev-util/gdbus-codegen )
 "
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/950568


