### PR TITLE
Make dev-python/tpm2-pytss respect CC when preproccesing

### DIFF
--- a/dev-python/tpm2-pytss/files/tpm2-pytss-2.3.0-use-CC-enviromental-variable.patch
+++ b/dev-python/tpm2-pytss/files/tpm2-pytss-2.3.0-use-CC-enviromental-variable.patch
@@ -1,0 +1,54 @@
+diff --git a/setup.py b/setup.py
+index 0e6208f..eec85ad 100644
+--- a/setup.py
++++ b/setup.py
+@@ -20,6 +20,14 @@ from textwrap import dedent
+ site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+ 
+ 
++def cpp_path():
++    return os.environ.get("CC", "cc")
++
++
++def cpp_args(args=[]):
++    return ["-E"] + args
++
++
+ class type_generator(build_ext):
+     cares = set(
+         (
+@@ -184,7 +192,9 @@ class type_generator(build_ext):
+                 f"unable to find tss2_tpm2_types.h in {pk['include_dirs']}"
+             )
+         pdata = preprocess_file(
+-            header_path, cpp_args=["-std=c99", "-D__extension__=", "-D__attribute__(x)="]
++            header_path,
++            cpp_path=cpp_path(),
++            cpp_args=cpp_args(["-std=c99", "-D__extension__=", "-D__attribute__(x)="]),
+         )
+         parser = c_parser.CParser()
+         ast = parser.parse(pdata, "tss2_tpm2_types.h")
+@@ -204,13 +214,16 @@ class type_generator(build_ext):
+             if policy_header_path:
+                 pdata = preprocess_file(
+                     policy_header_path,
+-                    cpp_args=[
+-                        "-std=c99",
+-                        "-D__extension__=",
+-                        "-D__attribute__(x)=",
+-                        "-D__float128=long double",
+-                        "-D_FORTIFY_SOURCE=0",
+-                    ],
++                    cpp_path=cpp_path(),
++                    cpp_args=cpp_args(
++                        [
++                            "-std=c99",
++                            "-D__extension__=",
++                            "-D__attribute__(x)=",
++                            "-D__float128=long double",
++                            "-D_FORTIFY_SOURCE=0",
++                        ]
++                    ),
+                 )
+                 parser = c_parser.CParser()
+                 past = parser.parse(pdata, "tss2_policy.h")

--- a/dev-python/tpm2-pytss/tpm2-pytss-2.3.0-r1.ebuild
+++ b/dev-python/tpm2-pytss/tpm2-pytss-2.3.0-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Python bindings for TSS"
+HOMEPAGE="
+	https://pypi.org/project/tpm2-pytss/
+	https://github.com/tpm2-software/tpm2-pytss/
+"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="+fapi test"
+
+DEPEND="
+	app-crypt/tpm2-tss:=[fapi=]
+	fapi? ( >=app-crypt/tpm2-tss-3.0.3:= )
+	test? ( app-crypt/swtpm )
+"
+RDEPEND="${DEPEND}
+	dev-python/cffi[${PYTHON_USEDEP}]
+	dev-python/asn1crypto[${PYTHON_USEDEP}]
+	dev-python/cryptography[${PYTHON_USEDEP}]
+	dev-python/pycparser[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	dev-python/pkgconfig[${PYTHON_USEDEP}]
+	dev-python/setuptools-scm[${PYTHON_USEDEP}]
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.0-preprocess-as-C99.patch"
+	"${FILESDIR}/${PN}-2.3.0-use-CC-enviromental-variable.patch"
+	)
+
+export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
+
+distutils_enable_tests pytest


### PR DESCRIPTION
See the history of this bug:

https://bugs.gentoo.org/show_bug.cgi?id=840296
https://bugs.gentoo.org/show_bug.cgi?id=891947
https://bugs.gentoo.org/show_bug.cgi?id=902001

The problem lies in dev-python/pycparser, as it does not respect the CPP environmental variable. I have created patches (and sent them upstream) to respect it, so this bug can finally be resolved.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:


- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
