### PR TITLE
app-arch/lzlib: add tools USE flag

### DIFF
--- a/app-arch/lzlib/lzlib-1.15-r1.ebuild
+++ b/app-arch/lzlib/lzlib-1.15-r1.ebuild
@@ -35,7 +35,11 @@ src_configure() {
 	./configure "${myconf[@]}" || die
 }
 
+src_compile() {
+	emake lib bin
+}
+
 src_install() {
-	emake DESTDIR="${D}" install install-man
+	emake DESTDIR="${D}" install install-bin
 	einstalldocs
 }


### PR DESCRIPTION
the current ebuild does `install-man` which install the manpage for minilzip tool, but the tool itself is never installed.

add a `tools` useflag to control the building and installation of the tool itself.

note that since 1.15 the minilzip tool is not built by default and requires explicitly doing `make bin`. similarly `install-bin` will install the tool along with the manpage.

Ref: https://lists.nongnu.org/archive/html/lzip-bug/2024-04/msg00007.html

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
