### PR TITLE
virtual/dist-kernel: slot per `major.minor` version

### DIFF
--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.234.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.234.ebuild
@@ -41,7 +41,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.178.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.178.ebuild
@@ -41,7 +41,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.129.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.129.ebuild
@@ -41,7 +41,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.16.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.16.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.17.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.12.17.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.13.4.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.13.4.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.13.5.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.13.5.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.79.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.79.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.80.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.80.ebuild
@@ -45,7 +45,7 @@ RDEPEND="
 	!sys-kernel/gentoo-kernel:${SLOT}
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 BDEPEND="
 	app-alternatives/bc

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.234.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.234.ebuild
@@ -54,7 +54,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.15.178.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.15.178.ebuild
@@ -58,7 +58,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.129.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.129.ebuild
@@ -59,7 +59,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.12.16.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.12.16.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.12.17.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.12.17.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.13.4.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.13.4.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.13.5.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.13.5.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.79.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.79.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.80.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.80.ebuild
@@ -64,7 +64,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 QA_FLAGS_IGNORED="

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.234.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.234.ebuild
@@ -52,7 +52,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.9999.ebuild
@@ -50,7 +50,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-$(ver_cut 1-2)
+	>=virtual/dist-kernel-$(ver_cut 1-2):$(ver_cut 1-2)
 "
 
 src_unpack() {

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.178.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.178.ebuild
@@ -52,7 +52,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.9999.ebuild
@@ -50,7 +50,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-$(ver_cut 1-2)
+	>=virtual/dist-kernel-$(ver_cut 1-2):$(ver_cut 1-2)
 "
 
 src_unpack() {

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.129.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.129.ebuild
@@ -52,7 +52,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.9999.ebuild
@@ -51,7 +51,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-$(ver_cut 1-2)
+	>=virtual/dist-kernel-$(ver_cut 1-2):$(ver_cut 1-2)
 "
 
 src_unpack() {

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.16.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.16.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.17.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.17.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.9999.ebuild
@@ -51,7 +51,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-$(ver_cut 1-2)
+	>=virtual/dist-kernel-$(ver_cut 1-2):$(ver_cut 1-2)
 "
 
 src_unpack() {

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.13.4.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.13.4.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.13.5.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.13.5.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.79.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.79.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.80.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.80.ebuild
@@ -53,7 +53,7 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-kernel )
 "
 PDEPEND="
-	>=virtual/dist-kernel-${PV}
+	>=virtual/dist-kernel-${PV}:$(ver_cut 1-2)
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.9999.ebuild
@@ -51,7 +51,7 @@ BDEPEND="
 	debug? ( dev-util/pahole )
 "
 PDEPEND="
-	>=virtual/dist-kernel-$(ver_cut 1-2)
+	>=virtual/dist-kernel-$(ver_cut 1-2):$(ver_cut 1-2)
 "
 
 src_unpack() {

--- a/virtual/dist-kernel/dist-kernel-5.10.234.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.10.234.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~ppc ppc64 x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-5.15.178.ebuild
+++ b/virtual/dist-kernel/dist-kernel-5.15.178.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~ppc ppc64 ~sparc x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.1.129.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.1.129.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.12.16.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.12.16.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.12.17.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.12.17.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.13.4.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.13.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.13.5.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.13.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.6.79.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.6.79.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="

--- a/virtual/dist-kernel/dist-kernel-6.6.80.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.6.80.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
-SLOT="0/${PVR}"
+SLOT="$(ver_cut 1-2)/${PVR}"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="


### PR DESCRIPTION
The idea here is that it becomes easier to install multiple branches of the kernel simultaneously. For example:
```
emerge virtual/dist-kernel:6.6 virtual/dist-kernel:6.12
```
would now install the latest versions of the 6.6 and 6.12 branches of the kernel. Currently this is difficult because the kernel packages (e.g. `sys-kernel/gentoo-kernel`) are slotted per `PVR` which means you would have to target it with the `bugfix.revision` part of the version number as well. Which is usually not what you want.

This integrates nicely with `>=sys-kernel/installkernel-56` which now has the capability of iterating over all installed (dist-)kernel versions and (re-)installing them (similar to `kernel-install add-all` which was already possible).

It would also integrate nicely with the proposed eclass level support for `sys-kernel/dkms`, which would make it possible to build out-of-tree kernel modules for an arbitrary number of (dist-)kernels.

No `slotmove` entries since these are virtual ebuilds anyway.

See-also: https://github.com/gentoo/gentoo/pull/40704
Signed-off-by: Nowa Ammerlaan <nowa@gentoo.org>
---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
