### PR TITLE
cargo.eclass: use static.crates.io cdn

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -269,7 +269,7 @@ _cargo_set_crate_uris() {
 			name="${BASH_REMATCH[1]}"
 			version="${BASH_REMATCH[2]}"
 		fi
-		url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${name}-${version}.crate"
+		url="https://static.crates.io/api/v1/crates/${name}/${version}/download -> ${name}-${version}.crate"
 		CARGO_CRATE_URIS+="${url} "
 
 		# when invoked by pkgbump, avoid fetching all the crates


### PR DESCRIPTION
Starting from 2024-03-12, cargo began to download crates directly from static.crates.io CDN servers worldwide. See
https://blog.rust-lang.org/2024/03/11/crates-io-download-changes.html

Since crates.io servers always redirect to static.crates.io, this should greatly increase cargo package fetching speed

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
