### PR TITLE
app-crypt/gnupg: 2.4.7 remove curl dep from gnupg

### DIFF
--- a/app-crypt/gnupg/gnupg-2.4.7.ebuild
+++ b/app-crypt/gnupg/gnupg-2.4.7.ebuild
@@ -36,7 +36,6 @@ DEPEND="
 	>=dev-libs/libgpg-error-1.46
 	>=dev-libs/libksba-1.6.3
 	>=dev-libs/npth-1.2
-	>=net-misc/curl-7.10
 	sys-libs/zlib
 	bzip2? ( app-arch/bzip2 )
 	ldap? ( net-nds/openldap:= )


### PR DESCRIPTION
* Apparently gnupg 2.4.x+ does not depend on curl/libcurl (anymore?).

[ebuild   R    ] app-crypt/gnupg-2.4.7::gentoo  USE="bzip2 nls readline smartcard ssl tofu usb -doc -ldap (-selinux) -test -tools -tpm -user-socket -verify-sig -wks-server" 0 KiB

Using these USE flags (the basic default ones).

```
stefan /work # qa-vdb gnupg
VDB: detected possibly incorrect RDEPEND (app-crypt/gnupg-2.4.7)
dev-db/sqlite | dev-db/sqlite:3
net-misc/curl < 
stefan /work #
```

Scanelfs:

```
stefan /home/work # qlist -e gnupg |  xargs scanelf -BF '%n' | grep -i curl
stefan /home/work #
```

Even grep'ing the source for curl doesn't find no actual usage.

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

