### PR TITLE
profiles: force llvm USE-flag for Zig on unsupported targets

### DIFF
--- a/profiles/arch/amd64/package.use.force
+++ b/profiles/arch/amd64/package.use.force
@@ -1,5 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Eric Joldasov <bratishkaerik@landless-city.net> (2025-03-11)
+# "x86_64" backend can succesfully bootstrap itself for Linux.
+>=dev-lang/zig-0.13 -llvm
 
 # James Le Cuirot <chewi@gentoo.org> (2024-07-02)
 # Needed to build gcc. Force here rather than using BDEPEND to simplify

--- a/profiles/arch/base/package.use.force
+++ b/profiles/arch/base/package.use.force
@@ -1,0 +1,10 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Eric Joldasov <bratishkaerik@landless-city.net> (2025-03-11)
+# Force building Zig with LLVM extensions enabled. Non-LLVM backends
+# are in active development, and while some backends progressed enough
+# to build some simple or complex program, only small amount of them
+# can succesfully bootstrap Zig.
+# Unforce on targets where it's possible to bootstrap without LLVM.
+dev-lang/zig llvm


### PR DESCRIPTION
Add an allowlist of targets where Zig can bootstrap itself without LLVM, and allow disabling `llvm` USE-flag only on that targets.

Saves users from cryptic errors when they unknowingly try to use it on ARM or other architecture, and help a little bit with future keywording.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
