### PR TITLE
dev-python/dns-lexicon: keyword for ~arm64, #949851

### DIFF
--- a/dev-python/dns-lexicon/dns-lexicon-3.19.0.ebuild
+++ b/dev-python/dns-lexicon/dns-lexicon-3.19.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,11 @@ S="${WORKDIR}/lexicon-${PV}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+# Limited to amd64, arm64, loong and x86 because of dev-python/tldextract
+#KEYWORDS="~amd64 ~arm64 ~loong ~x86"
+# Limited to amd64, arm64 and x86 because of dev-python/pyotp and dev-python/zeep
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="
 	>=dev-python/beautifulsoup4-4[${PYTHON_USEDEP}]

--- a/dev-python/dns-lexicon/dns-lexicon-3.20.0.ebuild
+++ b/dev-python/dns-lexicon/dns-lexicon-3.20.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,7 +20,11 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+# Limited to amd64, arm64, loong and x86 because of dev-python/tldextract
+#KEYWORDS="~amd64 ~arm64 ~loong ~x86"
+# Limited to amd64, arm64 and x86 because of dev-python/pyotp and dev-python/zeep
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="
 	>=dev-python/beautifulsoup4-4[${PYTHON_USEDEP}]

--- a/dev-python/dns-lexicon/dns-lexicon-3.20.1.ebuild
+++ b/dev-python/dns-lexicon/dns-lexicon-3.20.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,7 +20,11 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+# Limited to amd64, arm64, loong and x86 because of dev-python/tldextract
+#KEYWORDS="~amd64 ~arm64 ~loong ~x86"
+# Limited to amd64, arm64 and x86 because of dev-python/pyotp and dev-python/zeep
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="
 	>=dev-python/beautifulsoup4-4[${PYTHON_USEDEP}]


### PR DESCRIPTION
First step so app-crypt/certbot can be available on more supported architectures.
    
Closes: https://bugs.gentoo.org/949851
Signed-off-by: Thibaud CANALE <thican@thican.net>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
