### PR TITLE
dev-python/python-augeas: keyword 1.1.0-r1, #949852

### DIFF
--- a/dev-python/python-augeas/python-augeas-1.1.0-r1.ebuild
+++ b/dev-python/python-augeas/python-augeas-1.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,8 @@ HOMEPAGE="
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 x86"
+# Same set than app-admin/augeas
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc x86"
 
 RDEPEND="
 	app-admin/augeas


### PR DESCRIPTION
First step so app-crypt/certbot can be available on more supported architectures.

Closes: https://bugs.gentoo.org/949852
Signed-off-by: Thibaud CANALE <thican@thican.net>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
