### PR TITLE
toolchain.eclass: drop support EAPI 7

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: toolchain.eclass
 # @MAINTAINER:
 # Toolchain Ninjas <toolchain@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 8
 # @BLURB: Common code for sys-devel/gcc ebuilds
 # @DESCRIPTION:
 # Common code for sys-devel/gcc ebuilds (and occasionally GCC forks, like
@@ -17,7 +17,7 @@ _TOOLCHAIN_ECLASS=1
 RUST_OPTIONAL="1"
 
 case ${EAPI} in
-	7|8) ;;
+	8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -462,13 +462,8 @@ PDEPEND=">=sys-devel/gcc-config-2.11"
 # @ECLASS_VARIABLE: TOOLCHAIN_PATCH_SUFFIX
 # @DESCRIPTION:
 # Used to override compression used for for patchsets.
-# Default is xz for EAPI 8+ and bz2 for older EAPIs.
-if [[ ${EAPI} == 8 ]] ; then
+# Default is xz for EAPI 8+.
 	: "${TOOLCHAIN_PATCH_SUFFIX:=xz}"
-else
-	# Older EAPIs
-	: "${TOOLCHAIN_PATCH_SUFFIX:=bz2}"
-fi
 
 # @ECLASS_VARIABLE: TOOLCHAIN_SET_S
 # @DESCRIPTION:
@@ -765,11 +760,10 @@ do_gcc_gentoo_patches() {
 				fi
 			fi
 
-			local shopt_save=$(shopt -p nullglob)
+			local -
 			shopt -s nullglob
 			einfo "Applying musl patches ..."
 			eapply "${WORKDIR}"/musl/{,nocross/}*.patch
-			${shopt_save}
 		fi
 	fi
 }


### PR DESCRIPTION
should only supports EAPI=8 since rust was introduced in inherit.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
