### PR TITLE
x11-themes/elementary-xfce-icon-theme: fix DART icon

### DIFF
--- a/x11-themes/elementary-xfce-icon-theme/elementary-xfce-icon-theme-0.20.1-r1.ebuild
+++ b/x11-themes/elementary-xfce-icon-theme/elementary-xfce-icon-theme-0.20.1-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg toolchain-funcs
+
+MY_P="${PN%-icon-theme}-${PV}"
+DESCRIPTION="Elementary icons forked from upstream, extended and maintained for Xfce"
+HOMEPAGE="https://github.com/shimmerproject/elementary-xfce"
+SRC_URI="https://github.com/shimmerproject/elementary-xfce/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+# see AUTHORS
+LICENSE="
+	GPL-3+
+	Apache-2.0
+	CC-BY-4.0 CC-BY-SA-4.0
+"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+
+BDEPEND="
+	media-gfx/optipng
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3"
+
+src_prepare() {
+	sed -i -e 's:-Werror -O0 -pipe:${CFLAGS} ${CPPFLAGS} ${LDFLAGS}:' \
+		svgtopng/Makefile || die
+	default
+}
+
+src_configure() {
+	# custom script
+	./configure --prefix="${EPREFIX}/usr" || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	default
+	# delete dangling doc links
+	find -L "${D}" -type l -delete || die
+}

--- a/x11-themes/elementary-xfce-icon-theme/elementary-xfce-icon-theme-0.21-r1.ebuild
+++ b/x11-themes/elementary-xfce-icon-theme/elementary-xfce-icon-theme-0.21-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg toolchain-funcs
+
+MY_P="${PN%-icon-theme}-${PV}"
+DESCRIPTION="Elementary icons forked from upstream, extended and maintained for Xfce"
+HOMEPAGE="https://github.com/shimmerproject/elementary-xfce"
+SRC_URI="https://github.com/shimmerproject/elementary-xfce/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+# see AUTHORS
+LICENSE="
+	GPL-3+
+	Apache-2.0
+	CC-BY-4.0 CC-BY-SA-4.0
+"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+
+BDEPEND="
+	media-gfx/optipng
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3"
+
+src_prepare() {
+	sed -i -e 's:-Werror -O0 -pipe:${CFLAGS} ${CPPFLAGS} ${LDFLAGS}:' \
+		svgtopng/Makefile || die
+	default
+}
+
+src_configure() {
+	# custom script
+	./configure --prefix="${EPREFIX}/usr" || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}


### PR DESCRIPTION
The patch has been obsolete by https://github.com/shimmerproject/elementary-xfce/commit/f14cd8b70acfec89cee16e602c1a8f9027b0bb06.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
