### PR TITLE
app-text/cherrytree: remove unused cmake flag

### DIFF
--- a/app-text/cherrytree/cherrytree-1.2.0.ebuild
+++ b/app-text/cherrytree/cherrytree-1.2.0.ebuild
@@ -68,9 +68,14 @@ src_configure() {
 		-DUSE_NLS=$(usex nls)
 		-DBUILD_TESTING=$(usex test)
 		-DUSE_SHARED_FMT_SPDLOG=ON
-		-DAUTO_RUN_TESTING=OFF
 		-DUSE_SHARED_GTEST_GMOCK=$(usex test)
 	)
+
+	if use test; then
+		mycmakeargs+=(
+			-DAUTO_RUN_TESTING=OFF
+		)
+	fi
 
 	cmake_src_configure
 }


### PR DESCRIPTION
Specify the `AUTO_RUN_TESTING` flag only when testing is enabled, to avoid a CMake warning about unused variables.

Closes: https://bugs.gentoo.org/950341

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.