### PR TITLE
dev-java/javatoolkit: fix eprefix support

### DIFF
--- a/dev-java/javatoolkit/javatoolkit-0.6.8.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.6.8.ebuild
@@ -20,7 +20,7 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~sparc ~amd64-linux ~x86-linux ~ppc-macos ~x64-ma
 distutils_enable_tests unittest
 
 python_prepare_all() {
-	hprefixify src/py/buildparser src/py/findclass setup.py
+	hprefixify src/${PN}/scripts/findclass.py
 	distutils-r1_python_prepare_all
 }
 
@@ -36,6 +36,6 @@ src_install() {
 	local script
 	for script in *; do
 		rm "${script}" || die
-		dosym -r /usr/lib/python-exec/python-exec2 "${EPREFIX}/usr/libexec/${PN}/${script}"
+		dosym -r /usr/lib/python-exec/python-exec2 "/usr/libexec/${PN}/${script}"
 	done
 }


### PR DESCRIPTION
Avoid the double-prefix error and don't call hprefixify on files that don't exist.

Note that the findclass.py script is broken with dev-java/java-config:2 so patching it is somewhat pointless.

Bug: https://bugs.gentoo.org/354105

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
