### PR TITLE
dev-java/testng: depend on test dependency '--build-only' #948935

### DIFF
--- a/dev-java/testng/testng-6.11-r1.ebuild
+++ b/dev-java/testng/testng-6.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -75,7 +75,7 @@ src_test() {
 
 	JAVA_GENTOO_CLASSPATH_EXTRA=":${DISTDIR}/spock-core-${SCV}.jar"
 
-	ejavac -cp "${JAVA_TEST_SRC_DIR}:${PN}.jar:$(java-pkg_getjars guava)" \
+	ejavac -cp "${JAVA_TEST_SRC_DIR}:${PN}.jar:$(java-pkg_getjars --build-only guava)" \
 		src/test/java/test/SimpleBaseTest.java || die
 
 	# java-pkg-simple.eclass expects generated test classes in this


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/948935

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
