### PR TITLE
app-crypt/certbot: drop google dns module, #949851

### DIFF
--- a/app-crypt/certbot/certbot-3.2.0-r101.ebuild
+++ b/app-crypt/certbot/certbot-3.2.0-r101.ebuild
@@ -46,7 +46,7 @@ CERTBOT_MODULES_EXTRA=(
 	dns-dnsimple
 	dns-dnsmadeeasy
 	dns-gehirn
-	dns-google
+	#dns-google # Not supported currently, too restricted set of supported architectures in dependencies.
 	dns-linode
 	dns-luadns
 	dns-nsone
@@ -105,10 +105,6 @@ RDEPEND="
 	certbot-dns-gehirn? (
 		>=dev-python/dns-lexicon-3.14.1[${PYTHON_USEDEP}]
 	)
-	certbot-dns-google? (
-		>=dev-python/google-api-python-client-1.6.5[${PYTHON_USEDEP}]
-		>=dev-python/google-auth-2.16.0[${PYTHON_USEDEP}]
-	)
 	certbot-dns-linode? (
 		>=dev-python/dns-lexicon-3.14.1[${PYTHON_USEDEP}]
 	)
@@ -148,6 +144,10 @@ RDEPEND="
 # 	certbot-dns-digitalocean? (
 # 		# Available in GURU
 # 		>=dev-python/digitalocean-1.11[${PYTHON_USEDEP}]
+# 	)
+# 	certbot-dns-google? (
+# 		>=dev-python/google-api-python-client-1.6.5[${PYTHON_USEDEP}]
+# 		>=dev-python/google-auth-2.16.0[${PYTHON_USEDEP}]
 # 	)
 # "
 

--- a/app-crypt/certbot/certbot-9999.ebuild
+++ b/app-crypt/certbot/certbot-9999.ebuild
@@ -46,7 +46,7 @@ CERTBOT_MODULES_EXTRA=(
 	dns-dnsimple
 	dns-dnsmadeeasy
 	dns-gehirn
-	dns-google
+	#dns-google # Not supported currently, too restricted set of supported architectures in dependencies.
 	dns-linode
 	dns-luadns
 	dns-nsone
@@ -105,10 +105,6 @@ RDEPEND="
 	certbot-dns-gehirn? (
 		>=dev-python/dns-lexicon-3.14.1[${PYTHON_USEDEP}]
 	)
-	certbot-dns-google? (
-		>=dev-python/google-api-python-client-1.6.5[${PYTHON_USEDEP}]
-		>=dev-python/google-auth-2.16.0[${PYTHON_USEDEP}]
-	)
 	certbot-dns-linode? (
 		>=dev-python/dns-lexicon-3.14.1[${PYTHON_USEDEP}]
 	)
@@ -148,6 +144,10 @@ RDEPEND="
 # 	certbot-dns-digitalocean? (
 # 		# Available in GURU
 # 		>=dev-python/digitalocean-1.11[${PYTHON_USEDEP}]
+# 	)
+# 	certbot-dns-google? (
+# 		>=dev-python/google-api-python-client-1.6.5[${PYTHON_USEDEP}]
+# 		>=dev-python/google-auth-2.16.0[${PYTHON_USEDEP}]
 # 	)
 # "
 

--- a/app-crypt/certbot/metadata.xml
+++ b/app-crypt/certbot/metadata.xml
@@ -21,7 +21,9 @@
 		<flag name="certbot-dns-dnsimple">Enable DNSimple Authenticator plugin.</flag>
 		<flag name="certbot-dns-dnsmadeeasy">Enable DNS Made Easy DNS Authenticator plugin.</flag>
 		<flag name="certbot-dns-gehirn">Enable Gehirn Infrastructure Service DNS Authenticator plugin.</flag>
+		<!--
 		<flag name="certbot-dns-google">Enable Google Cloud DNS Authenticator plugin.</flag>
+		-->
 		<flag name="certbot-dns-linode">Enable Linode DNS Authenticator plugin plugin.</flag>
 		<flag name="certbot-dns-luadns">Enable LuaDNS Authenticator plugin.</flag>
 		<flag name="certbot-dns-nsone">Enable NS1 DNS Authenticator plugin.</flag>


### PR DESCRIPTION
Too restricted set of supported architectures in dependencies.

Bug: https://bugs.gentoo.org/949851

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
