### PR TITLE
profiles/arch: restrict Certbot’s module "google dns" to amd64, arm64 and x86, #949851

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Thibaud CANALE <thican@thican.net> (2025-03-09)
+# Google DNS dependencies available (bug 949851)
+app-crypt/certbot -certbot-dns-google
+
 # Nowa Ammerlaan <nowa@gentoo.org> (2025-02-03)
 # QtWebView is available here
 dev-python/pyside -webview

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Thibaud CANALE <thican@thican.net> (2025-03-09)
+# Google DNS dependencies available (bug 949851)
+app-crypt/certbot -certbot-dns-google
+
 # Paul Zander <negril.nx+gentoo@gmail.com> (2025-02-23)
 # Not part of the arm64 archive
 dev-util/nvidia-cuda-toolkit -examples -rdma

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,12 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Thibaud CANALE <thican@thican.net> (2025-03-09)
+# Too many dependencies are not keyworded (bug 949851)
+# - dev-python/google-api-python-client
+# - dev-python/google-auth
+app-crypt/certbot certbot-dns-google
+
 # Nowa Ammerlaan <nowa@gentoo.org> (2025-02-03)
 # QtWebView is not available everywhere
 dev-python/pyside webview

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Thibaud CANALE <thican@thican.net> (2025-03-09)
+# Google DNS dependencies available (bug 949851)
+app-crypt/certbot -certbot-dns-google
+
 # Alfred Wingate <parona@protonmail.com> (2025-02-22)
 # media-libs/zint is not keyworded here
 media-libs/zxing-cpp experimental


### PR DESCRIPTION
Dependencies for Certbot’s “Google DNS Authenticator” are only currently keyworded for amd64, arm64 and x86, so mask its USE flag by default.

Bug: https://bugs.gentoo.org/949851

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
