### PR TITLE
games-action/supertuxkart: add patch for gcc 15

### DIFF
--- a/games-action/supertuxkart/files/supertuxkart-1.4-gcc-15.patch
+++ b/games-action/supertuxkart/files/supertuxkart-1.4-gcc-15.patch
@@ -1,0 +1,24 @@
+https://github.com/supertuxkart/stk-code/issues/5301
+https://bugs.gentoo.org/937731
+
+From 83e029cc123176a77a239edf90ee461e46f9f8a2 Mon Sep 17 00:00:00 2001
+From: Gwyn Ciesla <gwync@protonmail.com>
+Date: Wed, 19 Feb 2025 09:34:58 -0600
+Subject: [PATCH] Add include to work with gcc15. (#5310)
+
+---
+ src/network/remote_kart_info.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/network/remote_kart_info.hpp b/src/network/remote_kart_info.hpp
+index 80a6339187c..9865dcda8c3 100644
+--- a/src/network/remote_kart_info.hpp
++++ b/src/network/remote_kart_info.hpp
+@@ -29,6 +29,7 @@
+ #include <string>
+ #include <vector>
+ #include <irrString.h>
++#include <cstdint>
+ 
+ enum KartTeam : int8_t
+ {

--- a/games-action/supertuxkart/supertuxkart-1.4-r1.ebuild
+++ b/games-action/supertuxkart/supertuxkart-1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -56,6 +56,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.1-irrlicht-arch-support.patch
 	"${FILESDIR}"/${PN}-1.3-irrlicht-system-libs.patch
 	"${FILESDIR}"/${P}-gcc-13.patch
+	"${FILESDIR}"/${P}-gcc-15.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Backport commit that adds an include that's been removed from the default ones in libstdc++.

Closes: https://bugs.gentoo.org/937731

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
