### PR TITLE
media-sound/pavucontrol: remove libcanberra automagic

### DIFF
--- a/media-sound/pavucontrol/files/pavucontrol-6.1-libcanberra-automagic.patch
+++ b/media-sound/pavucontrol/files/pavucontrol-6.1-libcanberra-automagic.patch
@@ -1,0 +1,39 @@
+https://bugs.gentoo.org/950761
+https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/merge_requests/104
+
+From 53b44d9ccd2e095a9c0ce1511e122e4ed37bbbb5 Mon Sep 17 00:00:00 2001
+From: Alfred Wingate <parona@protonmail.com>
+Date: Mon, 10 Mar 2025 20:44:02 +0200
+Subject: [PATCH] Add a option for controlling libcanberra feature
+
+The retains the previous behavior of automagic except it allows the user to
+explicitly enable or disable the feature.
+
+Chose to call the feature a more agnostic "audio-feedback".
+
+Bug: https://bugs.gentoo.org/950761
+See-Also: 22b04fff6e881b4e0a1b8344a6513bdf99a10c65
+Signed-off-by: Alfred Wingate <parona@protonmail.com>
+--- a/meson.build
++++ b/meson.build
+@@ -10,7 +10,7 @@ cpp = meson.get_compiler('cpp')
+ 
+ gtkmm_dep = dependency('gtkmm-4.0', version : '>= 4.0', required : true)
+ sigcpp_dep = dependency('sigc++-3.0', required : true)
+-canberragtk_dep = dependency('libcanberra', version : '>= 0.16', required : false)
++canberragtk_dep = dependency('libcanberra', version : '>= 0.16', required : get_option('audio-feedback'))
+ 
+ libpulse_dep = dependency('libpulse', version : '>= 5.0', required : true)
+ libpulsemlglib_dep = dependency('libpulse-mainloop-glib', version : '>= 0.9.16', required : true)
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -1,3 +1,6 @@
+ option('lynx',
+        type : 'boolean', value : true,
+        description : 'Enable building of the README text file for installation')
++option('audio-feedback',
++       type : 'feature', value: 'auto',
++       description : 'Play a sound when you change the volume of a sink')
+-- 
+GitLab
+

--- a/media-sound/pavucontrol/metadata.xml
+++ b/media-sound/pavucontrol/metadata.xml
@@ -5,6 +5,9 @@
 	<email>sound@gentoo.org</email>
 	<name>Gentoo Sound project</name>
 </maintainer>
+<upstream>
+	<remote-id type="freedesktop-gitlab">pulseaudio/pavucontrol</remote-id>
+</upstream>
 <use>
 	<flag name="sound">Enable sound notifications using <pkg>media-libs/libcanberra</pkg></flag>
 </use>

--- a/media-sound/pavucontrol/metadata.xml
+++ b/media-sound/pavucontrol/metadata.xml
@@ -5,4 +5,7 @@
 	<email>sound@gentoo.org</email>
 	<name>Gentoo Sound project</name>
 </maintainer>
+<use>
+	<flag name="sound">Enable sound notifications using <pkg>media-libs/libcanberra</pkg></flag>
+</use>
 </pkgmetadata>

--- a/media-sound/pavucontrol/pavucontrol-6.1-r1.ebuild
+++ b/media-sound/pavucontrol/pavucontrol-6.1-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Pulseaudio Volume Control, GTK based mixer for Pulseaudio"
+HOMEPAGE="https://freedesktop.org/software/pulseaudio/pavucontrol/"
+SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+IUSE="sound"
+
+RDEPEND="
+	dev-cpp/gtkmm:4.0
+	dev-libs/json-glib
+	dev-libs/libsigc++:3
+	>=media-libs/libpulse-15.0[glib]
+	virtual/freedesktop-icon-theme
+	sound? ( media-libs/libcanberra )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	sys-devel/gettext
+"
+
+PATCHES=(
+	"${FILESDIR}/pavucontrol-6.1-libcanberra-automagic.patch"
+)
+
+src_prepare() {
+	default
+
+	# Follow Gentoo FHS with docdir
+	sed -i -e "/^docdir/ { s/${PN}/${PF}/ }" meson.build || die
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dlynx=false
+		$(meson_feature sound audio-feedback)
+	)
+
+	meson_src_configure
+}


### PR DESCRIPTION
The X use flag did nothing and this didn't require libcanberra-gtk3.

Redo order of dependencies as well, and put the inherit above the rest of the metadata.

Closes: https://bugs.gentoo.org/950761

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
