### PR TITLE
app-misc/skim: only install bash and zsh completions

### DIFF
--- a/app-misc/skim/skim-0.16.1.ebuild
+++ b/app-misc/skim/skim-0.16.1.ebuild
@@ -190,7 +190,6 @@ src_install() {
 	doins shell/key-bindings.*
 
 	newbashcomp shell/completion.bash sk
-	newfishcomp shell/completion.fish sk.fish
 	newzshcomp shell/completion.zsh _sk
 }
 


### PR DESCRIPTION
skim doesn't ship a fish completion script.

Closes: https://bugs.gentoo.org/951106

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
