### PR TITLE
app-shells/fish: inject proper sysconfdir

### DIFF
--- a/app-shells/fish/fish-4.0.0-r1.ebuild
+++ b/app-shells/fish/fish-4.0.0-r1.ebuild
@@ -112,6 +112,7 @@ src_configure() {
 	else
 		mycmakeargs+=( -DBUILD_DOCS=OFF )
 	fi
+
 	cargo_src_configure --no-default-features --bin fish --bin fish_indent --bin fish_key_reader
 	cmake_src_configure
 }
@@ -119,6 +120,8 @@ src_configure() {
 src_compile() {
 	local -x PREFIX="${EPREFIX}/usr"
 	local -x DOCDIR="${EPREFIX}/usr/share/doc/${PF}"
+	# Bug: https://bugs.gentoo.org/950699
+	local -x SYSCONFDIR="${EPREFIX}/etc"
 	local -x CMAKE_WITH_GETTEXT
 	CMAKE_WITH_GETTEXT="$(usex nls 1 0)"
 	cargo_src_compile

--- a/app-shells/fish/fish-4.0.0-r1.ebuild
+++ b/app-shells/fish/fish-4.0.0-r1.ebuild
@@ -112,7 +112,6 @@ src_configure() {
 	else
 		mycmakeargs+=( -DBUILD_DOCS=OFF )
 	fi
-
 	cargo_src_configure --no-default-features --bin fish --bin fish_indent --bin fish_key_reader
 	cmake_src_configure
 }

--- a/app-shells/fish/fish-9999.ebuild
+++ b/app-shells/fish/fish-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit cargo cmake python-any-r1 readme.gentoo-r1 xdg
 
@@ -111,6 +111,8 @@ src_configure() {
 src_compile() {
 	local -x PREFIX="${EPREFIX}/usr"
 	local -x DOCDIR="${EPREFIX}/usr/share/doc/${PF}"
+	# Bug: https://bugs.gentoo.org/950699
+	local -x SYSCONFDIR="${EPREFIX}/etc"
 	local -x CMAKE_WITH_GETTEXT
 	CMAKE_WITH_GETTEXT="$(usex nls 1 0)"
 	cargo_src_compile


### PR DESCRIPTION
Older fish versions used /etc/fish as the sysconfdir and if not set explicitly fish 4 will default to /usr/share/etc/fish.

Closes: https://bugs.gentoo.org/950699

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
