### PR TITLE
dev-lang/uasm: fix build on newer gcc

### DIFF
--- a/dev-lang/uasm/uasm-2.56.2.ebuild
+++ b/dev-lang/uasm/uasm-2.56.2.ebuild
@@ -30,6 +30,8 @@ src_compile() {
 	append-cflags -fcommon
 	# https://github.com/Terraspace/UASM/issues/197
 	append-cflags -Wno-error=incompatible-pointer-types
+	# BUG: 951108
+	append-cflags -std=gnu17
 
 	emake -f gccLinux64.mak \
 		CC="$(tc-getCC)" \

--- a/dev-lang/uasm/uasm-2.57.ebuild
+++ b/dev-lang/uasm/uasm-2.57.ebuild
@@ -31,6 +31,8 @@ src_compile() {
 	append-cflags -fcommon
 	# BUG: https://github.com/Terraspace/UASM/issues/197
 	append-cflags -Wno-error=incompatible-pointer-types
+	# BUG: 951108
+	append-cflags -std=gnu17
 
 	emake -f Makefile-Linux-GCC-64.mak \
 		CC="$(tc-getCC)" \


### PR DESCRIPTION
ideally the source should be fixed upstream. but many of the existing fixes have already been reported to upstream, both by myself and others [1] [2] and upstream has not been responsive. so just patch it up with -std=gnu17 for now.

1: https://github.com/Terraspace/UASM/issues/197
2: https://github.com/Terraspace/UASM/pulls
Signed-off-by: NRK <nrk@disroot.org>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
