### PR TITLE
sys-power/tlp: fix install with elogind

### DIFF
--- a/sys-power/tlp/tlp-1.7.0-r1.ebuild
+++ b/sys-power/tlp/tlp-1.7.0-r1.ebuild
@@ -38,10 +38,6 @@ src_install() {
 	fperms 444 /usr/share/tlp/defaults.conf # manpage says this file should not be edited
 	newinitd "${FILESDIR}/tlp.init" tlp
 	keepdir /var/lib/tlp # created by Makefile, probably important
-
-	# <elogind-255.5 used a different path (bug #939216), keep a compat symlink
-	# TODO: cleanup after 255.5 been stable for a few months
-	dosym {/usr/lib,/"$(get_libdir)"}/elogind/system-sleep/49-tlp-sleep
 }
 
 pkg_postinst() {


### PR DESCRIPTION
I was getting an internal collision error and I fixed it by removing the code related to the sleep hook symlink.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
