### PR TITLE
x11-wm/herbstluftwm: add patch to fix building with gcc 15

### DIFF
--- a/x11-wm/herbstluftwm/files/herbstluftwm-0.9.5-gcc15.patch
+++ b/x11-wm/herbstluftwm/files/herbstluftwm-0.9.5-gcc15.patch
@@ -1,0 +1,32 @@
+https://github.com/herbstluftwm/herbstluftwm/issues/1612
+https://bugs.gentoo.org/937529
+
+From 5e4941c2aa12102cf86c8a69b65c7fa9086f50d6 Mon Sep 17 00:00:00 2001
+From: Kostadin Shishmanov <kostadinshishmanov@protonmail.com>
+Date: Tue, 11 Mar 2025 01:13:33 +0200
+Subject: [PATCH] Add #include <stdint.h> to fix building with gcc 15
+
+With gcc 15, the C++ Standard Library no longer includes other headers
+that were internally used by the library. In herbstluftwm's case the
+missing header is <stdint.h>
+
+Downstream Gentoo bug: https://bugs.gentoo.org/937529
+
+Closes: #1612
+Signed-off-by: Kostadin Shishmanov <kostadinshishmanov@protonmail.com>
+---
+ src/xconnection.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/xconnection.cpp b/src/xconnection.cpp
+index e2129db35..df77571e6 100644
+--- a/src/xconnection.cpp
++++ b/src/xconnection.cpp
+@@ -7,6 +7,7 @@
+ #include <X11/extensions/Xrender.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#include <stdint.h>
+ #include <climits>
+ #include <cstring>
+ #include <iostream>

--- a/x11-wm/herbstluftwm/herbstluftwm-0.9.5-r2.ebuild
+++ b/x11-wm/herbstluftwm/herbstluftwm-0.9.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -64,6 +64,10 @@ if [[ -n "${EGIT_REPO_URI}" ]]; then
 	# if we build from git asciidoc is needed.
 	BDEPEND+=" doc? ( app-text/asciidoc )"
 fi
+
+PATCHES=(
+	 "${FILESDIR}"/${PN}-0.9.5-gcc15.patch
+)
 
 src_prepare() {
 	# Do not install LICENSE and respect CMAKE_INSTALL_DOCDIR.


### PR DESCRIPTION
I've only added the patch to the stable version since one of the upstream contributors already approved my PR, so it might get merged in soon which would break the live ebuild.

Closes: https://bugs.gentoo.org/937529

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
