### PR TITLE
games-action/maelstrom: update EAPI 7 -> 8, fix build with GCC-15 and Clang

### DIFF
--- a/games-action/maelstrom/files/maelstrom-3.0.6-clang-sprintf.patch
+++ b/games-action/maelstrom/files/maelstrom-3.0.6-clang-sprintf.patch
@@ -1,0 +1,112 @@
+Fix build errors with clang caused by strict denial of Cisms in C++ code
+Folded sed to install the high scores file in ${GAMES_STATEDIR}
+sed -i -e "s:path.Path(MAELSTROM_SCORES):\"/var/games/\"MAELSTROM_SCORES:" scores.cpp
+and mangled it to work with C++
+https://bugs.gentoo.org/730822
+--- a/load.h
++++ b/load.h
+@@ -106,7 +106,7 @@
+ 		if ( strcmp(directory, DIR_SEP) == 0 ) {
+ 			sprintf(path, DIR_SEP"%s", filename);
+ 		} else {
+-			sprintf(path, "%s"DIR_SEP"%s", directory, filename);
++			sprintf(path, "%s%s%s", directory, DIR_SEP, filename);
+ 		}
+ 		return(path);
+ 	}
+--- a/screenlib/SDL_FrameBuf.cpp
++++ b/screenlib/SDL_FrameBuf.cpp
+@@ -519,7 +519,7 @@
+ 	}
+ #else
+ 	/* Swap two buffers using a temporary variable */
+-	register Uint8 tmp;
++	Uint8 tmp;
+ 
+ 	while ( len-- ) {
+ 		tmp = *dst;
+--- a/controls.cpp
++++ b/controls.cpp
+@@ -83,7 +83,7 @@
+ 	if ( fname ) {
+ 		*fname = datafile;
+ 	}
+-	snprintf(datafile, sizeof(datafile), "%s"DIR_SEP"%s", home, MAELSTROM_DATA);
++	snprintf(datafile, sizeof(datafile), "%s%s%s", home, DIR_SEP, MAELSTROM_DATA);
+ 	if ( (data=fopen(datafile, mode)) == NULL )
+ 		return(NULL);
+ 	return(data);
+--- a/fastrand.cpp
++++ b/fastrand.cpp
+@@ -30,10 +30,10 @@
+ Uint16 FastRandom(Uint16 range)
+ {
+ 	Uint16 result;
+-	register Uint32 calc;
+-	register Uint32 regD0;
+-	register Uint32 regD1;
+-	register Uint32 regD2;
++	Uint32 calc;
++	Uint32 regD0;
++	Uint32 regD1;
++	Uint32 regD2;
+ 
+ #ifdef SERIOUS_DEBUG
+   fprintf(stderr, "FastRandom(%hd)  Seed in: %lu ", range, randomSeed);
+--- a/load.cpp
++++ b/load.cpp
+@@ -81,7 +81,7 @@
+ 	SDL_Surface *bmp, *title;
+ 	
+ 	/* Open the title file -- we know its colormap is our global one */
+-	snprintf(file, sizeof(file), "Images"DIR_SEP"Maelstrom_Titles#%d.bmp", title_id);
++	snprintf(file, sizeof(file), "Images%sMaelstrom_Titles#%d.bmp", DIR_SEP, title_id);
+ 	bmp = SDL_LoadBMP(path.Path(file));
+ 	if ( bmp == NULL ) {
+ 		return(NULL);
+@@ -103,7 +103,7 @@
+ 	Uint16 w, h;
+ 	
+ 	/* Open the cicn sprite file.. */
+-	snprintf(file, sizeof(file), "Images"DIR_SEP"Maelstrom_Icon#%hd.cicn", cicn_id);
++	snprintf(file, sizeof(file), "Images%sMaelstrom_Icon#%hd.cicn", DIR_SEP, cicn_id);
+ 	if ( (cicn_src=SDL_RWFromFile(path.Path(file), "r")) == NULL ) {
+ 		error("GetCIcon(%hd): Can't open CICN %s: ",
+ 					cicn_id, path.Path(file));
+--- a/scores.cpp
++++ b/scores.cpp
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ 
+ #include "SDL_endian.h"
++#include <string>
+ 
+ #include "Maelstrom_Globals.h"
+ #include "load.h"
+@@ -44,7 +45,7 @@
+ 	}
+ 	memset(&hScores, 0, sizeof(hScores));
+ 
+-	scores_src = SDL_RWFromFile(path.Path(MAELSTROM_SCORES), "rb");
++	scores_src = SDL_RWFromFile((std::string("/var/games/") + MAELSTROM_SCORES).c_str(), "rb");
+ 	if ( scores_src != NULL ) {
+ 		for ( i=0; i<NUM_SCORES; ++i ) {
+ 			SDL_RWread(scores_src, hScores[i].name,
+@@ -72,7 +73,7 @@
+ #ifdef unix
+ 	omask=umask(SCORES_PERMMASK);
+ #endif
+-	scores_src = SDL_RWFromFile(path.Path(MAELSTROM_SCORES), "wb");
++	scores_src = SDL_RWFromFile((std::string("/var/games/") + MAELSTROM_SCORES).c_str(), "wb");
+ 	if ( scores_src != NULL ) {
+ 		for ( i=0; i<NUM_SCORES; ++i ) {
+ 			SDL_RWwrite(scores_src, hScores[i].name,
+@@ -83,7 +84,7 @@
+ 		SDL_RWclose(scores_src);
+ 	} else {
+ 		error("Warning: Couldn't save scores to %s\n",
+-						path.Path(MAELSTROM_SCORES));
++						(std::string("/var/games/") + MAELSTROM_SCORES).c_str());
+ 	}
+ #ifdef unix
+ 	umask(omask);

--- a/games-action/maelstrom/files/maelstrom-3.0.6-fix_return_type.patch
+++ b/games-action/maelstrom/files/maelstrom-3.0.6-fix_return_type.patch
@@ -1,0 +1,17 @@
+Adds void to main()
+
+Quick fix to the compile issue on main. There is no return statement, so return type is set to void. 
+
+Signed-off-by: Stephane Bakhos <nuitari@nuitari.net>
+https://bugs.gentoo.org/875431
+--- a/Maelstrom-netd.c
++++ b/Maelstrom-netd.c
+@@ -184,7 +184,7 @@
+        exit(sig);
+ }
+ 
+-main(int argc, char *argv[])
++void main(int argc, char *argv[])
+ {
+        int netfd, i, slot;
+        struct sockaddr_in serv_addr;

--- a/games-action/maelstrom/maelstrom-3.0.6-r4.ebuild
+++ b/games-action/maelstrom/maelstrom-3.0.6-r4.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools desktop
+
+DESCRIPTION="An asteroids battle game"
+HOMEPAGE="https://www.libsdl.org/projects/Maelstrom/"
+SRC_URI="https://www.libsdl.org/projects/Maelstrom/src/${P^}.tar.gz"
+S="${WORKDIR}/${P^}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	acct-group/gamestat
+	media-libs/libsdl[sound,joystick,video]
+	media-libs/sdl-net"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-security.patch
+	"${FILESDIR}"/${P}-64bits.patch
+	"${FILESDIR}"/${P}-gcc34.patch
+	"${FILESDIR}"/${P}-warnings.patch
+	"${FILESDIR}"/${P}-gcc53.patch
+	"${FILESDIR}"/${P}-autotools.patch
+	"${FILESDIR}"/${P}-fix_return_type.patch
+	"${FILESDIR}"/${P}-clang-sprintf.patch
+)
+
+src_prepare() {
+	default
+
+	rm aclocal.m4 acinclude.m4 || die
+	eautoreconf
+}
+
+src_install() {
+	default
+	dodoc Changelog Docs/{Maelstrom-Announce,*FAQ,MaelstromGPL_press_release,*.Paper,Technical_Notes*}
+
+	newicon "${ED}"/usr/share/Maelstrom/icon.xpm maelstrom.xpm
+	make_desktop_entry Maelstrom "Maelstrom" maelstrom
+
+	# Put the high scores file in the right place
+	insinto /var/games
+	doins "${ED}"/usr/share/Maelstrom/Maelstrom-Scores
+
+	# clean up some cruft
+	rm \
+		"${ED}"/usr/share/Maelstrom/Maelstrom-Scores \
+		"${ED}"/usr/share/Maelstrom/Images/Makefile* || die
+
+	# make sure we can update the high scores
+	fowners root:gamestat /var/games/Maelstrom-Scores /usr/bin/Maelstrom{,-netd}
+	fperms 2755 /usr/bin/Maelstrom{,-netd}
+	fperms 660 /var/games/Maelstrom-Scores
+}


### PR DESCRIPTION
Issues are more of Cisms in C++ code, and some of them had rather horrific fixes.

One is from the bug report, for wrong type of main().
Another one is about macros in string literals and `register` keyword.

Closes: https://bugs.gentoo.org/730822
Closes: https://bugs.gentoo.org/875431

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
