### PR TITLE
dev-util/btyacc: update EAPI 7 -> 8, port to C99, wire tests

### DIFF
--- a/dev-util/btyacc/btyacc-3.0-r5.ebuild
+++ b/dev-util/btyacc/btyacc-3.0-r5.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P="${PN}-3-0"
+DESCRIPTION="Backtracking YACC - modified from Berkeley YACC"
+HOMEPAGE="https://www.siber.com/btyacc"
+SRC_URI="https://www.siber.com/btyacc/${MY_P}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~x86-linux ~ppc-macos"
+
+PATCHES=(
+	"${FILESDIR}/${P}-includes.patch"
+	"${FILESDIR}/${P}-makefile.patch"
+	"${FILESDIR}/${P}-c99.patch"
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_test() {
+	for file in "${S}"/test/*.y;
+		do "${S}"/btyacc "${file}" || die
+		rm y_tab.c || die
+	done
+}
+
+src_install() {
+	dobin btyacc
+	dodoc README README.BYACC
+	newman manpage btyacc.1
+}

--- a/dev-util/btyacc/files/btyacc-3.0-c99.patch
+++ b/dev-util/btyacc/files/btyacc-3.0-c99.patch
@@ -1,0 +1,45 @@
+Fold sed that fixed https://bugs.gentoo.org/361013 into patch
+Correct type for signal handler that ignores argument.
+https://bugs.gentoo.org/880971
+--- a/defs.h
++++ b/defs.h
+@@ -391,7 +391,7 @@
+ 
+ /* main.c */
+ void done(int);
+-void onintr(void);
++void onintr(int);
+ void set_signals(void);
+ void usage(void);
+ void getargs(int, char **);
+--- a/main.c
++++ b/main.c
+@@ -76,7 +76,7 @@
+ }
+ 
+ 
+-void onintr()
++void onintr(int ignored) //signal handler
+ {
+     done(1);
+ }
+@@ -264,7 +264,7 @@
+     if (tmpdir == 0) tmpdir = DEFAULT_TMPDIR;
+ 
+     len = strlen(tmpdir);
+-    i = len + 13;
++    i = len + 14;
+     if (len && tmpdir[len-1] != DIR_CHAR)
+ 	++i;
+ 
+--- a/reader.c
++++ b/reader.c
+@@ -291,7 +291,7 @@
+     cachec(NUL);
+     
+     if ((key = bsearch(cache, keywords, sizeof(keywords)/sizeof(*key),
+-		       sizeof(*key), strcmp)))
++		       sizeof(*key), (int (*)(const void*, const void*))strcmp)))
+       return key->token; 
+   } else {
+     ++cptr;


### PR DESCRIPTION
Upstream apparently accidentally killed the tarball.

Closes: https://bugs.gentoo.org/880971

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
