### PR TITLE
update libplacebo bdep for vulkan disabled case

### DIFF
--- a/media-libs/libplacebo/files/Don-t-require-vulkan-header-when-vulkan-is-disabled.patch
+++ b/media-libs/libplacebo/files/Don-t-require-vulkan-header-when-vulkan-is-disabled.patch
@@ -1,0 +1,65 @@
+From 6f81a69f3abd441dd398990ab54e4c7282869379 Mon Sep 17 00:00:00 2001
+From: Zhang Ning <zhangn1985@outlook.com>
+Date: Wed, 12 Mar 2025 10:14:19 +0800
+Subject: [PATCH] Don't require vulkan header when vulkan is disabled.
+
+use typedef to for missing vulkan struct is working to build without vulkan
+when vulkan is disabled.
+
+close gentoo bug #882065
+
+Signed-off-by: Zhang Ning <zhangn1985@outlook.com>
+---
+ src/include/libplacebo/vulkan.h | 19 ++++++++++++++++++-
+ src/vulkan/meson.build          |  3 +--
+ 2 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/src/include/libplacebo/vulkan.h b/src/include/libplacebo/vulkan.h
+index b8d43e2c..1a49d702 100644
+--- a/src/include/libplacebo/vulkan.h
++++ b/src/include/libplacebo/vulkan.h
+@@ -17,8 +17,25 @@
+ 
+ #ifndef LIBPLACEBO_VULKAN_H_
+ #define LIBPLACEBO_VULKAN_H_
+-
++#ifdef PL_HAVE_VULKAN
+ #include <vulkan/vulkan.h>
++#else
++typedef     int     VkInstance;
++typedef     int     PFN_vkGetInstanceProcAddr;
++typedef     void   *VkPhysicalDevice;
++typedef     int     VkDevice;
++typedef     int     VkPhysicalDeviceFeatures2;
++typedef     int     VkSurfaceKHR;
++typedef     int     VkQueueFlags;
++typedef     int     VkPresentModeKHR;
++typedef     int     VkImage;
++typedef     int     VkImageAspectFlags;
++typedef     int     VkFormat;
++typedef     int     VkImageUsageFlags;
++typedef     int     VkSemaphore;
++typedef     int     VkImageLayout;
++typedef     int     VkSemaphoreType;
++#endif
+ #include <libplacebo/gpu.h>
+ #include <libplacebo/swapchain.h>
+ 
+diff --git a/src/vulkan/meson.build b/src/vulkan/meson.build
+index 64c55728..1756d19e 100644
+--- a/src/vulkan/meson.build
++++ b/src/vulkan/meson.build
+@@ -26,9 +26,8 @@ components.set('vulkan', vulkan_build.allowed())
+ vulkan_link = vulkan_link.require(vulkan_loader.found() and vulkan_build.allowed())
+ components.set('vk-proc-addr', vulkan_link.allowed())
+ 
+-build_deps += vulkan_headers
+-
+ if vulkan_build.allowed()
++  build_deps += vulkan_headers
+   sources += [
+     'vulkan/command.c',
+     'vulkan/context.c',
+-- 
+2.47.2
+

--- a/media-libs/libplacebo/libplacebo-6.338.2-r1.ebuild
+++ b/media-libs/libplacebo/libplacebo-6.338.2-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit meson-multilib python-any-r1
 
 if [[ ${PV} == 9999 ]]; then
@@ -22,7 +22,7 @@ else
 		)
 	"
 	S="${WORKDIR}/${PN}-v${PV}"
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
@@ -38,11 +38,11 @@ LICENSE="
 "
 SLOT="0/$(ver_cut 2 ${PV}.9999)" # soname
 IUSE="
-	+lcms libdovi llvm-libunwind +opengl +shaderc test
+	glslang +lcms libdovi llvm-libunwind +opengl +shaderc test
 	unwind +vulkan +xxhash
 "
 RESTRICT="!test? ( test )"
-REQUIRED_USE="vulkan? ( shaderc )"
+REQUIRED_USE="vulkan? ( || ( glslang shaderc ) )"
 
 # dlopen: libglvnd (glad)
 RDEPEND="
@@ -50,30 +50,31 @@ RDEPEND="
 	libdovi? ( media-libs/libdovi:=[${MULTILIB_USEDEP}] )
 	opengl? ( media-libs/libglvnd[${MULTILIB_USEDEP}] )
 	shaderc? ( media-libs/shaderc[${MULTILIB_USEDEP}] )
+	!shaderc? ( glslang? ( dev-util/glslang:=[${MULTILIB_USEDEP}] ) )
 	unwind? (
-		llvm-libunwind? ( llvm-runtimes/libunwind[${MULTILIB_USEDEP}] )
+		llvm-libunwind? ( sys-libs/llvm-libunwind[${MULTILIB_USEDEP}] )
 		!llvm-libunwind? ( sys-libs/libunwind:=[${MULTILIB_USEDEP}] )
 	)
 	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 "
-# vulkan-headers is required even with USE=-vulkan for the stub (bug #882065)
 DEPEND="
 	${RDEPEND}
 	vulkan? ( dev-util/vulkan-headers)
 	xxhash? ( dev-libs/xxhash[${MULTILIB_USEDEP}] )
 "
 BDEPEND="
-	$(python_gen_any_dep 'dev-python/jinja2[${PYTHON_USEDEP}]')
+	$(python_gen_any_dep 'dev-python/jinja[${PYTHON_USEDEP}]')
 	virtual/pkgconfig
 "
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.229.1-llvm-libunwind.patch
+	"${FILESDIR}"/${PN}-5.229.1-python-executable.patch
 	"${FILESDIR}"/Don-t-require-vulkan-header-when-vulkan-is-disabled.patch
 )
 
 python_check_deps() {
-	python_has_version "dev-python/jinja2[${PYTHON_USEDEP}]"
+	python_has_version "dev-python/jinja[${PYTHON_USEDEP}]"
 }
 
 src_unpack() {
@@ -110,12 +111,10 @@ multilib_src_configure() {
 		$(meson_use test tests)
 		$(meson_feature lcms)
 		$(meson_feature libdovi)
-		# glslang has a history of breaking things and shaderc
-		# is the build system preferred alternative if available
-		-Dglslang=disabled
 		$(meson_feature opengl)
 		$(meson_feature opengl gl-proc-addr)
 		$(meson_feature shaderc)
+		$(usex shaderc -Dglslang=disabled $(meson_feature glslang))
 		$(meson_feature unwind)
 		$(meson_feature vulkan)
 		$(meson_feature vulkan vk-proc-addr)
@@ -124,14 +123,4 @@ multilib_src_configure() {
 	)
 
 	meson_src_configure
-}
-
-multilib_src_install() {
-	meson_src_install
-
-	# prevent vulkan from leaking into the .pc here for now (bug #951125)
-	if use !vulkan && has_version media-libs/vulkan-loader; then
-		sed -Ee '/^Requires/s/vulkan[^,]*,? ?//;s/, $//;/^Requires[^:]*: $/d' \
-			-i "${ED}"/usr/$(get_libdir)/pkgconfig/libplacebo.pc || die
-	fi
 }


### PR DESCRIPTION
add a patch to build libplacebo without vulkan header and remove vulkan_header when USE=-vulkan

Bug: https://bugs.gentoo.org/882065

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
