### PR TITLE
app-office/libreoffice: use slotted dep declaration for jdk

### DIFF
--- a/app-office/libreoffice/libreoffice-24.2.7.2-r1.ebuild
+++ b/app-office/libreoffice/libreoffice-24.2.7.2-r1.ebuild
@@ -239,7 +239,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg

--- a/app-office/libreoffice/libreoffice-24.2.7.2-r2.ebuild
+++ b/app-office/libreoffice/libreoffice-24.2.7.2-r2.ebuild
@@ -239,7 +239,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg

--- a/app-office/libreoffice/libreoffice-25.2.1.2-r1.ebuild
+++ b/app-office/libreoffice/libreoffice-25.2.1.2-r1.ebuild
@@ -242,7 +242,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg

--- a/app-office/libreoffice/libreoffice-25.2.1.2.ebuild
+++ b/app-office/libreoffice/libreoffice-25.2.1.2.ebuild
@@ -242,7 +242,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg

--- a/app-office/libreoffice/libreoffice-25.2.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-25.2.9999.ebuild
@@ -242,7 +242,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -234,7 +234,10 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXtst
 	java? (
 		dev-java/ant:0
-		>=virtual/jdk-17
+		|| (
+		   virtual/jdk:17
+		   virtual/jdk:21
+		)
 	)
 	test? (
 		app-crypt/gnupg


### PR DESCRIPTION
The build fails with Java 25. Therefore, introduce an upper bound for jdk by only allowing Java 17 and Java 21.

Closes: https://bugs.gentoo.org/951189