### PR TITLE
dev-python/pyroute2: drop pypy from PYTHON_COMPAT

### DIFF
--- a/dev-python/pyroute2/pyroute2-0.8.1.ebuild
+++ b/dev-python/pyroute2/pyroute2-0.8.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="sqlite"
 
 inherit distutils-r1 pypi


### PR DESCRIPTION
Not sure why it was ever added, upstream makes no statements on its support status. Dropping it means we also do not have to deal with pypy3.11 and other future versions.
Can be re-added on user request.

Closes: https://bugs.gentoo.org/951027

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
