### PR TITLE
dev-util/nvidia-cuda-toolkit: Fix checking for build time python deps

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.0-r3.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.0-r3.ebuild
@@ -119,6 +119,10 @@ pkg_pretend() {
 pkg_setup() {
 	cuda-toolkit_check_reqs
 
+	if [[ "${MERGE_TYPE}" == binary ]]; then
+		return
+	fi
+
 	# we need python for manifest parsing and to determine the supported python versions for cuda-gdb
 	python_setup
 


### PR DESCRIPTION
Binary packages would fail to emerge as the ebuild would check for the build time dependency dev-python/defusedxml in non build time functions with python_setup.

Not sure if we want to revision bump for this fix, but at least it is easy to see what I changed at this point.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
