### PR TITLE
dev-lang/haxe: fix building with musl

### DIFF
--- a/dev-lang/haxe/haxe-4.3.6-r2.ebuild
+++ b/dev-lang/haxe/haxe-4.3.6-r2.ebuild
@@ -28,7 +28,7 @@ RESTRICT="strip"
 RDEPEND="
 	<=dev-ml/extlib-1.7.9:=
 	>=dev-lang/ocaml-4:=[ocamlopt?]
-	~dev-ml/luv-0.5.14:=
+	>=dev-ml/luv-0.5.12:=
 
 	dev-ml/ocaml-sha:=
 	dev-ml/ptmap:=

--- a/dev-lang/haxe/haxe-4.3.6-r2.ebuild
+++ b/dev-lang/haxe/haxe-4.3.6-r2.ebuild
@@ -28,7 +28,7 @@ RESTRICT="strip"
 RDEPEND="
 	<=dev-ml/extlib-1.7.9:=
 	>=dev-lang/ocaml-4:=[ocamlopt?]
-	>=dev-ml/luv-0.5.12:=
+	>=dev-ml/luv-0.5.13:=
 
 	dev-ml/ocaml-sha:=
 	dev-ml/ptmap:=

--- a/dev-lang/haxe/haxe-4.3.6-r2.ebuild
+++ b/dev-lang/haxe/haxe-4.3.6-r2.ebuild
@@ -28,7 +28,7 @@ RESTRICT="strip"
 RDEPEND="
 	<=dev-ml/extlib-1.7.9:=
 	>=dev-lang/ocaml-4:=[ocamlopt?]
-	~dev-ml/luv-0.5.12:=
+	~dev-ml/luv-0.5.14:=
 
 	dev-ml/ocaml-sha:=
 	dev-ml/ptmap:=


### PR DESCRIPTION
The version of `luv` this package required can't be built with musl.
Fixed the issue by bumping the version requirement.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
