### PR TITLE
dev-lang/rust: update experimental targets check

### DIFF
--- a/dev-lang/rust/rust-1.84.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.0-r1.ebuild
@@ -40,8 +40,11 @@ ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
 LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 # https://github.com/rust-lang/llvm-project/blob/rustc-1.84.0/llvm/CMakeLists.txt
-_ALL_LLVM_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
-ALL_LLVM_EXPERIMENTAL_TARGETS=( )
+_ALL_RUST_EXPERIMENTAL_TARGETS=( ARC CSKY DirectX M68k SPIRV Xtensa )
+declare -A ALL_RUST_EXPERIMENTAL_TARGETS
+for _x in "${_ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+	ALL_RUST_EXPERIMENTAL_TARGETS["llvm_targets_${_x}"]=0
+done
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 SLOT="${PV}"
@@ -52,12 +55,9 @@ LLVM_DEPEND=()
 # splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
 for _x in "${ALL_LLVM_TARGETS[@]}"; do
 	LLVM_DEPEND+=( "	${_x}? ( $(llvm_gen_dep "llvm-core/llvm:\${LLVM_SLOT}[${_x}]") )" )
-	for _xx in "${_ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if [[ "${_xx}" == "${_x}" ]] ; then
-			ALL_LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
-			break
-		fi
-	done
+	if [[ -v ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"] ]] ; then
+		ALL_RUST_EXPERIMENTAL_TARGETS["${_x}"]=1
+	fi
 done
 LLVM_DEPEND+=( "	wasm? ( $(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}') )" )
 LLVM_DEPEND+=( "	$(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}')" )
@@ -279,13 +279,13 @@ src_configure() {
 	rust_build="$(rust_abi "${CBUILD}")"
 	rust_host="$(rust_abi "${CHOST}")"
 
-	LLVM_EXPERIMENTAL_TARGETS=()
-	for _x in "${ALL_LLVM_EXPERIMENTAL_TARGETS[@]}"; do
-		if use llvm_targets_${_x} ; then
-			LLVM_EXPERIMENTAL_TARGETS+=( ${_x} )
+	RUST_EXPERIMENTAL_TARGETS=()
+	for _x in "${!ALL_RUST_EXPERIMENTAL_TARGETS[@]}"; do
+		if [[ ${ALL_RUST_EXPERIMENTAL_TARGETS[${_x}]} == 1 ]] && use ${_x} ; then
+			RUST_EXPERIMENTAL_TARGETS+=( ${_x#llvm_targets_} )
 		fi
 	done
-	LLVM_EXPERIMENTAL_TARGETS=${LLVM_EXPERIMENTAL_TARGETS[@]}
+	RUST_EXPERIMENTAL_TARGETS=${RUST_EXPERIMENTAL_TARGETS[@]}
 
 	local cm_btype="$(usex debug DEBUG RELEASE)"
 	cat <<- _EOF_ > "${S}"/config.toml
@@ -298,7 +298,7 @@ src_configure() {
 		assertions = $(toml_usex debug)
 		ninja = true
 		targets = "${LLVM_TARGETS// /;}"
-		experimental-targets = "${LLVM_EXPERIMENTAL_TARGETS// /;}"
+		experimental-targets = "${RUST_EXPERIMENTAL_TARGETS// /;}"
 		link-shared = $(toml_usex system-llvm)
 		$(if is_libcxx_linked; then
 			# https://bugs.gentoo.org/732632


### PR DESCRIPTION
apply patch in commit c81a596be7fa480e369c0ce7464f92e45e332610 which is applied before revert of rust-1.84.0-r1

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
