### PR TITLE
llvm-runtimes/compiler-rt: create libatomic.a if atomic-builtins enabled

### DIFF
--- a/llvm-runtimes/libatomic-stub/libatomic-stub-0.ebuild
+++ b/llvm-runtimes/libatomic-stub/libatomic-stub-0.ebuild
@@ -1,0 +1,25 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Stub library which allows compiler-rt to replace libatomic"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+S="${WORKDIR}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+
+RDEPEND="
+	llvm-runtimes/compiler-rt[atomic-builtins(-)]
+	!sys-devel/gcc
+"
+
+src_install() {
+	# Create an empty library, so that -latomic will not fail.
+	# The atomic routines will be provided implicitly by the compiler-rt
+	# builtins library.
+	${AR} rc libatomic.a || die
+	dolib.a libatomic.a
+}

--- a/llvm-runtimes/libatomic-stub/metadata.xml
+++ b/llvm-runtimes/libatomic-stub/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person" proxied="yes">
+        <email>mojyack@gmail.com</email>
+        <name>mojyack</name>
+    </maintainer>
+    <maintainer type="project">
+        <email>llvm@gentoo.org</email>
+    </maintainer>
+    <maintainer type="project" proxied="proxy">
+        <email>proxy-maint@gentoo.org</email>
+        <name>Proxy Maintainers</name>
+    </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
**(I'll create proper rev-bumped commit once this method is approved)**

Clang(LLVM) implements atomic functions in compiler-rt, while GCC provides a dedicated libatomic for it.
Some apps such as nodejs erroneously depend on GCC through libatomic. LLVM's atomic builtins and libatomic are source-compatible so such packages should be also buildable with LLVM.
It would be hard to fix all those packages, so let's deal with it on compiler-rt side by installing a stub libatomic.a.

Bug: https://bugs.gentoo.org/911340

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
