### PR TITLE
dev-cpp/elfio: fix build with gcc 15, remove CMake variable

### DIFF
--- a/dev-cpp/elfio/elfio-3.12.ebuild
+++ b/dev-cpp/elfio/elfio-3.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,11 +20,11 @@ DEPEND="test? ( dev-cpp/gtest )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.12-gnuinstalldirs-docdir.patch
+	"${FILESDIR}"/${PN}-3.12-gcc15.patch
 )
 
 src_configure() {
 	local mycmakeargs=(
-		-DFETCHCONTENT_FULLY_DISCONNECTED=ON
 		-DELFIO_BUILD_TESTS=$(usex test)
 	)
 

--- a/dev-cpp/elfio/files/elfio-3.12-gcc15.patch
+++ b/dev-cpp/elfio/files/elfio-3.12-gcc15.patch
@@ -1,0 +1,24 @@
+https://bugs.gentoo.org/937460
+
+From 34d2c64237bb40f09879e7421db120e50e7e2923 Mon Sep 17 00:00:00 2001
+From: Orion Poplawski <orion@nwra.com>
+Date: Fri, 31 Jan 2025 20:22:26 -0700
+Subject: [PATCH] Add missing #include <stdint.h> for gcc 15
+
+---
+ elfio/elf_types.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/elfio/elf_types.hpp b/elfio/elf_types.hpp
+index 3a6850a..cd9aa7f 100644
+--- a/elfio/elf_types.hpp
++++ b/elfio/elf_types.hpp
+@@ -23,6 +23,8 @@ THE SOFTWARE.
+ #ifndef ELFTYPES_H
+ #define ELFTYPES_H
+ 
++#include <stdint.h>
++
+ #ifdef __cplusplus
+ namespace ELFIO {
+ #endif


### PR DESCRIPTION
Backport upstream commit [1] to fix build with gcc 15 and get rid of CMake variable that is obsolete and is not getting used.

[1] https://github.com/serge1/ELFIO/commit/34d2c64

Closes: https://bugs.gentoo.org/881859
Closes: https://bugs.gentoo.org/937460

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
