### PR TITLE
autotools.eclass: add slibtool dir for aclocal

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -378,7 +378,14 @@ eaclocal() {
 	# See bug #677002
 	if [[ ! -f "${T}"/aclocal/dirlist ]] ; then
 		mkdir "${T}"/aclocal || die
-		cat <<- EOF > "${T}"/aclocal/dirlist || die
+		if [[ "${LIBTOOLIZE:-}" == 'slibtoolize' ]]; then
+			cat <<- EOF > "${T}"/aclocal/dirlist || die
+				${BROOT}/usr/share/slibtool
+				${ESYSROOT}/usr/share/slibtool
+			EOF
+		fi
+
+		cat <<- EOF >> "${T}"/aclocal/dirlist || die
 			${BROOT}/usr/share/aclocal
 			${ESYSROOT}/usr/share/aclocal
 		EOF


### PR DESCRIPTION
I also sent this to the ML and created this PR so it can be linked to the issue.

---

When using slibtoolize it needs the /usr/share/slibtool/slibtool.m4 file to properly create the configure script. The current method of using it is to set AT_SYS_M4DIR in make.conf, while this works for most cases it does not work for app-crypt/tpm2-tss which uses ACLOCAL_AMFLAGS with the '--install' argument in Makefile.am which results in it trying to install .m4 files to /usr/share/slibtool. This thankfully fails due to sandbox.

To solve this problem the /usr/share/slibtool path can be directly added to "${T}"/aclocal/dirlist if the LIBTOOLIZE variable is set to 'slibtoolize'.

Closes: https://bugs.gentoo.org/950648

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
