### PR TITLE
games-emulation/dolphin: add missing X USE flag for dev-qt/qtbase, #951303

### DIFF
--- a/games-emulation/dolphin/dolphin-2407-r1.ebuild
+++ b/games-emulation/dolphin/dolphin-2407-r1.ebuild
@@ -96,7 +96,7 @@ RDEPEND="
 	)
 	ffmpeg? ( media-video/ffmpeg:= )
 	gui? (
-		dev-qt/qtbase:6[gui,widgets]
+		dev-qt/qtbase:6[X,gui,widgets]
 		dev-qt/qtsvg:6
 	)
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )

--- a/games-emulation/dolphin/dolphin-2412-r1.ebuild
+++ b/games-emulation/dolphin/dolphin-2412-r1.ebuild
@@ -95,7 +95,7 @@ RDEPEND="
 	)
 	ffmpeg? ( media-video/ffmpeg:= )
 	gui? (
-		dev-qt/qtbase:6[gui,widgets]
+		dev-qt/qtbase:6[X,gui,widgets]
 		dev-qt/qtsvg:6
 	)
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )

--- a/games-emulation/dolphin/dolphin-2503.ebuild
+++ b/games-emulation/dolphin/dolphin-2503.ebuild
@@ -95,7 +95,7 @@ RDEPEND="
 	)
 	ffmpeg? ( media-video/ffmpeg:= )
 	gui? (
-		dev-qt/qtbase:6[gui,widgets]
+		dev-qt/qtbase:6[X,gui,widgets]
 		dev-qt/qtsvg:6
 	)
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )

--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -95,7 +95,7 @@ RDEPEND="
 	)
 	ffmpeg? ( media-video/ffmpeg:= )
 	gui? (
-		dev-qt/qtbase:6[gui,widgets]
+		dev-qt/qtbase:6[X,gui,widgets]
 		dev-qt/qtsvg:6
 	)
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )


### PR DESCRIPTION
As noticed in commit in upstream[0], Wayland is not fully supported yet, it requires XCB so it needs `dev-qt/qtbase[X,…]`.

0: https://github.com/dolphin-emu/dolphin/commit/a3b06b0572d7a16d8ede9c849e9f549a283123df

Closes: https://bugs.gentoo.org/951303

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
