### PR TITLE
gnome-extra/gnome-tweaks: enable py3.13

### DIFF
--- a/gnome-extra/gnome-tweaks/gnome-tweaks-46.1-r1.ebuild
+++ b/gnome-extra/gnome-tweaks/gnome-tweaks-46.1-r1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit gnome.org gnome2-utils meson python-single-r1 xdg
 


### PR DESCRIPTION
Adds support for python 3.13 for `gnome-extra/gnome-tweaks`.

I just updated an existing ebuild, but if you want me to do so, I can create a new one.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
