### PR TITLE
app-admin/sud: port to C23, mask on musl, add license for init script

### DIFF
--- a/app-admin/sud/files/sud-1.3-c23.patch
+++ b/app-admin/sud/files/sud-1.3-c23.patch
@@ -1,0 +1,97 @@
+Fix signal handler function types, switch to canonical way to put time
+into utmp struct.
+https://bugs.gentoo.org/919361
+--- a/login/login.c
++++ b/login/login.c
+@@ -90,7 +90,7 @@
+ #endif
+ 
+ RETSIGTYPE
+-sig_int()
++sig_int(int ignored) //signal handler, parameter ignored
+ {
+ 	return;
+ }
+--- a/su/su.c
++++ b/su/su.c
+@@ -76,7 +76,7 @@
+ }
+ 
+ RETSIGTYPE
+-sig_winch()
++sig_winch(int ignored) //sighandler, argument is ignored
+ {
+ 	int saved_errno = errno;
+ 
+--- a/sud/main.c
++++ b/sud/main.c
+@@ -63,17 +63,17 @@
+ static void sud_opts(int, char **);
+ static void usage(char *);
+ static int sud_dispatch(int);
+-static RETSIGTYPE sud_sigchld();
+-static RETSIGTYPE sud_sighup();
++static RETSIGTYPE sud_sigchld(int);
++static RETSIGTYPE sud_sighup(int);
+ 
+ static RETSIGTYPE
+-sud_sigchld()
++sud_sigchld(int ignored) //signal handler, parameter ignored
+ {
+ 	have_sigchld = 1;
+ }
+ 
+ static RETSIGTYPE
+-sud_sighup()
++sud_sighup(int ignored) //signal handler, parameter ignored
+ {
+ 	have_sighup++;
+ }
+--- a/sud/service.c
++++ b/sud/service.c
+@@ -54,7 +54,7 @@
+ static int 	sun_desc;
+ static int 	pipechld[2] 	= { -1, -1 };
+ 
+-static RETSIGTYPE	service_sigchld();
++static RETSIGTYPE	service_sigchld(int);
+ 
+ int
+ service_init(struct conf *cfp)
+@@ -107,7 +107,7 @@
+ }
+ 
+ static RETSIGTYPE
+-service_sigchld()
++service_sigchld(int ignored) //signal handler, value ignored
+ {
+ 	int saved_errno = errno;
+ 
+--- a/sud/interactive.c
++++ b/sud/interactive.c
+@@ -68,10 +68,10 @@
+ static int pipechld[2] = { -1, -1 };
+ 
+ static int select_fd(struct conf *, int, int, int, int);
+-static RETSIGTYPE sig_chld(); 
++static RETSIGTYPE sig_chld(int); 
+ 
+ static RETSIGTYPE
+-sig_chld()
++sig_chld(int ignored) //sighandler, parameter ignored
+ {
+ 	int saved_errno = errno;
+ 
+@@ -317,8 +317,10 @@
+ 		if (cfp->uthost)
+ 			(void)strncpy(ut.ut_host, cfp->uthost, 
+ 				sizeof(ut.ut_host));
+-	
+-		(void)time(&ut.ut_time);	
++		struct timeval tv;
++		gettimeofday(&tv, NULL);
++		ut.ut_tv.tv_sec = tv.tv_sec;
++		ut.ut_tv.tv_usec = tv.tv_usec;
+ 	}
+ 
+         /*

--- a/app-admin/sud/sud-1.3-r3.ebuild
+++ b/app-admin/sud/sud-1.3-r3.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="A daemon to execute processes with special privileges in a nosuid environment"
+HOMEPAGE="https://s0ftpj.org/projects/sud/index.htm"
+SRC_URI="https://s0ftpj.org/projects/sud/${P}.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="elibc_musl? ( sys-libs/queue-standalone )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3-fix-build-system.patch
+	"${FILESDIR}"/${PN}-1.3-use-system-queue.patch
+	"${FILESDIR}"/${PN}-1.3-c23.patch
+)
+
+src_prepare() {
+	default
+
+	# bug #713470
+	rm sud/queue.h || die
+
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags -D_GNU_SOURCE
+	default
+}
+
+src_install() {
+	default
+
+	doman ilogin.1 sud.1 suz.1
+	insinto /etc
+	doins miscs/sud.conf*
+	newinitd "${FILESDIR}"/sud.rc6 sud
+}

--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# NHOrus <jy6x2b32pie9@yahoo.com> (2025-03-13)
+# uses functions musl will not implement, bug #942215
+app-admin/sud
+
 # NHOrus <jy6x2b32pie9@yahoo.com> (2025-02-01)
 # not ported to musl, bug #713434
 app-crypt/mit-krb5-appl


### PR DESCRIPTION
Package is bsd-licensed, init script is gpl-2 licensed, added GPL-2 into license line.
Ported to C23 -corrected wrong signal handler signatures, used canonical way to insert time into utmp structure.
Masked on musl in separate commit - login() function to register login in utmp logs is one of features muls is not implementing.


Closes: https://bugs.gentoo.org/942215
Closes: https://bugs.gentoo.org/830075
Closes: https://bugs.gentoo.org/425874
Closes: https://bugs.gentoo.org/919361
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
