### PR TITLE
games-emulation/dolphin: set explicit `CUBEB` cmake argument

### DIFF
--- a/games-emulation/dolphin/dolphin-2503.ebuild
+++ b/games-emulation/dolphin/dolphin-2503.ebuild
@@ -208,6 +208,7 @@ src_configure() {
 		-DENABLE_AUTOUPDATE=OFF
 		-DENABLE_BLUEZ=$(usex bluetooth)
 		-DENABLE_CLI_TOOL=ON
+		-DENABLE_CUBEB=ON
 		-DENABLE_EGL=$(usex egl)
 		-DENABLE_EVDEV=$(usex evdev)
 		-DENABLE_LLVM=$(usex llvm)

--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -208,6 +208,7 @@ src_configure() {
 		-DENABLE_AUTOUPDATE=OFF
 		-DENABLE_BLUEZ=$(usex bluetooth)
 		-DENABLE_CLI_TOOL=ON
+		-DENABLE_CUBEB=ON
 		-DENABLE_EGL=$(usex egl)
 		-DENABLE_EVDEV=$(usex evdev)
 		-DENABLE_LLVM=$(usex llvm)

--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -22,12 +22,12 @@ if [[ ${PV} == *9999 ]]; then
 	)
 else
 	MGBA_COMMIT=8739b22fbc90fdf0b4f6612ef9c0520f0ba44a51
-	IMPLOT_COMMIT=cc5e1daa5c7f2335a9460ae79c829011dc5cef2d
+	IMPLOT_COMMIT=18c72431f8265e2b0b5378a3a73d8a883b2175ff
 	TINYGLTF_COMMIT=c5641f2c22d117da7971504591a8f6a41ece488b
-	VULKAN_HEADERS_COMMIT=05fe2cc910a68c9ba5dac07db46ef78573acee72
-	VULKANMEMORYALLOCATOR_COMMIT=009ecd192c1289c7529bff248a16cfe896254816
+	VULKAN_HEADERS_COMMIT=39f924b810e561fd86b2558b6711ca68d4363f68
+	VULKANMEMORYALLOCATOR_COMMIT=3bab6924988e5f19bf36586a496156cf72f70d9f
 	ZLIB_NG_COMMIT=ce01b1e41da298334f8214389cc9369540a7560f
-	MINIZIP_NG_COMMIT=3eed562ef0ea3516db30d1c8ecb0e1b486d8cb70
+	MINIZIP_NG_COMMIT=55db144e03027b43263e5ebcb599bf0878ba58de
 	SRC_URI="
 		https://github.com/dolphin-emu/dolphin/archive/${PV}.tar.gz
 			-> ${P}.tar.gz
@@ -101,7 +101,7 @@ RDEPEND="
 	llvm? ( $(llvm_gen_dep 'llvm-core/llvm:${LLVM_SLOT}=') )
 	profile? ( dev-util/oprofile )
 	pulseaudio? ( media-libs/libpulse )
-	sdl? ( media-libs/libsdl2 )
+	sdl? ( >=media-libs/libsdl2-2.30.9 )
 	systemd? ( sys-apps/systemd:0= )
 	upnp? ( net-libs/miniupnpc:= )
 "


### PR DESCRIPTION
Misc commits.

See upstream commit:
> CMakeLists: Add flag to disable Cubeb
> d89e7c84fbd938dc9f2265363334ec46c4cb321f
https://github.com/dolphin-emu/dolphin/commit/d89e7c84fbd938dc9f2265363334ec46c4cb321f

And update 9999 from 2503 release.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
