### PR TITLE
app-shells/fish: avoid unnecessary rebuild, fix linker error with gcc due to rebuild

### DIFF
--- a/app-shells/fish/files/fish-4.0.1-use-cargo-eclass-for-build.patch
+++ b/app-shells/fish/files/fish-4.0.1-use-cargo-eclass-for-build.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 496226e89..cb032d6d5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,17 +51,6 @@ function(CREATE_TARGET target)
+   add_custom_target(
+     ${target} ALL
+     COMMAND
+-      "${CMAKE_COMMAND}" -E
+-        env ${VARS_FOR_CARGO}
+-          ${Rust_CARGO}
+-            build --bin ${target}
+-            $<$<CONFIG:Release>:--release>
+-            $<$<CONFIG:RelWithDebInfo>:--profile=release-with-debug>
+-            --target ${Rust_CARGO_TARGET}
+-            --no-default-features
+-            ${CARGO_FLAGS}
+-            ${FEATURES_ARG}
+-      &&
+       "${CMAKE_COMMAND}" -E
+         copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
+     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+diff --git a/cmake/Rust.cmake b/cmake/Rust.cmake
+index 40887be45..fa0f7ab6f 100644
+--- a/cmake/Rust.cmake
++++ b/cmake/Rust.cmake
+@@ -5,7 +5,7 @@ set(Rust_RESOLVE_RUSTUP_TOOLCHAINS Off)
+ include(FindRust)
+ find_package(Rust REQUIRED)
+ 
+-set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo/build")
++set(FISH_RUST_BUILD_DIR "${CMAKE_SOURCE_DIR}/target")
+ 
+ if(DEFINED ASAN)
+     list(APPEND CARGO_FLAGS "-Z" "build-std")
+@@ -22,8 +22,8 @@ else()
+     set(rust_target_dir "${FISH_RUST_BUILD_DIR}/${Rust_CARGO_HOST_TARGET}")
+ endif()
+ 
+-set(rust_profile $<IF:$<CONFIG:Debug>,debug,$<IF:$<CONFIG:RelWithDebInfo>,release-with-debug,release>>)
+-set(rust_debugflags "$<$<CONFIG:Debug>:-g>$<$<CONFIG:RelWithDebInfo>:-g>")
++set(rust_profile $<IF:$<CONFIG:Debug>,debug,release>)
++set(rust_debugflags "$<$<CONFIG:Debug>:-g>")
+ 
+ 
+ # Temporary hack to propogate CMake flags/options to build.rs. We need to get CMake to evaluate the

--- a/app-shells/fish/files/fish-9999-use-cargo-eclass-for-build.patch
+++ b/app-shells/fish/files/fish-9999-use-cargo-eclass-for-build.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0510cd2d7..c49f80d69 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,17 +41,6 @@ function(CREATE_TARGET target)
+   add_custom_target(
+     ${target} ALL
+     COMMAND
+-      "${CMAKE_COMMAND}" -E
+-        env ${VARS_FOR_CARGO}
+-          ${Rust_CARGO}
+-            build --bin ${target}
+-            $<$<CONFIG:Release>:--release>
+-            $<$<CONFIG:RelWithDebInfo>:--profile=release-with-debug>
+-            --target ${Rust_CARGO_TARGET}
+-            --no-default-features
+-            ${CARGO_FLAGS}
+-            ${FEATURES_ARG}
+-      &&
+       "${CMAKE_COMMAND}" -E
+         copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
+     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+diff --git a/cmake/Rust.cmake b/cmake/Rust.cmake
+index c5bb1b1b3..618b47183 100644
+--- a/cmake/Rust.cmake
++++ b/cmake/Rust.cmake
+@@ -5,7 +5,7 @@ set(Rust_RESOLVE_RUSTUP_TOOLCHAINS Off)
+ include(FindRust)
+ find_package(Rust 1.70 REQUIRED)
+ 
+-set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo/build")
++set(FISH_RUST_BUILD_DIR "${CMAKE_SOURCE_DIR}/target")
+ 
+ if(DEFINED ASAN)
+     list(APPEND CARGO_FLAGS "-Z" "build-std")
+@@ -22,8 +22,8 @@ else()
+     set(rust_target_dir "${FISH_RUST_BUILD_DIR}/${Rust_CARGO_HOST_TARGET}")
+ endif()
+ 
+-set(rust_profile $<IF:$<CONFIG:Debug>,debug,$<IF:$<CONFIG:RelWithDebInfo>,release-with-debug,release>>)
+-set(rust_debugflags "$<$<CONFIG:Debug>:-g>$<$<CONFIG:RelWithDebInfo>:-g>")
++set(rust_profile $<IF:$<CONFIG:Debug>,debug,release>)
++set(rust_debugflags "$<$<CONFIG:Debug>:-g>")
+ 
+ 
+ # Temporary hack to propagate CMake flags/options to build.rs. We need to get CMake to evaluate the

--- a/app-shells/fish/fish-4.0.1.ebuild
+++ b/app-shells/fish/fish-4.0.1.ebuild
@@ -10,7 +10,7 @@ declare -A GIT_CRATES=(
 	[pcre2]='https://github.com/fish-shell/rust-pcre2;85b7afba1a9d9bd445779800e5bcafeb732e4421;rust-pcre2-%commit%'
 )
 
-inherit cargo cmake multiprocessing readme.gentoo-r1 xdg
+inherit cargo cmake readme.gentoo-r1 xdg
 
 DESCRIPTION="Friendly Interactive SHell"
 HOMEPAGE="https://fishshell.com/"
@@ -60,7 +60,6 @@ src_unpack() {
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_SYSCONFDIR="${EPREFIX}/etc"
-		-DCTEST_PARALLEL_LEVEL="$(makeopts_jobs)"
 		-DINSTALL_DOCS="$(usex doc)"
 	)
 	cargo_src_configure --no-default-features \
@@ -99,8 +98,6 @@ src_compile() {
 
 src_test() {
 	local -x CARGO_TERM_COLOR=always
-	local -x FISH_SOURCE_DIR="${S}"
-	local -x FISH_FORCE_COLOR=1
 	local -x TEST_VERBOSE=1
 	cargo_env cmake_src_test -R cargo-test
 }

--- a/app-shells/fish/fish-4.0.1.ebuild
+++ b/app-shells/fish/fish-4.0.1.ebuild
@@ -46,6 +46,10 @@ BDEPEND="
 # Release tarballs contain prebuilt documentation.
 [[ ${PV} == 9999 ]] && BDEPEND+=" doc? ( dev-python/sphinx )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.1-use-cargo-eclass-for-build.patch"
+)
+
 QA_FLAGS_IGNORED="usr/bin/.*"
 
 src_unpack() {
@@ -86,14 +90,6 @@ src_compile() {
 	fi
 
 	cargo_src_compile
-
-	# Copy built binaries into the cmake build directory to mark the targets
-	# up-to-date in cmake.
-	for target in fish fish_indent fish_key_reader; do
-		cp "$(cargo_target_dir)/${target}" "${BUILD_DIR}" || die
-	done
-
-	cmake_src_compile
 }
 
 src_test() {

--- a/app-shells/fish/fish-9999.ebuild
+++ b/app-shells/fish/fish-9999.ebuild
@@ -50,6 +50,10 @@ BDEPEND="
 # Release tarballs contain prebuilt documentation.
 [[ ${PV} == 9999 ]] && BDEPEND+=" doc? ( dev-python/sphinx )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-9999-use-cargo-eclass-for-build.patch"
+)
+
 QA_FLAGS_IGNORED="usr/bin/.*"
 
 python_check_deps() {
@@ -101,14 +105,6 @@ src_compile() {
 	fi
 
 	cargo_src_compile
-
-	# Copy built binaries into the cmake build directory to mark the targets
-	# up-to-date in cmake.
-	for target in fish fish_indent fish_key_reader; do
-		cp "$(cargo_target_dir)/${target}" "${BUILD_DIR}" || die
-	done
-
-	cmake_src_compile
 }
 
 src_test() {
@@ -129,7 +125,6 @@ src_test() {
 
 	# Enable colored output for building tests.
 	local -x CARGO_TERM_COLOR=always
-	# TODO: Figure out why we link again.
 	cargo_env cmake_build fish_run_tests
 }
 


### PR DESCRIPTION
Previously `cmake_src_compile` choose it's cargo output dir to be `${CMAKE_BINARY_DIR}/cargo/build/` and cargo.eclass choose it's output dir to be "${S}/target". This lead to cargo, invoked by cmake, finding an empty out dir and rebuilding everything. This also lead to link failures (undefined references) with gcc.

I bet we could get away with ignoring `cmake_src_compile` all together but this needs more investigation. At the moment it is used to copy the binaries into `${CMAKE_SOURCE_DIR}`

^^^
This should probably go into the commit message if this is an acceptable solution.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
