### PR TITLE
metadata: add BlueOak-1.0.0 to license-mapping

### DIFF
--- a/metadata/license-mapping.conf
+++ b/metadata/license-mapping.conf
@@ -35,6 +35,7 @@ Artistic-1.0-cl8 = Artistic
 Artistic-1.0-Perl = Artistic
 Artistic-2.0 = Artistic-2
 Beerware = BEER-WARE
+BlueOak-1.0.0 = BlueOak-1.0.0
 BSD-1-Clause = BSD-1
 BSD-2-Clause = BSD-2
 BSD-2-Clause-Patent = BSD-2-with-patent


### PR DESCRIPTION
Simple pr to add BlueOak-1.0.0 to license-mapping
https://github.com/projg2/pycargoebuild/issues/35

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
