### PR TITLE
x11-plugins/wmmand: port to C23

### DIFF
--- a/x11-plugins/wmmand/files/wmmand-1.3.2-gcc-15.patch
+++ b/x11-plugins/wmmand/files/wmmand-1.3.2-gcc-15.patch
@@ -1,0 +1,75 @@
+Port to C23, minimal fix to enable rudimentary test
+Correct function declaration, use correct type for Window:
+X expects that it's value everywhere, with pointer already inside
+Return 0 when asked for help, not default 1
+https://bugs.gentoo.org/943913
+https://bugs.gentoo.org/880965
+--- a/wmgeneral/wmgeneral.c
++++ b/wmgeneral/wmgeneral.c
+@@ -46,7 +46,7 @@
+ char		*Geometry = "";
+ Pixmap		pixmask;
+ Display		*display;
+-Window		*Root;
++Window		Root;
+ int			d_depth;
+ GC			NormalGC;
+ XpmIcon		wmgen;
+--- a/wmgeneral/wmgeneral.h
++++ b/wmgeneral/wmgeneral.h
+@@ -29,7 +29,7 @@
+ /*******************/
+ 
+ extern Display	*display;
+-extern Window	*Root;
++extern Window	Root;
+ extern int		d_depth;
+ extern GC		NormalGC;
+ extern XpmIcon	wmgen;
+--- a/wmMand/wmMand.c
++++ b/wmMand/wmMand.c
+@@ -124,8 +124,10 @@
+ int maxIterations;
+ LargeViewer largeViewProg = LARGEVIEWER_IM;
+ 
+-int WriteGIF();
+-
++typedef unsigned char byte;
++int WriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap,
++                byte *gmap, byte *bmap, int numcols, int colorstyle,
++                char *comment);
+ 
+ /*
+  *	 main
+--- a/wmMand/xvgifwr.c
++++ b/wmMand/xvgifwr.c
+@@ -78,14 +78,9 @@
+ 
+ 
+ /*************************************************************/
+-int WriteGIF(fp, pic, ptype, w, h, rmap, gmap, bmap, numcols, colorstyle,
+-	     comment)
+-     FILE *fp;
+-     byte *pic;
+-     int   ptype, w,h;
+-     byte *rmap, *gmap, *bmap;
+-     int   numcols, colorstyle;
+-     char *comment;
++int WriteGIF(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap,
++		byte *gmap, byte *bmap, int numcols, int colorstyle,
++		char *comment)
+ {
+   int   RWidth, RHeight;
+   int   LeftOfs, TopOfs;
+--- a/wmMand/wmMand.c
++++ b/wmMand/wmMand.c
+@@ -392,6 +392,9 @@
+ 			printf("\t\E[1m-d, --delayzoom <number>\E[m\n\t\tset delay for autozooming with mouse (default %d, larger values give longer delay). Dependent on CPU cycle availability\n", autoZoomDelay);
+ 			printf("\t\E[1m-x, --xv\E[m\n\t\tuse xv to display large image instead of ImageMagic's display program\n");
+ 			printf("\t\E[1m-h, --help\E[m\n\t\tdisplay help screen\n");
++			if (!strcmp(argv[i], "--help") || !strcmp(argv[i] , "-h")) {
++				exit(0);
++			}
+ 			exit(1);
+ 		}
+ 	}

--- a/x11-plugins/wmmand/wmmand-1.3.2-r2.ebuild
+++ b/x11-plugins/wmmand/wmmand-1.3.2-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop toolchain-funcs edo
+
+MY_P="wmMand-${PV}"
+
+DESCRIPTION="a dockable mandelbrot browser"
+HOMEPAGE="https://sourceforge.net/projects/wmmand/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}/wmMand"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=( ../{BUGS,changelog,TODO} )
+
+src_prepare() {
+	default
+	gunzip wmMand.6.gz || die
+
+	pushd "${WORKDIR}"/${MY_P} || die
+	eapply "${FILESDIR}"/${P}-gcc-10.patch
+	eapply "${FILESDIR}"/${P}-gcc-15.patch
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" \
+		SYSTEM="${LDFLAGS}" \
+		INCDIR="" LIBDIR=""
+}
+
+src_test() {
+	edo "${S}"/wmMand -h
+}
+
+src_install() {
+	dobin wmMand
+	doman wmMand.6
+	doicon wmMand.png
+	einstalldocs
+}


### PR DESCRIPTION
Patch conditions to enable rudimentary test
Correct X.Org handle type, correct function declaration to use full type.

Closes: https://bugs.gentoo.org/880965
Closes: https://bugs.gentoo.org/943913

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
