### PR TITLE
systemd.eclass: silence pkg-config output

### DIFF
--- a/eclass/systemd.eclass
+++ b/eclass/systemd.eclass
@@ -1,4 +1,4 @@
-# Copyright 2011-2024 Gentoo Authors
+# Copyright 2011-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: systemd.eclass
@@ -50,7 +50,7 @@ _systemd_get_dir() {
 	# https://github.com/pkgconf/pkgconf/issues/205
 	local -x PKG_CONFIG_FDO_SYSROOT_RULES=1
 
-	if $(tc-getPKG_CONFIG) --exists systemd; then
+	if $(tc-getPKG_CONFIG) --exists systemd >/dev/null 2>&1; then
 		d=$($(tc-getPKG_CONFIG) --variable="${variable}" systemd) || die
 	else
 		d="${EPREFIX}${fallback}"


### PR DESCRIPTION
otherwise it prints "not found" error messages unnecessary for openrc users.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
