### PR TITLE
java eclasses should consider also JREs dependencies when validating JVM version

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2646,7 +2646,7 @@ java-pkg_setup-vm() {
 # @FUNCTION: java-pkg_needs-vm
 # @INTERNAL
 # @DESCRIPTION:
-# Does the current package depend on virtual/jdk or does it set
+# Does the current package depend on virtual/jdk, virtual/jre or does it set
 # JAVA_PKG_WANT_BUILD_VM?
 #
 # @RETURN: 0 - Package depends on virtual/jdk; 1 - Package does not depend on virtual/jdk
@@ -2654,6 +2654,10 @@ java-pkg_needs-vm() {
 	debug-print-function ${FUNCNAME} $*
 
 	if [[ -n "$(echo ${JAVA_PKG_NV_DEPEND:-${DEPEND}} | sed -e '\:virtual/jdk:!d')" ]]; then
+		return 0
+	fi
+
+	if [[ -n "$(echo ${JAVA_PKG_NV_DEPEND:-${DEPEND}} | sed -e '\:virtual/jre:!d')" ]]; then
 		return 0
 	fi
 


### PR DESCRIPTION
The virtual/jdk dependencies are used to validate the current selected JVM to see its version is compatible with the requirements. This is not done if the JVM dependency is expressed in terms of a JRE, in that case there is no check which will likely lead to a failure if there is a mismatch between the bytecode version of the classes to be executed and the JRE itself.

This PR addresses the problem by moving in the `java-pkg_init()` function the crosscheck (the sooner the better) and considering also packages that need only a JRE and not a JDK. With the occasion I rearranged a little bit the code to make it more linear and simpler to read.

Another step would be to check in advance not only the JVM version but also the target bytecode of all the java dependencies to detect as soon as possible incompatibilities that would lead to a failure during the merge process.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
