### PR TITLE
media-libs/libsfml: fix build with clang-19

### DIFF
--- a/media-libs/libsfml/files/libsfml-2.6.2-utf32-clang.patch
+++ b/media-libs/libsfml/files/libsfml-2.6.2-utf32-clang.patch
@@ -1,0 +1,292 @@
+Fixes build on Clang-19.
+Eduted until works on 2.6.2 and not intermediate tree
+https://bugs.gentoo.org/951353
+https://github.com/SFML/SFML/commit/f371a99b398f8cd2eedb79c6d68ee00ddea0a9cb
+From f371a99b398f8cd2eedb79c6d68ee00ddea0a9cb Mon Sep 17 00:00:00 2001
+From: Chris Thrasher <chrisjthrasher@gmail.com>
+Date: Sat, 25 Mar 2023 22:02:29 -0600
+Subject: [PATCH] Implement `sf::String` in terms of `std::u32string`
+
+---
+ include/SFML/System/String.hpp                | 28 +++---
+ src/SFML/Network/Packet.cpp                   |  2 +-
+ src/SFML/System/String.cpp                    | 18 ++--
+ src/SFML/Window/OSX/HIDInputManager.mm        |  2 +-
+ .../Window/Unix/KeySymToUnicodeMapping.cpp    |  2 +-
+ .../Window/Unix/KeySymToUnicodeMapping.hpp    |  2 +-
+ src/SFML/Window/Unix/KeyboardImpl.cpp         |  4 +-
+ test/System/String.test.cpp                   | 94 ++++++++++---------
+ 8 files changed, 81 insertions(+), 71 deletions(-)
+
+diff --git a/include/SFML/System/String.hpp b/include/SFML/System/String.hpp
+index a217539d53..5d79e30a82 100644
+@@ -49,13 +49,13 @@
+     ////////////////////////////////////////////////////////////
+     // Types
+     ////////////////////////////////////////////////////////////
+-    typedef std::basic_string<Uint32>::iterator       Iterator;      //!< Iterator type
+-    typedef std::basic_string<Uint32>::const_iterator ConstIterator; //!< Read-only iterator type
++    using Iterator      = std::u32string::iterator;       //!< Iterator type
++    using ConstIterator = std::u32string::const_iterator; //!< Read-only iterator type
+ 
+     ////////////////////////////////////////////////////////////
+     // Static member data
+     ////////////////////////////////////////////////////////////
+-    static const std::size_t InvalidPos; //!< Represents an invalid position in the string
++    static const std::size_t InvalidPos{std::u32string::npos}; //!< Represents an invalid position in the string
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Default constructor
+@@ -91,7 +91,7 @@
+     /// \param utf32Char UTF-32 character to convert
+     ///
+     ////////////////////////////////////////////////////////////
+-    String(Uint32 utf32Char);
++    String(char32_t utf32Char);
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Construct from a null-terminated C-style ANSI string and a locale
+@@ -139,7 +139,7 @@
+     /// \param utf32String UTF-32 string to assign
+     ///
+     ////////////////////////////////////////////////////////////
+-    String(const Uint32* utf32String);
++    String(const char32_t* utf32String);
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Construct from an UTF-32 string
+@@ -147,7 +147,7 @@
+     /// \param utf32String UTF-32 string to assign
+     ///
+     ////////////////////////////////////////////////////////////
+-    String(const std::basic_string<Uint32>& utf32String);
++    String(const std::u32string& utf32String);
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Copy constructor
+@@ -189,8 +189,8 @@
+     /// \brief Create a new sf::String from a UTF-32 encoded string
+     ///
+     /// This function is provided for consistency, it is equivalent to
+-    /// using the constructors that takes a const sf::Uint32* or
+-    /// a std::basic_string<sf::Uint32>.
++    /// using the constructors that takes a const char32_t* or
++    /// a std::u32string
+     ///
+     /// \param begin Forward iterator to the beginning of the UTF-32 sequence
+     /// \param end   Forward iterator to the end of the UTF-32 sequence
+@@ -283,7 +283,7 @@
+     /// \see toUtf8, toUtf32
+     ///
+     ////////////////////////////////////////////////////////////
+-    std::basic_string<Uint16> toUtf16() const;
++    std::u16string toUtf16() const;
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Convert the Unicode string to a UTF-32 string
+@@ -296,7 +296,7 @@
+     /// \see toUtf8, toUtf16
+     ///
+     ////////////////////////////////////////////////////////////
+-    std::basic_string<Uint32> toUtf32() const;
++    std::u32string toUtf32() const;
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Overload of assignment operator
+@@ -329,7 +329,7 @@
+     /// \return Character at position \a index
+     ///
+     ////////////////////////////////////////////////////////////
+-    Uint32 operator [](std::size_t index) const;
++    char32_t operator [](std::size_t index) const;
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Overload of [] operator to access a character by its position
+@@ -342,7 +342,7 @@
+     /// \return Reference to the character at position \a index
+     ///
+     ////////////////////////////////////////////////////////////
+-    Uint32& operator [](std::size_t index);
++    char32_t& operator [](std::size_t index);
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Clear the string
+@@ -466,7 +466,7 @@
+     /// \return Read-only pointer to the array of characters
+     ///
+     ////////////////////////////////////////////////////////////
+-    const Uint32* getData() const;
++    const char32_t* getData() const;
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Return an iterator to the beginning of the string
+diff --git a/src/SFML/Network/Packet.cpp b/src/SFML/Network/Packet.cpp
+index 1fc05ca13f..3f41038db3 100644
+--- a/src/SFML/Network/Packet.cpp
++++ b/src/SFML/Network/Packet.cpp
+@@ -381,7 +381,7 @@ Packet& Packet::operator>>(String& data)
+         {
+             std::uint32_t character = 0;
+             *this >> character;
+-            data += character;
++            data += static_cast<char32_t>(character);
+         }
+     }
+ 
+diff --git a/src/SFML/System/String.cpp b/src/SFML/System/String.cpp
+index 2524fbf2b4..f0ef7ab63d 100644
+--- a/src/SFML/System/String.cpp
++++ b/src/SFML/System/String.cpp
+@@ -57,7 +57,7 @@ String::String(wchar_t wideChar)
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-String::String(Uint32 utf32Char)
++String::String(char32_t utf32Char)
+ {
+     m_string += utf32Char;
+ }
+@@ -110,7 +110,7 @@ String::String(const std::wstring& wideString)
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-String::String(const Uint32* utf32String)
++String::String(const char32_t* utf32String)
+ {
+     if (utf32String)
+         m_string = utf32String;
+@@ -118,8 +118,7 @@ String::String(const Uint32* utf32String)
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-String::String(const std::basic_string<Uint32>& utf32String) :
+-m_string(utf32String)
++String::String(const std::u32string& utf32String) : m_string(utf32String)
+ {
+ }
+ 
+@@ -180,10 +180,10 @@ std::basic_string<std::uint8_t> String::toUtf8() const
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-std::basic_string<Uint16> String::toUtf16() const
++std::u16string String::toUtf16() const
+ {
+     // Prepare the output string
+-    std::basic_string<Uint16> output;
++    std::u16string output;
+     output.reserve(m_string.length());
+ 
+     // Convert
+@@ -194,7 +194,7 @@ std::basic_string<std::uint16_t> String::toUtf16() const
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-std::basic_string<Uint32> String::toUtf32() const
++std::u32string String::toUtf32() const
+ {
+     return m_string;
+ }
+@@ -209,14 +209,14 @@ String& String::operator+=(const String& right)
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-Uint32 String::operator [](std::size_t index) const
++char32_t String::operator[](std::size_t index) const
+ {
+     return m_string[index];
+ }
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-Uint32& String::operator [](std::size_t index)
++char32_t& String::operator[](std::size_t index)
+ {
+     return m_string[index];
+ }
+@@ -295,7 +295,7 @@ String String::substring(std::size_t position, std::size_t length) const
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-const Uint32* String::getData() const
++const char32_t* String::getData() const
+ {
+     return m_string.c_str();
+ }
+diff --git a/src/SFML/Window/OSX/HIDInputManager.mm b/src/SFML/Window/OSX/HIDInputManager.mm
+index d9c41af634..95c75f7abb 100644
+--- a/src/SFML/Window/OSX/HIDInputManager.mm
++++ b/src/SFML/Window/OSX/HIDInputManager.mm
+@@ -690,7 +690,7 @@
+             // Phase 2: Try to convert the key to unicode
+             UniChar unicode = toUnicode(localize(code));
+             if (unicode != 0x00)
+-                return String(static_cast<Uint32>(unicode));
++                return String(static_cast<char32_t>(unicode));
+         }
+ 
+         // Phase 3: Return final fallback
+diff --git a/src/SFML/Window/Unix/KeySymToUnicodeMapping.cpp b/src/SFML/Window/Unix/KeySymToUnicodeMapping.cpp
+index 01f333b422..40d3d25965 100644
+--- a/src/SFML/Window/Unix/KeySymToUnicodeMapping.cpp
++++ b/src/SFML/Window/Unix/KeySymToUnicodeMapping.cpp
+@@ -30,7 +30,7 @@
+ namespace sf::priv
+ {
+ 
+-Uint32 keysymToUnicode(KeySym keysym)
++char32_t keysymToUnicode(KeySym keysym)
+ {
+     // clang-format off
+     switch (keysym)
+diff --git a/src/SFML/Window/Unix/KeySymToUnicodeMapping.hpp b/src/SFML/Window/Unix/KeySymToUnicodeMapping.hpp
+index ba05c75cc3..42c2883359 100644
+--- a/src/SFML/Window/Unix/KeySymToUnicodeMapping.hpp
++++ b/src/SFML/Window/Unix/KeySymToUnicodeMapping.hpp
+@@ -49,6 +49,6 @@ namespace sf::priv
+ /// \return corresponding UTF-32
+ ///
+ ////////////////////////////////////////////////////////////
+-Uint32 keysymToUnicode(KeySym keysym);
++char32_t keysymToUnicode(KeySym keysym);
+ 
+ } // namespace sf::priv
+diff --git a/src/SFML/Window/Unix/KeyboardImpl.cpp b/src/SFML/Window/Unix/KeyboardImpl.cpp
+index c4dc9dd0c9..f4628a3d52 100644
+--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
++++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
+@@ -671,8 +671,8 @@ String KeyboardImpl::getDescription(Keyboard::Scancode code)
+ 
+     if (checkInput)
+     {
+-        KeySym keysym = scancodeToKeySym(code);
+-        Uint32 unicode = keysymToUnicode(keysym);
++        KeySym   keysym  = scancodeToKeySym(code);
++        char32_t unicode = keysymToUnicode(keysym);
+ 
+         if (unicode != 0)
+             return String(unicode);
+--- SFML-2.6.2.old/src/SFML/System/String.cpp   2025-03-15 11:16:29.517316746 +0300
++++ SFML-2.6.2/src/SFML/System/String.cpp       2025-03-15 11:16:39.622424519 +0300
+@@ -34,10 +34,6 @@
+ namespace sf
+ {
+ ////////////////////////////////////////////////////////////
+-const std::size_t String::InvalidPos = std::basic_string<Uint32>::npos;
+-
+-
+-////////////////////////////////////////////////////////////
+ String::String()
+ {
+ }
+--- SFML-2.6.2.old/include/SFML/System/String.hpp       2025-03-15 11:22:27.154597927 +0300
++++ SFML-2.6.2/include/SFML/System/String.hpp   2025-03-15 11:24:06.809419147 +0300
+@@ -524,7 +524,7 @@
+     ////////////////////////////////////////////////////////////
+     // Member data
+     ////////////////////////////////////////////////////////////
+-    std::basic_string<Uint32> m_string; //!< Internal string of UTF-32 characters
++    std::u32string m_string; //!< Internal string of UTF-32 characters
+ };
+ 
+ ////////////////////////////////////////////////////////////

--- a/media-libs/libsfml/files/libsfml-2.6.2-utf8-clang.patch
+++ b/media-libs/libsfml/files/libsfml-2.6.2-utf8-clang.patch
@@ -1,0 +1,248 @@
+Patch to fix build on clang, edited to work with 2.6.2.
+https://bugs.gentoo.org/951353
+https://github.com/SFML/SFML/commit/9022d9564de071e944d20f3419bb6203c46b7a2b
+From 9022d9564de071e944d20f3419bb6203c46b7a2b Mon Sep 17 00:00:00 2001
+From: Chris Thrasher <chrisjthrasher@gmail.com>
+Date: Wed, 17 Jan 2024 17:03:04 -0700
+Subject: [PATCH] Define character traits for `std::uint8_t`
+
+Character traits are only standardized for character types of which
+std::uint8_t is not. All major C++ implementations happen to define
+this specialization but because it is not standard C++ they are
+allowed to remove it as LLVM has done by deprecating this specialization
+in LLVM 18. It is slated for removal in LLVM 19. To avoid compilation
+errors and to get ahead of any deprecation warnings when LLVM 18 ships
+we need to define our own std::uint8_t character traits.
+
+SFML 4 will have access to C++20's std::u8string which should let us
+remove this code.
+---
+ include/SFML/System/String.hpp         |  42 ++++++-
+ src/SFML/System/String.cpp             | 106 +++++++++++++++-
+ src/SFML/Window/Unix/ClipboardImpl.cpp |   2 +-
+ src/SFML/Window/Unix/WindowImplX11.cpp |   2 +-
+ src/SFML/Window/iOS/ClipboardImpl.mm   |   4 +-
+ src/SFML/Window/macOS/ClipboardImpl.mm |   6 +-
+ test/System/String.test.cpp            | 165 ++++++++++++++++++++++---
+ 7 files changed, 303 insertions(+), 24 deletions(-)
+
+diff --git a/include/SFML/System/String.hpp b/include/SFML/System/String.hpp
+index ea14cbad58..345b663d3e 100644
+--- a/include/SFML/System/String.hpp
++++ b/include/SFML/System/String.hpp
+@@ -30,6 +30,7 @@
+ ////////////////////////////////////////////////////////////
+ #include <SFML/System/Export.hpp>
+ #include <SFML/System/Utf.hpp>
++#include <cstdint>
+ #include <iterator>
+ #include <locale>
+ #include <string>
+@@ -39,6 +39,46 @@
+ 
+ namespace sf
+ {
++////////////////////////////////////////////////////////////
++/// \brief Character traits for std::uint8_t
++///
++////////////////////////////////////////////////////////////
++struct SFML_SYSTEM_API U8StringCharTraits
++{
++    // NOLINTBEGIN(readability-identifier-naming)
++    using char_type  = std::uint8_t;
++    using int_type   = std::char_traits<char>::int_type;
++    using off_type   = std::char_traits<char>::off_type;
++    using pos_type   = std::char_traits<char>::pos_type;
++    using state_type = std::char_traits<char>::state_type;
++
++    static void             assign(char_type& c1, char_type c2) noexcept;
++    static char_type*       assign(char_type* s, std::size_t n, char_type c);
++    static bool             eq(char_type c1, char_type c2) noexcept;
++    static bool             lt(char_type c1, char_type c2) noexcept;
++    static char_type*       move(char_type* s1, const char_type* s2, std::size_t n);
++    static char_type*       copy(char_type* s1, const char_type* s2, std::size_t n);
++    static int              compare(const char_type* s1, const char_type* s2, std::size_t n);
++    static std::size_t      length(const char_type* s);
++    static const char_type* find(const char_type* s, std::size_t n, const char_type& c);
++    static char_type        to_char_type(int_type i) noexcept;
++    static int_type         to_int_type(char_type c) noexcept;
++    static bool             eq_int_type(int_type i1, int_type i2) noexcept;
++    static int_type         eof() noexcept;
++    static int_type         not_eof(int_type i) noexcept;
++    // NOLINTEND(readability-identifier-naming)
++};
++
++////////////////////////////////////////////////////////////
++/// \brief Portable replacement for std::basic_string<std::uint8_t>
++///
++/// While all major C++ implementations happen to define this
++/// as of early 2024, this specialization is not strictly speaking
++/// standard C++. Thus we can't depend on its continued existence.
++///
++////////////////////////////////////////////////////////////
++using U8String = std::basic_string<std::uint8_t, U8StringCharTraits>;
++
+ ////////////////////////////////////////////////////////////
+ /// \brief Utility string class that automatically handles
+ ///        conversions between types and encodings
+@@ -313,7 +313,7 @@ class SFML_SYSTEM_API String
+     /// \see toUtf16, toUtf32
+     ///
+     ////////////////////////////////////////////////////////////
+-    std::basic_string<Uint8> toUtf8() const;
++    sf::U8String toUtf8() const;
+ 
+     ////////////////////////////////////////////////////////////
+     /// \brief Convert the Unicode string to a UTF-16 string
+diff --git a/src/SFML/System/String.cpp b/src/SFML/System/String.cpp
+index 44a1391a65..959f354cd7 100644
+--- a/src/SFML/System/String.cpp
++++ b/src/SFML/System/String.cpp
+@@ -37,6 +37,108 @@
+ 
+ namespace sf
+ {
++////////////////////////////////////////////////////////////
++void U8StringCharTraits::assign(char_type& c1, char_type c2) noexcept
++{
++    c1 = c2;
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::char_type* U8StringCharTraits::assign(char_type* s, std::size_t n, char_type c)
++{
++    return reinterpret_cast<U8StringCharTraits::char_type*>(
++        std::char_traits<char>::assign(reinterpret_cast<char*>(s), n, static_cast<char>(c)));
++}
++
++
++////////////////////////////////////////////////////////////
++bool U8StringCharTraits::eq(char_type c1, char_type c2) noexcept
++{
++    return c1 == c2;
++}
++
++
++////////////////////////////////////////////////////////////
++bool U8StringCharTraits::lt(char_type c1, char_type c2) noexcept
++{
++    return c1 < c2;
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::char_type* U8StringCharTraits::move(char_type* s1, const char_type* s2, std::size_t n)
++{
++    std::memmove(s1, s2, n);
++    return s1;
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::char_type* U8StringCharTraits::copy(char_type* s1, const char_type* s2, std::size_t n)
++{
++    std::memcpy(s1, s2, n);
++    return s1;
++}
++
++
++////////////////////////////////////////////////////////////
++int U8StringCharTraits::compare(const char_type* s1, const char_type* s2, std::size_t n)
++{
++    return std::memcmp(s1, s2, n);
++}
++
++
++////////////////////////////////////////////////////////////
++std::size_t U8StringCharTraits::length(const char_type* s)
++{
++    return std::strlen(reinterpret_cast<const char*>(s));
++}
++
++
++////////////////////////////////////////////////////////////
++const U8StringCharTraits::char_type* U8StringCharTraits::find(const char_type* s, std::size_t n, const char_type& c)
++{
++    return reinterpret_cast<const U8StringCharTraits::char_type*>(
++        std::char_traits<char>::find(reinterpret_cast<const char*>(s), n, static_cast<char>(c)));
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::char_type U8StringCharTraits::to_char_type(int_type i) noexcept
++{
++    return static_cast<U8StringCharTraits::char_type>(std::char_traits<char>::to_char_type(i));
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::int_type U8StringCharTraits::to_int_type(char_type c) noexcept
++{
++    return std::char_traits<char>::to_int_type(static_cast<char>(c));
++}
++
++
++////////////////////////////////////////////////////////////
++bool U8StringCharTraits::eq_int_type(int_type i1, int_type i2) noexcept
++{
++    return i1 == i2;
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::int_type U8StringCharTraits::eof() noexcept
++{
++    return std::char_traits<char>::eof();
++}
++
++
++////////////////////////////////////////////////////////////
++U8StringCharTraits::int_type U8StringCharTraits::not_eof(int_type i) noexcept
++{
++    return std::char_traits<char>::not_eof(i);
++}
++
++
+ ////////////////////////////////////////////////////////////
+ String::String(char ansiChar, const std::locale& locale)
+ {
+@@ -161,10 +277,10 @@ std::wstring String::toWideString() const
+ 
+ 
+ ////////////////////////////////////////////////////////////
+-std::basic_string<Uint8> String::toUtf8() const
++sf::U8String String::toUtf8() const
+ {
+     // Prepare the output string
+-    std::basic_string<Uint8> output;
++    sf::U8String output;
+     output.reserve(m_string.length());
+ 
+     // Convert
+diff --git a/src/SFML/Window/Unix/ClipboardImpl.cpp b/src/SFML/Window/Unix/ClipboardImpl.cpp
+index 6f7df635c7..132d7a5289 100644
+--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
++++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
+@@ -344,7 +344,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
+                 {
+                     // Respond to a request for conversion to a UTF-8 string
+                     // or an encoding of our choosing (we always choose UTF-8)
+-                    std::basic_string<Uint8> data = m_clipboardContents.toUtf8();
++                    const auto data = m_clipboardContents.toUtf8();
+ 
+                     XChangeProperty(
+                         m_display,diff --git a/src/SFML/Window/Unix/WindowImplX11.cpp b/src/SFML/Window/Unix/WindowImplX11.cpp
+index e8df7ff68d..b4205dacba 100644
+--- a/src/SFML/Window/Unix/WindowImplX11.cpp
++++ b/src/SFML/Window/Unix/WindowImplX11.cpp
+@@ -895,8 +895,7 @@ void WindowImplX11::setTitle(const String& title)
+     // There is however an option to tell the window manager your Unicode title via hints.
+ 
+     // Convert to UTF-8 encoding.
+-    std::basic_string<Uint8> utf8Title;
+-    Utf32::toUtf8(title.begin(), title.end(), std::back_inserter(utf8Title));
++    const auto utf8Title = title.toUtf8();
+ 
+     Atom useUtf8 = getAtom("UTF8_STRING", false);
+ 

--- a/media-libs/libsfml/libsfml-2.6.2-r1.ebuild
+++ b/media-libs/libsfml/libsfml-2.6.2-r1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Simple and Fast Multimedia Library (SFML)"
+HOMEPAGE="https://www.sfml-dev.org/ https://github.com/SFML/SFML"
+SRC_URI="https://github.com/SFML/SFML/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/SFML-${PV}"
+
+LICENSE="ZLIB"
+SLOT="0/$(ver_cut 1-2)"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="debug doc examples"
+
+RDEPEND="
+	media-libs/flac:=
+	media-libs/freetype:2
+	media-libs/libjpeg-turbo:=
+	media-libs/libogg
+	media-libs/libpng:=
+	media-libs/libvorbis
+	media-libs/openal
+	sys-libs/zlib
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXcursor
+	x11-libs/libXrandr
+	x11-libs/libxcb
+	x11-libs/xcb-util-image
+	kernel_linux? ( virtual/libudev:= )
+"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto
+"
+BDEPEND="
+	doc? ( app-text/doxygen )
+"
+
+DOCS=( changelog.md readme.md )
+
+PATCHES=(
+	"${FILESDIR}"/"${PN}"-2.6.0-supress-werror.patch
+	"${FILESDIR}"/"${PN}"-2.6.2-utf32-clang.patch
+	"${FILESDIR}"/"${PN}"-2.6.2-utf8-clang.patch
+)
+
+src_prepare() {
+	sed -i "s:DESTINATION .*:DESTINATION /usr/share/doc/${PF}:" \
+		doc/CMakeLists.txt || die
+
+	find examples -name CMakeLists.txt -delete || die
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSFML_BUILD_DOC=$(usex doc)
+		-DSFML_INSTALL_PKGCONFIG_FILES=TRUE
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	insinto /usr/share/cmake/Modules
+	doins cmake/SFMLConfig.cmake.in
+	doins cmake/SFMLConfigDependencies.cmake.in
+
+	if use examples ; then
+		docompress -x /usr/share/doc/${PF}/examples
+		dodoc -r examples
+	fi
+}

--- a/media-libs/libsfml/metadata.xml
+++ b/media-libs/libsfml/metadata.xml
@@ -12,6 +12,5 @@
 	</longdescription>
 	<upstream>
 		<remote-id type="github">SFML/SFML</remote-id>
-		<remote-id type="sourceforge">sfml</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Clang-19 removed deprecated basic_string<> classes. Backport two upstream patches that deal with that in 32-bit and 8-bit UTF encoding respectively.
Correct metadata - SFML is gone from SourceForge

Closes: https://bugs.gentoo.org/951353

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
