### PR TITLE
sci-visualization/xd3d: Fix build failures with GCC-15

### DIFF
--- a/sci-visualization/xd3d/files/xd3d-8.3.1-c99.patch
+++ b/sci-visualization/xd3d/files/xd3d-8.3.1-c99.patch
@@ -1,0 +1,464 @@
+Fix implicit function declarations: remove all underscore redefines, ask gfortran not
+to append underscores to function names it tries to call, add some type definitions,
+missing include for library function.
+Clean up K&R style decls when we have perfectly fine modern declarations
+https://bugs.gentoo.org/944746
+https://bugs.gentoo.org/886609
+https://bugs.gentoo.org/875236
+Folded sed -i -e 's:"zutil.h":<zlib.h>:g' src/qlib/timestuff.c into patch
+diff '--color=auto' -ru xd3d-8.3.1.old/src/qlib/perfide.c xd3d-8.3.1/src/qlib/perfide.c
+--- xd3d-8.3.1.old/src/qlib/perfide.c	2025-03-15 21:14:08.508332791 +0300
++++ xd3d-8.3.1/src/qlib/perfide.c	2025-03-15 21:15:03.043870607 +0300
+@@ -4,10 +4,6 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ 
+-#ifndef F77_NO_UNDER_SCORE
+-#define perfide perfide_
+-#endif
+-
+ int LANG,DEBUG;
+ 
+ #ifdef ENGLISH
+@@ -23,7 +19,7 @@
+ #endif
+ 
+ 
+-perfide(ilang,idebug)
++int perfide(ilang,idebug)
+ int *ilang,*idebug;
+ {
+     *ilang=LANG;
+diff '--color=auto' -ru xd3d-8.3.1.old/src/qlib/timestuff.c xd3d-8.3.1/src/qlib/timestuff.c
+--- xd3d-8.3.1.old/src/qlib/timestuff.c	2025-03-15 21:14:08.508332791 +0300
++++ xd3d-8.3.1/src/qlib/timestuff.c	2025-03-15 21:15:03.046444412 +0300
+@@ -7,50 +7,10 @@
+ #include <math.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include "zutil.h"
++#include <zlib.h>
+ 
+ FILE *fichin[99];
+ 
+-#ifndef F77_NO_UNDER_SCORE
+-#define datefichier datefichier_
+-#define timec timec_
+-#define timeprecisc timeprecisc_
+-#define etimec etimec_
+-#define idatec idatec_
+-#define ctimec ctimec_
+-#define fflushc fflushc_
+-#define testtypebin testtypebin_
+-#define ouvrebin ouvrebin_
+-#define fermebin fermebin_
+-#define litduncoup litduncoup_
+-#define ecritduncoup ecritduncoup_
+-#define litrecbin litrecbin_
+-#define litrecbinspeed litrecbinspeed_
+-#define ecritrecbin ecritrecbin_
+-#define ecritrecbinspeed ecritrecbinspeed_
+-#define fnaninf4 fnaninf4_
+-#define fnaninf8 fnaninf8_
+-#define fmemcpy fmemcpy_
+-#define fmalloc fmalloc_
+-#define fcalloc fcalloc_
+-#define ffree ffree_
+-#define frealloc frealloc_
+-#define zouvrel zouvrel_
+-#define zouvree zouvree_
+-#define zferme zferme_
+-#define zlit zlit_
+-#define zliti zliti_
+-#define zecrit zecrit_
+-#define zlitrec zlitrec_
+-#define zecritrec zecritrec_
+-#define zlitrecbin zlitrecbin_
+-#define zlitrecshortbin zlitrecshortbin_
+-#define ztesttypebin ztesttypebin_
+-#define zlitrecvbin zlitrecvbin_
+-#define zcompress zcompress_
+-#define zdecompress zdecompress_
+-#endif
+-
+ /* 
+ sur HP compiler avec : cc +O3 -DF77_NO_UNDER_SCORE -c timestuff.c
+ */
+diff '--color=auto' -ru xd3d-8.3.1.old/src/X/getenvc.c xd3d-8.3.1/src/X/getenvc.c
+--- xd3d-8.3.1.old/src/X/getenvc.c	2025-03-15 21:14:08.505568877 +0300
++++ xd3d-8.3.1/src/X/getenvc.c	2025-03-15 21:15:03.044048075 +0300
+@@ -8,16 +8,11 @@
+  */
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ 
+-#ifndef F77_NO_UNDER_SCORE
+-#define getenvc getenvc_
+-#endif
+-
+-void getenvc(nom, val, lval_admis, lval_trouve)
+-char *nom, *val ;
+-int  *lval_admis, *lval_trouve ;
++void getenvc(char *nom, char *val, int *lval_admis, int *lval_trouve)
+ {
+-   char *ptenv, *getenv() ;
++   char *ptenv ;
+    int i ;
+ 
+    ptenv = getenv(nom) ;
+diff '--color=auto' -ru xd3d-8.3.1.old/src/X/rotated.c xd3d-8.3.1/src/X/rotated.c
+--- xd3d-8.3.1.old/src/X/rotated.c	2025-03-15 21:14:08.507568863 +0300
++++ xd3d-8.3.1/src/X/rotated.c	2025-03-15 21:15:03.044289517 +0300
+@@ -133,26 +133,16 @@
+ /* ---------------------------------------------------------------------- */
+ 
+ 
+-static char            *my_strdup();
+-static char            *my_strtok();
+-
+-float                   XRotVersion();
+-void                    XRotSetMagnification();
+-void                    XRotSetBoundingBoxPad();
+-int                     XRotDrawString();
+-int                     XRotDrawImageString();
+-int                     XRotDrawAlignedString();
+-int                     XRotDrawAlignedImageString();
+-XPoint                 *XRotTextExtents();
+-
+-static XImage          *MakeXImage();
+-static int              XRotPaintAlignedString();
+-static int              XRotDrawHorizontalString();
+-static RotatedTextItem *XRotRetrieveFromCache();
+-static RotatedTextItem *XRotCreateTextItem();
+-static void             XRotAddToLinkedList();
+-static void             XRotFreeTextItem();
+-static XImage          *XRotMagnifyImage();
++static XImage          *MakeXImage(Display *dpy, int w, int h);
++static int              XRotPaintAlignedString(Display *dpy, XFontStruct *font, float angle, Drawable drawable, GC gc, int x, int y, char *text,
++                                  int align, int bg);
++static int              XRotDrawHorizontalString(Display *dpy, XFontStruct *font, Drawable drawable, GC gc, int x, int y, char *text, 
++                             int align, int bg);
++static RotatedTextItem *XRotRetrieveFromCache(Display *dpy, XFontStruct *font, float angle, char *text, int align);
++static RotatedTextItem *XRotCreateTextItem(Display *dpy, XFontStruct *font, float angle, char *text, int align);
++static void             XRotAddToLinkedList(Display *dpy, RotatedTextItem *item);
++static void             XRotFreeTextItem(Display *dpy, RotatedTextItem *item);
++static XImage          *XRotMagnifyImage(Display *dpy, XImage *ximage);
+ 
+ 
+ /* ---------------------------------------------------------------------- */
+@@ -284,9 +274,7 @@
+ /*  Create an XImage structure and allocate memory for it                 */
+ /**************************************************************************/
+ 
+-static XImage *MakeXImage(dpy, w, h)
+-    Display *dpy;
+-    int w, h;
++static XImage *MakeXImage(Display *dpy, int w, int h)
+ {
+     XImage *I;
+     char *data;
+@@ -405,17 +393,8 @@
+ /*  Aligns and paints a rotated string                                    */
+ /**************************************************************************/
+ 
+-static int XRotPaintAlignedString(dpy, font, angle, drawable, gc, x, y, text,
+-				  align, bg)
+-    Display *dpy;
+-    XFontStruct *font;
+-    float angle;
+-    Drawable drawable;
+-    GC gc;
+-    int x, y;
+-    char *text;
+-    int align;
+-    int bg;
++static int XRotPaintAlignedString(Display *dpy, XFontStruct *font, float angle, Drawable drawable, GC gc, int x, int y, char *text,
++				  int align, int bg)
+ {
+     int i;
+     GC my_gc;
+@@ -647,16 +626,8 @@
+ /*  Draw a horizontal string in a quick fashion                           */
+ /**************************************************************************/
+ 
+-static int XRotDrawHorizontalString(dpy, font, drawable, gc, x, y, text, 
+-			     align, bg)
+-    Display *dpy;
+-    XFontStruct *font;
+-    Drawable drawable;
+-    GC gc;
+-    int x, y;
+-    char *text;
+-    int align;
+-    int bg;
++static int XRotDrawHorizontalString(Display *dpy, XFontStruct *font, Drawable drawable, GC gc, int x, int y, char *text,
++			     int align, int bg)
+ {
+     GC my_gc;
+     int nl=1, i;
+@@ -748,12 +719,7 @@
+ /*       request, otherwise arrange for its creation                      */
+ /**************************************************************************/
+ 
+-static RotatedTextItem *XRotRetrieveFromCache(dpy, font, angle, text, align)
+-    Display *dpy;
+-    XFontStruct *font;
+-    float angle;
+-    char *text;
+-    int align;
++static RotatedTextItem *XRotRetrieveFromCache(Display *dpy, XFontStruct *font, float angle, char *text, int align)
+ {
+     Font fid;
+     char *font_name=NULL;
+@@ -897,12 +863,7 @@
+ /*  Create a rotated text item                                            */
+ /**************************************************************************/
+ 
+-static RotatedTextItem *XRotCreateTextItem(dpy, font, angle, text, align)
+-    Display *dpy;
+-    XFontStruct *font;
+-    float angle;
+-    char *text;
+-    int align;
++static RotatedTextItem *XRotCreateTextItem(Display *dpy, XFontStruct *font, float angle, char *text, int align)
+ {
+     RotatedTextItem *item=NULL;
+     Pixmap canvas;
+@@ -1195,9 +1156,7 @@
+ /*      from the front as required to keep cache size below limit         */
+ /**************************************************************************/
+ 
+-static void XRotAddToLinkedList(dpy, item)
+-    Display *dpy;
+-    RotatedTextItem *item;
++static void XRotAddToLinkedList(Display *dpy, RotatedTextItem *item)
+ {
+     
+     static long int current_size=0;
+@@ -1305,9 +1264,7 @@
+ /*  Free the resources used by a text item                                */
+ /**************************************************************************/
+ 
+-static void XRotFreeTextItem(dpy, item)
+-    Display *dpy;
+-    RotatedTextItem *item;
++static void XRotFreeTextItem(Display *dpy, RotatedTextItem *item)
+ {
+     free(item->text);
+ 
+@@ -1334,9 +1291,7 @@
+ /* Magnify an XImage using bilinear interpolation                         */
+ /**************************************************************************/
+ 
+-static XImage *XRotMagnifyImage(dpy, ximage)
+-    Display *dpy;
+-    XImage *ximage;
++static XImage *XRotMagnifyImage(Display *dpy, XImage *ximage)
+ {
+     int i, j;
+     float x, y;
+diff '--color=auto' -ru xd3d-8.3.1.old/src/X/rotated.h xd3d-8.3.1/src/X/rotated.h
+--- xd3d-8.3.1.old/src/X/rotated.h	2025-03-15 21:14:08.506568870 +0300
++++ xd3d-8.3.1/src/X/rotated.h	2025-03-15 21:15:03.044845038 +0300
+@@ -40,8 +40,8 @@
+      vlp@latina.inesc.pt (Vasco Lopes Paulo) */
+ 
+ #if defined(__cplusplus) || defined(c_plusplus)
+-
+ extern "C" {
++#endif
+ float   XRotVersion(char*, int);
+ void    XRotSetMagnification(float);
+ void    XRotSetBoundingBoxPad(int);
+@@ -55,20 +55,9 @@
+                                    Drawable, GC, int, int, char*, int);
+ XPoint *XRotTextExtents(Display*, XFontStruct*, float,
+ 			int, int, char*, int);
++#if defined(__cplusplus) || defined(c_plusplus)
+ }
+-
+-#else
+-
+-extern float   XRotVersion();
+-extern void    XRotSetMagnification();
+-extern void    XRotSetBoundingBoxPad();
+-extern int     XRotDrawString();
+-extern int     XRotDrawImageString();
+-extern int     XRotDrawAlignedString();
+-extern int     XRotDrawAlignedImageString();
+-extern XPoint *XRotTextExtents();
+-
+-#endif /* __cplusplus */
++#endif
+ 
+ /* ---------------------------------------------------------------------- */
+ 
+diff '--color=auto' -ru xd3d-8.3.1.old/src/X/x11device.c xd3d-8.3.1/src/X/x11device.c
+--- xd3d-8.3.1.old/src/X/x11device.c	2025-03-15 21:14:08.505568877 +0300
++++ xd3d-8.3.1/src/X/x11device.c	2025-03-15 21:15:03.045827221 +0300
+@@ -33,97 +33,6 @@
+ #define X_POS 100
+ #define Y_POS 50
+ 
+-#ifndef F77_NO_UNDER_SCORE
+-#define drawarc drawarc_
+-#define drawfilledarc drawfilledarc_
+-#define getbuttonrelease getbuttonrelease_
+-#define getxycx11 getxycx11_
+-#define getxycx11b getxycx11b_
+-#define getxycx11c getxycx11c_
+-#define getxycx11d getxycx11d_
+-#define getxycx11e getxycx11e_
+-#define mybackingput mybackingput_
+-#define mybackingput2 mybackingput2_
+-#define mybackingsave mybackingsave_
+-#define mybackingsave2 mybackingsave2_
+-#define mybackingsaveloc mybackingsaveloc_
+-#define myusleep myusleep_
+-#define myusleep2 myusleep2_
+-#define seldialog seldialog_
+-#define selgraphix11 selgraphix11_
+-#define viderbuff viderbuff_
+-#define viderbuff2 viderbuff2_
+-#define viderbuff3 viderbuff3_
+-#define x11ColormapRVB x11ColormapRVB_
+-#define x11allevents x11allevents_
+-#define x11alleventsvraiment x11alleventsvraiment_
+-#define x11askbacking x11askbacking_
+-#define x11blackwhite x11blackwhite_
+-#define x11bord x11bord_
+-#define x11changecolormap x11changecolormap_
+-#define x11changecurseur x11changecurseur_
+-#define x11clean x11clean_
+-#define x11clearrect x11clearrect_
+-#define x11clip x11clip_
+-#define x11cloche x11cloche_
+-#define x11detruitpop x11detruitpop_
+-#define x11device x11device_
+-#define x11draw3 x11draw3_
+-#define x11ecran x11ecran_
+-#define x11effacepix x11effacepix_
+-#define x11enddev x11enddev_
+-#define x11etoudessin x11etoudessin_
+-#define x11facette x11facette_
+-#define x11facette2 x11facette2_
+-#define x11garderect x11garderect_
+-#define x11garderect2 x11garderect2_
+-#define x11key x11key_
+-#define x11linsrn x11linsrn_
+-#define x11loadcolor x11loadcolor_
+-#define x11loadcolorback x11loadcolorback_
+-#define x11loadcolorbackold x11loadcolorbackold_
+-#define x11loadcolorold x11loadcolorold_
+-#define x11loadfont x11loadfont_
+-#define x11loadfont2 x11loadfont2_
+-#define x11magfont x11magfont_
+-#define x11makecolormap x11makecolormap_
+-#define x11makecolors x11makecolors_
+-#define x11mark x11mark_
+-#define x11meticone x11meticone_
+-#define x11metrect x11metrect_
+-#define x11metrect2 x11metrect2_
+-#define x11nomfenetre x11nomfenetre_
+-#define x11nomicone x11nomicone_
+-#define x11opendisplay x11opendisplay_
+-#define x11polyconvex x11polyconvex_
+-#define x11polyligne x11polyligne_
+-#define x11pop x11pop_
+-#define x11popup x11popup_
+-#define x11press x11press_
+-#define x11progressif x11progressif_
+-#define x11release x11release_
+-#define x11sauvecolormap x11sauvecolormap_
+-#define x11sauvepix x11sauvepix_
+-#define x11sauvexpm x11sauvexpm_
+-#define x11setcurs x11setcurs_
+-#define x11szscrn x11szscrn_
+-#define x11szwin x11szwin_
+-#define x11taillefen x11taillefen_
+-#define x11textextend x11textextend_
+-#define x11textextendall x11textextendall_
+-#define x11thermoini x11thermoini_
+-#define x11thick x11thick_
+-#define x11trouvecouleur x11trouvecouleur_
+-#define x11txtsrn x11txtsrn_
+-#define x11txtsrn2 x11txtsrn2_
+-#define x11txtsrnrot x11txtsrnrot_
+-#define x11txtsrnrot2 x11txtsrnrot2_
+-#define x11txtsrnrot3 x11txtsrnrot3_
+-#define x11unclip x11unclip_
+-#define x11videqueue x11videqueue_
+-#define zcolor zcolor_
+-#endif
+-
+ Drawable drawable;
+ Pixmap pixsauve, pixbacking, pixbacking2;
+ Pixmap pixpoursauvegarde;
+@@ -168,6 +77,23 @@
+ 
+ Time timeclick0=0, timeclick1=0;
+ 
++static int x11ColormapRVB(Colormap color_maploc, float redloc[], float greenloc[], float blueloc[], int nbcolor);
++static int x11makecolors(float redloc[], float greenloc[], float blueloc[]);
++static int x11makecolormap(float redloc[], float greenloc[], float blueloc[], Colormap color_maploc, int nbcells);
++static int MyXSelectInput(Display *dpyloc, Window w, int mask);
++static int x11meticone();
++static int mybackingput();
++static int mybackingput2();
++
++int myusleep(int *microsecond);
++int mybackingsave();
++void mybackingsave2();
++int viderbuff2();
++int viderbuff3();
++int x11allevents();
++
++extern int zcolor(float redloc[], float greenloc[], float blueloc[], int *nbcolor);
++
+ /*------------------------------------------------------------------*/
+ void x11opendisplay(char *string)
+ {
+@@ -657,7 +583,7 @@
+   XMapWindow(dpy, window2);
+   XRaiseWindow(dpy, window2);
+ 
+-  MyXSelectInput(dpy, window, NULL);
++  MyXSelectInput(dpy, window, 0);
+   MyXSelectInput(dpy, window2, ExposureMask |
+                                KeyPressMask |
+                                ButtonPressMask |
+@@ -801,10 +727,7 @@
+     }
+ }
+ /*------------------------------------------------------------------*/
+-int x11ColormapRVB(color_maploc, redloc, greenloc, blueloc, nbcolor)
+-Colormap color_maploc;
+-float redloc[], greenloc[], blueloc[];
+-int nbcolor;
++int x11ColormapRVB(Colormap color_maploc, float redloc[], float greenloc[], float blueloc[], int nbcolor)
+ {
+   XColor rgb_def, hardware_def, colorcell_defs;
+   unsigned short maxvalue;
+@@ -824,8 +747,7 @@
+   }
+ }
+ /*------------------------------------------------------------------*/
+-int x11makecolors(redloc, greenloc, blueloc)
+-float redloc[], greenloc[], blueloc[];
++int x11makecolors(float redloc[], float greenloc[], float blueloc[])
+ {
+   int index, size=16;
+   int i,jtable;
+@@ -871,10 +793,7 @@
+   tabledirect[jtable] = coulproche.pixel;
+ }
+ /*------------------------------------------------------------------*/
+-int x11makecolormap(redloc, greenloc, blueloc, color_maploc, nbcells)
+-Colormap color_maploc;
+-float redloc[], greenloc[], blueloc[];
+-int nbcells;
++int x11makecolormap(float redloc[], float greenloc[], float blueloc[], Colormap color_maploc, int nbcells)
+ {
+   int index;
+   XColor colorcell_defs[256];

--- a/sci-visualization/xd3d/files/xd3d-8.3.1-sane-makefiles.patch
+++ b/sci-visualization/xd3d/files/xd3d-8.3.1-sane-makefiles.patch
@@ -1,0 +1,219 @@
+Remove stripping from makefiles.
+Fold makefile patching into one file and competely fix makefiles
+so they are sane-ish. Because it looked like original author lacked
+tabs and made do with what he had.
+diff '--color=auto' -ru a/Makefile b/Makefile
+--- a/Makefile	2025-03-15 19:12:02.768683219 +0300
++++ b/Makefile	2025-03-15 19:24:18.419580611 +0300
+@@ -13,22 +13,31 @@
+ $(BINDIR)/xd3d$(SUFF) \
+ $(BINDIR)/xgraphic$(SUFF)
+ 
+-all :; make libs ; make utils ; make xgraphic ; make xd3d
++all : libs utils xgraphic xd3d
+ 
+-install :; /bin/cp -pidvu $(EXE) ./infps $(INSTALL_DIR)
++install :
++	cp -pidvu $(EXE) ./infps $(INSTALL_DIR)
+ 
+-libs :; \
+-cd $(SRCDIR)/qlib   ; echo "---- Building utility lib ----" ; make ;\
+-cd $(SRCDIR)/interp ; echo "---- Building parsing lib ----" ; make ;\
+-cd $(SRCDIR)/X      ; echo "---- Building X interface lib ----" ; make
++libs :
++	@echo "---- Building utility lib ----"
++	$(MAKE) -C $(SRCDIR)/qlib
++	@echo "---- Building parsing lib ----" ;
++	$(MAKE) -C $(SRCDIR)/interp
++	@echo "---- Building X interface lib ----"
++	$(MAKE) -C $(SRCDIR)/X
++
++xd3d : libs
++	@echo "---- Building xd3d ----"
++	$(MAKE) -C $(SRCDIR)/d3d
++
++xgraphic : libs
++	@echo "---- Building xgraphic ----"
++	$(MAKE) -C $(SRCDIR)/graphic
++
++utils : libs
++	@echo " ---- Building various utils ----" ;\
++	$(MAKE) -C $(SRCDIR)/trad_nopo
++	$(MAKE) -C $(SRCDIR)/various
+ 
+-xd3d :; cd $(SRCDIR)/d3d ; echo "---- Building xd3d ----" ; make
+-
+-xgraphic :; cd $(SRCDIR)/graphic ; echo "---- Building xgraphic ----" ; make
+-
+-utils :; \
+-echo " ---- Building various utils ----" ;\
+-cd $(SRCDIR)/trad_nopo ; make ;\
+-cd $(SRCDIR)/various  ; make
+-
+-clean :; /bin/rm -f $(SRCDIR)/*/*.o $(LIBRAIRIE) $(MYXLIB) $(INTERP) $(EXE)
++clean :
++	rm -f $(SRCDIR)/*/*.o $(LIBRAIRIE) $(MYXLIB) $(INTERP) $(EXE)
+Only in xd3d-8.3.1: RULES.gentoo
+diff '--color=auto' -ru a/src/d3d/Makefile b/src/d3d/Makefile
+--- a/src/d3d/Makefile	2025-03-15 19:12:02.763459402 +0300
++++ b/src/d3d/Makefile	2025-03-15 19:31:48.183325701 +0300
+@@ -82,10 +82,11 @@
+ VIEUCU  = com_vieucu.f
+ VERSION = Version.f
+ 
+-$(BINDIR)/$(EXEC) : $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE);\
+-         $(LINK) $@ $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE) $(LINKOPTX) ; $(STRIP)
++$(BINDIR)/$(EXEC) : $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE)
++	$(LINK) $@ $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE) $(LINKOPTX)
+ 
+-clean : ; /bin/rm -f $(OBJETS) $(BINDIR)/$(EXEC)
++clean :
++	/bin/rm -f $(OBJETS) $(BINDIR)/$(EXEC)
+ 
+ include Makefile.dep
+ 
+diff '--color=auto' -ru a/src/graphic/Makefile b/src/graphic/Makefile
+--- a/src/graphic/Makefile	2025-03-15 19:12:02.768269406 +0300
++++ b/src/graphic/Makefile	2025-03-15 19:30:51.942572716 +0300
+@@ -15,10 +15,11 @@
+         trace.o    \
+         trad.o
+ 
+-$(BINDIR)/$(EXEC) : $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE);\
+-         $(LINK) $@ $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE) $(LINKOPTX) ; $(STRIP)
++$(BINDIR)/$(EXEC) : $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE)
++	$(LINK) $@ $(OBJETS) $(MYXLIB) $(INTERP) $(LIBRAIRIE) $(LINKOPTX)
+ 
+-clean : ; /bin/rm -f $(OBJETS) $(BINDIR)/$(EXEC)
++clean :
++	rm -f $(OBJETS) $(BINDIR)/$(EXEC)
+ 
+ include Makefile.dep
+ 
+diff '--color=auto' -ru a/src/interp/Makefile b/src/interp/Makefile
+--- a/src/interp/Makefile	2025-03-15 19:12:02.761608455 +0300
++++ b/src/interp/Makefile	2025-03-15 19:26:50.149040700 +0300
+@@ -43,6 +43,9 @@
+          zaldy6.o 
+ 
+ 
+-$(LIB) : $(OBJETS) ; $(AR) $@ $(OBJETS) ; $(RANLIB) $@
++$(LIB) : $(OBJETS)
++	$(AR) $@ $(OBJETS)
++	$(RANLIB) $@
+ 
+-clean : ; /bin/rm -f $(OBJETS) $(LIB)
++clean :
++	rm -f $(OBJETS) $(LIB)
+diff '--color=auto' -ru a/src/qlib/Makefile b/src/qlib/Makefile
+--- a/src/qlib/Makefile	2025-03-15 19:12:02.768683219 +0300
++++ b/src/qlib/Makefile	2025-03-15 19:31:11.734959768 +0300
+@@ -27,7 +27,10 @@
+ temps.o	\
+ timestuff.o
+ 
+-$(LIB) : $(OBJETS) ; $(AR) $@ $(OBJETS) ; $(RANLIB) $@
++$(LIB) : $(OBJETS)
++	$(AR) $@ $(OBJETS)
++	$(RANLIB) $@
+ 
+-clean : ; /bin/rm -f $(OBJETS) $(LIB)
++clean :
++	rm -f $(OBJETS) $(LIB)
+ 
+diff '--color=auto' -ru a/src/trad_nopo/Makefile b/src/trad_nopo/Makefile
+--- a/src/trad_nopo/Makefile	2025-03-15 19:12:02.764459397 +0300
++++ b/src/trad_nopo/Makefile	2025-03-15 19:32:01.911008245 +0300
+@@ -16,7 +16,8 @@
+         indice.o          \
+         lrang_poin.o
+ 
+-$(BINDIR)/$(EXEC) : $(OBJETS) $(LIBRAIRIE) ; \
+-         $(LINK) $@ $(OBJETS) $(LIBRAIRIE) ; $(STRIP)
++$(BINDIR)/$(EXEC) : $(OBJETS) $(LIBRAIRIE)
++	$(LINK) $@ $(OBJETS) $(LIBRAIRIE)
+ 
+-clean : ; /bin/rm $(OBJETS) $(BINDIR)/$(EXEC)
++clean :
++	rm $(OBJETS) $(BINDIR)/$(EXEC)
+diff '--color=auto' -ru a/src/various/Makefile b/src/various/Makefile
+--- a/src/various/Makefile	2025-03-15 19:12:02.765192945 +0300
++++ b/src/various/Makefile	2025-03-15 19:28:43.598136485 +0300
+@@ -1,27 +1,27 @@
+ include ../../RULES
+ 
+-all :; make clair clairc3d create_c3d obscur obscurc3d tradavoir translation txt2avoir
++all : clair clairc3d create_c3d obscur obscurc3d tradavoir translation txt2avoir
+ 
+-clair : clair.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/clair $(INCF) clair.f $(LIBRAIRIE) $(LINKOPTX)
++clair : clair.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/clair $(FCFLAGS) $(INCF) clair.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-clairc3d : clairc3d.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/clairc3d $(INCF) clairc3d.f $(LIBRAIRIE) $(LINKOPTX)
++clairc3d : clairc3d.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/clairc3d $(FCFLAGS) $(INCF) clairc3d.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-create_c3d : create_c3d.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/create_c3d $(INCF) create_c3d.f $(LIBRAIRIE) $(LINKOPTX)
++create_c3d : create_c3d.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/create_c3d $(FCFLAGS) $(INCF) create_c3d.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-obscur : obscur.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/obscur $(INCF) obscur.f $(LIBRAIRIE) $(LINKOPTX)
++obscur : obscur.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/obscur $(FCFLAGS) $(INCF) obscur.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-obscurc3d : obscurc3d.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/obscurc3d $(INCF) obscurc3d.f $(LIBRAIRIE) $(LINKOPTX)
++obscurc3d : obscurc3d.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/obscurc3d $(FCFLAGS) $(INCF) obscurc3d.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-tradavoir : tradavoir.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/tradavoir $(INCF) tradavoir.f $(LIBRAIRIE) $(LINKOPTX)
++tradavoir : tradavoir.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/tradavoir $(FCFLAGS) $(INCF) tradavoir.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-translation : translation.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/translation $(INCF) translation.f $(LIBRAIRIE) $(LINKOPTX)
++translation : translation.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/translation $(FCFLAGS) $(INCF) translation.f $(LIBRAIRIE) $(LINKOPTX)
+ 
+-txt2avoir : txt2avoir.f $(LIBRAIRIE) ;\
+-$(LINK) $(BINDIR)/txt2avoir $(INCF) txt2avoir.f $(LIBRAIRIE) $(LINKOPTX)
++txt2avoir : txt2avoir.f $(LIBRAIRIE)
++	$(LINK) $(BINDIR)/txt2avoir $(FCFLAGS) $(INCF) txt2avoir.f $(LIBRAIRIE) $(LINKOPTX)
+diff '--color=auto' -ru a/src/X/Makefile b/src/X/Makefile
+--- a/src/X/Makefile	2025-03-15 19:12:02.767459381 +0300
++++ b/src/X/Makefile	2025-03-15 19:29:26.910237495 +0300
+@@ -113,16 +113,22 @@
+ tabcol.o \
+ table.o
+ 
+-$(LIB) : $(OBJETS) ; $(AR) $@ $(OBJETS) ; $(RANLIB) $@
++$(LIB) : $(OBJETS)
++	$(AR) $@ $(OBJETS)
++	$(RANLIB) $@
+ 
+ lib : $(LIBMARC)
+-$(LIBMARC) : $(OBJETS) $(OBJETSMARC) ; $(AR) $@ $(OBJETS) $(OBJETSMARC) ; $(RANLIB) $@
++$(LIBMARC) : $(OBJETS) $(OBJETSMARC)
++	$(AR) $@ $(OBJETS) $(OBJETSMARC)
++	$(RANLIB) $@
+ 
+-all :; make ; make lib
++all : lib
+ 
+-clean : ; /bin/rm -f $(OBJETS) $(LIB) $(LIBMARC)
++clean :
++	rm -f $(OBJETS) $(LIB) $(LIBMARC)
+ 
+ x11device.o : mapixmap.h mabitmap.h
+-rotated.o   : rotated.c ; $(COMPILC) $(INCC) $(CACHEROT) $(OPTC) -c rotated.c
++rotated.o   : rotated.c
++	$(COMPILC) $(INCC) $(CACHEROT) $(OPTC) -c rotated.c
+ 
+-include Makefile.dep
+\ No newline at end of file
++include Makefile.dep

--- a/sci-visualization/xd3d/xd3d-8.3.1-r3.ebuild
+++ b/sci-visualization/xd3d/xd3d-8.3.1-r3.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo fortran-2 flag-o-matic toolchain-funcs
+
+DESCRIPTION="Scientific visualization tool"
+HOMEPAGE="https://www.ljll.fr/jouve/xd3d/"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc examples"
+
+RDEPEND="x11-libs/libXpm"
+DEPEND="${RDEPEND}"
+BDEPEND="app-shells/tcsh"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-r1-gentoo.patch
+	"${FILESDIR}"/${P}-sane-makefiles.patch
+	"${FILESDIR}"/${P}-rotated.patch
+	"${FILESDIR}"/${P}-c99.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e "s:##lib##:$(get_libdir):" RULES.gentoo || die "failed to set up RULES.gentoo"
+}
+
+src_configure() {
+	tc-export CC
+
+	export MY_AR="$(tc-getAR)"
+	export MY_RANLIB="$(tc-getRANLIB)"
+
+	# bug #863368
+	append-flags -fno-strict-aliasing
+	# bug #875236
+	append-cflags -std=gnu17
+	# I do not want to muck with redefining function names and linking problems, easiest way to deal with that
+	append-fflags -fno-underscoring
+	filter-lto
+
+	# GCC 10 workaround
+	# bug #722426
+	append-fflags $(test-flags-FC -fallow-argument-mismatch)
+
+	edo ./configure -arch=gentoo
+}
+
+src_install() {
+	dodir /usr/bin
+	emake INSTALL_DIR="${ED}/usr/bin" install
+	dodoc FORMATS
+
+	use doc && dodoc -r Manuals
+
+	if use examples; then
+		mv {E,e}xamples || die
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}


### PR DESCRIPTION
By slapping -std=gnu17 on it. And fortran option to remove underscore insertion in function names.
Patched relevant files to remove function name defines that fixed name incompatibility (due to underscores) but also caused implicit declaration errors.
Re-wrote makefiles - they were written like the author was lacking tab key and worked around that. Now it finally stops on error, and not when next job fails with bad dependencies.
Found and changed homepage to new URL.
Was unable to remove `which` - how do you do that in C shell??? It's not POSIX, lacks `command` build-in.

Closes: https://bugs.gentoo.org/944746
Closes: https://bugs.gentoo.org/886609
Closes: https://bugs.gentoo.org/875236

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
