### PR TITLE
sys-devel/dwz: fix installation on prefix

### DIFF
--- a/sys-devel/dwz/dwz-0.15-r1.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r1.ebuild
@@ -51,5 +51,5 @@ src_test() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" CFLAGS="${CFLAGS}" srcdir="${S}" install
+	emake DESTDIR="${ED}" CFLAGS="${CFLAGS}" srcdir="${S}" install
 }

--- a/sys-devel/dwz/dwz-0.15-r4.ebuild
+++ b/sys-devel/dwz/dwz-0.15-r4.ebuild
@@ -70,5 +70,5 @@ src_test() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" CFLAGS="${CFLAGS}" LIBS="${LIBS}" srcdir="${S}" install
+	emake DESTDIR="${ED}" CFLAGS="${CFLAGS}" LIBS="${LIBS}" srcdir="${S}" install
 }

--- a/sys-devel/dwz/dwz-9999.ebuild
+++ b/sys-devel/dwz/dwz-9999.ebuild
@@ -51,5 +51,5 @@ src_test() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" CFLAGS="${CFLAGS}" srcdir="${S}" install
+	emake DESTDIR="${ED}" CFLAGS="${CFLAGS}" srcdir="${S}" install
 }


### PR DESCRIPTION
Previously installation would fail:

```
Aborting due to QA concerns: there are files installed outside the prefix
```

This is fixed by using the prefix aware "${ED}" as DESTDIR.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
