### PR TITLE
games-arcade/lbreakout: fix build with modern compilers

### DIFF
--- a/games-arcade/lbreakout/lbreakout-010315-r2.ebuild
+++ b/games-arcade/lbreakout/lbreakout-010315-r2.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop toolchain-funcs autotools
+
+DESCRIPTION="Breakout clone written with the SDL library"
+HOMEPAGE="https://lgames.sourceforge.io/LBreakout/"
+SRC_URI="
+	https://downloads.sourceforge.net/lgames/${P}.tar.gz
+	https://dev.gentoo.org/~ionen/distfiles/${PN}.png"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	acct-group/gamestat
+	media-libs/libsdl[sound,video]"
+DEPEND="${RDEPEND}"
+
+HTML_DOCS=( lbreakout/manual/. )
+
+src_prepare() {
+	default
+
+	# bug 880949
+	eautoreconf
+
+	# remove /games from datadir, and use /var/games for highscore file
+	sed -e '/^sdir=/s|/games.*||;' \
+		-e "/^hdir=/s|=.*|=${EPREFIX}/var/games|" \
+		-i configure || die
+
+	tc-export CC CXX
+}
+
+src_install() {
+	dodir /var/games #655000
+
+	default
+
+	fowners :gamestat /usr/bin/${PN} /var/games/${PN}.hscr
+	fperms g+s /usr/bin/${PN}
+	fperms 660 /var/games/${PN}.hscr
+
+	doicon "${DISTDIR}"/${PN}.png
+	make_desktop_entry ${PN} LBreakout
+}


### PR DESCRIPTION
Autoreconf corrects bad bundled configure

Closes: https://bugs.gentoo.org/880949

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
