### PR TITLE
app-crypt/certbot: fix documentation, #950581

### DIFF
--- a/app-crypt/certbot/certbot-3.2.0-r101.ebuild
+++ b/app-crypt/certbot/certbot-3.2.0-r101.ebuild
@@ -23,7 +23,7 @@ else
 	# Only for amd64, arm64 and x86 because of dev-python/python-augeas
 	#KEYWORDS="~amd64 ~arm64 ~x86"
 	# Only for amd64 and x86 because of dev-python/dns-lexicon
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Let’s Encrypt client to automate deployment of X.509 certificates"

--- a/app-crypt/certbot/certbot-3.3.0-r1.ebuild
+++ b/app-crypt/certbot/certbot-3.3.0-r1.ebuild
@@ -19,11 +19,7 @@ else
 		https://github.com/certbot/certbot/archive/v${PV}.tar.gz
 			-> ${P}.gh.tar.gz
 	"
-	#KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
-	# Only for amd64, arm64 and x86 because of dev-python/python-augeas
-	#KEYWORDS="~amd64 ~arm64 ~x86"
-	# Only for amd64 and x86 because of dev-python/dns-lexicon
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Let’s Encrypt client to automate deployment of X.509 certificates"


### PR DESCRIPTION
Create dedicated directory to store each modules’ documentation.

Closes: https://bugs.gentoo.org/950581

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
