### PR TITLE
java-utils-2: Allow use of BDEPEND

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1580,7 +1580,7 @@ java-pkg_ensure-vm-version-sufficient() {
 java-pkg_is-vm-version-sufficient() {
 	debug-print-function ${FUNCNAME} $*
 
-	depend-java-query --is-sufficient "${DEPEND}" > /dev/null
+	depend-java-query --is-sufficient "${DEPEND} ${RDEPEND} ${BDEPEND}" > /dev/null
 	return $?
 }
 
@@ -1691,7 +1691,7 @@ java-pkg_current-vm-matches() {
 #
 # @RETURN: string - Either the lowest possible source, or JAVA_PKG_WANT_SOURCE
 java-pkg_get-source() {
-	echo ${JAVA_PKG_WANT_SOURCE:-$(depend-java-query --get-lowest "${DEPEND} ${RDEPEND}")}
+	echo ${JAVA_PKG_WANT_SOURCE:-$(depend-java-query --get-lowest "${DEPEND} ${RDEPEND} ${BDEPEND}")}
 }
 
 # @FUNCTION: java-pkg_get-target
@@ -2504,7 +2504,7 @@ java-pkg_do_write_() {
 			&& echo "DEPEND=\"$(sort -u "${JAVA_PKG_DEPEND_FILE}" | tr '\n' ':')\""
 		[[ -f "${JAVA_PKG_OPTIONAL_DEPEND_FILE}" ]] \
 			&& echo "OPTIONAL_DEPEND=\"$(sort -u "${JAVA_PKG_OPTIONAL_DEPEND_FILE}" | tr '\n' ':')\""
-		echo "VM=\"$(echo ${RDEPEND} ${DEPEND} | sed -e 's/ /\n/g' | sed -n -e '/virtual\/\(jre\|jdk\)/ { p;q }')\"" # TODO cleanup !
+		echo "VM=\">=virtual/jre-$(java-pkg_get-source):*\""
 		[[ -f "${JAVA_PKG_BUILD_DEPEND_FILE}" ]] \
 			&& echo "BUILD_DEPEND=\"$(sort -u "${JAVA_PKG_BUILD_DEPEND_FILE}" | tr '\n' ':')\""
 	) > "${JAVA_PKG_ENV}"
@@ -2653,9 +2653,7 @@ java-pkg_setup-vm() {
 java-pkg_needs-vm() {
 	debug-print-function ${FUNCNAME} $*
 
-	if [[ -n "$(echo ${JAVA_PKG_NV_DEPEND:-${DEPEND}} | sed -e '\:virtual/jdk:!d')" ]]; then
-		return 0
-	fi
+	java-pkg_get-source &>/dev/null && return 0
 
 	[[ -n "${JAVA_PKG_WANT_BUILD_VM}" ]] && return 0
 
@@ -2687,6 +2685,24 @@ java-pkg_get-vm-version() {
 	debug-print-function ${FUNCNAME} $*
 
 	java-config -g PROVIDES_VERSION
+}
+
+# @FUNCTION: java-pkg_determine-vm-version
+# @INTERNAL
+# @RETURN: Returns the highest supported version
+java-pkg_determine-vm-version() {
+	debug-print-function ${FUNCNAME} $*
+
+        local dep val min_val
+
+	for dep in "${DEPEND}" "${RDEPEND}" "${BDEPEND}"; do
+    		val="$(depend-java-query --get-vm "$dep" 2>/dev/null)"
+	        if [[ -n "$val" ]] && [[ ! "$min_val" || "$val" < "$min_val" ]]; then
+		        min_val="$val"
+	        fi
+        done
+
+	echo "$min_val"
 }
 
 # @FUNCTION: java-pkg_build-vm-from-handle
@@ -2763,11 +2779,11 @@ java-pkg_switch-vm() {
 				fi
 			# otherwise determine a vm from dep string
 			else
-				debug-print "depend-java-query:  NV_DEPEND:	${JAVA_PKG_NV_DEPEND:-${DEPEND}}"
-				GENTOO_VM="$(depend-java-query --get-vm "${JAVA_PKG_NV_DEPEND:-${DEPEND}}")"
+				debug-print "depend-java-query:  NV_DEPEND:	${DEPEND} ${RDEPEND} ${BDEPEND}"
+				GENTOO_VM="$(java-pkg_determine-vm-version)"
 				if [[ -z "${GENTOO_VM}" || "${GENTOO_VM}" == "None" ]]; then
 					eerror "Unable to determine VM for building from dependencies:"
-					echo "NV_DEPEND: ${JAVA_PKG_NV_DEPEND:-${DEPEND}}"
+					echo "NV_DEPEND: ${DEPEND} ${RDEPEND} ${BDEPEND}"
 					die "Failed to determine VM for building."
 				fi
 			fi


### PR DESCRIPTION
* It allows you to use different requirements to compile a Java ebuild that needs a specific version to be compiled, but to run it can use other versions.
* Delete never used variable JAVA_PKG_NV_DEPEND

For example: dev-java/javaparser-core-3.13.10

<pre>
--- javaparser-core-3.13.10.ebuild	2025-03-19 12:41:47.556386364 +0100
+++ javaparser-core-3.13.10.ebuild	2025-03-19 12:41:47.556386364 +0100 @@
-19,9 +19,8 @@

 JAVACC_SLOT="7.0.4"

-BDEPEND="dev-java/javacc:7.0.4"
-# Does not compile with Java 21
-DEPEND="<=virtual/jdk-17:*"
+BDEPEND="dev-java/javacc:7.0.4
+	<=virtual/jdk-17:*" RDEPEND=">=virtual/jre-1.8:*"

 DOCS=( CONTRIBUTING.md changelog.md readme.md )
</pre>

Java version less than 17 is required to compile, but it runs smoothly with Java version 21. This is useful when generating binpkg, so unnecessary dependencies are not installed.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

Signed-off-by: Fco Javier Felix <web@inode64.com>