### PR TITLE
dev-db/mysql-workbench: Allow to build with system-vm set to openjdk-8

### DIFF
--- a/dev-db/mysql-workbench/mysql-workbench-8.0.41-r1.ebuild
+++ b/dev-db/mysql-workbench/mysql-workbench-8.0.41-r1.ebuild
@@ -9,7 +9,7 @@ PYTHON_REQ_USE="sqlite"
 
 ANTLR_VERSION=4.13.2
 
-inherit gnome2 flag-o-matic python-single-r1 cmake
+inherit gnome2 flag-o-matic java-pkg-2 python-single-r1 cmake
 
 MY_P="${PN}-community-${PV}-src"
 
@@ -59,11 +59,14 @@ CDEPEND="${PYTHON_DEPS}
 
 RDEPEND="${CDEPEND}
 		app-admin/sudo
+		>=virtual/jre-1.8:*
 		>=sys-apps/net-tools-1.60_p20120127084908"
 
+# To allow building with java system-vm set to openjdk{,-bin}-8 it needs DEPEND with jdk
+# https://bugs.gentoo.org/933844
 DEPEND="${CDEPEND}
 		dev-lang/swig
-		>=virtual/jre-11
+		>=virtual/jdk-11:*
 		virtual/pkgconfig"
 
 PATCHES=(
@@ -71,6 +74,11 @@ PATCHES=(
 	"${FILESDIR}/${PN}-8.0.19-mysql-connector-8.patch"
 	"${FILESDIR}/${PN}-8.0.33-gcc13.patch"
 )
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	python-single-r1_pkg_setup
+}
 
 src_unpack() {
 	unpack ${PN}-community-${PV}-src.tar.gz
@@ -84,6 +92,12 @@ src_prepare() {
 
 	## package is very fragile...
 	strip-flags
+
+	java-pkg-2_src_prepare
+
+	# bundled jar and class should be built from source and exclusions be removed.
+	java-pkg_clean ! -path "./library/sql.parser/yy_purify-tool/dist/yy_purify.jar" \
+		! -path "./library/sql.parser/update-tool/classes/BisonHelper.class"
 
 	cmake_src_prepare
 }


### PR DESCRIPTION
This ebuild did not inherit a java eclass nor did it depend on virtual/jdk.  On systems having java system-vm set to openjdk{,-bin}-8 this was causing errors.

This commit adds java-pkg-2 to inherit, switches dependencies to java defaults and adds the pkg_setup() section with java-pkg-2_pkg_setup.

Revbump because of dependency changes.

Closes: https://bugs.gentoo.org/933844
Closes: https://bugs.gentoo.org/914052

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
