### PR TITLE
dev-cpp/libjson-rpc-cpp: Bump minimal required CMake version

### DIFF
--- a/dev-cpp/libjson-rpc-cpp/files/libjson-rpc-cpp-1.4.0-cmake.patch
+++ b/dev-cpp/libjson-rpc-cpp/files/libjson-rpc-cpp-1.4.0-cmake.patch
@@ -1,0 +1,33 @@
+Bump CMake minimum version, delete obsolete policy that's related to MacOS and
+doesn't worry us
+https://bugs.gentoo.org/951671
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # setup directory where we should look for cmake files
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+--- a/src/catch/CMakeLists.txt
++++ b/src/catch/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ project(catch_builder CXX)
+ include(ExternalProject)
+ 
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,11 +16,6 @@
+ cmake_policy(SET CMP0007 NEW)
+ cmake_policy(SET CMP0012 NEW)
+ 
+-if (${CMAKE_MAJOR_VERSION} GREATER 2)
+-    # old policy do not use MACOSX_RPATH
+-    cmake_policy(SET CMP0042 OLD)
+-endif()
+-
+ set(MAJOR_VERSION 1)
+ set(MINOR_VERSION 4)
+ set(PATCH_VERSION 0)

--- a/dev-cpp/libjson-rpc-cpp/libjson-rpc-cpp-1.4.0-r1.ebuild
+++ b/dev-cpp/libjson-rpc-cpp/libjson-rpc-cpp-1.4.0-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="JSON-RPC (1.0 & 2.0) framework for C++"
+HOMEPAGE="https://github.com/cinemast/libjson-rpc-cpp/"
+SRC_URI="
+	https://github.com/cinemast/${PN}/archive/v${PV}.tar.gz
+		-> ${P}.tar.gz
+"
+
+LICENSE="MIT"
+SLOT="0/1"
+KEYWORDS="~amd64 ~x86"
+IUSE="+http-client +http-server redis-client redis-server +stubgen test"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	dev-libs/jsoncpp:=
+	http-client? ( net-misc/curl:= )
+	http-server? ( net-libs/libmicrohttpd:= )
+	redis-client? ( dev-libs/hiredis:= )
+	redis-server? ( dev-libs/hiredis:= )
+	stubgen? ( dev-libs/argtable:= )
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	test? (
+		<dev-cpp/catch-3
+	)
+"
+
+PATCHES=( "${FILESDIR}/${P}-cmake.patch" )
+
+src_configure() {
+	local mycmakeargs=(
+		-DHTTP_CLIENT=$(usex http-client)
+		-DHTTP_SERVER=$(usex http-server)
+		-DREDIS_CLIENT=$(usex redis-client)
+		-DREDIS_SERVER=$(usex redis-server)
+		# they have no deps
+		-DTCP_SOCKET_CLIENT=ON
+		-DTCP_SOCKET_SERVER=ON
+		-DSERIAL_PORT_CLIENT=ON
+		-DSERIAL_PORT_SERVER=ON
+		-DUNIX_DOMAIN_SOCKET_CLIENT=ON
+		-DUNIX_DOMAIN_SOCKET_SERVER=ON
+		# they are not installed
+		-DCOMPILE_EXAMPLES=OFF
+		-DCOMPILE_STUBGEN=$(usex stubgen)
+		-DCOMPILE_TESTS=$(usex test)
+		# disable coverage-related flags
+		-DWITH_COVERAGE=OFF
+	)
+	use test && mycmakeargs+=(
+		-DCATCH_INCLUDE_DIR="${EPREFIX}/usr/include"
+	)
+
+	cmake_src_configure
+}
+
+src_test() {
+	# Tests fail randomly when run in parallel
+	local MAKEOPTS=-j1
+	cmake_src_test
+}


### PR DESCRIPTION
Fix for CMake 4

Closes: https://bugs.gentoo.org/951671

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
