### PR TITLE
sys-boot/woeusb-ng: fix syntax warning in Python 3.12

### DIFF
--- a/sys-boot/woeusb-ng/files/woeusb-ng-0.2.12-python3.12.patch
+++ b/sys-boot/woeusb-ng/files/woeusb-ng-0.2.12-python3.12.patch
@@ -1,0 +1,16 @@
+https://github.com/WoeUSB/WoeUSB-ng/pull/134
+Fix invalid escape sequence
+\. is not a valid escape sequence since Python 3.12 and generates a warning.
+It will become an error in a future version.
+https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes
+--- a/WoeUSB/workaround.py
++++ b/WoeUSB/workaround.py
+@@ -52,7 +52,7 @@ def support_windows_7_uefi_boot(source_fs_mountpoint, target_fs_mountpoint):
+     :param target_fs_mountpoint:
+     :return:
+     """
+-    grep = subprocess.run(["grep", "--extended-regexp", "--quiet", "^MinServer=7[0-9]{3}\.[0-9]",
++    grep = subprocess.run(["grep", "--extended-regexp", "--quiet", r"^MinServer=7[0-9]{3}\.[0-9]",
+                            source_fs_mountpoint + "/sources/cversion.ini"],
+                           stdout=subprocess.PIPE).stdout.decode("utf-8").strip()
+     if grep == "" and not os.path.isfile(source_fs_mountpoint + "/bootmgr.efi"):

--- a/sys-boot/woeusb-ng/woeusb-ng-0.2.12.ebuild
+++ b/sys-boot/woeusb-ng/woeusb-ng-0.2.12.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-pkg-discovery.patch
+	"${FILESDIR}"/${P}-python3.12.patch
 	"${FILESDIR}"/${P}-skip-postinstall.patch
 )
 


### PR DESCRIPTION
https://github.com/gentoo/gentoo/pull/41195#pullrequestreview-2705158301

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
