### PR TITLE
sys-libs/glibc: Restore stripping for cross-compile if using llvm-strip

### DIFF
--- a/sys-libs/glibc/glibc-2.31-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.31-r7.ebuild
@@ -1219,7 +1219,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.32-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r8.ebuild
@@ -1248,7 +1248,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.33-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.33-r14.ebuild
@@ -1270,7 +1270,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.34-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.34-r14.ebuild
@@ -1291,7 +1291,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.35-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.35-r11.ebuild
@@ -1299,7 +1299,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.36-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r8.ebuild
@@ -1329,7 +1329,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 	# gdb thread introspection relies on local libpthreas symbols. stripping breaks it
 	# See Note [Disable automatic stripping]
 	dostrip -x $(alt_libdir)/libpthread-${upstream_pv}.so

--- a/sys-libs/glibc/glibc-2.37-r10.ebuild
+++ b/sys-libs/glibc/glibc-2.37-r10.ebuild
@@ -1348,7 +1348,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-2.38-r13.ebuild
+++ b/sys-libs/glibc/glibc-2.38-r13.ebuild
@@ -1367,7 +1367,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-2.39-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.39-r11.ebuild
@@ -1375,7 +1375,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-2.40-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.40-r8.ebuild
@@ -1355,7 +1355,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-2.40-r9.ebuild
+++ b/sys-libs/glibc/glibc-2.40-r9.ebuild
@@ -1355,7 +1355,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-2.41.ebuild
+++ b/sys-libs/glibc/glibc-2.41.ebuild
@@ -1360,7 +1360,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -1360,7 +1360,8 @@ glibc_do_src_install() {
 
 	# Avoid stripping binaries not targeted by ${CHOST}. Or else
 	# ${CHOST}-strip would break binaries build for ${CTARGET}.
-	is_crosscompile && dostrip -x /
+	# Do this only if stripping with GNU tools.
+	[[ $STRIP != llvm-strip ]] && is_crosscompile && dostrip -x /
 
 	# gdb thread introspection relies on local libpthreads symbols. stripping breaks it
 	# See Note [Disable automatic stripping]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/950662

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
