### PR TITLE
games-action/koth: update EAPI 7 -> 8, fix build under LTO

### DIFF
--- a/games-action/koth/files/koth-0.8.0-lto.patch
+++ b/games-action/koth/files/koth-0.8.0-lto.patch
@@ -1,0 +1,13 @@
+Remove extraneous inline that prevents successful linking under LTO
+https://bugs.gentoo.org/942296
+--- a/src/cfgfile.c
++++ b/src/cfgfile.c
+@@ -53,7 +53,7 @@
+     return result;
+ }
+ 
+-inline char *cfgClearWS(char *string)
++char *cfgClearWS(char *string)
+ {
+     char *ret = string, *temp;
+     while(isspace(*ret))

--- a/games-action/koth/koth-0.8.0-r2.ebuild
+++ b/games-action/koth/koth-0.8.0-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Multiplayer, networked game of little tanks with really big weapons"
+HOMEPAGE="http://www.nongnu.org/koth/"
+SRC_URI="https://savannah.nongnu.org/download/${PN}/default.pkg/${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/libggi"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-autotools.patch
+	"${FILESDIR}"/${P}-gcc.patch
+	"${FILESDIR}"/${P}-lto.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_install() {
+	default
+	dodoc doc/*.txt
+
+	insinto /etc/koth
+	doins src/koth.cfg
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/942296

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
