### PR TITLE
dev-libs/unittest++: update EAPI 7 -> 8, fix build with CMake4

### DIFF
--- a/dev-libs/unittest++/files/unittest++-2.0.0-cmake4.patch
+++ b/dev-libs/unittest++/files/unittest++-2.0.0-cmake4.patch
@@ -1,0 +1,11 @@
+Bump minimum cmake version, this builds with no warnings
+beyond request to bump to 3.10
+https://bugs.gentoo.org/951811
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.1)
++cmake_minimum_required(VERSION 3.5)
+ project(UnitTest++)
+ 
+ option(UTPP_USE_PLUS_SIGN

--- a/dev-libs/unittest++/unittest++-2.0.0-r3.ebuild
+++ b/dev-libs/unittest++/unittest++-2.0.0-r3.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+MY_PN="unittest-cpp"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="A lightweight unit testing framework for C++"
+HOMEPAGE="https://unittest-cpp.github.io/"
+SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	# https://github.com/unittest-cpp/unittest-cpp/commit/2423fcac7668aa9c331a2dcf024c3ca06742942d
+	"${FILESDIR}"/${P}-fix-tests-with-clang.patch
+
+	"${FILESDIR}"/${P}-cmake-fix-pkgconfig-dir-path-on-FreeBSD.patch
+	"${FILESDIR}"/${P}-Add-support-for-LIB_SUFFIX.patch
+	"${FILESDIR}"/${P}-cmake4.patch
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# https://github.com/unittest-cpp/unittest-cpp/pull/163
+	sed -i '/run unit tests as post build step/,/Running unit tests/d' \
+		CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		# Don't build with -Werror: https://bugs.gentoo.org/747583
+		-DUTPP_AMPLIFY_WARNINGS=OFF
+		-DUTPP_INCLUDE_TESTS_IN_BUILD=$(usex test)
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	"${BUILD_DIR}/TestUnitTest++" || die "Tests failed"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951811

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
