### PR TITLE
mv sci-ml/caffe2 from python-single-r1 to python-r1

### DIFF
--- a/sci-ml/accelerate/accelerate-1.5.2-r1.ebuild
+++ b/sci-ml/accelerate/accelerate-1.5.2-r1.ebuild
@@ -2,9 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
-DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1
 
 DESCRIPTION="Run your *raw* PyTorch training script on any kind of device"
@@ -17,9 +16,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 RDEPEND="
-	$(python_gen_cond_dep '
-		sci-ml/pytorch[${PYTHON_USEDEP}]
-	')
+	sci-ml/pytorch[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"
 BDEPEND="test? (

--- a/sci-ml/datasets/datasets-2.21.0-r4.ebuild
+++ b/sci-ml/datasets/datasets-2.21.0-r4.ebuild
@@ -4,8 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
-DISTUTILS_SINGLE_IMPL=1
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="Access and share datasets for Audio, Computer Vision, and NLP tasks"
@@ -21,38 +20,34 @@ IUSE="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
-	$(python_gen_cond_dep '
-		dev-python/aiohttp[${PYTHON_USEDEP}]
-		dev-python/dill[${PYTHON_USEDEP}]
-		dev-python/filelock[${PYTHON_USEDEP}]
-		dev-python/fsspec[${PYTHON_USEDEP}]
-		dev-python/multiprocess[${PYTHON_USEDEP}]
-		dev-python/numpy[${PYTHON_USEDEP}]
-		dev-python/packaging[${PYTHON_USEDEP}]
-		dev-python/pandas[${PYTHON_USEDEP}]
-		dev-python/pyarrow[${PYTHON_USEDEP},parquet,snappy]
-		dev-python/pyyaml[${PYTHON_USEDEP}]
-		dev-python/requests[${PYTHON_USEDEP}]
-		dev-python/tqdm[${PYTHON_USEDEP}]
-		dev-python/xxhash[${PYTHON_USEDEP}]
-		sci-ml/caffe2[${PYTHON_USEDEP},numpy]
-		sci-ml/huggingface_hub[${PYTHON_USEDEP}]
-		sci-ml/pytorch[${PYTHON_USEDEP}]
-	')
+	dev-python/aiohttp[${PYTHON_USEDEP}]
+	dev-python/dill[${PYTHON_USEDEP}]
+	dev-python/filelock[${PYTHON_USEDEP}]
+	dev-python/fsspec[${PYTHON_USEDEP}]
+	dev-python/multiprocess[${PYTHON_USEDEP}]
+	dev-python/numpy[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/pandas[${PYTHON_USEDEP}]
+	dev-python/pyarrow[${PYTHON_USEDEP},parquet,snappy]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	dev-python/tqdm[${PYTHON_USEDEP}]
+	dev-python/xxhash[${PYTHON_USEDEP}]
+	sci-ml/caffe2[${PYTHON_USEDEP},numpy]
+	sci-ml/huggingface_hub[${PYTHON_USEDEP}]
+	sci-ml/pytorch[${PYTHON_USEDEP}]
 "
 DEPEND="${RDEPEND}"
 BDEPEND="test? (
-	$(python_gen_cond_dep '
-		dev-python/absl-py[${PYTHON_USEDEP}]
-		dev-python/decorator[${PYTHON_USEDEP}]
-		dev-python/pytest-datadir[${PYTHON_USEDEP}]
-		dev-python/scikit-learn[${PYTHON_USEDEP}]
-		dev-python/sqlalchemy[${PYTHON_USEDEP}]
-		dev-python/zstandard[${PYTHON_USEDEP}]
-		sci-ml/jiwer[${PYTHON_USEDEP}]
-		sci-ml/seqeval[${PYTHON_USEDEP}]
-	')
-	sci-ml/torchvision[${PYTHON_SINGLE_USEDEP}]
+	dev-python/absl-py[${PYTHON_USEDEP}]
+	dev-python/decorator[${PYTHON_USEDEP}]
+	dev-python/pytest-datadir[${PYTHON_USEDEP}]
+	dev-python/scikit-learn[${PYTHON_USEDEP}]
+	dev-python/sqlalchemy[${PYTHON_USEDEP}]
+	dev-python/zstandard[${PYTHON_USEDEP}]
+	sci-ml/jiwer[${PYTHON_USEDEP}]
+	sci-ml/seqeval[${PYTHON_USEDEP}]
+	sci-ml/torchvision[${PYTHON_USEDEP}]
 )"
 
 PATCHES=(

--- a/sci-ml/evaluate/evaluate-0.4.3.ebuild
+++ b/sci-ml/evaluate/evaluate-0.4.3.ebuild
@@ -25,8 +25,8 @@ RDEPEND="
 		dev-python/matplotlib[${PYTHON_USEDEP}]
 		dev-python/pyarrow[${PYTHON_USEDEP},parquet]
 		dev-python/unidecode[${PYTHON_USEDEP}]
+		sci-ml/datasets[${PYTHON_USEDEP}]
 	')
-	sci-ml/datasets[${PYTHON_SINGLE_USEDEP}]
 	sci-ml/transformers[${PYTHON_SINGLE_USEDEP}]
 "
 BDEPEND="test? (

--- a/sci-ml/huggingface_hub/huggingface_hub-0.24.7.ebuild
+++ b/sci-ml/huggingface_hub/huggingface_hub-0.24.7.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="a client library to interact with the Hugging Face Hub"

--- a/sci-ml/huggingface_hub/huggingface_hub-0.25.2.ebuild
+++ b/sci-ml/huggingface_hub/huggingface_hub-0.25.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="a client library to interact with the Hugging Face Hub"

--- a/sci-ml/huggingface_hub/huggingface_hub-0.26.5.ebuild
+++ b/sci-ml/huggingface_hub/huggingface_hub-0.26.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="a client library to interact with the Hugging Face Hub"

--- a/sci-ml/jiwer/jiwer-3.0.3.ebuild
+++ b/sci-ml/jiwer/jiwer-3.0.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="Evaluate an automatic speech recognition system"

--- a/sci-ml/safetensors/safetensors-0.4.5-r1.ebuild
+++ b/sci-ml/safetensors/safetensors-0.4.5-r1.ebuild
@@ -50,7 +50,7 @@ CRATES="
 "
 
 DISTUTILS_USE_PEP517=maturin
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit distutils-r1 cargo
 

--- a/sci-ml/seqeval/seqeval-1.2.2-r3.ebuild
+++ b/sci-ml/seqeval/seqeval-1.2.2-r3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit distutils-r1
 
 DESCRIPTION="Python framework for sequence labeling evaluation"

--- a/sci-ml/tokenizers/tokenizers-0.20.1-r1.ebuild
+++ b/sci-ml/tokenizers/tokenizers-0.20.1-r1.ebuild
@@ -283,8 +283,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 BDEPEND="
-	test? ( sci-ml/datasets[${PYTHON_SINGLE_USEDEP}] )
 	$(python_gen_cond_dep '
+		test? (
+			sci-ml/datasets[${PYTHON_USEDEP}]
+		)
 		dev-python/setuptools-rust[${PYTHON_USEDEP}]
 	')
 "

--- a/sci-ml/tokenizers/tokenizers-0.21.0.ebuild
+++ b/sci-ml/tokenizers/tokenizers-0.21.0.ebuild
@@ -6,7 +6,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=maturin
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_EXT=1
 DISTUTILS_SINGLE_IMPL=1
 
@@ -319,8 +319,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 BDEPEND="
-	test? ( sci-ml/datasets[${PYTHON_SINGLE_USEDEP}] )
 	$(python_gen_cond_dep '
+		test? (
+			sci-ml/datasets[${PYTHON_USEDEP}]
+		)
 		dev-python/setuptools-rust[${PYTHON_USEDEP}]
 	')
 "

--- a/sci-ml/torchvision/torchvision-0.20.0-r1.ebuild
+++ b/sci-ml/torchvision/torchvision-0.20.0-r1.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
-DISTUTILS_SINGLE_IMPL=1
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_EXT=1
 inherit cuda distutils-r1 multiprocessing
@@ -22,21 +21,17 @@ KEYWORDS="~amd64"
 IUSE="cuda"
 
 RDEPEND="
-	=sci-ml/caffe2-2.5*[cuda?]
 	dev-python/numpy
 	dev-python/pillow
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
-	$(python_gen_cond_dep '
-		=sci-ml/pytorch-2.5*[${PYTHON_USEDEP}]
-	')
+	=sci-ml/caffe2-2.5*[cuda?]
+	=sci-ml/pytorch-2.5*[${PYTHON_USEDEP}]
 "
 BDEPEND="
 	test? (
-		$(python_gen_cond_dep '
-			dev-python/pytest-mock[${PYTHON_USEDEP}]
-			dev-python/lmdb[${PYTHON_USEDEP}]
-		')
+		dev-python/lmdb[${PYTHON_USEDEP}]
+		dev-python/pytest-mock[${PYTHON_USEDEP}]
 	)
 "
 

--- a/sci-ml/transformers/transformers-4.49.0-r4.ebuild
+++ b/sci-ml/transformers/transformers-4.49.0-r4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1
 
@@ -35,13 +35,11 @@ RDEPEND="
 		>=sci-ml/huggingface_hub-0.26[${PYTHON_USEDEP}]
 		>=sci-ml/safetensors-0.4.1[${PYTHON_USEDEP}]
 		torch? (
+			sci-ml/accelerate[${PYTHON_USEDEP}]
 			sci-ml/caffe2[${PYTHON_USEDEP}]
 			sci-ml/pytorch[${PYTHON_USEDEP}]
 		)
 	')
-	torch? (
-		sci-ml/accelerate[${PYTHON_SINGLE_USEDEP}]
-	)
 "
 BDEPEND="
 	$(python_gen_cond_dep '


### PR DESCRIPTION
I want to move caffe2 from single python implementation to multi, so to easy all reverse dependency

All the actual reverse dependency should be updated 

---

Please check all the boxes that apply:

- [ X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
