### PR TITLE
sys-process/tini: update EAPI 7 -> 8, fix build with CMake 4

### DIFF
--- a/sys-process/tini/files/tini-0.19.0-cmake4.patch
+++ b/sys-process/tini/files/tini-0.19.0-cmake4.patch
@@ -1,0 +1,10 @@
+Version bump for compatibility with CMake 4
+https://bugs.gentoo.org/951903
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.0)
++cmake_minimum_required (VERSION 3.5.0)
+ project (tini C)
+ 
+ # Config

--- a/sys-process/tini/tini-0.19.0-r2.ebuild
+++ b/sys-process/tini/tini-0.19.0-r2.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+# guard against forgetfulness, https://bugs.gentoo.org/795936
+GIT_COMMIT_0190="de40ad007797e0dcd8b7126f27bb87401d224240"
+GIT_COMMIT="GIT_COMMIT_${PV//./}"
+GIT_COMMIT="${!GIT_COMMIT}"
+
+DESCRIPTION="A tiny but valid init for containers"
+HOMEPAGE="https://github.com/krallin/tini"
+SRC_URI="https://github.com/krallin/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~riscv ~x86"
+IUSE="+args +static"
+
+PATCHES=(
+	"${FILESDIR}/${P}-musl-basename.patch"
+	"${FILESDIR}/${P}-cmake4.patch"
+	)
+
+src_prepare() {
+
+	[[ -z ${GIT_COMMIT} ]] && die "forgetful maintainer! please define GIT_COMMIT_${PV//./} on bump"
+
+	cmake_src_prepare
+
+	local sed_args=(
+		# Do not strip binary
+		-e 's/-Wl,-s")$/")/'
+
+		# Remove -Werror and -pedantic-errors in order to allow macro
+		# redefinition, so that CFLAGS="-U_FORTIFY_SOURCE" does not
+		# trigger an error due to add_definitions(-D_FORTIFY_SOURCE=2)
+		# in CMakeLists.txt (bug 626438).
+		-e "s/ -Werror / /"
+		-e "s/ -pedantic-errors / /"
+	)
+
+	sed -i "${sed_args[@]}" \
+		-e "s/git.*status --porcelain.*/true/" \
+		-e "s/git.*log -n 1.*/true/" \
+		-e "s/git.\${tini_VERSION_GIT}/git.${GIT_COMMIT}/" \
+		CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=()
+	use args || mycmakeargs+=(-DMINIMAL=ON)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	append-cflags -DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37
+	cmake_src_compile
+}
+
+src_install() {
+	cmake_src_install
+	if use static; then
+		mv "${ED}"/usr/bin/{${PN}-static,${PN}} || die
+	else
+		rm "${ED}"/usr/bin/${PN}-static || die
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951903

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
