### PR TITLE
media-video/mkvalidator: Fix build with CMake4

### DIFF
--- a/media-video/mkvalidator/files/mkvalidator-0.6.0-cmake4.patch
+++ b/media-video/mkvalidator/files/mkvalidator-0.6.0-cmake4.patch
@@ -1,0 +1,10 @@
+Fix build with CMake4
+https://bugs.gentoo.org/951925
+--- a/CMakeLists.txt	2025-03-23 21:09:27.899813094 +0300
++++ b/CMakeLists.txt	2025-03-23 21:12:50.990263429 +0300
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.2)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project("mkvalidator")
+ 

--- a/media-video/mkvalidator/mkvalidator-0.6.0-r1.ebuild
+++ b/media-video/mkvalidator/mkvalidator-0.6.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+DESCRIPTION="mkvalidator is a command line tool to verify Matroska files for spec conformance"
+HOMEPAGE="https://www.matroska.org/downloads/mkvalidator.html"
+SRC_URI="https://downloads.sourceforge.net/project/matroska/${PN}/${P}.tar.bz2"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=( "${FILESDIR}/${P}-cmake4.patch" )
+
+src_configure() {
+	# https://bugs.gentoo.org/949733
+	append-flags -fno-strict-aliasing
+	filter-lto
+
+	local mycmakeargs=(
+		-DCMAKE_SKIP_RPATH=ON
+		-DBUILD_SHARED_LIBS=OFF
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	newdoc ChangeLog.txt ChangeLog
+	newdoc ReadMe.txt README
+
+	cd "${BUILD_DIR}" || die
+	dobin mkvalidator/mkvalidator
+}


### PR DESCRIPTION
And add -fno-strict-aliasing and filter lto due to funky video bit fiddling

Closes: https://bugs.gentoo.org/949733
Closes: https://bugs.gentoo.org/951925

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
