### PR TITLE
sys-kernel/dracut: do not call mdadm with full path

### DIFF
--- a/sys-kernel/dracut/dracut-106-r2.ebuild
+++ b/sys-kernel/dracut/dracut-106-r2.ebuild
@@ -103,6 +103,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-106-acct-user-group-gentoo.patch
 	# https://github.com/dracut-ng/dracut-ng/pull/1207
 	"${FILESDIR}"/${PN}-106-fix-rngd-module.patch
+	# https://github.com/dracut-ng/dracut-ng/pull/1250
+	"${FILESDIR}"/${PN}-106-fix-mdraid-module.patch
 )
 
 pkg_setup() {

--- a/sys-kernel/dracut/files/dracut-106-fix-mdraid-module.patch
+++ b/sys-kernel/dracut/files/dracut-106-fix-mdraid-module.patch
@@ -1,0 +1,17 @@
+https://github.com/dracut-ng/dracut-ng/pull/1250
+diff --git a/modules.d/90mdraid/module-setup.sh b/modules.d/90mdraid/module-setup.sh
+index 8ce5f2ee..b0ab8411 100755
+--- a/modules.d/90mdraid/module-setup.sh
++++ b/modules.d/90mdraid/module-setup.sh
+@@ -46,7 +46,7 @@ cmdline() {
+         [[ ${host_fs_types[$dev]} != *_raid_member ]] && continue
+ 
+         UUID=$(
+-            /sbin/mdadm --examine --export "$dev" \
++            mdadm --examine --export "$dev" \
+                 | while read -r line || [[ "$line" ]]; do
+                     [[ ${line#MD_UUID=} == "$line" ]] && continue
+                     printf "%s" "${line#MD_UUID=} "
+-- 
+2.48.1
+


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/951284

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
