### PR TITLE
sys-boot/syslinux: fix pkgcheck warning & force gcc

### DIFF
--- a/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,6 +9,8 @@ DESCRIPTION="SYSLINUX, PXELINUX, ISOLINUX, EXTLINUX and MEMDISK bootloaders"
 HOMEPAGE="https://www.syslinux.org/"
 MY_P=${P/_/-}
 SRC_URI="https://git.zytor.com/syslinux/syslinux.git/snapshot/${MY_P}.tar.gz"
+
+S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -22,6 +24,7 @@ RESTRICT="test"
 BDEPEND="
 	dev-lang/perl
 	bios? ( dev-lang/nasm )
+	sys-devel/gcc:*
 "
 RDEPEND="
 	sys-apps/util-linux
@@ -33,8 +36,6 @@ DEPEND="${RDEPEND}
 	uefi? ( sys-boot/gnu-efi[abi_x86_32(-)?,abi_x86_64(-)?] )
 	virtual/os-headers
 "
-
-S=${WORKDIR}/${MY_P}
 
 QA_EXECSTACK="usr/share/syslinux/*"
 QA_WX_LOAD="usr/share/syslinux/*"
@@ -51,6 +52,15 @@ src_prepare() {
 		"${FILESDIR}/6.04_pre3"
 	)
 	default
+
+	# Force gcc because build failed with clang, #729426
+	if ! tc-is-gcc ; then
+		ewarn "syslinux can be built with gcc only."
+		ewarn "Ignoring CC=$(tc-getCC) and forcing ${CHOST}-gcc"
+		export CC=${CHOST}-gcc
+		export CXX=${CHOST}-g++
+		tc-is-gcc || die "tc-is-gcc failed in spite of CC=${CC}"
+	fi
 }
 
 efimake() {


### PR DESCRIPTION
'#include_next <stdarg.h>' can be fixed by append
'-I/usr/lib/clang/19/include', but gcc only option is used, for example '--print-libgcc' is used in mk/{elf,embedded}.mk:

> LIBGCC    := $(shell $(CC) $(GCCOPT) --print-libgcc)

Closes: https://bugs.gentoo.org/729426

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
