### PR TITLE
media-libs/libavif: enable libyuv on multilib native only

### DIFF
--- a/media-libs/libavif/libavif-1.2.0.ebuild
+++ b/media-libs/libavif/libavif-1.2.0.ebuild
@@ -74,7 +74,6 @@ multilib_src_configure() {
 		-DAVIF_CODEC_DAV1D=$(usex dav1d SYSTEM OFF)
 		-DAVIF_ZLIBPNG=SYSTEM
 		-DAVIF_JPEG=SYSTEM
-		-DAVIF_LIBYUV=$(usex libyuv SYSTEM OFF)
 
 		-DAVIF_BUILD_GDK_PIXBUF=$(usex gdk-pixbuf ON OFF)
 
@@ -85,6 +84,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DAVIF_CODEC_RAV1E=$(usex rav1e SYSTEM OFF)
 			-DAVIF_CODEC_SVT=$(usex svt-av1 SYSTEM OFF)
+			-DAVIF_LIBYUV=$(usex libyuv SYSTEM OFF)
 
 			-DAVIF_BUILD_EXAMPLES=$(usex examples ON OFF)
 			-DAVIF_BUILD_APPS=$(usex extras ON OFF)
@@ -95,6 +95,7 @@ multilib_src_configure() {
 		mycmakeargs+=(
 			-DAVIF_CODEC_RAV1E=OFF
 			-DAVIF_CODEC_SVT=OFF
+			-DAVIF_LIBYUV=OFF
 
 			-DAVIF_BUILD_EXAMPLES=OFF
 			-DAVIF_BUILD_APPS=OFF


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951819

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
