### PR TITLE
sci-mathematics/fann: update EAPI 7 -> 8, fix build with CMake 4

### DIFF
--- a/sci-mathematics/fann/fann-2.2.0-r2.ebuild
+++ b/sci-mathematics/fann/fann-2.2.0-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P=FANN-${PV}-Source
+inherit cmake
+
+DESCRIPTION="Fast Artificial Neural Network Library"
+HOMEPAGE="https://leenissen.dk"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.zip"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="examples"
+
+BDEPEND="app-arch/unzip"
+
+PATCHES=(
+	"${FILESDIR}/${P}-examples.patch"
+	"${FILESDIR}/${P}-cmake.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		# https://bugs.gentoo.org/863050
+		-DPKGCONFIG_INSTALL_DIR="${EPREFIX}/$(get_libdir)/pkgconfig"
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	cd examples || die
+	emake CFLAGS="${CFLAGS} -I../src/include -L${BUILD_DIR}/src"
+	LD_LIBRARY_PATH="${BUILD_DIR}/src" emake runtest
+	emake clean
+}
+
+src_install() {
+	cmake_src_install
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}

--- a/sci-mathematics/fann/fann-9999.ebuild
+++ b/sci-mathematics/fann/fann-9999.ebuild
@@ -1,17 +1,42 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake git-r3 toolchain-funcs
 
 DESCRIPTION="Fast Artificial Neural Network Library"
-HOMEPAGE="http://leenissen.dk/fann/wp/"
+HOMEPAGE="https://leenissen.dk"
 EGIT_REPO_URI="https://github.com/libfann/fann"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="examples"
+IUSE="examples test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	test? ( dev-cpp/gtest )
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-cmake.patch"
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	if use !test; then
+		sed -i '/ADD_SUBDIRECTORY( tests )/d' CMakeLists.txt || die
+	fi
+}
+
+src_configure() {
+	local mycmakeargs=(
+		# https://bugs.gentoo.org/863050
+		-DPKGCONFIG_INSTALL_DIR="${EPREFIX}/$(get_libdir)/pkgconfig"
+	)
+	cmake_src_configure
+}
 
 src_test() {
 	cd examples || die 'fails to enter examples directory'

--- a/sci-mathematics/fann/files/fann-2.2.0-cmake.patch
+++ b/sci-mathematics/fann/files/fann-2.2.0-cmake.patch
@@ -1,0 +1,22 @@
+Correct cmake_minimum_required for CMake4
+Fix paths for pkgconfig file installation
+https://bugs.gentoo.org/951922
+https://bugs.gentoo.org/863050
+--- a/CMakeLists.txt	2025-03-24 15:32:02.295787034 +0300
++++ b/CMakeLists.txt	2025-03-24 15:33:46.099775849 +0300
+@@ -1,6 +1,6 @@
++cmake_minimum_required(VERSION 3.5)
+ PROJECT (FANN)
+ #SET(CMAKE_VERBOSE_MAKEFILE ON)
+-cmake_minimum_required(VERSION 2.8)
+ 
+ SET(CMAKE_MODULE_PATH
+ 	${CMAKE_SOURCE_DIR}/cmake/Modules 
+@@ -16,7 +16,6 @@
+ 
+ configure_file( ${CMAKE_SOURCE_DIR}/cmake/fann.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/fann.pc @ONLY )
+ 
+-SET(PKGCONFIG_INSTALL_DIR /lib/pkgconfig)
+ 
+ ########### install files ###############
+ 

--- a/sci-mathematics/fann/files/fann-9999-cmake.patch
+++ b/sci-mathematics/fann/files/fann-9999-cmake.patch
@@ -1,0 +1,23 @@
+Bump minimum CMake version to fix build with CMake 4
+Unbundle gtest
+https://bugs.gentoo.org/863050
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,7 +38,7 @@
+ 	  ENDIF()
+ 	ENDIF()
+ ELSE()
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 3.5)
+ 
+ if (NOT DEFINED CMAKE_BUILD_TYPE)
+     set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+@@ -161,8 +161,6 @@
+ 
+ ################# compile tests ################
+ 
+-ADD_SUBDIRECTORY( lib/googletest )
+-
+ if(COMPILER_SUPPORTS_CXX11)
+   ADD_SUBDIRECTORY( tests )
+ endif()


### PR DESCRIPTION
Also correct installation folder for pkg-config files

Closes: https://bugs.gentoo.org/863050
Closes: https://bugs.gentoo.org/951922

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
