### PR TITLE
net-analyzer/zmap: bump cmake_minimum_required and fix pkgconfig detection

### DIFF
--- a/net-analyzer/zmap/files/zmap-4.3.2-cmake.patch
+++ b/net-analyzer/zmap/files/zmap-4.3.2-cmake.patch
@@ -1,0 +1,12 @@
+Compat with cmake-4
+https://github.com/zmap/zmap/pull/933.patch
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index baa524a..60e3839 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
+ project(ZMAP C)
+ set(ZMAP_VERSION DEVELOPMENT) # Change DEVELOPMENT to version number for release
+ 

--- a/net-analyzer/zmap/files/zmap-4.3.2-pkgconfig.patch
+++ b/net-analyzer/zmap/files/zmap-4.3.2-pkgconfig.patch
@@ -1,0 +1,18 @@
+use find_package to prevent failure without native-symlinks
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index baa524a..60e3839 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -85,11 +85,7 @@ if (NOT FOUND_LIBUNISTRING)
+     message(FATAL_ERROR "Missing dependency: did not find libunistring, please install libunistring or equivalent. More details in INSTALL.md")
+ endif()
+ 
+-find_program(FOUND_PKGCONFIG HINTS /usr/include/ NAMES pkg-config dev-util/pkgconf)
+-if (NOT FOUND_PKGCONFIG)
+-    message(FATAL_ERROR "Missing dependency: did not find pkg-config, please install pkg-config or equivalent. More details in INSTALL.md")
+-endif()
+-
++find_package(PkgConfig REQUIRED)
+ 
+ if(ENABLE_DEVELOPMENT)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb")

--- a/net-analyzer/zmap/zmap-4.3.2.ebuild
+++ b/net-analyzer/zmap/zmap-4.3.2.ebuild
@@ -31,6 +31,12 @@ BDEPEND="
 
 FILECAPS=( cap_net_raw=ep usr/sbin/zmap )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.3.2-pkgconfig.patch
+	# Merged. To be removed at next version.
+	"${FILESDIR}"/${PN}-4.3.2-cmake.patch
+)
+
 DOCS=( AUTHORS CHANGELOG.md README.md examples )
 
 src_configure() {


### PR DESCRIPTION
bump cmake_minimum_required
EDIT: set to 3.5.0 to preserve compatiblity with CI upstream ubuntu 16.04

use find_package to check pkgconfig instead of find_program to avoid failure without native-symlinks

Closes: https://bugs.gentoo.org/952027

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
