### PR TITLE
dev-debug/apitrace: fix snappy detection

### DIFF
--- a/dev-debug/apitrace/apitrace-12.0.ebuild
+++ b/dev-debug/apitrace/apitrace-12.0.ebuild
@@ -40,6 +40,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.0-disable-multiarch.patch
 	"${FILESDIR}"/${PN}-9.0-pkgconfig-waffle.patch
+	"${FILESDIR}"/${PN}-12.0-find_snappy.patch
 	"${FILESDIR}"/${PN}-12.0-no_qtnetwork.patch
 	"${FILESDIR}"/${PN}-12.0-tests.patch
 	"${FILESDIR}"/${PN}-12.0-unbundle.patch

--- a/dev-debug/apitrace/files/apitrace-12.0-find_snappy.patch
+++ b/dev-debug/apitrace/files/apitrace-12.0-find_snappy.patch
@@ -1,0 +1,14 @@
+Use config mode to prevent conflict with /usr/lib64/cmake/Qt6/FindSnappy.cmake (qtwebengine)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 34123b3..eef8a38 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -535,7 +535,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/compat)
+ if (NOT WIN32 AND NOT ENABLE_STATIC_EXE)
+ 
+     if (NOT ENABLE_STATIC_SNAPPY)
+-        find_package (Snappy)
++        find_package (Snappy CONFIG)
+     endif ()
+ 
+     # zlib 1.2.4-1.2.5 made it impossible to read the last block of incomplete


### PR DESCRIPTION
Use config mode for find_package(Snappy) to prevent conflict with /usr/lib64/cmake/Qt6/FindSnappy.cmake provided by qtwebengine.

Thanks to Paul Zander <negril.nx+gentoo@gmail.com> for finding conflict.

Closes: https://bugs.gentoo.org/951977

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
