### PR TITLE
kernel-build.eclass: do not override MODULES_SIGN_KEY with temp key

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -741,18 +741,19 @@ kernel-build_merge_configs() {
 	fi
 
 	if [[ ${KERNEL_IUSE_MODULES_SIGN} ]] && use modules-sign; then
+		local modules_sign_key=${MODULES_SIGN_KEY}
 		if [[ -n ${MODULES_SIGN_KEY_CONTENTS} ]]; then
-			(umask 066 && touch "${T}/kernel_key.pem" || die)
-			echo "${MODULES_SIGN_KEY_CONTENTS}" > "${T}/kernel_key.pem" || die
+			modules_sign_key="${T}/kernel_key.pem"
+			(umask 066 && touch "${modules_sign_key}" || die)
+			echo "${MODULES_SIGN_KEY_CONTENTS}" > "${modules_sign_key}" || die
 			unset MODULES_SIGN_KEY_CONTENTS
-			export MODULES_SIGN_KEY="${T}/kernel_key.pem"
 		fi
-		if [[ ${MODULES_SIGN_KEY} == pkcs11:* || -r ${MODULES_SIGN_KEY} ]]; then
-			echo "CONFIG_MODULE_SIG_KEY=\"${MODULES_SIGN_KEY}\"" \
+		if [[ ${modules_sign_key} == pkcs11:* || -r ${modules_sign_key} ]]; then
+			echo "CONFIG_MODULE_SIG_KEY=\"${modules_sign_key}\"" \
 				>> "${WORKDIR}/modules-sign-key.config"
 			merge_configs+=( "${WORKDIR}/modules-sign-key.config" )
-		elif [[ -n ${MODULES_SIGN_KEY} ]]; then
-			die "MODULES_SIGN_KEY=${MODULES_SIGN_KEY} not found or not readable!"
+		elif [[ -n ${modules_sign_key} ]]; then
+			die "MODULES_SIGN_KEY=${modules_sign_key} not found or not readable!"
 		fi
 	fi
 


### PR DESCRIPTION
The kernel build system expects the module signing key and certificate in one file. In order to accommodate this we merge the `MODULES_SIGN_KEY` and `MODULES_SIGN_CERT` into a temporary key in `$T`.

However, in doing so we override the `MODULES_SIGN_KEY` variable (but not the `MODULES_SIGN_CERT` variable). This becomes a problem when merging binpkgs because then the `MODULES_SIGN_KEY` variable points to a temporary signing key that does not exist (whereas the untouched `MODULES_SIGN_CERT` does exist). Usually this is not an issue except if the `MODULES_SIGN_KEY` is to be used later in the binpkg merging process such as is the case in, for example, the dkms `installkernel` hook.

Here we resolve this unfortunate situation by using a local variable during the config merging process and not touching the original `MODULES_SIGN_KEY`. Therefore, the `MODULES_SIGN_KEY` will now also point us to an existing key if we are merging a binpkg of the kernel.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
