### PR TITLE
net-im/telegram-desktop: Force USE=ssl on qtbase

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-5.12.3-r3.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-5.12.3-r3.ebuild
@@ -29,7 +29,7 @@ CDEPEND="
 	dev-libs/openssl:=
 	>=dev-libs/protobuf-21.12
 	dev-libs/xxhash
-	>=dev-qt/qtbase-6.5:6=[dbus?,gui,network,opengl,wayland?,widgets,X?]
+	>=dev-qt/qtbase-6.5:6=[dbus?,gui,network,opengl,ssl,wayland?,widgets,X?]
 	>=dev-qt/qtimageformats-6.5:6
 	>=dev-qt/qtsvg-6.5:6
 	media-libs/libjpeg-turbo:=


### PR DESCRIPTION
I ran into someone today who had a build error because it was disabled.

Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
