### PR TITLE
dev-vcs/git: Use emesonargs instead of sed to disable coccinelle

### DIFF
--- a/dev-vcs/git/git-2.49.0-r1.ebuild
+++ b/dev-vcs/git/git-2.49.0-r1.ebuild
@@ -257,7 +257,9 @@ src_configure() {
 		# otherwise.
 		#
 		# Fixes https://bugs.gentoo.org/952004
-		sed -i "s/subdir('coccinelle')/# subdir('coccinelle')/" "${WORKDIR}/git-${PV}/contrib/meson.build" || die
+		emesonargs+=(
+			-Dcoccinelle=disabled
+		)
 	fi
 
 	meson_src_configure


### PR DESCRIPTION
A previous fix to a bug used sed  but it should be handled with `emesonargs` instead.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
