### PR TITLE
net-im/pidgin: drop strip/replace compiler flags by default, enable py3.13

### DIFF
--- a/net-im/pidgin/pidgin-2.14.14-r1.ebuild
+++ b/net-im/pidgin/pidgin-2.14.14-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 GENTOO_DEPEND_ON_PERL=no
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools gnome2-utils flag-o-matic perl-module python-single-r1 xdg
 
@@ -184,9 +184,6 @@ src_configure() {
 	# bug #944076 (check if we can remove it w/ 3.x)
 	append-cflags -std=gnu17
 
-	# Stabilize things, for your own good
-	strip-flags
-	replace-flags -O? -O2
 	use pie && append-cflags -fPIE -pie
 
 	use gadu 	&& DEFAULT_PRPLS+=",gg"

--- a/x11-plugins/pidgin-encryption/pidgin-encryption-3.1-r4.ebuild
+++ b/x11-plugins/pidgin-encryption/pidgin-encryption-3.1-r4.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Pidgin IM Encryption PlugIn"
+HOMEPAGE="https://pidgin-encrypt.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/pidgin-encrypt/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="nls"
+
+BDEPEND="virtual/pkgconfig"
+RDEPEND="
+	>=dev-libs/nss-3.11
+	net-im/pidgin[gui]
+	x11-libs/gtk+:2
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-glib2.32.patch"
+	"${FILESDIR}/${P}-time.patch"
+	"${FILESDIR}/${P}-includes.patch"
+)
+
+src_configure() {
+	econf $(use_enable nls)
+}
+
+src_install() {
+	emake install DESTDIR="${ED}"
+	dodoc CHANGELOG INSTALL NOTES README TODO VERSION WISHLIST
+
+	find "${ED}" -type f -name "*.la" -delete || die
+}


### PR DESCRIPTION

+20 years ago there was a bug with ```net-im/gaim```, probably caused by
gcc-2.95 and ```-Os``` optimization.

The following developers and maintainers just copied those lines when bumping
versions, and nobody tried to remove them with new Gaim/Pidgin/GCC versions.

Also x11-plugins/pidgin-encryption has the same code; I guess the Gentoo
maintainer/developer was extra cautious.

Bug: https://bugs.gentoo.org/29394
Closes: https://bugs.gentoo.org/944837
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
