### PR TITLE
net-libs/libtorrent and net-p2p/rtorrent segfault workaround

### DIFF
--- a/net-libs/libtorrent/libtorrent-0.15.1-r1.ebuild
+++ b/net-libs/libtorrent/libtorrent-0.15.1-r1.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="BitTorrent library written in C++ for *nix"
+HOMEPAGE="https://rakshasa.github.io/rtorrent/"
+SRC_URI="https://github.com/rakshasa/rtorrent/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+# The README says that the library ABI is not yet stable and dependencies on
+# the library should be an explicit, syncronized version until the library
+# has had more time to mature. Until it matures we should not include a soname
+# subslot.
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="debug ssl test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	sys-libs/zlib
+	ssl? ( dev-libs/openssl:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( dev-util/cppunit )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.14.0-tests-address.patch
+)
+
+src_prepare() {
+	default
+	if [[ ${CHOST} != *-darwin* ]]; then
+		# syslibroot is only for macos, change to sysroot for others
+		sed -i 's/Wl,-syslibroot,/Wl,--sysroot,/' "${S}/scripts/common.m4" || die
+	fi
+	eautoreconf
+}
+
+src_configure() {
+	# https://bugs.gentoo.org/946551
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
+	fi
+
+	# bug 518582
+	local disable_instrumentation
+	echo -e "#include <inttypes.h>\nint main(){ int64_t var = 7; __sync_add_and_fetch(&var, 1); return 0;}" \
+		> "${T}/sync_add_and_fetch.c" || die
+	$(tc-getCC) ${CFLAGS} -o /dev/null -x c "${T}/sync_add_and_fetch.c" >/dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		einfo "Disabling instrumentation"
+		disable_instrumentation="--disable-instrumentation"
+	fi
+
+	# configure needs bash or script bombs out on some null shift, bug #291229
+	CONFIG_SHELL=${BASH} econf \
+		--enable-aligned \
+		$(use_enable debug) \
+		$(use_enable ssl openssl) \
+		${disable_instrumentation} \
+		--with-posix-fallocate
+}
+
+src_install() {
+	default
+
+	find "${ED}" -type f -name '*.la' -delete || die
+}

--- a/net-p2p/rtorrent/rtorrent-0.15.1-r1.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.15.1-r1.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info systemd
+
+DESCRIPTION="BitTorrent Client using libtorrent"
+HOMEPAGE="https://rakshasa.github.io/rtorrent/"
+SRC_URI="https://github.com/rakshasa/rtorrent/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="debug selinux test tinyxml2 xmlrpc"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="tinyxml2? ( !xmlrpc )"
+
+DEPEND="
+	~net-libs/libtorrent-${PV}
+	net-misc/curl
+	sys-libs/ncurses:0=
+	xmlrpc? ( dev-libs/xmlrpc-c:= )
+"
+RDEPEND="
+	${DEPEND}
+	selinux? ( sec-policy/selinux-rtorrent )
+"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( dev-util/cppunit )
+"
+
+DOCS=( doc/rtorrent.rc )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.15.1-tests-fix-arrays.patch
+)
+
+pkg_setup() {
+	if ! linux_config_exists || ! linux_chkconfig_present IPV6; then
+		ewarn "rtorrent will not start without IPv6 support in your kernel"
+		ewarn "without further configuration. Please set bind=0.0.0.0 or"
+		ewarn "similar in your rtorrent.rc"
+		ewarn "Upstream bug: https://github.com/rakshasa/rtorrent/issues/732"
+	fi
+}
+
+src_prepare() {
+	default
+
+	# https://github.com/rakshasa/rtorrent/issues/332
+	cp "${FILESDIR}"/rtorrent.1 "${S}"/doc/ || die
+
+	if [[ ${CHOST} != *-darwin* ]]; then
+		# syslibroot is only for macos, change to sysroot for others
+		sed -i 's/Wl,-syslibroot,/Wl,--sysroot,/' "${S}/scripts/common.m4" || die
+	fi
+
+	eautoreconf
+}
+
+src_configure() {
+
+	# https://bugs.gentoo.org/946551
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
+	fi
+
+	# configure needs bash or script bombs out on some null shift, bug #291229
+	CONFIG_SHELL=${BASH} econf \
+		$(use_enable debug) \
+		$(usev xmlrpc --with-xmlrpc-c) \
+		$(usev tinyxml2 --with-xmlrpc-tinyxml2)
+}
+
+src_install() {
+	default
+	doman doc/rtorrent.1
+
+	newinitd "${FILESDIR}/rtorrent-r1.init" rtorrent
+	newconfd "${FILESDIR}/rtorrentd.conf" rtorrent
+	systemd_newunit "${FILESDIR}/rtorrentd_at-r1.service" "rtorrentd@.service"
+}


### PR DESCRIPTION
net-p2p/rtorrent: revbump 0.10.0-r1, add -mno-avx
net/libs/libtorrent-0.15.1-r1: revbump 
This works around rtorrent segfaulting at start.
Upstream is unwilling to fix in this release.

Bug: https://bugs.gentoo.org/946551

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
