### PR TITLE
media-libs/portsmf: fix build with CMake 4

### DIFF
--- a/media-libs/portsmf/files/portsmf-239-cmake4.patch
+++ b/media-libs/portsmf/files/portsmf-239-cmake4.patch
@@ -1,0 +1,27 @@
+Cmake4 minimum version bump, edited to work with release cmakelists.txt
+https://bugs.gentoo.org/952094
+https://codeberg.org/tenacityteam/portsmf/commit/99310ab5662ce76bbf47936fa414cd4fccaa7177.patch
+From 99310ab5662ce76bbf47936fa414cd4fccaa7177 Mon Sep 17 00:00:00 2001
+From: Avery King <gperson@disroot.org>
+Date: Wed, 26 Mar 2025 22:00:06 -0700
+Subject: [PATCH] CMake: Bump minimum required version to 3.10
+
+CMake 4.0 drops compatibility with CMake versions < 3.5, and currently,
+CMake compatibility with versions less than 3.10 is deprecated, so bump
+our minimum required version to 3.10. Fixes #14.
+
+Reference-to: https://codeberg.org/tenacityteam/portsmf/issues/14
+Signed-off-by: Avery King <gperson@disroot.org>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 278adb8..54731e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,3 +1,3 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(PortSMF VERSION 239 LANGUAGES CXX)

--- a/media-libs/portsmf/portsmf-239-r1.ebuild
+++ b/media-libs/portsmf/portsmf-239-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="The Tenacity fork of PortSMF, a Standard MIDI File library"
+HOMEPAGE="https://codeberg.org/tenacityteam/portsmf"
+SRC_URI="
+	https://codeberg.org/tenacityteam/portsmf/archive/${PV}.tar.gz -> ${P}.tar.gz
+"
+S="${WORKDIR}/${PN}"
+LICENSE="MIT"
+SLOT="0/1"  # SOVERSION in CMakeLists.txt / SONAME suffix
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}"-239-revert-extern-to-static-change.patch
+	"${FILESDIR}/${PN}"-239-set-correct-cmake-project-ver.patch
+	"${FILESDIR}/${PN}"-239-set-correct-pkg-config-ver.patch
+	"${FILESDIR}/${PN}"-239-cmake4.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_TESTING=$(usex test on off)
+		## This is "Build example applications" according to upstream
+		#-DBUILD_APPS=$(usex examples on off)
+		# The above requires a non-existent PortMidiConfig.cmake.
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	# Remove this function when bumping. Upstream HEAD has CTest.
+	cd "${BUILD_DIR}"/test || die
+	./test </dev/null || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952094

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
