### PR TITLE
dev-python/pyroute2: enable python3_13

### DIFF
--- a/dev-python/pyroute2/pyroute2-0.8.1.ebuild
+++ b/dev-python/pyroute2/pyroute2-0.8.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="sqlite"
 
 inherit distutils-r1 pypi


### PR DESCRIPTION
While not yet officially supported by upstream, the tests succeed and other distros already ship that combination.

Closes: https://bugs.gentoo.org/952376

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
