### PR TITLE
dev-java/velocity: set TimeZone for tests #952126

### DIFF
--- a/dev-java/velocity/velocity-2.4.1.ebuild
+++ b/dev-java/velocity/velocity-2.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -99,6 +99,7 @@ src_prepare() {
 }
 
 src_test() {
+	export TZ="Europe/Berlin"	# https://bugs.gentoo.org/952126
 	pushd src/test/java > /dev/null || die
 		# DataSourceResourceLoaderTestCase.java requires configured jdbc
 		local JAVA_TEST_RUN_ONLY=$(find * \

--- a/dev-java/velocity/velocity-2.4.1.ebuild
+++ b/dev-java/velocity/velocity-2.4.1.ebuild
@@ -99,7 +99,7 @@ src_prepare() {
 }
 
 src_test() {
-	export TZ="Europe/Berlin"	# https://bugs.gentoo.org/952126
+	local -x TZ="Europe/Berlin"	# https://bugs.gentoo.org/952126
 	pushd src/test/java > /dev/null || die
 		# DataSourceResourceLoaderTestCase.java requires configured jdbc
 		local JAVA_TEST_RUN_ONLY=$(find * \


### PR DESCRIPTION
One of four tests in Velocity952TestCase fails when using a different timezone. we export TZ="Europe/Berlin" in test() phase.

Closes: https://bugs.gentoo.org/952126

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
