### PR TITLE
net-wireless/bss: update EAPI 7 -> 8, fix build with C23 compilers

### DIFF
--- a/net-wireless/bss/bss-0.8-r3.ebuild
+++ b/net-wireless/bss/bss-0.8-r3.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Bluetooth stack smasher / fuzzer"
+HOMEPAGE="http://securitech.homeunix.org/blue/"
+SRC_URI="http://securitech.homeunix.org/blue/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="net-wireless/bluez"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Makefile.patch
+	"${FILESDIR}"/${P}-includes.patch
+)
+
+src_configure() {
+	tc-export CC
+}
+
+src_install() {
+	dosbin bss
+	dodoc AUTHOR BUGS CHANGELOG CONTRIB NOTES README TODO \
+		replay_packet/replay_l2cap_packet.c
+}

--- a/net-wireless/bss/files/bss-0.8-Makefile.patch
+++ b/net-wireless/bss/files/bss-0.8-Makefile.patch
@@ -1,3 +1,4 @@
+Make build system respect CFLAGS and PREFIX
 https://bugs.gentoo.org/725228
 --- a/Makefile
 +++ b/Makefile
@@ -25,7 +26,7 @@ https://bugs.gentoo.org/725228
 -	$(CC) -c $(L2P_SRC)
 -	$(CC) -c $(REP_SRC)
 -	$(CC) $(BSS_TMP) $(L2P_TMP) $(REP_TMP) -o $(BSS_OBJ) $(CFLAGS) $(BSS_FLAGS) $(BSS_LIBS)
-+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(BSS_SRC) 
++	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(BSS_SRC)
 +	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(L2P_SRC)
 +	$(CC) $(CFLAGS) $(CPPFLAGS) -c $(REP_SRC)
 +	$(CC) $(LDFLAGS) $(BSS_TMP) $(L2P_TMP) $(REP_TMP) -o $(BSS_OBJ) $(CFLAGS) $(BSS_LIBS)

--- a/net-wireless/bss/files/bss-0.8-includes.patch
+++ b/net-wireless/bss/files/bss-0.8-includes.patch
@@ -1,0 +1,24 @@
+Add missing includes for compilation with C23
+https://bugs.gentoo.org/880799
+diff '--color=auto' -ru bss-0.8.old/bss.c bss-0.8/bss.c
+--- a/bss.c	2025-03-28 23:12:14.780857512 +0300
++++ b/bss.c	2025-03-28 23:13:44.003579006 +0300
+@@ -34,6 +34,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#include <time.h>
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+diff '--color=auto' -ru bss-0.8.old/replace.c bss-0.8/replace.c
+--- a/replace.c	2025-03-28 23:12:14.780857512 +0300
++++ b/replace.c	2025-03-28 23:14:07.107852000 +0300
+@@ -10,6 +10,7 @@
+ // Modifications by Ollie Whitehouse <ol at uncon dot org>
+ // 
+ #include <stdio.h>
++#include <string.h>
+ 
+ char *replace(char *string, char *oldpiece, char *newpiece) {
+ 


### PR DESCRIPTION
Added missing includes.
Also, modified existing makefile patch to include EPFERIX in paths

Closes: https://bugs.gentoo.org/880799

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
