### PR TITLE
x11-plugins/wmdiskmon: update EAPI 7 -> 8, fix build

### DIFF
--- a/x11-plugins/wmdiskmon/files/wmdiskmon-0.0.2-include.patch
+++ b/x11-plugins/wmdiskmon/files/wmdiskmon-0.0.2-include.patch
@@ -1,0 +1,12 @@
+Add missing include
+https://bugs.gentoo.org/878641
+--- a/src/main.c
++++ b/src/main.c
+@@ -25,6 +25,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <ctype.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/x11-plugins/wmdiskmon/wmdiskmon-0.0.2-r2.ebuild
+++ b/x11-plugins/wmdiskmon/wmdiskmon-0.0.2-r2.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="a dockapp to display disk space usage"
+HOMEPAGE="http://tnemeth.free.fr/projets/dockapps.html"
+SRC_URI="http://tnemeth.free.fr/projets/programmes/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-libs/libXt"
+
+PATCHES=( "${FILESDIR}/${P}-include.patch" )
+
+src_prepare() {
+	default
+
+	# https://bugs.gentoo.org/908911
+	eautoreconf
+}


### PR DESCRIPTION
Add missing include, eautoreconf to fix configure

Closes: https://bugs.gentoo.org/878641
Closes: https://bugs.gentoo.org/908911

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
