### PR TITLE
sys-process/btop: add USE toggling gpu support

### DIFF
--- a/sys-process/btop/btop-1.3.2.ebuild
+++ b/sys-process/btop/btop-1.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Gentoo Authors
+# Copyright 2021-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,14 +14,15 @@ SRC_URI="
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~loong ~m68k ~mips ~ppc ppc64 ~riscv x86"
+IUSE="gpu"
 
 pkg_setup() {
 	if [[ "${MERGE_TYPE}" != "binary" ]]; then
-		if tc-is-clang ; then
+		if tc-is-clang; then
 			if [[ "$(clang-major-version)" -lt 16 ]]; then
 				die "sys-process/btop requires >=llvm-core/clang-16.0.0 to build."
 			fi
-		elif ! tc-is-gcc ; then
+		elif ! tc-is-gcc; then
 			die "$(tc-getCXX) is not a supported compiler. Please use sys-devel/gcc or >=llvm-core/clang-16.0.0 instead."
 		fi
 	fi
@@ -29,7 +30,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBTOP_GPU=true
+		-DBTOP_GPU="$(usex gpu)"
 		-DBTOP_RSMI_STATIC=false
 		# Fortification can be set in CXXFLAGS instead
 		-DBTOP_FORTIFY=false

--- a/sys-process/btop/btop-1.4.0.ebuild
+++ b/sys-process/btop/btop-1.4.0.ebuild
@@ -14,20 +14,21 @@ SRC_URI="
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv x86"
+IUSE="gpu"
 
 BDEPEND="
 	app-text/lowdown
 "
 
-DOCS=( "README.md" "CHANGELOG.md" )
+DOCS=("README.md" "CHANGELOG.md")
 
 pkg_setup() {
 	if [[ "${MERGE_TYPE}" != "binary" ]]; then
-		if tc-is-clang ; then
+		if tc-is-clang; then
 			if [[ "$(clang-major-version)" -lt 16 ]]; then
 				die "sys-process/btop requires >=llvm-core/clang-16.0.0 to build."
 			fi
-		elif ! tc-is-gcc ; then
+		elif ! tc-is-gcc; then
 			die "$(tc-getCXX) is not a supported compiler. Please use sys-devel/gcc or >=llvm-core/clang-16.0.0 instead."
 		fi
 	fi
@@ -35,7 +36,7 @@ pkg_setup() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBTOP_GPU=true
+		-DBTOP_GPU="$(usex gpu)"
 		-DBTOP_RSMI_STATIC=false
 		-DBTOP_STATIC=false
 		# These settings can be controlled in make.conf CFLAGS/CXXFLAGS

--- a/sys-process/btop/metadata.xml
+++ b/sys-process/btop/metadata.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>nex+b-g-o@nexadn.de</email>
-		<name>Adrian Schollmeyer</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-	<upstream>
-		<remote-id type="github">aristocratos/btop</remote-id>
-		<bugs-to>https://github.com/aristocratos/btop/issues</bugs-to>
-	</upstream>
+  <maintainer type="person" proxied="yes">
+    <email>nex+b-g-o@nexadn.de</email>
+    <name>Adrian Schollmeyer</name>
+  </maintainer>
+  <maintainer type="project" proxied="proxy">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+  <use>
+    <flag name="gpu">Enable support for GPU monitoring</flag>
+  </use>
+  <upstream>
+    <remote-id type="github">aristocratos/btop</remote-id>
+    <bugs-to>https://github.com/aristocratos/btop/issues</bugs-to>
+  </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Add a _USE_ flag to toggle gpu support.

Some machines find it helpful to disable gpu support since it can lead to slow startup in some occasions -- e.g. btop retries loading a module several times but is forbidden by a secure boot configuration, causing a 2sec startup delay.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
