### PR TITLE
fix make.defaults PMS compliance

### DIFF
--- a/profiles/default/linux/mips/23.0/mipsel/multilib/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/multilib/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/mipsel/multilib/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/multilib/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/mipsel/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/mipsel/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/mipsel/o32/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/o32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/mipsel/o32_sf/make.defaults
+++ b/profiles/default/linux/mips/23.0/mipsel/o32_sf/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-softfloat-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/multilib/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/multilib/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/multilib/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/multilib/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/o32/make.defaults
+++ b/profiles/default/linux/mips/23.0/o32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/o32_sf/make.defaults
+++ b/profiles/default/linux/mips/23.0/o32_sf/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-softfloat-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/multilib/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/multilib/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/multilib/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/multilib/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/o32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/o32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-unknown-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/split-usr/mipsel/o32_sf/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/mipsel/o32_sf/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mipsel-softfloat-linux-gnu"
 CHOST_n32="mips64el-unknown-linux-gnuabin32"
 CHOST_n64="mips64el-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/split-usr/multilib/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/multilib/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/split-usr/multilib/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/multilib/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/split-usr/n32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/n32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n32}
+CHOST="${CHOST_n32}"

--- a/profiles/default/linux/mips/23.0/split-usr/n64/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/n64/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_n64}
+CHOST="${CHOST_n64}"

--- a/profiles/default/linux/mips/23.0/split-usr/o32/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/o32/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-unknown-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/default/linux/mips/23.0/split-usr/o32_sf/make.defaults
+++ b/profiles/default/linux/mips/23.0/split-usr/o32_sf/make.defaults
@@ -5,4 +5,4 @@ CHOST_o32="mips-softfloat-linux-gnu"
 CHOST_n32="mips64-unknown-linux-gnuabin32"
 CHOST_n64="mips64-unknown-linux-gnuabi64"
 
-CHOST=${CHOST_o32}
+CHOST="${CHOST_o32}"

--- a/profiles/features/time64/make.defaults
+++ b/profiles/features/time64/make.defaults
@@ -3,12 +3,10 @@
 
 # Many profiles and stages override CFLAGS etc, and need then to eat their
 # own dogfood. For those who don't...
-__COMMON_FLAGS_TIME64="-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
-
-CFLAGS="${CFLAGS} ${__COMMON_FLAGS_TIME64} -Werror=implicit-function-declaration -Werror=implicit-int -Werror=incompatible-pointer-types -Werror=return-type -Werror=int-conversion"
-CXXFLAGS="${CXXFLAGS} ${__COMMON_FLAGS_TIME64}"
-FCFLAGS="${FCFLAGS} ${__COMMON_FLAGS_TIME64}"
-FFLAGS="${FFLAGS} ${__COMMON_FLAGS_TIME64}"
+CFLAGS="${CFLAGS} -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64 -Werror=implicit-function-declaration -Werror=implicit-int -Werror=incompatible-pointer-types -Werror=return-type -Werror=int-conversion"
+CXXFLAGS="${CXXFLAGS} -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
+FCFLAGS="${FCFLAGS} -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
+FFLAGS="${FFLAGS} -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64"
 
 # We need to switch this explicitly on since it's explicitly disabled
 # in profiles otherwise.


### PR DESCRIPTION
see https://dev.gentoo.org/~ulm/pms/head/pms.html#section-5.2.4

> Each line contains a single VAR="value" entry, where the value must be double quoted
> A variable name must start with one of a-zA-Z

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
