### PR TITLE
www-apps/tt-rss: Set compatible PHP versions to 8.2-8.4

### DIFF
--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="8.3 8.2 8.1" # Check with: grep PHP_VERSION classes/Config.php
+PHP_SLOTS="8.4 8.3 8.2" # Check with: grep PHP_VERSION classes/Config.php
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {


### PR DESCRIPTION
Upstream uses PHP 8.4 by default: https://gitlab.tt-rss.org/tt-rss/tt-rss/-/blob/c1e6a5ff634c46a0df3fb8d7a21bd3db96be5a69/.docker/app/Dockerfile#L12

The application requires PHP 8.2.0 or above: https://gitlab.tt-rss.org/tt-rss/tt-rss/-/blob/c1e6a5ff634c46a0df3fb8d7a21bd3db96be5a69/classes/Config.php#L523

8.1 is no longer in the tree, and I'm running on 8.4 without problems.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
