### PR TITLE
media-sound/musescore: add pipewire USE flag for sound support

### DIFF
--- a/media-sound/musescore/metadata.xml
+++ b/media-sound/musescore/metadata.xml
@@ -11,5 +11,6 @@
 	</upstream>
 	<use>
 		<flag name="video">Support exporting scores as videos using the command line</flag>
+		<flag name="pipewire">Bring in pipewire's alsa plugin dependency</flag>
 	</use>
 </pkgmetadata>

--- a/media-sound/musescore/musescore-4.4.4-r1.ebuild
+++ b/media-sound/musescore/musescore-4.4.4-r1.ebuild
@@ -14,7 +14,7 @@ else
 	SRC_URI="
 		https://github.com/musescore/MuseScore/archive/v${PV}.tar.gz -> ${P}.tar.gz
 	"
-	KEYWORDS="~amd64 ~arm64 ~x86"
+	KEYWORDS="amd64 ~arm64 ~x86"
 	S="${WORKDIR}/MuseScore-${PV}"
 fi
 
@@ -60,10 +60,9 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-uncompressed-man-pages.patch"
-	"${FILESDIR}/${PN}-4.5.0-unbundle-deps.patch"
+	"${FILESDIR}/${PN}-4.4.0-unbundle-deps.patch"
 	"${FILESDIR}/${PN}-4.2.0-dynamic_cast-crash.patch"
 	"${FILESDIR}/${PN}-4.4.0-include.patch"
-	"${FILESDIR}/${PN}-4.5.0-missing-includes.patch"
 )
 
 src_unpack() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/952950

This commit adds the pipewire _USE_ flag. Its only purpose is to pull in pipewire[pipewire-alsa], a dependency that may be otherwise missed on some pipewire systems. See above

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
