### PR TITLE
profiles: last rite Certbot modules, #952977

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -36,6 +36,18 @@
 
 #--- END OF EXAMPLES ---
 
+# Thibaud CANALE <thican@thican.net> (2025-09-13)
+# Certbot modules are handled in main package since version 3.2.0-r100
+# See related news item 2025-03-14-certbot-rework
+# Masking for removal in 30 days: 2025-10-13, bug 952977
+# See also bug 950247, bug 915050, bug 949120
+app-crypt/acme
+app-crypt/certbot-apache
+app-crypt/certbot-dns-dnsimple
+app-crypt/certbot-dns-nsone
+app-crypt/certbot-dns-rfc2136
+app-crypt/certbot-nginx
+
 # Rick Farina <zerochaos@gentoo.org> (2025-09-11)
 # Dead upstream, fails to compile on modern gcc. Bug #919250
 # Removal on 2025-10-12


### PR DESCRIPTION
Merge **AFTER** PR #41252 **AND** stable request (see [bug 952978](https://bugs.gentoo.org/952978)).

Following procedure after news item 2025-03-14-certbot-rework.

Bug: https://bugs.gentoo.org/950247
Bug: https://bugs.gentoo.org/915050
Bug: https://bugs.gentoo.org/949120
Closes: https://bugs.gentoo.org/952977

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
