### PR TITLE
app-pda/pilot-link: port to C23

### DIFF
--- a/app-pda/pilot-link/files/pilot-link-0.12.5-C23.patch
+++ b/app-pda/pilot-link/files/pilot-link-0.12.5-C23.patch
@@ -1,0 +1,85 @@
+Correct build for C23
+Wrong type for size variable, missing parameters in decls
+Missing include and wrong types in bundled libusb library
+https://bugs.gentoo.org/944433
+https://bugs.gentoo.org/883101
+--- a/src/parsedate.c
++++ b/src/parsedate.c
+@@ -175,8 +175,8 @@
+ static time_t	yyRelSeconds;
+ 
+ 
+-extern struct tm	*localtime();
+-static void		date_error();
++extern struct tm	*localtime(const time_t *timep);
++static void		date_error(char *s);
+ 
+ 
+ /* Enabling traces.  */
+--- a/src/parsedate.y
++++ b/src/parsedate.y
+@@ -94,8 +94,8 @@
+ static time_t	yyRelSeconds;
+ 
+ 
+-extern struct tm	*localtime();
+-static void		date_error();
++extern struct tm	*localtime(const time_t *timep);
++static void		date_error(char *s);
+ %}
+ 
+ %union {
+--- a/src/pilot-read-todos.c
++++ b/src/pilot-read-todos.c
+@@ -202,8 +202,8 @@
+ 
+ 	for (i = 0;; i++) {
+ 		int 	attr,
+-			category,
+-			len;
++			category;
++		ssize_t	len;
+ 
+ 		struct 	ToDo todo;
+ 
+--- a/libpisock/linuxusb.c
++++ b/libpisock/linuxusb.c
+@@ -27,6 +27,7 @@
+ #include <stdio.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/socket.h>
+ 
+ #include "pi-debug.h"
+ #include "pi-source.h"
+@@ -48,8 +49,8 @@
+ 
+ static int u_open(pi_socket_t *ps, struct pi_sockaddr *addr, size_t addrlen);
+ static int u_close(pi_socket_t *ps);
+-static int u_write(pi_socket_t *ps, unsigned char *buf, size_t len, int flags);
+-static int u_read(pi_socket_t *ps, pi_buffer_t *buf, size_t len, int flags);
++static ssize_t u_write(pi_socket_t *ps, const unsigned char *buf, size_t len, int flags);
++static ssize_t u_read(pi_socket_t *ps, pi_buffer_t *buf, size_t len, int flags);
+ static int u_poll(pi_socket_t *ps, int timeout);
+ static int u_flush(pi_socket_t *ps, int flags);
+ 
+@@ -188,8 +189,8 @@
+  * Returns:     Nothing
+  *
+  ***********************************************************************/
+-static int
+-u_write(pi_socket_t *ps, unsigned char *buf, size_t len, int flags)
++static ssize_t
++u_write(pi_socket_t *ps, const unsigned char *buf, size_t len, int flags)
+ {
+ 	int 	total,
+ 		nwrote;
+@@ -281,7 +282,7 @@
+  * Returns:     number of bytes read or negative otherwise
+  *
+  ***********************************************************************/
+-static int
++static ssize_t
+ u_read(pi_socket_t *ps, pi_buffer_t *buf, size_t len, int flags)
+ {
+ 	ssize_t rbuf = 0,

--- a/app-pda/pilot-link/pilot-link-0.12.5-r5.ebuild
+++ b/app-pda/pilot-link/pilot-link-0.12.5-r5.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic perl-module
+
+DESCRIPTION="Suite of tools for moving data between a Palm device and a desktop"
+# this is a new mirror; the distfile has the same content inside the tarball,
+# but the tarball itself doesn't match due to recompression and Git
+# indirection.
+HOMEPAGE="https://github.com/jichu4n/pilot-link"
+SRC_URI="
+	mirror://gentoo/${P}.tar.bz2
+	https://dev.gentoo.org/~soap/distfiles/${P}-gentoo-patchset-r2.tar.xz"
+
+LICENSE="|| ( GPL-2 LGPL-2 )"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="bluetooth perl png threads usb"
+RESTRICT="test" #672872
+
+RDEPEND="
+	dev-libs/popt
+	sys-libs/ncurses:=
+	sys-libs/readline:=
+	virtual/libiconv
+	bluetooth? ( net-wireless/bluez )
+	perl? ( dev-lang/perl:= )
+	png? ( media-libs/libpng:= )
+	usb? ( virtual/libusb:0 )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	perl? ( dev-lang/perl )
+	sys-devel/bison"
+
+PATCHES=(
+	"${WORKDIR}/${P}-gentoo-patchset"/
+	"${FILESDIR}/${P}-C23.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/924480
+	#
+	# Upstream is abandoned since 2016, existing issue offering gentoo-patchset
+	# has been ignored. No bug filed.
+	#
+	# The issue is in the internal compat code for *not* using libusb.
+	use usb || filter-lto
+
+	# tcl/tk support is disabled as per upstream request.
+	# readline is not really optional, bug #626504
+	# Does not build with Java 8
+	# Does not build with Python 3, bug #735238
+	econf \
+		--includedir="${EPREFIX}"/usr/include/libpisock \
+		--enable-conduits \
+		--with-readline \
+		$(use_enable threads) \
+		$(use_enable usb libusb) \
+		$(use_with png libpng) \
+		$(use_with bluetooth bluez) \
+		$(use_with perl) \
+		--without-java \
+		--without-tcl \
+		--without-python
+
+	if use perl; then
+		perl_set_version
+
+		cd bindings/Perl || die
+		perl-module_src_configure
+	fi
+}
+
+src_compile() {
+	emake
+
+	if use perl; then
+		cd bindings/Perl || die
+		local mymake=( OTHERLDFLAGS="${LDFLAGS} -L../../libpisock/.libs -lpisock" ) #308629
+		perl-module_src_compile
+	fi
+}
+
+src_install() {
+	default
+	dodoc doc/{README*,TODO}
+
+	if use perl; then
+		cd bindings/Perl || die
+		perl-module_src_install
+	fi
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Fix build issues, including with and without usb USE flag set.

Closes: https://bugs.gentoo.org/883101
Closes: https://bugs.gentoo.org/944433

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
