### PR TITLE
dev-java/java-dep-check: drop wrong PDEPEND on javatoolkit

### DIFF
--- a/dev-java/java-dep-check/java-dep-check-0.5-r5.ebuild
+++ b/dev-java/java-dep-check/java-dep-check-0.5-r5.ebuild
@@ -1,0 +1,27 @@
+# Copyright 2016-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Java Dependency checker"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+
+CP_DEPEND="
+	dev-java/commons-cli:0
+	>=dev-java/asm-9.8:0"
+RDEPEND=">=virtual/jre-1.8:*
+	${CP_DEPEND}"
+DEPEND=">=virtual/jdk-1.8:*
+	${CP_DEPEND}"
+
+JAVA_MAIN_CLASS="javadepchecker.Main"
+
+src_unpack() {
+	cp "${FILESDIR}/Main-${PV}.java" Main.java || die
+}


### PR DESCRIPTION
Also, switch to latest dev-java/asm-9.8 which has switched to SLOT=0. PDEPEND was added erroneously.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
