### PR TITLE
media-libs/libva-compat: update EAPI 7 -> 8, fix build porblems

### DIFF
--- a/media-libs/libva-compat/files/libva-compat-1.8.3-missing-decl.patch
+++ b/media-libs/libva-compat/files/libva-compat-1.8.3-missing-decl.patch
@@ -1,0 +1,13 @@
+Add missing parameters in declaration for C23
+https://bugs.gentoo.org/944163
+--- a/va/x11/va_nvctrl.c
++++ b/va/x11/va_nvctrl.c
+@@ -130,7 +130,7 @@
+ #define XNVCTRLSimpleCheckExtension(dpy,i) \
+   XextSimpleCheckExtension (dpy, i, nvctrl_extension_name)
+ 
+-static int close_display();
++static int close_display(Display *, XExtCodes *);
+ static /* const */ XExtensionHooks nvctrl_extension_hooks = {
+     NULL,                               /* create_gc */
+     NULL,                               /* copy_gc */

--- a/media-libs/libva-compat/files/libva-compat-1.8.3-nonexisting-symbol.patch
+++ b/media-libs/libva-compat/files/libva-compat-1.8.3-nonexisting-symbol.patch
@@ -1,0 +1,26 @@
+https://bugs.gentoo.org/925671
+https://github.com/intel/libva/commit/45acdece2c8b7d8f6d4e5edd9b9da89e78f18ba2
+From 45acdece2c8b7d8f6d4e5edd9b9da89e78f18ba2 Mon Sep 17 00:00:00 2001
+From: Tamir Duberstein <tamird@google.com>
+Date: Wed, 21 Dec 2022 11:11:08 -0500
+Subject: [PATCH] Remove reference to non-existent symbol
+
+This fixes compilation in recent clang versions (tested against
+https://github.com/llvm/llvm-project/commit/6443c0e) which is apparently
+stricter with respect to undefined symbols. It appears that this version
+script reference was never correct.
+---
+ va/libva.syms | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/va/libva.syms b/va/libva.syms
+index b15d5460d..b3f91f935 100644
+--- a/va/libva.syms
++++ b/va/libva.syms
+@@ -6,6 +6,4 @@ VA_API_0.32.0 {
+ VA_API_0.33.0 {
+     global:
+         vaCreateSurfaces;
+-    local:
+-        vaCreateSurfaces_0_33_0;
+ } VA_API_0.32.0;

--- a/media-libs/libva-compat/libva-compat-1.8.3-r3.ebuild
+++ b/media-libs/libva-compat/libva-compat-1.8.3-r3.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal optfeature
+
+MY_PN="${PN%-compat}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Video Acceleration (VA) API for Linux"
+HOMEPAGE="https://github.com/intel/libva"
+SRC_URI="https://github.com/intel/libva/archive/${PV}.tar.gz -> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="MIT"
+SLOT="1"
+KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="+drm egl opengl wayland X"
+
+RDEPEND=">=x11-libs/libdrm-2.4.46[${MULTILIB_USEDEP}]
+	X? (
+		>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXfixes-5.0.1[${MULTILIB_USEDEP}]
+	)
+	egl? ( >=media-libs/mesa-9.1.6[egl(+),${MULTILIB_USEDEP}] )
+	opengl? ( >=virtual/opengl-7.0-r1[${MULTILIB_USEDEP}] )
+	wayland? ( >=dev-libs/wayland-1.0.6[${MULTILIB_USEDEP}] )
+	!media-libs/libva:0/0"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+REQUIRED_USE="|| ( drm wayland X )
+		opengl? ( X )"
+
+DOCS=( NEWS )
+
+PATCHES=(
+	"${FILESDIR}/${P}-missing-decl.patch"
+	"${FILESDIR}/${P}-nonexisting-symbol.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--with-drivers-path="${EPREFIX}/usr/$(get_libdir)/va/drivers"
+		$(use_enable opengl glx)
+		$(use_enable X x11)
+		$(use_enable wayland)
+		$(use_enable egl)
+		$(use_enable drm)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install() {
+	emake -C va DESTDIR="${D}" install-libLTLIBRARIES
+	rm -vf "${ED}"/usr/$(get_libdir)/*.{la,so} || die
+}
+
+pkg_postinst() {
+	optfeature_header
+	optfeature "Older Intel GPU support" media-libs/libva-intel-driver
+	optfeature "Newer Intel GPU support" media-libs/libva-intel-media-driver
+}


### PR DESCRIPTION
Fix missing function parameters for C23.
Add upstream patch that deleted nonexistent symbol from linking script for Clang/LLD

Closes: https://bugs.gentoo.org/925671
Closes: https://bugs.gentoo.org/944163

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
