### PR TITLE
media-libs/game-music-emu: depend on sys-libs/zlib

### DIFF
--- a/media-libs/game-music-emu/game-music-emu-0.6.3-r1.ebuild
+++ b/media-libs/game-music-emu/game-music-emu-0.6.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,6 +16,8 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 BDEPEND="test? ( sys-process/parallel )"
+DEPEND="sys-libs/zlib[${MULTILIB_USEDEP}]"
+RDEPEND="${DEPEND}"
 
 DOCS=( changes.txt design.txt gme.txt readme.txt )
 


### PR DESCRIPTION
Adds a missing build- and runtime-dependency on `sys-libs/zlib` to libgme-0.6.3.

I could also bump this to EAPI 8 if desired, but I'm about to open a separate pull request with libgme-0.6.4 which I *did* bump to EAPI 8. Given this is now an old version I wanted to keep the changes minimal.

I didn't revbump here because this should fail to build in most cases, though the linked bug is perhaps the exception that proves I should have revbumped. I'm happy to revbump if desired :)

Closes: https://bugs.gentoo.org/834552

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
