### PR TITLE
app-shells/fish: adjust patches to find right target dir

### DIFF
--- a/app-shells/fish/files/fish-4.0.1-use-cargo-eclass-for-build.patch
+++ b/app-shells/fish/files/fish-4.0.1-use-cargo-eclass-for-build.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 496226e89..cb032d6d5 100644
+index 496226e89..69bdf037d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -51,17 +51,6 @@ function(CREATE_TARGET target)
-   add_custom_target(
+@@ -52,18 +52,7 @@ function(CREATE_TARGET target)
      ${target} ALL
      COMMAND
--      "${CMAKE_COMMAND}" -E
+       "${CMAKE_COMMAND}" -E
 -        env ${VARS_FOR_CARGO}
 -          ${Rust_CARGO}
 -            build --bin ${target}
@@ -17,9 +16,12 @@ index 496226e89..cb032d6d5 100644
 -            ${CARGO_FLAGS}
 -            ${FEATURES_ARG}
 -      &&
-       "${CMAKE_COMMAND}" -E
-         copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
+-      "${CMAKE_COMMAND}" -E
+-        copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
++        copy "${FISH_RUST_BUILD_DIR}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+     USES_TERMINAL
+   )
 diff --git a/cmake/Rust.cmake b/cmake/Rust.cmake
 index 40887be45..fa0f7ab6f 100644
 --- a/cmake/Rust.cmake

--- a/app-shells/fish/files/fish-9999-use-cargo-eclass-for-build.patch
+++ b/app-shells/fish/files/fish-9999-use-cargo-eclass-for-build.patch
@@ -1,12 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0510cd2d7..c49f80d69 100644
+index 0510cd2d7..84fa35e2e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -41,17 +41,6 @@ function(CREATE_TARGET target)
-   add_custom_target(
+@@ -42,18 +42,7 @@ function(CREATE_TARGET target)
      ${target} ALL
      COMMAND
--      "${CMAKE_COMMAND}" -E
+       "${CMAKE_COMMAND}" -E
 -        env ${VARS_FOR_CARGO}
 -          ${Rust_CARGO}
 -            build --bin ${target}
@@ -17,23 +16,26 @@ index 0510cd2d7..c49f80d69 100644
 -            ${CARGO_FLAGS}
 -            ${FEATURES_ARG}
 -      &&
-       "${CMAKE_COMMAND}" -E
-         copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
+-      "${CMAKE_COMMAND}" -E
+-        copy "${rust_target_dir}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
++        copy "${FISH_RUST_BUILD_DIR}/${rust_profile}/${target}" "${CMAKE_CURRENT_BINARY_DIR}"
      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+     USES_TERMINAL
+   )
 diff --git a/cmake/Rust.cmake b/cmake/Rust.cmake
-index c5bb1b1b3..618b47183 100644
+index 9cdd01c30..5c554dd2d 100644
 --- a/cmake/Rust.cmake
 +++ b/cmake/Rust.cmake
-@@ -5,7 +5,7 @@ set(Rust_RESOLVE_RUSTUP_TOOLCHAINS Off)
+@@ -1,7 +1,7 @@
  include(FindRust)
- find_package(Rust 1.70 REQUIRED)
+ find_package(Rust REQUIRED)
  
 -set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo/build")
 +set(FISH_RUST_BUILD_DIR "${CMAKE_SOURCE_DIR}/target")
  
  if(DEFINED ASAN)
      list(APPEND CARGO_FLAGS "-Z" "build-std")
-@@ -22,8 +22,8 @@ else()
+@@ -18,8 +18,8 @@ else()
      set(rust_target_dir "${FISH_RUST_BUILD_DIR}/${Rust_CARGO_HOST_TARGET}")
  endif()
  


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/953010
Closes: https://bugs.gentoo.org/953027

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
