### PR TITLE
net-im/synapse: rdepend on sec-policy/selinux-matrixd for USE=selinux

### DIFF
--- a/net-im/synapse/synapse-1.127.1.ebuild
+++ b/net-im/synapse/synapse-1.127.1.ebuild
@@ -114,7 +114,7 @@ LICENSE+="
 "
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~ppc64"
-IUSE="postgres systemd test"
+IUSE="postgres selinux systemd test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -151,6 +151,7 @@ RDEPEND="
 	dev-python/typing-extensions[${PYTHON_USEDEP}]
 	dev-python/unpaddedbase64[${PYTHON_USEDEP}]
 	postgres? ( dev-python/psycopg:2[${PYTHON_USEDEP}] )
+	selinux? ( sec-policy/selinux-matrixd )
 	systemd? ( dev-python/python-systemd[${PYTHON_USEDEP}] )
 "
 BDEPEND="


### PR DESCRIPTION
sec-policy/selinux-matrixd has policy for synapse.

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.