### PR TITLE
dev-libs/cdk: add --with-shlib-version=abi for configure

### DIFF
--- a/dev-libs/cdk/cdk-5.0.20230201-r2.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20230201-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/${PN}/${MY_P}.tgz
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
-SLOT="0/6" # subslot = soname version
+SLOT="0/6.3.4" # subslot = soname version, check VERSION
 KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="examples unicode"
 
@@ -41,8 +41,7 @@ src_configure() {
 		--enable-const \
 		--with-shared \
 		--with-pkg-config \
-		--enable-pc-files \
-		--with-pkg-config-libdir="${EPREFIX}/usr/$(get_libdir)/pkgconfig" \
+		--with-shlib-version=abi \
 		--with-ncurses$(usex unicode "w" "")
 }
 

--- a/dev-libs/cdk/cdk-5.0.20230201.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20230201.ebuild
@@ -15,7 +15,7 @@ SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/${PN}/${MY_P}.tgz
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
-SLOT="0/6" # subslot = soname version
+SLOT="0/6.3.4" # subslot = soname version, check VERSION
 KEYWORDS="~alpha amd64 ~arm64 ~hppa ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="examples unicode"
 

--- a/dev-libs/cdk/cdk-5.0.20240331-r1.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20240331-r1.ebuild
@@ -15,8 +15,8 @@ SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/${PN}/${MY_P}.tgz
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
-SLOT="0/6" # subslot = soname version
-KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+SLOT="0/6.3.4" # subslot = soname version, check VERSION
+KEYWORDS="~alpha amd64 ~arm64 ~hppa ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="examples unicode"
 
 DEPEND="sys-libs/ncurses:=[unicode(+)?]"
@@ -25,10 +25,6 @@ BDEPEND="
 	virtual/pkgconfig
 	verify-sig? ( sec-keys/openpgp-keys-thomasdickey )
 "
-
-PATCHES=(
-	"${FILESDIR}/${PN}-5.0.20240619-xlib.patch"
-)
 
 src_configure() {
 	if [[ ${CHOST} == *-*-darwin* ]] ; then
@@ -45,8 +41,7 @@ src_configure() {
 		--enable-const \
 		--with-shared \
 		--with-pkg-config \
-		--enable-pc-files \
-		--with-pkg-config-libdir="${EPREFIX}/usr/$(get_libdir)/pkgconfig" \
+		--with-shlib-version=abi \
 		--with-ncurses$(usex unicode "w" "")
 }
 

--- a/dev-libs/cdk/cdk-5.0.20240619-r2.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20240619-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/${PN}/${MY_P}.tgz
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
-SLOT="0/6" # subslot = soname version
+SLOT="0/6.3.4" # subslot = soname version, check VERSION
 KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="examples unicode"
 
@@ -25,6 +25,10 @@ BDEPEND="
 	virtual/pkgconfig
 	verify-sig? ( sec-keys/openpgp-keys-thomasdickey )
 "
+
+PATCHES=(
+	"${FILESDIR}/${PN}-5.0.20240619-xlib.patch"
+)
 
 src_configure() {
 	if [[ ${CHOST} == *-*-darwin* ]] ; then
@@ -41,6 +45,9 @@ src_configure() {
 		--enable-const \
 		--with-shared \
 		--with-pkg-config \
+		--with-shlib-version=abi \
+		--enable-pc-files \
+		--with-pkg-config-libdir="${EPREFIX}/usr/$(get_libdir)/pkgconfig" \
 		--with-ncurses$(usex unicode "w" "")
 }
 

--- a/dev-libs/cdk/cdk-5.0.20250116-r1.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20250116-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,8 +15,8 @@ SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/${PN}/${MY_P}.tgz
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
-SLOT="0/6" # subslot = soname version
-KEYWORDS="~alpha amd64 ~arm64 ~hppa ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
+SLOT="0/6.3.5" # subslot = soname version, check VERSION
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="examples unicode"
 
 DEPEND="sys-libs/ncurses:=[unicode(+)?]"
@@ -41,6 +41,9 @@ src_configure() {
 		--enable-const \
 		--with-shared \
 		--with-pkg-config \
+		--enable-pc-files \
+		--with-shlib-version=abi \
+		--with-pkg-config-libdir="${EPREFIX}/usr/$(get_libdir)/pkgconfig" \
 		--with-ncurses$(usex unicode "w" "")
 }
 


### PR DESCRIPTION
so for example:
  /usr/lib64/libcdk.so -> libcdk.so.6.3.4 -> libcdk.so.5.0
will turn into:
  /usr/lib64/libcdk.so -> libcdk.so.5.0 -> libcdk.so.6.3.4

libcdk.so.6.3.4 is the soname, will be kept by preserved-libs

Closes: https://bugs.gentoo.org/831226

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
