### PR TITLE
app-editors/nano: Fix cross compilation

### DIFF
--- a/app-editors/nano/nano-8.4.ebuild
+++ b/app-editors/nano/nano-8.4.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=8
 
+inherit toolchain-funcs
+
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/git/nano.git"
 	inherit autotools git-r3
@@ -60,6 +62,11 @@ src_configure() {
 		$(use_enable unicode utf8)
 		$(use_enable minimal tiny)
 	)
+
+	if tc-is-cross-compiler ; then
+		# bug 953104
+		export gl_cv_func_strcasecmp_works=yes
+	fi
 
 	econf "${myconfargs[@]}"
 }


### PR DESCRIPTION
Gnulib recently added a check for strcasecmp
(https://git.savannah.gnu.org/cgit/gnulib.git/commit/m4/strcasecmp.m4?id=9980b9e526d3436524fb148fc8ed8ebbd15e76dc) and the build system tries to run the test when cross-compiling, so we can set the corresponding variable to avoid running it.

Closes: https://bugs.gentoo.org/953104