### PR TITLE
net-libs/loudmouth: improve current ebuild

### DIFF
--- a/net-libs/loudmouth/loudmouth-1.5.4-r1.ebuild
+++ b/net-libs/loudmouth/loudmouth-1.5.4-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Lightweight & easy-to-use Jabber library written in C"
+HOMEPAGE="https://mcabber.com"
+SRC_URI="https://mcabber.com/files/${PN}/${P}.tar.bz2"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm ~arm64 ppc ppc64 ~riscv sparc x86 ~ppc-macos"
+IUSE="asyncns debug +gnutls idn +ssl"
+
+RDEPEND="
+	>=dev-libs/glib-2.38
+	asyncns? ( >=net-libs/libasyncns-0.3 )
+	idn? ( net-dns/libidn:= )
+	ssl? (
+		gnutls? ( >=net-libs/gnutls-3.0.20:= )
+		!gnutls? ( dev-libs/openssl:= )
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	virtual/pkgconfig
+"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.5.4-freeaddrinfo-musl.patch )
+
+src_configure() {
+	local SSL=no
+	use ssl && SSL=$(usex gnutls gnutls openssl)
+
+	local myeconfargs=(
+		--with-compile-warnings=yes # avoid default =error
+		--with-ssl=${SSL}
+		$(use_enable debug)
+		$(use_with asyncns)
+		$(use_with idn)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	find "${ED}" -type f -name '*.la' -delete || die
+}

--- a/net-libs/loudmouth/metadata.xml
+++ b/net-libs/loudmouth/metadata.xml
@@ -7,6 +7,7 @@
 		<flag name="openssl">Enable <pkg>dev-libs/openssl</pkg> support instead of gnutls (which is the default).</flag>
 	</use>
 	<upstream>
+		<bugs-to>https://github.com/mcabber/loudmouth/issues</bugs-to>
 		<remote-id type="github">mcabber/loudmouth</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
<!-- Please put the pull request description above -->
Pinging gnome@gentoo as abiword depends on this library

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
