### PR TITLE
net-analyzer/wireshark: revert to old zlib due to conflict with minizip-ng

### DIFF
--- a/net-analyzer/wireshark/wireshark-4.4.5-r1.ebuild
+++ b/net-analyzer/wireshark/wireshark-4.4.5-r1.ebuild
@@ -61,7 +61,7 @@ RDEPEND="
 	lua? ( ${LUA_DEPS} )
 	lz4? ( app-arch/lz4:= )
 	maxminddb? ( dev-libs/libmaxminddb:= )
-	minizip? ( sys-libs/minizip-ng )
+	minizip? ( sys-libs/zlib[minizip] )
 	netlink? ( dev-libs/libnl:3 )
 	opus? ( media-libs/opus )
 	pcap? ( net-libs/libpcap )
@@ -80,7 +80,7 @@ RDEPEND="
 	sshdump? ( >=net-libs/libssh-0.6:= )
 	ssl? ( >=net-libs/gnutls-3.5.8:= )
 	wifi? ( >=net-libs/libssh-0.6:= )
-	zlib? ( sys-libs/zlib-ng )
+	zlib? ( sys-libs/zlib )
 	zstd? ( app-arch/zstd:= )
 "
 DEPEND="
@@ -217,6 +217,7 @@ src_configure() {
 		-DLUA_FIND_VERSIONS="${ELUA#lua}"
 		-DENABLE_LZ4=$(usex lz4)
 		-DENABLE_MINIZIP=$(usex minizip)
+		-DENABLE_MINIZIPNG=OFF
 		-DENABLE_NETLINK=$(usex netlink)
 		-DENABLE_NGHTTP2=$(usex http2)
 		-DENABLE_NGHTTP3=$(usex http3)
@@ -229,8 +230,8 @@ src_configure() {
 		-DENABLE_SNAPPY=$(usex snappy)
 		-DENABLE_SPANDSP=$(usex spandsp)
 		-DBUILD_wifidump=$(usex wifi)
-		-DENABLE_ZLIB=OFF
-		-DENABLE_ZLIBNG=$(usex zlib)
+		-DENABLE_ZLIB=$(usex zlib)
+		-DENABLE_ZLIBNG=OFF
 		-DENABLE_ZSTD=$(usex zstd)
 	)
 

--- a/net-analyzer/wireshark/wireshark-9999.ebuild
+++ b/net-analyzer/wireshark/wireshark-9999.ebuild
@@ -23,7 +23,7 @@ else
 	S="${WORKDIR}/${P/_/}"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+		KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc64 ~riscv ~x86"
 	fi
 fi
 

--- a/net-analyzer/wireshark/wireshark-9999.ebuild
+++ b/net-analyzer/wireshark/wireshark-9999.ebuild
@@ -61,7 +61,7 @@ RDEPEND="
 	lua? ( ${LUA_DEPS} )
 	lz4? ( app-arch/lz4:= )
 	maxminddb? ( dev-libs/libmaxminddb:= )
-	minizip? ( sys-libs/minizip-ng )
+	minizip? ( sys-libs/zlib[minizip] )
 	netlink? ( dev-libs/libnl:3 )
 	opus? ( media-libs/opus )
 	pcap? ( net-libs/libpcap )
@@ -80,7 +80,7 @@ RDEPEND="
 	sshdump? ( >=net-libs/libssh-0.6:= )
 	ssl? ( >=net-libs/gnutls-3.5.8:= )
 	wifi? ( >=net-libs/libssh-0.6:= )
-	zlib? ( sys-libs/zlib-ng )
+	zlib? ( sys-libs/zlib )
 	zstd? ( app-arch/zstd:= )
 "
 DEPEND="
@@ -215,6 +215,7 @@ src_configure() {
 		-DLUA_FIND_VERSIONS="${ELUA#lua}"
 		-DENABLE_LZ4=$(usex lz4)
 		-DENABLE_MINIZIP=$(usex minizip)
+		-DENABLE_MINIZIPNG=OFF
 		-DENABLE_NETLINK=$(usex netlink)
 		-DENABLE_NGHTTP2=$(usex http2)
 		-DENABLE_NGHTTP3=$(usex http3)
@@ -227,8 +228,8 @@ src_configure() {
 		-DENABLE_SNAPPY=$(usex snappy)
 		-DENABLE_SPANDSP=$(usex spandsp)
 		-DBUILD_wifidump=$(usex wifi)
-		-DENABLE_ZLIB=OFF
-		-DENABLE_ZLIBNG=$(usex zlib)
+		-DENABLE_ZLIB=$(usex zlib)
+		-DENABLE_ZLIBNG=OFF
 		-DENABLE_ZSTD=$(usex zstd)
 	)
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/953390
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
