### PR TITLE
dev-build/auto{conf,make}{,-vanilla}: touch .keepinfodir

### DIFF
--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.13.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,4 +58,11 @@ src_configure() {
 		--bindir="${EPREFIX}"/usr/bin \
 		--datadir="${EPREFIX}"/usr/share/"${P}" \
 		--infodir="${TC_AUTOCONF_INFOPATH}"
+}
+
+src_install() {
+	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
 }

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.69-r1.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.69-r1.ebuild
@@ -93,3 +93,10 @@ src_prepare() {
 		 -execdir sed -i '/^pkgdatadir/s/@PACKAGE@/&-vanilla/g' {} + \
 		 || die
 }
+
+src_install() {
+	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+}

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.71-r1.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.71-r1.ebuild
@@ -81,6 +81,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.72-r1.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.72-r1.ebuild
@@ -92,6 +92,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-9999.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-9999.ebuild
@@ -92,6 +92,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/autoconf/autoconf-2.13-r8.ebuild
+++ b/dev-build/autoconf/autoconf-2.13-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -57,4 +57,11 @@ src_configure() {
 		--bindir="${EPREFIX}"/usr/bin \
 		--program-suffix="-${PV}" \
 		--infodir="${TC_AUTOCONF_INFOPATH}"
+}
+
+src_install() {
+	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
 }

--- a/dev-build/autoconf/autoconf-2.69-r10.ebuild
+++ b/dev-build/autoconf/autoconf-2.69-r10.ebuild
@@ -80,3 +80,10 @@ src_prepare() {
 src_test() {
 	emake check TESTSUITEFLAGS="--jobs=$(get_makeopts_jobs)"
 }
+
+src_install() {
+	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+}

--- a/dev-build/autoconf/autoconf-2.71-r6.ebuild
+++ b/dev-build/autoconf/autoconf-2.71-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -79,6 +79,9 @@ src_test() {
 
 src_install() {
 	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
 
 	local f
 	for f in config.{guess,sub} ; do

--- a/dev-build/autoconf/autoconf-2.71-r8.ebuild
+++ b/dev-build/autoconf/autoconf-2.71-r8.ebuild
@@ -93,6 +93,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/autoconf/autoconf-2.72-r1.ebuild
+++ b/dev-build/autoconf/autoconf-2.72-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -88,6 +88,9 @@ src_test() {
 
 src_install() {
 	toolchain-autoconf_src_install
+
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
 
 	local f
 	for f in config.{guess,sub} ; do

--- a/dev-build/autoconf/autoconf-2.72-r3.ebuild
+++ b/dev-build/autoconf/autoconf-2.72-r3.ebuild
@@ -92,6 +92,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/autoconf/autoconf-9999.ebuild
+++ b/dev-build/autoconf/autoconf-9999.ebuild
@@ -91,6 +91,9 @@ src_test() {
 src_install() {
 	toolchain-autoconf_src_install
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	local f
 	for f in config.{guess,sub} ; do
 		ln -fs ../../gnuconfig/${f} \

--- a/dev-build/automake-vanilla/automake-vanilla-1.11.6.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.11.6.ebuild
@@ -72,6 +72,9 @@ src_compile() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	rm \
 		"${ED}"/usr/bin/{aclocal,automake}-vanilla \
 		"${ED}"/usr/share/man/man1/{aclocal,automake}-vanilla.1 || die

--- a/dev-build/automake-vanilla/automake-vanilla-1.15.1.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.15.1.ebuild
@@ -81,6 +81,9 @@ src_configure() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake-vanilla/automake-vanilla-1.16.5.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.16.5.ebuild
@@ -100,6 +100,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake-vanilla/automake-vanilla-1.17.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.17.ebuild
@@ -88,6 +88,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake-vanilla/automake-vanilla-1.18.1.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.18.1.ebuild
@@ -88,6 +88,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake-vanilla/automake-vanilla-1.18.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-1.18.ebuild
@@ -88,6 +88,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake-vanilla/automake-vanilla-9999.ebuild
+++ b/dev-build/automake-vanilla/automake-vanilla-9999.ebuild
@@ -87,6 +87,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	#rm "${ED}"/usr/share/aclocal/README || die
 	#rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake/automake-1.11.6-r4.ebuild
+++ b/dev-build/automake/automake-1.11.6-r4.ebuild
@@ -57,6 +57,9 @@ src_compile() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	rm \
 		"${ED}"/usr/bin/{aclocal,automake} \
 		"${ED}"/usr/share/man/man1/{aclocal,automake}.1 || die

--- a/dev-build/automake/automake-1.17-r2.ebuild
+++ b/dev-build/automake/automake-1.17-r2.ebuild
@@ -106,6 +106,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	rm "${ED}"/usr/share/aclocal/README || die
 	rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake/automake-1.18.1.ebuild
+++ b/dev-build/automake/automake-1.18.1.ebuild
@@ -101,6 +101,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	rm "${ED}"/usr/share/aclocal/README || die
 	rmdir "${ED}"/usr/share/aclocal || die
 	rm \

--- a/dev-build/automake/automake-9999.ebuild
+++ b/dev-build/automake/automake-9999.ebuild
@@ -101,6 +101,9 @@ src_test() {
 src_install() {
 	default
 
+	# dissuade Portage from removing our dir file
+	touch "${ED}"/usr/share/${P}/info/.keepinfodir || die
+
 	rm "${ED}"/usr/share/aclocal/README || die
 	rmdir "${ED}"/usr/share/aclocal || die
 	rm \


### PR DESCRIPTION
inspired by https://bugs.gentoo.org/257260

prevent portage from rebuilding the info dir, so `equery check` won't complain:

> /usr/share/autoconf-2.72/info/dir does not exist

or 
> /usr/share/autoconf-2.72/info/dir has wrong mtime (is 1744192720, should be 1744192708)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
