### PR TITLE
media-libs/libva: add USE=glx

### DIFF
--- a/media-libs/libva/libva-2.22.0-r1.ebuild
+++ b/media-libs/libva/libva-2.22.0-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} = *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/intel/libva"
 else
 	SRC_URI="https://github.com/intel/libva/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm64 ~loong ~mips ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 fi
 
 LICENSE="MIT"
@@ -37,7 +37,10 @@ RDEPEND="
 		x11-libs/libxcb:=[${MULTILIB_USEDEP}]
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	X? ( x11-base/xorg-proto )
+"
 BDEPEND="
 	wayland? ( dev-util/wayland-scanner )
 	virtual/pkgconfig

--- a/media-libs/libva/metadata.xml
+++ b/media-libs/libva/metadata.xml
@@ -8,4 +8,7 @@
   <upstream>
   <remote-id type="github">intel/libva</remote-id>
   </upstream>
+  <use>
+    <flag name="glx">Enable GLX backend (requires X)</flag>
+  </use>
 </pkgmetadata>


### PR DESCRIPTION
Unbreaks pre-compiled binaries that were linked against that library.

Closes: https://bugs.gentoo.org/916192

---
`glx` was chosen to no be pulled in by system wide `USE=opengl`.
<!-- Please put the pull request description above -->

@mattst88 @Nowa-Ammerlaan 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
