### PR TITLE
sys-libs/libnvidia-container: apply patch for go 1.24

### DIFF
--- a/sys-libs/libnvidia-container/libnvidia-container-1.17.3.ebuild
+++ b/sys-libs/libnvidia-container/libnvidia-container-1.17.3.ebuild
@@ -53,6 +53,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.17.0-fix-makefile-r1.patch"
+	"${FILESDIR}/${PN}-1.17.4-go-1.24.patch"
 )
 
 DOCS=( NOTICE README.md )

--- a/sys-libs/libnvidia-container/libnvidia-container-9999.ebuild
+++ b/sys-libs/libnvidia-container/libnvidia-container-9999.ebuild
@@ -53,6 +53,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.17.0-fix-makefile-r1.patch"
+	"${FILESDIR}/${PN}-1.17.4-go-1.24.patch"
 )
 
 DOCS=( NOTICE README.md )


### PR DESCRIPTION
go 1.24 is stabled, build failed w/o this patch

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
