### PR TITLE
app-misc/elasticsearch: mkdir /usr/share/${PN}/plugins in pkg_postinst

### DIFF
--- a/app-misc/elasticsearch/elasticsearch-8.15.1.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-8.15.1.ebuild
@@ -62,8 +62,6 @@ src_install() {
 	insinto /usr/share/${PN}
 	doins -r .
 
-	keepdir /usr/share/${PN}/plugins
-
 	exeinto /usr/share/${PN}/bin
 	doexe "${FILESDIR}"/elasticsearch-systemd-pre-exec
 
@@ -88,9 +86,11 @@ src_install() {
 
 pkg_postinst() {
 	# Elasticsearch will choke on our keep file and dodir will not preserve the empty dir
-	local KEEPFILE
-	KEEPFILE=$(find "${EROOT}/usr/share/${PN}/plugins/" -type f -name '.keep*')
-	rm "${KEEPFILE}" || die
+	# equery check complain .keep* file not exist after rm .keep*
+	if [[ ! -d ${EROOT}/usr/share/${PN}/plugins ]] ; then
+		mkdir ${EROOT}/usr/share/${PN}/plugins || die
+	fi
+
 	tmpfiles_process /usr/lib/tmpfiles.d/${PN}.conf
 	if ! systemd_is_booted ; then
 		elog "You may create multiple instances of ${PN} by"

--- a/app-misc/elasticsearch/elasticsearch-8.17.3.ebuild
+++ b/app-misc/elasticsearch/elasticsearch-8.17.3.ebuild
@@ -62,8 +62,6 @@ src_install() {
 	insinto /usr/share/${PN}
 	doins -r .
 
-	keepdir /usr/share/${PN}/plugins
-
 	exeinto /usr/share/${PN}/bin
 	doexe "${FILESDIR}"/elasticsearch-systemd-pre-exec
 
@@ -88,9 +86,11 @@ src_install() {
 
 pkg_postinst() {
 	# Elasticsearch will choke on our keep file and dodir will not preserve the empty dir
-	local KEEPFILE
-	KEEPFILE=$(find "${EROOT}/usr/share/${PN}/plugins/" -type f -name '.keep*')
-	rm "${KEEPFILE}" || die
+	# equery check complain .keep* file not exist after rm .keep*
+	if [[ ! -d ${EROOT}/usr/share/${PN}/plugins ]] ; then
+		mkdir ${EROOT}/usr/share/${PN}/plugins || die
+	fi
+
 	tmpfiles_process /usr/lib/tmpfiles.d/${PN}.conf
 	if ! systemd_is_booted ; then
 		elog "You may create multiple instances of ${PN} by"


### PR DESCRIPTION
equery check will complain file not exist if do 'rm "${KEEPFILE}"'

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
