### PR TITLE
net-analyzer/ntopng: replace symlink with real file

### DIFF
--- a/net-analyzer/ntopng/ntopng-5.6-r2.ebuild
+++ b/net-analyzer/ntopng/ntopng-5.6-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -76,6 +76,13 @@ src_compile() {
 }
 
 src_install() {
+	# httpdocs/geoip/README.geolocation.md is a symlink, change to real file
+	GEOLOCATION_MD="httpdocs/geoip/README.geolocation.md"
+	if [[ -h "${GEOLOCATION_MD}" ]] ; then
+		GEOLOCATION_MD_REAL=$(readlink -m -- "${GEOLOCATION_MD}" || die)
+		ln -f ${GEOLOCATION_MD_REAL} ${GEOLOCATION_MD} || die
+	fi
+
 	SHARE_NTOPNG_DIR="${EPREFIX}/usr/share/${PN}"
 	insinto "${SHARE_NTOPNG_DIR}"
 	doins -r httpdocs

--- a/net-analyzer/ntopng/ntopng-6.0.ebuild
+++ b/net-analyzer/ntopng/ntopng-6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -76,6 +76,13 @@ src_compile() {
 }
 
 src_install() {
+	# httpdocs/geoip/README.geolocation.md is a symlink, change to real file
+	GEOLOCATION_MD="httpdocs/geoip/README.geolocation.md"
+	if [[ -h "${GEOLOCATION_MD}" ]] ; then
+		GEOLOCATION_MD_REAL=$(readlink -m -- "${GEOLOCATION_MD}" || die)
+		ln -f ${GEOLOCATION_MD_REAL} ${GEOLOCATION_MD} || die
+	fi
+
 	SHARE_NTOPNG_DIR="${EPREFIX}/usr/share/${PN}"
 	insinto "${SHARE_NTOPNG_DIR}"
 	doins -r httpdocs


### PR DESCRIPTION
otherwise a broken symlink is installed because doc is not installed:

$ ls -l /usr/share/ntopng/httpdocs/geoip/README.geolocation.md README.geolocation.md -> ../../doc/README.geolocation.md

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
