### PR TITLE
app-shells/smrsh: fix compilation for musl, c23/gcc-15

### DIFF
--- a/app-shells/smrsh/files/site.config.m4
+++ b/app-shells/smrsh/files/site.config.m4
@@ -1,6 +1,6 @@
 define(`confCCOPTS', `@@confCCOPTS@@')
 define(`confSTDIO_TYPE', `portable')
-define(`confENVDEF', `-DXDEBUG=0')
+define(`confENVDEF', `@@confENVDEF@@')
 define(`confLDOPTS', `@@confLDOPTS@@')
 define(`confMANOWN', `root')
 define(`confMANGRP', `root')

--- a/app-shells/smrsh/files/smrsh-8.18.1-c23-sm_strtoll.patch
+++ b/app-shells/smrsh/files/smrsh-8.18.1-c23-sm_strtoll.patch
@@ -1,0 +1,29 @@
+Bug: https://bugs.gentoo.org/944460
+
+--- a/libsm/vfscanf.c
++++ b/libsm/vfscanf.c
+@@ -240,13 +240,13 @@
+ 			/* FALLTHROUGH */
+ 		  case 'd':
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)())sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int))sm_strtoll;
+ 			base = 10;
+ 			break;
+ 
+ 		  case 'i':
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)())sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int))sm_strtoll;
+ 			base = 0;
+ 			break;
+ 
+@@ -324,7 +324,7 @@
+ 			if (isupper(c))
+ 				flags |= LONG;
+ 			c = CT_INT;
+-			ccfn = (ULONGLONG_T (*)()) sm_strtoll;
++			ccfn = (ULONGLONG_T (*)(const char *, char **, int)) sm_strtoll;
+ 			base = 10;
+ 			break;
+ 		}

--- a/app-shells/smrsh/files/smrsh-musl-disable-cdefs.patch
+++ b/app-shells/smrsh/files/smrsh-musl-disable-cdefs.patch
@@ -1,0 +1,11 @@
+--- a/include/sm/os/sm_os_linux.h	2020-06-09 11:57:46.789786561 +0200
++++ b/include/sm/os/sm_os_linux.h	2020-06-09 11:57:49.174781812 +0200
+@@ -33,7 +33,7 @@
+ # endif /* LINUX_VERSION_CODE */
+ #endif /* SM_CONF_SHM */
+
+-#define SM_CONF_SYS_CDEFS_H	1
++#define SM_CONF_SYS_CDEFS_H	0
+ #ifndef SM_CONF_SEM
+ # define SM_CONF_SEM	2
+ #endif /* SM_CONF_SEM */

--- a/app-shells/smrsh/smrsh-8.15.2-r1.ebuild
+++ b/app-shells/smrsh/smrsh-8.15.2-r1.ebuild
@@ -26,6 +26,15 @@ DEPEND="${RDEPEND}
 	sys-devel/m4"
 
 src_prepare() {
+	local confENVDEF="-DXDEBUG=0"
+
+	eapply "${FILESDIR}"/${PN}-8.18.1-c23-sm_strtoll.patch
+
+	if use elibc_musl; then
+		eapply "${FILESDIR}"/${PN}-musl-disable-cdefs.patch
+		confENVDEF+=" -DHASSTRERROR"
+	fi
+
 	cd "${S}/${PN}" || die
 
 	default
@@ -36,6 +45,7 @@ src_prepare() {
 
 	sed -e "s|@@confCCOPTS@@|${CFLAGS}|" \
 		-e "s|@@confLDOPTS@@|${LDFLAGS}|" \
+		-e "s|@@confENVDEF@@|${confENVDEF}|" \
 		-e "s:@@confCC@@:$(tc-getCC):" "${FILESDIR}/site.config.m4" \
 		> "${S}/devtools/Site/site.config.m4" || die "sed failed"
 }

--- a/app-shells/smrsh/smrsh-8.18.1.ebuild
+++ b/app-shells/smrsh/smrsh-8.18.1.ebuild
@@ -26,6 +26,15 @@ DEPEND="${RDEPEND}
 	sys-devel/m4"
 
 src_prepare() {
+	local confENVDEF="-DXDEBUG=0"
+
+	eapply "${FILESDIR}"/${PN}-8.18.1-c23-sm_strtoll.patch
+
+	if use elibc_musl; then
+		eapply "${FILESDIR}"/${PN}-musl-disable-cdefs.patch
+		confENVDEF+=" -DHASSTRERROR"
+	fi
+
 	cd "${S}/${PN}" || die
 
 	default
@@ -36,6 +45,7 @@ src_prepare() {
 
 	sed -e "s|@@confCCOPTS@@|${CFLAGS}|" \
 		-e "s|@@confLDOPTS@@|${LDFLAGS}|" \
+		-e "s|@@confENVDEF@@|${confENVDEF}|" \
 		-e "s:@@confCC@@:$(tc-getCC):" "${FILESDIR}/site.config.m4" \
 		> "${S}/devtools/Site/site.config.m4" || die "sed failed"
 }


### PR DESCRIPTION
The value ```-DXDEBUG=0``` was fixed in the ```site.config.m4``` file, and now
it's in the ebuild file. In order to support musl, we need to add a new value
to the ```confENVDEF``` define.

Closes: https://bugs.gentoo.org/715280
Closes: https://bugs.gentoo.org/944460
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
