### PR TITLE
media-libs/mesa: Enable support for the Asahi and Honeykrisp drivers

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -99,10 +99,34 @@ RDEPEND="
 	unwind? ( sys-libs/libunwind[${MULTILIB_USEDEP}] )
 	llvm? (
 		$(llvm_gen_dep "
-			llvm-core/llvm:\${LLVM_SLOT}[llvm_targets_AMDGPU(+),${MULTILIB_USEDEP}]
+			llvm-core/llvm:\${LLVM_SLOT}[${MULTILIB_USEDEP}]
+			video_cards_r300? (
+				llvm-core/llvm:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+			)
+			video_cards_r600? (
+				llvm-core/llvm:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+			)
+			video_cards_radeon? (
+				llvm-core/llvm:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+			)
+			video_cards_radeonsi? (
+				llvm-core/llvm:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+			)
 			opencl? (
 				dev-util/spirv-llvm-translator:\${LLVM_SLOT}
-				llvm-core/clang:\${LLVM_SLOT}[llvm_targets_AMDGPU(+),${MULTILIB_USEDEP}]
+				llvm-core/clang:\${LLVM_SLOT}[${MULTILIB_USEDEP}]
+				video_cards_r300? (
+					llvm-core/clang:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+				)
+				video_cards_r600? (
+					llvm-core/clang:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+				)
+				video_cards_radeon? (
+					llvm-core/clang:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+				)
+				video_cards_radeonsi? (
+					llvm-core/clang:\${LLVM_SLOT}[llvm_targets_AMDGPU(+)]
+				)
 				=llvm-core/libclc-\${LLVM_SLOT}*[spirv(-)]
 			)
 		")

--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -6,6 +6,7 @@
 # Keep it sorted.
 
 amdgpu - VIDEO_CARDS setting to build driver for AMDGPU video cards
+asahi - VIDEO_CARDS setting to build support for Apple AGX GPUs
 ast - VIDEO_CARDS setting to build driver for ASpeedTech video cards
 d3d12 - VIDEO_CARDS seeting to build driver for Microsoft WSL video cards
 dummy - VIDEO_CARDS setting to build driver for dummy video cards


### PR DESCRIPTION
Now that the stable UAPI has been integrated into mainline linux, Mesa has merged and enabled support for the Asahi and Honeykrisp drivers upstream. These drivers implement OpenGL and Vulkan support for the Apple AGX GPU family, which are found in Apple Silicon Macs. 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
