### PR TITLE
app-misc/digitemp: update EAPI 7 -> 8, fix build with gcc15

### DIFF
--- a/app-misc/digitemp/digitemp-3.7.2-r1.ebuild
+++ b/app-misc/digitemp/digitemp-3.7.2-r1.ebuild
@@ -1,0 +1,85 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Temperature logging and reporting using Maxim's iButtons and 1-Wire protocol"
+HOMEPAGE="https://www.digitemp.com/ https://www.ibutton.com/"
+SRC_URI="https://github.com/bcl/digitemp/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="ds9097 ds9097u ds2490"
+
+DEPEND="ds2490? ( virtual/libusb:0 )"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-conflict-types.patch"
+)
+
+targets() {
+	# default is to compile to the ds9097u.
+	if ! ( use ds9097 || use ds9097u || use ds2490 ); then
+		echo ds9097u
+	fi
+
+	local target
+	for target in ds9097 ds9097u ds2490; do
+		if use ${target}; then
+			echo ${target}
+		fi
+	done
+}
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e "/^CFLAGS/s|-O2|${CFLAGS}|" \
+		Makefile || die
+
+	# default is to compile to the ds9097u.
+	if ! ( use ds9097 || use ds9097u || use ds2490 ); then
+		ewarn "If you don't choose a component to install, we default to ds9097u"
+	fi
+}
+
+src_compile() {
+	local targets=$(targets)
+
+	local target
+	for target in ${targets}; do
+		emake clean
+		emake CC="$(tc-getCC)" LOCK="no" ${target}
+	done
+}
+
+src_install() {
+	local target
+	for target in $(echo $(targets) | tr '[:lower:]' '[:upper:]'); do
+		dobin digitemp_${target} && \
+		dosym digitemp_${target} /usr/bin/digitemp
+	done
+
+	if [[ $(targets|wc -l) -ge 1 ]]; then
+		ewarn "/usr/bin/digitemp has been symlinked to /usr/bin/digitemp_${target}"
+		ewarn "If you want to access the others, they are available at /usr/bin/digitemp_*"
+	fi
+
+	dodoc README FAQ TODO
+
+	local example
+	for example in perl python rrdb; do
+		docinto ${example}_examples
+		dodoc -r ${example}/*
+	done
+}
+
+pkg_postinst() {
+	elog "Examples of using digitemp with python, perl, and rrdtool are"
+	elog "located in /usr/share/doc/${PF}/"
+}

--- a/app-misc/digitemp/files/digitemp-3.7.2-conflict-types.patch
+++ b/app-misc/digitemp/files/digitemp-3.7.2-conflict-types.patch
@@ -1,0 +1,35 @@
+https://bugs.gentoo.org/943788
+https://github.com/bcl/digitemp/commit/fa56b0f78d12f97ac44e0a367d413a9e88611d1c
+
+From fa56b0f78d12f97ac44e0a367d413a9e88611d1c Mon Sep 17 00:00:00 2001
+From: Robert Scheck <robert-scheck@users.noreply.github.com>
+Date: Thu, 16 Jan 2025 21:24:41 +0100
+Subject: [PATCH] Fix conflicting prototype
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+src/digitemp.c:171:6: error: conflicting types for ‘free_coupler’; have ‘void(int)’
+  171 | void free_coupler( int free_only )
+      |      ^~~~~~~~~~~~
+In file included from src/digitemp.c:78:
+src/digitemp.h:90:6: note: previous declaration of ‘free_coupler’ with type ‘void(void)’
+   90 | void free_coupler();
+      |      ^~~~~~~~~~~~
+---
+ src/digitemp.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/digitemp.h b/src/digitemp.h
+index 06d50e9..e81a7be 100644
+--- a/src/digitemp.h
++++ b/src/digitemp.h
+@@ -87,7 +87,7 @@ struct _coupler {
+ 
+ /* Prototypes */
+ void usage();
+-void free_coupler();
++void free_coupler( int free_only );
+ float c2f( float temp );
+ int build_tf( char *time_format, char *format, int sensor, 
+               float temp_c, int humidity, unsigned char *sn );


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/806088
Closes: https://bugs.gentoo.org/943788

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
