### PR TITLE
sys-auth/nss_ldap: replace #else -> #endif

### DIFF
--- a/sys-auth/nss_ldap/files/nss_ldap-257.2-gssapi-headers.patch
+++ b/sys-auth/nss_ldap/files/nss_ldap-257.2-gssapi-headers.patch
@@ -47,19 +47,18 @@ diff -ruN nss_ldap-257.2.orig/configure.in nss_ldap-257.2/configure.in
 diff -ruN nss_ldap-257.2.orig/ldap-nss.c nss_ldap-257.2/ldap-nss.c
 --- nss_ldap-257.2.orig/ldap-nss.c	2007-10-24 14:22:55.000000000 +0200
 +++ nss_ldap-257.2/ldap-nss.c	2007-10-24 14:27:32.000000000 +0200
-@@ -82,10 +82,14 @@
+@@ -82,10 +82,13 @@
  #endif
  #ifdef HAVE_GSSAPI_H
  #include <gssapi.h>
 -#elif defined(HAVE_GSSAPI_GSSAPI_KRB5_H)
-+#else
++#endif
 +#ifdef HAVE_GSSAPI_GSSAPI_H
  #include <gssapi/gssapi.h>
 +#endif
 +#ifdef HAVE_GSSAPI_GSSAPI_KRB5_H
  #include <gssapi/gssapi_krb5.h>
  #endif
-+#endif
  #ifdef CONFIGURE_KRB5_CCNAME
  #include <krb5.h>
  #endif


### PR DESCRIPTION
"gssapi.h" is a wrapper to "gssapi/gssapi.h" but w/o "gssapi/gssapi_krb5.h", then build will fail with:

> error: call to undeclared function 'gss_krb5_ccache_name'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
