### PR TITLE
dev-db/mariadb: Skip ssl when setting the root password for 11.4

### DIFF
--- a/dev-db/mariadb/mariadb-11.4.5-r1.ebuild
+++ b/dev-db/mariadb/mariadb-11.4.5-r1.ebuild
@@ -1294,6 +1294,8 @@ pkg_config() {
 	cmd=(
 		"${mysql_binary}"
 		--no-defaults
+		# Skip SSL for client connections, see bug #951865
+		--skip-ssl
 		"--socket='${socket}'"
 		-hlocalhost
 		"-e \"${sql}\""


### PR DESCRIPTION
Starting with MariaDB 11.3, SSL is enabled on the server by default, so while setting up the root password while skipping the default config file, we have to run the MariaDB client with the --skip-ssl option.

Bug: https://bugs.gentoo.org/951865

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
