### PR TITLE
net-libs/nodejs: allow to use libatomic-stub instead of gcc

### DIFF
--- a/net-libs/nodejs/nodejs-22.13.1.ebuild
+++ b/net-libs/nodejs/nodejs-22.13.1.ebuild
@@ -48,7 +48,10 @@ RDEPEND=">=app-arch/brotli-1.1.0:=
 		>=dev-libs/openssl-1.1.1:0=
 	)
 	!system-ssl? ( >=net-libs/ngtcp2-1.9.1:=[-gnutls] )
-	sys-devel/gcc:*"
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)"
 BDEPEND="${PYTHON_DEPS}
 	app-alternatives/ninja
 	sys-apps/coreutils
@@ -128,12 +131,6 @@ src_configure() {
 	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# https://bugs.gentoo.org/931514
 	use arm64 && append-flags $(test-flags-CXX -mbranch-protection=none)
-	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by llvm-runtimes/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
 
 	local myconf=(
 		--ninja

--- a/net-libs/nodejs/nodejs-22.16.0.ebuild
+++ b/net-libs/nodejs/nodejs-22.16.0.ebuild
@@ -48,7 +48,10 @@ RDEPEND=">=app-arch/brotli-1.1.0:=
 		>=dev-libs/openssl-1.1.1:0=
 	)
 	!system-ssl? ( >=net-libs/ngtcp2-1.9.1:=[-gnutls] )
-	sys-devel/gcc:*"
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)"
 BDEPEND="${PYTHON_DEPS}
 	app-alternatives/ninja
 	sys-apps/coreutils
@@ -128,12 +131,6 @@ src_configure() {
 	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# https://bugs.gentoo.org/931514
 	use arm64 && append-flags $(test-flags-CXX -mbranch-protection=none)
-	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by llvm-runtimes/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
 
 	local myconf=(
 		--ninja

--- a/net-libs/nodejs/nodejs-24.1.0.ebuild
+++ b/net-libs/nodejs/nodejs-24.1.0.ebuild
@@ -48,7 +48,10 @@ RDEPEND=">=app-arch/brotli-1.1.0:=
 		>=dev-libs/openssl-1.1.1:0=
 	)
 	!system-ssl? ( >=net-libs/ngtcp2-1.9.1:=[-gnutls] )
-	sys-devel/gcc:*"
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)"
 BDEPEND="${PYTHON_DEPS}
 	app-alternatives/ninja
 	sys-apps/coreutils
@@ -125,12 +128,6 @@ src_configure() {
 	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# https://bugs.gentoo.org/931514
 	use arm64 && append-flags $(test-flags-CXX -mbranch-protection=none)
-	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by llvm-runtimes/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
 
 	local myconf=(
 		--ninja

--- a/net-libs/nodejs/nodejs-24.2.0.ebuild
+++ b/net-libs/nodejs/nodejs-24.2.0.ebuild
@@ -48,7 +48,10 @@ RDEPEND=">=app-arch/brotli-1.1.0:=
 		>=dev-libs/openssl-1.1.1:0=
 	)
 	!system-ssl? ( >=net-libs/ngtcp2-1.9.1:=[-gnutls] )
-	sys-devel/gcc:*"
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)"
 BDEPEND="${PYTHON_DEPS}
 	app-alternatives/ninja
 	sys-apps/coreutils
@@ -125,12 +128,6 @@ src_configure() {
 	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# https://bugs.gentoo.org/931514
 	use arm64 && append-flags $(test-flags-CXX -mbranch-protection=none)
-	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by llvm-runtimes/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
 
 	local myconf=(
 		--ninja

--- a/net-libs/nodejs/nodejs-99999999.ebuild
+++ b/net-libs/nodejs/nodejs-99999999.ebuild
@@ -48,7 +48,10 @@ RDEPEND=">=app-arch/brotli-1.1.0:=
 		>=dev-libs/openssl-1.1.1:0=
 	)
 	!system-ssl? ( >=net-libs/ngtcp2-1.9.1:=[-gnutls] )
-	sys-devel/gcc:*"
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)"
 BDEPEND="${PYTHON_DEPS}
 	app-alternatives/ninja
 	sys-apps/coreutils
@@ -128,12 +131,6 @@ src_configure() {
 	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# https://bugs.gentoo.org/931514
 	use arm64 && append-flags $(test-flags-CXX -mbranch-protection=none)
-	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by llvm-runtimes/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
 
 	local myconf=(
 		--ninja


### PR DESCRIPTION
(This PR depends on #41045)
(I'll revbump later)

This PR allows pure LLVM profile users to build nodejs without gcc.
To do this, first create a libatomic virtual package.
Then, make nodejs use it.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
