### PR TITLE
metadata/install-qa-check.d: Check for Python exts for wrong impl

### DIFF
--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -2,6 +2,12 @@
 # Distributed under the terms of the GNU General Public License v2
 
 # QA checks related to site-packages directory:
+# - files installed top-level instead of into site-packages
+# - bad/unknown package versions
+# - deprecated .egg files
+# - stray files in top-level site-packages directory
+# - forbidden top-level package names ("test" and so on)
+# - extensions compiled for wrong Python implementation
 # - missing, mismatched or stray .pyc files
 # Maintainer: Python project <python@gentoo.org>
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Gentoo Authors
+# Copyright 2019-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # QA checks related to site-packages directory:
@@ -34,6 +34,7 @@ python_site_check() {
 	local eggs=()
 	local outside_site=()
 	local stray_packages=()
+	local wrong_ext=()
 
 	# Avoid running the check if sufficiently new gpep517 is not installed
 	# yet. It's valid to schedule (for merge order) >=gpep517-8 after
@@ -104,12 +105,29 @@ python_site_check() {
 					-name 'README.txt' \
 				')' -print0
 		)
+
 		# check for forbidden packages
 		for f in "${forbidden_package_names[@]}"; do
 			[[ -d ${sitedir}/${f} ]] && stray_packages+=(
 				"${sitedir#${ED}}/${f}"
 			)
 		done
+
+		# check for extensions compiled for wrong implementations
+		local ext_suffix=$(
+			"${impl}" - <<-EOF
+				import sysconfig
+				print(sysconfig.get_config_var("EXT_SUFFIX"))
+			EOF
+		)
+		while IFS= read -d $'\0' -r f; do
+			wrong_ext+=( "${f#${ED}}" )
+		done < <(
+			find "${sitedir}" '(' \
+				-name "*.pypy*$(get_modname)" -o \
+				-name "*.cpython*$(get_modname)" \
+				')' -a '!' -name "*${ext_suffix}" -print0
+		)
 
 		einfo "Verifying compiled files for ${impl}"
 		local kind pyc py
@@ -243,6 +261,14 @@ python_site_check() {
 		eqawarn "instead of site-packages (use \$(python_get_sitedir)):"
 		eqawarn
 		eqatag -v python-site.stdlib "${outside_site[@]}"
+	fi
+
+	if [[ ${wrong_ext[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: Extensions found compiled for the wrong Python version"
+		eqawarn "(likely broken build isolation):"
+		eqawarn
+		eqatag -v python-site.wrong-ext "${wrong_ext[@]}"
 	fi
 }
 


### PR DESCRIPTION
Add a QA check for Python extensions that were compiled for the wrong implementation.  This is particularly a case when build is not properly isolated and extensions built for earlier Python versions end up being included in the subsequent installs.

-----

E.g. wxpython:

```
 * QA Notice: Extensions found compiled for the wrong Python version
 * (likely broken build isolation):
 * 
 *   /usr/lib/python3.13/site-packages/wx/_adv.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_aui.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_core.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_dataview.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_glcanvas.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_grid.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_html.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_media.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_propgrid.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_ribbon.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_richtext.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_stc.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_xml.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/_xrc.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/siplib.cpython-312-x86_64-linux-gnu.so
 *   /usr/lib/python3.13/site-packages/wx/svg/_nanosvg.cpython-312-x86_64-linux-gnu.so
```