### PR TITLE
media-tv/kodi: fix build against pipewire-1.4.0 and USE="-system-ffmpeg" with ffmpeg-compat change

### DIFF
--- a/media-tv/kodi/files/kodi-21.2-pipewire-1.4.0-fix.patch
+++ b/media-tv/kodi/files/kodi-21.2-pipewire-1.4.0-fix.patch
@@ -1,0 +1,27 @@
+https://github.com/xbmc/xbmc/issues/26526
+https://github.com/xbmc/xbmc/commit/269053ebbfd3cc4a3156a511f54ab7f08a09a730
+https://github.com/xbmc/xbmc/pull/26502
+https://github.com/xbmc/xbmc/pull/26527
+
+From e23a105b8988aba9b8401493bf6031a6878bd435 Mon Sep 17 00:00:00 2001
+From: Timo Gurr <timo.gurr@gmail.com>
+Date: Fri, 7 Mar 2025 13:30:47 +0100
+Subject: [PATCH] [AudioEngine] PipeWire: Fix build with PipeWire 1.4.0
+
+PipeWire >= 1.4.0 requires the correct struct type to be used, otherwise
+it will fail to compile.
+
+Reference: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/188d920733f0791413d3386e5536ee7377f71b2f
+(cherry picked from commit 269053ebbfd3cc4a3156a511f54ab7f08a09a730)
+--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+@@ -40,7 +40,8 @@ void CPipewireNode::EnumerateFormats()
+   for (uint32_t param = 0; param < m_info->n_params; param++)
+   {
+     if (m_info->params[param].id == SPA_PARAM_EnumFormat)
+-      pw_node_enum_params(m_proxy.get(), 0, m_info->params[param].id, 0, 0, NULL);
++      pw_node_enum_params(reinterpret_cast<struct pw_node*>(m_proxy.get()), 0,
++                          m_info->params[param].id, 0, 0, NULL);
+   }
+ }
+ 

--- a/media-tv/kodi/kodi-21.2-r2.ebuild
+++ b/media-tv/kodi/kodi-21.2-r2.ebuild
@@ -272,6 +272,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/kodi-21-optional-ffmpeg-libx11.patch
 	"${FILESDIR}"/kodi-21.1-silence-libdvdread-git.patch
+	"${FILESDIR}"/kodi-21.2-pipewire-1.4.0-fix.patch
 )
 
 # bug #544020

--- a/media-tv/kodi/kodi-21.2-r2.ebuild
+++ b/media-tv/kodi/kodi-21.2-r2.ebuild
@@ -439,10 +439,12 @@ src_configure() {
 		mycmakeargs+=( -DENABLE_${name^^}=$(usex ${flag}) )
 	done
 
-	# TODO: drop compat and allow using >=media-video/ffmpeg-7
-	ffmpeg_compat_setup 6
-	ffmpeg_compat_add_flags
-	mycmakeargs+=( -DFFMPEG_INCLUDE_DIRS="${SYSROOT}$(ffmpeg_compat_get_prefix 6)" )
+	if use system-ffmpeg; then
+		# TODO: drop compat and allow using >=media-video/ffmpeg-7
+		ffmpeg_compat_setup 6
+		ffmpeg_compat_add_flags
+		mycmakeargs+=( -DFFMPEG_INCLUDE_DIRS="${SYSROOT}$(ffmpeg_compat_get_prefix 6)" )
+	fi
 
 	if ! is-flag -DNDEBUG && ! is-flag -D_DEBUG ; then
 		# Kodi requires one of the 'NDEBUG' or '_DEBUG' defines


### PR DESCRIPTION
<!-- Please put the pull request description above -->


CC @ionenwks 
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
