### PR TITLE
net-misc/dhcpcd: update optfeature to net-dns/bind

### DIFF
--- a/net-misc/dhcpcd/dhcpcd-10.2.2.ebuild
+++ b/net-misc/dhcpcd/dhcpcd-10.2.2.ebuild
@@ -168,5 +168,5 @@ pkg_postinst() {
 		elog "https://bugs.gentoo.org/show_bug.cgi?id=477356"
 	fi
 
-	optfeature "lookup-hostname hook" net-dns/bind-tools
+	optfeature "lookup-hostname hook" '<net-dns/bind-tools-9.18' '>=net-dns/bind-9.18'
 }

--- a/net-misc/dhcpcd/dhcpcd-9999.ebuild
+++ b/net-misc/dhcpcd/dhcpcd-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -168,5 +168,5 @@ pkg_postinst() {
 		elog "https://bugs.gentoo.org/show_bug.cgi?id=477356"
 	fi
 
-	optfeature "lookup-hostname hook" net-dns/bind-tools
+	optfeature "lookup-hostname hook" '<net-dns/bind-tools-9.18' '>=net-dns/bind-9.18'
 }


### PR DESCRIPTION
net-dns/bind-tools has been merged into net-dns/bind, update optfeature accordingly.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
