### PR TITLE
dev-libs/modsecurity: revbump 3.0.1{3,4}, drop libpcre dep, unbreak POSIX shells

### DIFF
--- a/dev-libs/modsecurity/modsecurity-3.0.13-r1.ebuild
+++ b/dev-libs/modsecurity/modsecurity-3.0.13-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{1..4} )
+
+inherit lua-single
+
+MY_P=${PN}-v${PV}
+
+DESCRIPTION="Application firewall and intrusion detection"
+HOMEPAGE="https://github.com/owasp-modsecurity/ModSecurity"
+SRC_URI="
+	https://github.com/owasp-modsecurity/ModSecurity/releases/download/v${PV}/${MY_P}.tar.gz
+"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="Apache-2.0"
+SLOT="0/3"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="doc fuzzyhash geoip geoip2 json lmdb lua"
+
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
+RDEPEND="
+	dev-libs/libpcre2:=
+	dev-libs/libxml2
+	net-misc/curl
+	fuzzyhash? ( app-crypt/ssdeep )
+	geoip? ( dev-libs/geoip )
+	geoip2? ( dev-libs/libmaxminddb )
+	json? ( dev-libs/yajl )
+	lmdb? ( dev-db/lmdb )
+	lua? ( ${LUA_DEPS} )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	doc? ( app-text/doxygen[dot] )"
+
+DOCS=( AUTHORS CHANGES README.md modsecurity.conf-recommended unicode.mapping )
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
+
+src_configure() {
+	local myconf=(
+		$(use_with fuzzyhash ssdeep)
+		$(use_with geoip )
+		$(use_with geoip2 maxmind)
+		$(use_with json yajl)
+		$(use_with lmdb)
+		$(use_with lua)
+		--with-pcre2
+	)
+
+	CONFIG_SHELL="${BROOT}/bin/bash" econf "${myconf[@]}"
+}
+
+src_compile() {
+	default
+
+	if use doc; then
+		cd doc && doxygen doxygen.cfg || die
+	fi
+}
+
+src_install() {
+	default
+	use doc && dodoc -r doc/html
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/dev-libs/modsecurity/modsecurity-3.0.14-r1.ebuild
+++ b/dev-libs/modsecurity/modsecurity-3.0.14-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{1..4} )
+
+inherit lua-single
+
+MY_P=${PN}-v${PV}
+
+DESCRIPTION="Application firewall and intrusion detection"
+HOMEPAGE="https://github.com/owasp-modsecurity/ModSecurity"
+SRC_URI="
+	https://github.com/owasp-modsecurity/ModSecurity/releases/download/v${PV}/${MY_P}.tar.gz
+"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="Apache-2.0"
+SLOT="0/3"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="doc fuzzyhash geoip geoip2 json lmdb lua"
+
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
+RDEPEND="
+	dev-libs/libpcre2:=
+	dev-libs/libxml2
+	net-misc/curl
+	fuzzyhash? ( app-crypt/ssdeep )
+	geoip? ( dev-libs/geoip )
+	geoip2? ( dev-libs/libmaxminddb )
+	json? ( dev-libs/yajl )
+	lmdb? ( dev-db/lmdb )
+	lua? ( ${LUA_DEPS} )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	doc? ( app-text/doxygen[dot] )"
+
+DOCS=( AUTHORS CHANGES README.md modsecurity.conf-recommended unicode.mapping )
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
+
+src_configure() {
+	local myconf=(
+		$(use_with fuzzyhash ssdeep)
+		$(use_with geoip )
+		$(use_with geoip2 maxmind)
+		$(use_with json yajl)
+		$(use_with lmdb)
+		$(use_with lua)
+		--with-pcre2
+	)
+
+	CONFIG_SHELL="${BROOT}/bin/bash" econf "${myconf[@]}"
+}
+
+src_compile() {
+	default
+
+	if use doc; then
+		cd doc && doxygen doxygen.cfg || die
+	fi
+}
+
+src_install() {
+	default
+	use doc && dodoc -r doc/html
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION

The autotool-based build system uses a lot of Bash == comparison operators, which obviously causes breakages on non-Bash POSIX-compliant shells. This commit sets the CONFIG_SHELL environment variable for econf and drops libpcre in favour for libpcre2.

Closes: https://bugs.gentoo.org/886539
Closes: https://bugs.gentoo.org/887135

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
