### PR TITLE
dev-java/snappy-java: build native library in the ebuild #953364

### DIFF
--- a/dev-java/snappy-java/files/snappy-java-1.1.10.7-skipFailingTest.patch
+++ b/dev-java/snappy-java/files/snappy-java-1.1.10.7-skipFailingTest.patch
@@ -1,0 +1,48 @@
+
+There was 1 failure:
+1) loadSnappyByDiffentClassloadersInTheSameJVM(org.xerial.snappy.SnappyLoaderTest)
+java.lang.UnsatisfiedLinkError: Native Library /var/tmp/portage/dev-java/snappy-java-1.1.10.7-r2/work/snappy-java-1.1.10.7/build/objects/libsnappyjava.so already loaded in another classloader
+	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:157)
+	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:129)
+	at java.base/jdk.internal.loader.NativeLibraries.findFromPaths(NativeLibraries.java:249)
+	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:241)
+	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2278)
+	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:822)
+	at java.base/java.lang.System.loadLibrary(System.java:1663)
+	at org.xerial.snappy.SnappyLoader.loadNativeLibrary(SnappyLoader.java:185)
+	at org.xerial.snappy.SnappyLoader.loadSnappyApi(SnappyLoader.java:157)
+	at org.xerial.snappy.Snappy.init(Snappy.java:70)
+	at org.xerial.snappy.Snappy.<clinit>(Snappy.java:47)
+	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
+	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1169)
+	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:341)
+	at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newMethodAccessor(MethodHandleAccessorFactory.java:72)
+	at java.base/jdk.internal.reflect.ReflectionFactory.newMethodAccessor(ReflectionFactory.java:124)
+	at java.base/java.lang.reflect.Method.acquireMethodAccessor(Method.java:711)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:562)
+	at org.xerial.snappy.SnappyLoaderTest.loadSnappyByDiffentClassloadersInTheSameJVM(SnappyLoaderTest.java:106)
+
+FAILURES!!!
+Tests run: 103,  Failures: 1
+
+This failure would not occur if the native library was included in the jar.
+
+--- a/src/test/java/org/xerial/snappy/SnappyLoaderTest.java
++++ b/src/test/java/org/xerial/snappy/SnappyLoaderTest.java
+@@ -27,6 +27,7 @@ package org.xerial.snappy;
+ import org.codehaus.plexus.classworlds.ClassWorld;
+ import org.codehaus.plexus.classworlds.realm.ClassRealm;
+ import org.junit.Test;
++import org.junit.Ignore;
+ import org.xerial.util.FileResource;
+ import org.xerial.util.log.Logger;
+ 
+@@ -77,7 +78,7 @@ public class SnappyLoaderTest
+         }
+     }
+ 
+-    @Test
++    @Test @Ignore
+     public void loadSnappyByDiffentClassloadersInTheSameJVM()
+             throws Exception
+     {

--- a/dev-java/snappy-java/snappy-java-1.1.10.7-r1.ebuild
+++ b/dev-java/snappy-java/snappy-java-1.1.10.7-r1.ebuild
@@ -1,0 +1,156 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+MAVEN_ID="org.xerial.snappy:snappy-java:${PV}"
+JAVA_TESTING_FRAMEWORKS="junit-4"
+
+inherit edo check-reqs java-pkg-2 java-pkg-simple toolchain-funcs
+
+DESCRIPTION="Snappy compressor/decompressor for Java"
+HOMEPAGE="https://github.com/xerial/snappy-java/"
+# ::gentoo does not have hadoop-common packaged. Currently we bundle the binary version.
+# It's used for testing only and does not get installed.
+HCV="3.3.5"
+SRC_URI="https://github.com/xerial/snappy-java/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/${HCV}/hadoop-common-${HCV}.jar )"
+S="${WORKDIR}/${P}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
+
+CP_DEPEND="dev-java/osgi-core:0"
+
+CDEPEND="
+	app-arch/snappy
+	>=dev-libs/bitshuffle-0.3.5-r1
+"
+
+DEPEND="
+	>=virtual/jdk-1.8:*
+	${CP_DEPEND}
+	${CDEPEND}
+	test? (
+		>=dev-java/ant-1.10.15:0[junit4]
+		dev-java/commons-io:1
+		dev-java/commons-lang:3.6
+		dev-java/plexus-classworlds:0
+		dev-java/xerial-core:0
+	)
+"
+
+RDEPEND="
+	>=virtual/jre-1.8:*
+	${CP_DEPEND}
+	${CDEPEND}
+"
+
+PATCHES=(
+	"${FILESDIR}/snappy-1.1.10.5-SnappyOutputStreamTest.patch"
+	"${FILESDIR}/snappy-java-1.1.10.7-skipFailingTest.patch"
+)
+
+JAVA_RESOURCE_DIRS="src/main/resources"
+JAVA_SRC_DIR="src/main/java"
+
+JAVA_TEST_GENTOO_CLASSPATH="
+	commons-io-1
+	commons-lang-3.6
+	junit-4
+	plexus-classworlds
+	xerial-core
+"
+
+JAVA_TEST_RESOURCE_DIRS="src/test/resources"
+JAVA_TEST_SRC_DIR="src/test/java"
+
+check_env() {
+	if use test; then
+		# this is needed only for tests
+		CHECKREQS_MEMORY="2560M"
+		check-reqs_pkg_pretend
+	fi
+}
+
+pkg_pretend() {
+	check_env
+}
+
+pkg_setup() {
+	check_env
+	java-pkg-2_pkg_setup
+}
+
+src_prepare() {
+	default #780585
+	java-pkg-2_src_prepare
+	# remove pre-compiled sofiles
+	rm -r src/main/resources/org/xerial/snappy/native || die
+	rm -r src/test/resources/lib || die
+}
+
+compile_lib() {
+	edo "$(tc-getCC)" "${@}" ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} \
+		$(java-pkg_get-jni-cflags)
+}
+
+src_compile() {
+	java-pkg-simple_src_compile
+
+	# Create some directories, Java 8 doesn't do it for us.
+	mkdir -p build/objects target/jni-classes || die "mkdir"
+
+	einfo "Generate headers"
+	ejavac \
+		-h build/jni-headers \
+		-d target/jni-classes \
+		-sourcepath src/main/java \
+		src/main/java/org/xerial/snappy/SnappyNative.java \
+		src/main/java/org/xerial/snappy/BitShuffleNative.java
+
+	einfo "Generate native library"
+	compile_lib -o build/objects/BitShuffleNative.o \
+		-Ibuild/build/jni-headers \
+		-c src/main/java/org/xerial/snappy/BitShuffleNative.cpp
+
+	compile_lib -o build/objects/SnappyNative.o \
+		-Ibuild/build/jni-headers \
+		-c src/main/java/org/xerial/snappy/SnappyNative.cpp
+
+	compile_lib -o build/objects/libsnappyjava.so \
+		build/objects/{SnappyNative.o,BitShuffleNative.o} \
+		-shared -lsnappy -lbitshuffle
+}
+
+src_test() {
+	JAVA_GENTOO_CLASSPATH_EXTRA="${DISTDIR}/hadoop-common-${HCV}.jar"
+
+	# Setting use.systemlib=true is essential.
+	JAVA_TEST_EXTRA_ARGS=(
+		-Xmx${CHECKREQS_MEMORY}
+		-Djava.library.path=build/objects
+		-Dorg.xerial.snappy.use.systemlib=true
+	)
+	local vm_version="$(java-config -g PROVIDES_VERSION)"
+	if ver_test "${vm_version}" -ge 17; then
+		java-pkg-simple_src_test
+	else
+		einfo "Tests need jdk-17 to pass."
+	fi
+}
+
+src_install() {
+	java-pkg-simple_src_install
+
+	local jniext=.so
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		jniext=.jnilib
+		# avoid install_name check failure
+		install_name_tool -id "@loader_path/libsnappyjava${jniext}" \
+			"target/libsnappyjava${jniext}"
+	fi
+	java-pkg_doso "build/objects/libsnappyjava${jniext}"
+}


### PR DESCRIPTION
- minor style update
- generates native library using $(tc-getCC)
- no longer includes native library in the jar
- drops all Makefile related patches
- skips one test from SnappyLoaderTest

Bug: https://bugs.gentoo.org/953364

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
