### PR TITLE
app-containers/docker-compose: add 2.34.0-r1

### DIFF
--- a/app-containers/docker-compose/docker-compose-2.34.0-r1.ebuild
+++ b/app-containers/docker-compose/docker-compose-2.34.0-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 2018-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit eapi9-ver go-module
+MY_PV=${PV/_/-}
+
+DESCRIPTION="Multi-container orchestration for Docker"
+HOMEPAGE="https://github.com/docker/compose"
+SRC_URI="https://github.com/docker/compose/archive/v${MY_PV}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~williamh/dist/${P}-deps.tar.xz"
+
+S="${WORKDIR}/compose-${MY_PV}"
+
+LICENSE="Apache-2.0"
+SLOT="2"
+KEYWORDS="~amd64 ~arm64"
+
+RDEPEND=">=app-containers/docker-cli-23.0.0"
+
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.34.0-revert-secrets-file-mode.patch"
+)
+
+src_prepare() {
+	default
+	# do not strip
+	sed -i -e 's/-s -w//' Makefile || die
+}
+
+src_compile() {
+	emake VERSION=v${PV}
+}
+
+src_test() {
+	emake test
+}
+
+src_install() {
+	exeinto /usr/libexec/docker/cli-plugins
+	doexe bin/build/docker-compose
+	dodoc README.md
+}
+
+pkg_postinst() {
+	ver_replacing -ge 2 && return
+	ewarn
+	ewarn "docker-compose 2.x is a sub command of docker"
+	ewarn "Use 'docker compose' from the command line instead of"
+	ewarn "'docker-compose'"
+	ewarn "If you need to keep 1.x around, please run the following"
+	ewarn "command before your next --depclean"
+	ewarn "# emerge --noreplace docker-compose:0"
+}

--- a/app-containers/docker-compose/files/docker-compose-2.34.0-revert-secrets-file-mode.patch
+++ b/app-containers/docker-compose/files/docker-compose-2.34.0-revert-secrets-file-mode.patch
@@ -1,0 +1,24 @@
+From 9c7ddf217747baf414aea1ef7242b0a219180e39 Mon Sep 17 00:00:00 2001
+From: Suleiman Dibirov <idsulik@gmail.com>
+Date: Tue, 25 Mar 2025 04:23:35 +0200
+Subject: [PATCH] fix(secrets): Reverted secrets file mode 440 -> 444
+
+Signed-off-by: Suleiman Dibirov <idsulik@gmail.com>
+---
+ pkg/compose/secrets.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/compose/secrets.go b/pkg/compose/secrets.go
+index 2ebaa0e6bb..e8064cca8b 100644
+--- a/pkg/compose/secrets.go
++++ b/pkg/compose/secrets.go
+@@ -110,7 +110,7 @@ func createTar(env string, config types.FileReferenceConfig) (bytes.Buffer, erro
+ 	value := []byte(env)
+ 	b := bytes.Buffer{}
+ 	tarWriter := tar.NewWriter(&b)
+-	mode := types.FileMode(0o440)
++	mode := types.FileMode(0o444)
+ 	if config.Mode != nil {
+ 		mode = *config.Mode
+ 	}
+


### PR DESCRIPTION
Applies upstream patch for regression in service configs.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
