### PR TITLE
dev-php/pecl-xdiff: Add support for PHP 8.4 and remove old

### DIFF
--- a/dev-php/pecl-xdiff/pecl-xdiff-2.1.1.ebuild
+++ b/dev-php/pecl-xdiff/pecl-xdiff-2.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ PHP_EXT_NAME="xdiff"
 PHP_EXT_PECL_PKG="xdiff"
 DOCS=( README.API )
 
-USE_PHP="php8-1 php8-2 php8-3"
+USE_PHP="php8-2 php8-3 php8-4"
 
 inherit php-ext-pecl-r3
 


### PR DESCRIPTION
All tests passing, just make sure you haven't copied any deprecated ini settings from prior PHP passess into 8.4, or the deprecation warnings will cause unexpected test failures.


---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
