### PR TITLE
app-editors/emacs: improve ebuild 2

### DIFF
--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -42,6 +42,7 @@ HOMEPAGE="https://www.gnu.org/software/emacs/"
 LICENSE="GPL-3+ FDL-1.3+ BSD HPND MIT W3C unicode PSF-2"
 IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif oss png selinux source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
 REQUIRED_USE="
+	?? ( alsa oss )
 	jit? ( zlib )
 "
 
@@ -237,8 +238,9 @@ src_configure() {
 		--without-compress-install
 		--without-hesiod
 		--without-pop
-		--with-file-notification=$(usev inotify || usev gfile || echo no)
 		--with-pdumper
+		--with-file-notification=$(usev inotify || usev gfile || echo no)
+		--with-sound=$(usev alsa || usev oss || printf no)
 		$(use_enable acl)
 		$(use_enable xattr)
 		$(use_with dbus)
@@ -260,14 +262,6 @@ src_configure() {
 		$(use_with wide-int)
 		$(use_with zlib)
 	)
-
-	if use alsa; then
-		use oss || ewarn \
-			"USE flag \"alsa\" overrides \"-oss\"; enabling sound support."
-		myconf+=( --with-sound=alsa )
-	else
-		myconf+=( --with-sound=$(usex oss oss no) )
-	fi
 
 	# Emacs supports these window systems:
 	# X11, pure GTK (without X11), or Nextstep (Aqua/Cocoa).

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -40,7 +40,7 @@ DESCRIPTION="The extensible, customizable, self-documenting real-time display ed
 HOMEPAGE="https://www.gnu.org/software/emacs/"
 
 LICENSE="GPL-3+ FDL-1.3+ BSD HPND MIT W3C unicode PSF-2"
-IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif png selinux sound source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
+IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif oss png selinux source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
 REQUIRED_USE="
 	jit? ( zlib )
 "
@@ -262,11 +262,11 @@ src_configure() {
 	)
 
 	if use alsa; then
-		use sound || ewarn \
-			"USE flag \"alsa\" overrides \"-sound\"; enabling sound support."
+		use oss || ewarn \
+			"USE flag \"alsa\" overrides \"-oss\"; enabling sound support."
 		myconf+=( --with-sound=alsa )
 	else
-		myconf+=( --with-sound=$(usex sound oss no) )
+		myconf+=( --with-sound=$(usex oss oss no) )
 	fi
 
 	# Emacs supports these window systems:

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -463,7 +463,6 @@ src_test() {
 	# Redirect GnuPG's sockets, in order not to exceed the 108 char limit
 	# for socket paths on Linux.
 	mkdir "${T}"/gpg || die
-	local f
 	for f in browser extra ssh; do
 		printf "%%Assuan%%\nsocket=%s\n" "${T}/gpg/S.${f}" \
 			> "test/lisp/gnus/mml-sec-resources/S.gpg-agent.${f}" || die

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -44,6 +44,7 @@ IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm g
 REQUIRED_USE="
 	?? ( alsa oss )
 	?? ( gfile inotify )
+	cairo? ( xft )
 	gui? ( ^^ ( aqua || ( X gtk ) ) )
 	motif? ( xpm )
 	jit? ( zlib )
@@ -301,6 +302,7 @@ src_configure() {
 		myconf+=(
 			--without-pgtk
 			--without-gconf
+			$(use_with cairo)
 			$(use_with gsettings)
 			$(use_with toolkit-scroll-bars)
 			$(use_with xft)
@@ -309,18 +311,12 @@ src_configure() {
 
 		if use xft; then
 			myconf+=(
-				$(use_with cairo)
 				$(use_with harfbuzz)
 				$(use_with m17n-lib libotf)
 				$(use_with m17n-lib m17n-flt)
 			)
 		else
-			myconf+=(
-				--without-cairo
-				--without-libotf --without-m17n-flt
-			)
-			use cairo && ewarn \
-				"USE flag \"cairo\" has no effect if \"xft\" is not set."
+			myconf+=( --without-libotf --without-m17n-flt )
 			use m17n-lib && ewarn \
 				"USE flag \"m17n-lib\" has no effect if \"xft\" is not set."
 		fi

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -303,12 +303,12 @@ src_configure() {
 			--without-gconf
 			$(use_with gsettings)
 			$(use_with toolkit-scroll-bars)
+			$(use_with xft)
 			$(use_with xpm)
 		)
 
 		if use xft; then
 			myconf+=(
-				--with-xft
 				$(use_with cairo)
 				$(use_with harfbuzz)
 				$(use_with m17n-lib libotf)
@@ -316,7 +316,6 @@ src_configure() {
 			)
 		else
 			myconf+=(
-				--without-xft
 				--without-cairo
 				--without-libotf --without-m17n-flt
 			)

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -41,6 +41,9 @@ HOMEPAGE="https://www.gnu.org/software/emacs/"
 
 LICENSE="GPL-3+ FDL-1.3+ BSD HPND MIT W3C unicode PSF-2"
 IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif png selinux sound source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
+REQUIRED_USE="
+	jit? ( zlib )
+"
 
 X_DEPEND="x11-libs/libICE
 	x11-libs/libSM
@@ -98,10 +101,7 @@ RDEPEND=">=app-emacs/emacs-common-1.11[games?,gui?]
 	gmp? ( dev-libs/gmp:0= )
 	gpm? ( sys-libs/gpm )
 	!inotify? ( gfile? ( >=dev-libs/glib-2.28.6 ) )
-	jit? (
-		sys-devel/gcc:=[jit(-)]
-		sys-libs/zlib
-	)
+	jit? ( sys-devel/gcc:=[jit(-)] )
 	kerberos? ( virtual/krb5 )
 	lcms? ( media-libs/lcms:2 )
 	libxml2? ( >=dev-libs/libxml2-2.2.0 )
@@ -258,6 +258,7 @@ src_configure() {
 		$(use_with threads)
 		$(use_with tree-sitter)
 		$(use_with wide-int)
+		$(use_with zlib)
 	)
 
 	if use alsa; then
@@ -266,14 +267,6 @@ src_configure() {
 		myconf+=( --with-sound=alsa )
 	else
 		myconf+=( --with-sound=$(usex sound oss no) )
-	fi
-
-	if use jit; then
-		use zlib || ewarn \
-			"USE flag \"jit\" overrides \"-zlib\"; enabling zlib support."
-		myconf+=( --with-zlib )
-	else
-		myconf+=( $(use_with zlib) )
 	fi
 
 	# Emacs supports these window systems:

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -43,6 +43,7 @@ LICENSE="GPL-3+ FDL-1.3+ BSD HPND MIT W3C unicode PSF-2"
 IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif oss png selinux source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
 REQUIRED_USE="
 	?? ( alsa oss )
+	gui? ( ^^ ( aqua || ( X gtk ) ) )
 	jit? ( zlib )
 	X? ( ?? ( gtk motif || ( athena Xaw3d ) ) )
 "
@@ -529,7 +530,7 @@ src_install() {
 
 	dodoc README BUGS CONTRIBUTE
 
-	if use gui && use aqua; then
+	if use aqua; then
 		dodir /Applications/Gentoo
 		rm -rf "${ED}"/Applications/Gentoo/${EMACS_SUFFIX^}.app || die
 		mv nextstep/Emacs.app \

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -252,6 +252,7 @@ src_configure() {
 		$(use_with games gameuser ":gamestat")
 		$(use_with gmp libgmp)
 		$(use_with gpm)
+		$(use_with !gtk xwidgets)
 		$(use_with jit native-compilation aot)
 		$(use_with kerberos) $(use_with kerberos kerberos5)
 		$(use_with lcms lcms2)
@@ -291,7 +292,6 @@ src_configure() {
 			--with-pgtk
 			--with-toolkit-scroll-bars #836392
 			--without-gconf
-			--without-xwidgets
 			$(use_with gsettings)
 			$(use_with harfbuzz)
 			$(use_with m17n-lib libotf)
@@ -334,7 +334,7 @@ src_configure() {
 				recommended that you compile Emacs with the Athena/Lucid or the
 				Motif toolkit instead.
 			EOF
-			myconf+=( --with-x-toolkit=gtk3 --without-xwidgets )
+			myconf+=( --with-x-toolkit=gtk3 )
 		elif use motif; then
 			einfo "Configuring to build with Motif toolkit"
 			myconf+=( --with-x-toolkit=motif )

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -44,6 +44,7 @@ IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm g
 REQUIRED_USE="
 	?? ( alsa oss )
 	jit? ( zlib )
+	X? ( ?? ( gtk motif || ( athena Xaw3d ) ) )
 "
 
 X_DEPEND="x11-libs/libICE
@@ -341,17 +342,9 @@ src_configure() {
 				Motif toolkit instead.
 			EOF
 			myconf+=( --with-x-toolkit=gtk3 --without-xwidgets )
-			for f in motif Xaw3d athena; do
-				use ${f} && ewarn \
-					"USE flag \"${f}\" has no effect if \"gtk\" is set."
-			done
 		elif use motif; then
 			einfo "Configuring to build with Motif toolkit"
 			myconf+=( --with-x-toolkit=motif )
-			for f in Xaw3d athena; do
-				use ${f} && ewarn \
-					"USE flag \"${f}\" has no effect if \"motif\" is set."
-			done
 		elif use athena || use Xaw3d; then
 			einfo "Configuring to build with Athena/Lucid toolkit"
 			myconf+=( --with-x-toolkit=lucid $(use_with Xaw3d xaw3d) )

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -473,13 +473,13 @@ src_install() {
 
 	# avoid collision between slots, see bug #169033 e.g.
 	rm "${ED}"/usr/share/emacs/site-lisp/subdirs.el || die
-	rm -rf "${ED}"/usr/share/{applications,icons} || die
-	rm -rf "${ED}"/usr/share/glib-2.0 || die #911117
-	rm -rf "${ED}/usr/$(get_libdir)/systemd" || die
-	rm -rf "${ED}"/var || die
+	rm -r "${ED}"/usr/share/{applications,icons} || die
+	rm -r "${ED}/usr/$(get_libdir)/systemd" || die
+	rm -rf "${ED}"/var
+	rm -rf "${ED}"/usr/share/glib-2.0 #911117
 
 	# remove unused <version>/site-lisp dir
-	rm -rf "${ED}"/usr/share/emacs/${FULL_VERSION}/site-lisp || die
+	rm -r "${ED}"/usr/share/emacs/${FULL_VERSION}/site-lisp || die
 
 	# remove COPYING file (except for etc/COPYING used by describe-copying)
 	rm "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp/COPYING || die
@@ -526,7 +526,7 @@ src_install() {
 
 	if use aqua; then
 		dodir /Applications/Gentoo
-		rm -rf "${ED}"/Applications/Gentoo/${EMACS_SUFFIX^}.app || die
+		rm -r "${ED}"/Applications/Gentoo/${EMACS_SUFFIX^}.app || die
 		mv nextstep/Emacs.app \
 			"${ED}"/Applications/Gentoo/${EMACS_SUFFIX^}.app || die
 	fi

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -151,8 +151,7 @@ DEPEND="${RDEPEND}
 	) )"
 
 BDEPEND="sys-apps/texinfo
-	virtual/pkgconfig
-	gzip-el? ( app-arch/gzip )"
+	virtual/pkgconfig"
 
 IDEPEND="app-eselect/eselect-emacs"
 

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -220,7 +220,7 @@ src_prepare() {
 }
 
 src_configure() {
-	replace-flags "-O[3-9]" -O2			#839405
+	replace-flags "-O[3-9]" -O2 #839405
 
 	# We want floating-point arithmetic to be correct #933380
 	replace-flags -Ofast -O2
@@ -398,7 +398,7 @@ src_compile() {
 	if tc-is-cross-compiler; then
 		# Build native tools for compiling lisp etc.
 		emake -C "${S}-build" src
-		emake lib	   # Cross-compile dependencies first for timestamps
+		emake lib # Cross-compile dependencies first for timestamps
 		# Save native build tools in the cross-directory
 		cp "${S}-build"/lib-src/make-{docfile,fingerprint} lib-src || die
 		# Specify the native Emacs to compile lisp

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -245,6 +245,7 @@ src_configure() {
 		--with-sound=$(usev alsa || usev oss || printf no)
 		$(use_enable acl)
 		$(use_enable xattr)
+		$(use_with aqua ns)
 		$(use_with dbus)
 		$(use_with dynamic-loading modules)
 		$(use_with games gameuser ":gamestat")
@@ -263,6 +264,7 @@ src_configure() {
 		$(use_with tree-sitter)
 		$(use_with wide-int)
 		$(use_with zlib)
+		$(use_with X x)
 	)
 
 	# Emacs supports these window systems:
@@ -278,18 +280,14 @@ src_configure() {
 
 	if ! use gui; then
 		einfo "Configuring to build without window system support"
-		myconf+=(
-			--without-x --without-pgtk --without-ns
-		)
+		myconf+=( --without-pgtk )
 	elif use aqua; then
 		einfo "Configuring to build with Nextstep (Macintosh Cocoa) support"
-		myconf+=(
-			--with-ns --without-x --without-pgtk
-		)
+		myconf+=( --without-pgtk )
 	elif use gtk && ! use X; then
 		einfo "Configuring to build with pure GTK (without X11) support"
 		myconf+=(
-			--with-pgtk --without-x --without-ns
+			--with-pgtk
 			--with-toolkit-scroll-bars #836392
 			--without-gconf
 			--without-xwidgets
@@ -301,7 +299,7 @@ src_configure() {
 	else
 		# X11
 		myconf+=(
-			--with-x --without-pgtk --without-ns
+			--without-pgtk
 			--without-gconf
 			$(use_with gsettings)
 			$(use_with toolkit-scroll-bars)

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -44,6 +44,7 @@ IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm g
 REQUIRED_USE="
 	?? ( alsa oss )
 	gui? ( ^^ ( aqua || ( X gtk ) ) )
+	motif? ( xpm )
 	jit? ( zlib )
 	X? ( ?? ( gtk motif || ( athena Xaw3d ) ) )
 "
@@ -77,7 +78,6 @@ X_DEPEND="x11-libs/libICE
 	!gtk? (
 		motif? (
 			>=x11-libs/motif-2.3:0
-			x11-libs/libXpm
 			x11-libs/libXmu
 			x11-libs/libXt
 		)

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -25,7 +25,7 @@ else
 	# 27.0.9999            live ebuild (slot 27-vcs)
 	# 27.0.90              upstream prerelease snapshot (27-vcs)
 	# 27.0.50_pre20191223  snapshot by Gentoo developer (27-vcs)
-	if [[ ${PV} == *_pre* ]]; then
+	if [[ ${PV} =~ _pre ]]; then
 		SRC_URI="https://dev.gentoo.org/~ulm/distfiles/${P}.tar.xz"
 		S="${WORKDIR}/emacs"
 	elif [[ ${PV//[0-9]} != "." ]]; then

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -549,14 +549,12 @@ src_install() {
 			\"${EPREFIX}/Applications/Gentoo\". You may want to copy or
 			symlink it into /Applications by yourself."
 	fi
-	if ! use mailutils; then
-		DOC_CONTENTS+="\\n\\nThe mailutils USE flag is disabled. If Emacs'
+	use mailutils || DOC_CONTENTS+="\\n\\nThe mailutils USE flag is disabled. If Emacs'
 		own e-mail features are going to be used as an e-mail client
 		(e.g. Rmail), you are strongly encouraged to enable it. If not,
 		Emacs will use its own implementation of movemail; which has
 		fewer features and is less secure. For more information see:
 		https://www.gnu.org/software/emacs/manual/html_node/emacs/Movemail.html"
-	fi
 	tc-is-cross-compiler && DOC_CONTENTS+="\\n\\nEmacs did not write
 		a portable dump file due to being cross-compiled.
 		To create this file at run time, execute the following command:

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -80,18 +80,16 @@ X_DEPEND="x11-libs/libICE
 			x11-libs/libXmu
 			x11-libs/libXt
 		)
-		!motif? (
-			Xaw3d? (
-				x11-libs/libXaw3d
-				x11-libs/libXmu
-				x11-libs/libXt
-			)
-			!Xaw3d? ( athena? (
-				x11-libs/libXaw
-				x11-libs/libXmu
-				x11-libs/libXt
-			) )
+		Xaw3d? (
+			x11-libs/libXaw3d
+			x11-libs/libXmu
+			x11-libs/libXt
 		)
+		!Xaw3d? ( athena? (
+			x11-libs/libXaw
+			x11-libs/libXmu
+			x11-libs/libXt
+		) )
 	)"
 
 RDEPEND=">=app-emacs/emacs-common-1.11[games?,gui?]

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -43,6 +43,7 @@ LICENSE="GPL-3+ FDL-1.3+ BSD HPND MIT W3C unicode PSF-2"
 IUSE="acl alsa aqua athena cairo dbus dynamic-loading games gfile gif +gmp gpm gsettings gtk gui gzip-el harfbuzz imagemagick +inotify jit jpeg kerberos lcms libxml2 livecd m17n-lib mailutils motif oss png selinux source sqlite ssl svg systemd +threads tiff toolkit-scroll-bars tree-sitter valgrind webp wide-int +X xattr Xaw3d xft +xpm zlib"
 REQUIRED_USE="
 	?? ( alsa oss )
+	?? ( gfile inotify )
 	gui? ( ^^ ( aqua || ( X gtk ) ) )
 	motif? ( xpm )
 	jit? ( zlib )
@@ -99,9 +100,9 @@ RDEPEND=">=app-emacs/emacs-common-1.11[games?,gui?]
 	alsa? ( media-libs/alsa-lib )
 	dbus? ( sys-apps/dbus )
 	games? ( acct-group/gamestat )
+	gfile? ( >=dev-libs/glib-2.28.6 )
 	gmp? ( dev-libs/gmp:0= )
 	gpm? ( sys-libs/gpm )
-	!inotify? ( gfile? ( >=dev-libs/glib-2.28.6 ) )
 	jit? ( sys-devel/gcc:=[jit(-)] )
 	kerberos? ( virtual/krb5 )
 	lcms? ( media-libs/lcms:2 )
@@ -239,7 +240,7 @@ src_configure() {
 		--without-hesiod
 		--without-pop
 		--with-pdumper
-		--with-file-notification=$(usev inotify || usev gfile || echo no)
+		--with-file-notification=$(usev inotify || usev gfile || printf no)
 		--with-sound=$(usev alsa || usev oss || printf no)
 		$(use_enable acl)
 		$(use_enable xattr)

--- a/app-editors/emacs/emacs-30.1-r1.ebuild
+++ b/app-editors/emacs/emacs-30.1-r1.ebuild
@@ -236,6 +236,7 @@ src_configure() {
 		--infodir="${EPREFIX}"/usr/share/info/${EMACS_SUFFIX}
 		--localstatedir="${EPREFIX}"/var
 		--enable-locallisppath="${EPREFIX}/etc/emacs:${EPREFIX}${SITELISP}"
+		--disable-ns-self-contained # effective only with USE=aqua
 		--without-compress-install
 		--without-hesiod
 		--without-pop
@@ -283,8 +284,7 @@ src_configure() {
 	elif use aqua; then
 		einfo "Configuring to build with Nextstep (Macintosh Cocoa) support"
 		myconf+=(
-			--with-ns --disable-ns-self-contained
-			--without-x --without-pgtk
+			--with-ns --without-x --without-pgtk
 		)
 	elif use gtk && ! use X; then
 		einfo "Configuring to build with pure GTK (without X11) support"


### PR DESCRIPTION
This is a second take on https://github.com/gentoo/gentoo/pull/41595.

I understand all the points that @ulm has made there but still think it is worthwhile to improve the ebuild.
Stability is good but at the point where changes [like these](https://github.com/gentoo/gentoo/pull/41595/commits/8a53b1d6f6e04579f60719cb649c9576dbdc229a) are rejected I am starting to think that this is more stagnant than stable.

In this PR I have explained all of the changes made and dropped purely stylistic ones (like removing `-e` from `sed`).
I have kept all the logical changes atomic so that they can be easily discussed and, if need be, dropped.
In my opinion every commit there improves the current state of the ebuild.

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
