### PR TITLE
sys-cluster/ceph: respect MAKEOPTS (partly)

### DIFF
--- a/sys-cluster/ceph/ceph-18.2.4-r4.ebuild
+++ b/sys-cluster/ceph/ceph-18.2.4-r4.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_COMPAT=( python3_{10..12} )
 LUA_COMPAT=( lua5-{3..4} )
 
-inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single \
+inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single multiprocessing \
 		python-r1 udev readme.gentoo-r1 toolchain-funcs systemd tmpfiles
 
 XSIMD_HASH="aeec9c872c8b475dedd7781336710f2dd2666cb2"
@@ -414,6 +414,7 @@ src_configure() {
 }
 
 src_compile() {
+	export CMAKE_BUILD_PARALLEL_LEVEL=$(makeopts_jobs)
 	cmake_build all
 
 	# we have to do this here to prevent from building everything multiple times

--- a/sys-cluster/ceph/ceph-19.2.0-r3.ebuild
+++ b/sys-cluster/ceph/ceph-19.2.0-r3.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_COMPAT=( python3_{10..12} )
 LUA_COMPAT=( lua5-{3..4} )
 
-inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single \
+inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single multiprocessing \
 		python-r1 udev readme.gentoo-r1 toolchain-funcs systemd tmpfiles
 
 XSIMD_HASH="aeec9c872c8b475dedd7781336710f2dd2666cb2"
@@ -423,6 +423,7 @@ src_configure() {
 }
 
 src_compile() {
+	export CMAKE_BUILD_PARALLEL_LEVEL=$(makeopts_jobs)
 	cmake_build all
 
 	# we have to do this here to prevent from building everything multiple times

--- a/sys-cluster/ceph/ceph-19.2.1-r2.ebuild
+++ b/sys-cluster/ceph/ceph-19.2.1-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_COMPAT=( python3_{10..12} )
 LUA_COMPAT=( lua5-{3..4} )
 
-inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single \
+inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single multiprocessing \
 		python-r1 udev readme.gentoo-r1 toolchain-funcs systemd tmpfiles
 
 XSIMD_HASH="aeec9c872c8b475dedd7781336710f2dd2666cb2"
@@ -430,6 +430,7 @@ src_configure() {
 }
 
 src_compile() {
+	export CMAKE_BUILD_PARALLEL_LEVEL=$(makeopts_jobs)
 	cmake_build all
 
 	# we have to do this here to prevent from building everything multiple times


### PR DESCRIPTION
ninja call cmake, the final solution could be to call "cmake --build" instead of "ninja ..." at the top level.

Closes: https://bugs.gentoo.org/924998

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
