### PR TITLE
net-misc/rsync-bpc: fix gettimeofday error

### DIFF
--- a/net-misc/rsync-bpc/files/rsync-bpc-3.1.3.0-fix-gettimeofday-error.patch
+++ b/net-misc/rsync-bpc/files/rsync-bpc-3.1.3.0-fix-gettimeofday-error.patch
@@ -1,0 +1,14 @@
+--- rsync-bpc-3.1.3.0/configure.ac.old	2025-02-21 20:05:47.000000000 -0600
++++ rsync-bpc-3.1.3.0/configure.ac	2025-02-21 20:02:27.000000000 -0600
+@@ -852,7 +852,9 @@
+ 
+ AC_CACHE_CHECK([if gettimeofday takes tz argument],rsync_cv_HAVE_GETTIMEOFDAY_TZ,[
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/time.h>
+-#include <unistd.h>]], [[struct timeval tv; exit(gettimeofday(&tv, NULL));]])],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=yes],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=no])])
++#ifdef HAVE_UNISTD_H
++#include <unistd.h>
++#endif]], [[struct timeval tv; return gettimeofday(&tv, NULL);]])],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=yes],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=no])])
+ if test x"$rsync_cv_HAVE_GETTIMEOFDAY_TZ" != x"no"; then
+     AC_DEFINE(HAVE_GETTIMEOFDAY_TZ, 1, [Define to 1 if gettimeofday() takes a time-zone arg])
+ fi
+

--- a/net-misc/rsync-bpc/metadata.xml
+++ b/net-misc/rsync-bpc/metadata.xml
@@ -9,4 +9,7 @@
     <email>proxy-maint@gentoo.org</email>
     <name>Proxy Maintainers</name>
   </maintainer>
+  <upstream>
+    <remote-id type="github">backuppc/rsync-bpc</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/net-misc/rsync-bpc/rsync-bpc-3.1.3.0-r1.ebuild
+++ b/net-misc/rsync-bpc/rsync-bpc-3.1.3.0-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 2022-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Rsync-bpc is a customized version of rsync that is used as part of BackupPC"
+HOMEPAGE="https://github.com/backuppc/rsync-bpc"
+SRC_URI="https://github.com/backuppc/rsync-bpc/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="virtual/ssh"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-gettimeofday-error.patch" #874666
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/874666
Suggested-by: Grant Taylor <gentoo@gtaylor.tnetconsulting.net>

Fixes an error with the gettimeofday function by adapting the configuration script

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
