### PR TITLE
app-text/sword: bump cmake_min for cmake4, add myself as a maintainer

### DIFF
--- a/app-text/sword/files/sword-1.9.0-cmake4.patch
+++ b/app-text/sword/files/sword-1.9.0-cmake4.patch
@@ -1,0 +1,15 @@
+bump CMake minimum version for CMake 4
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c23f7fa..53104f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,8 +11,8 @@
+ # of their own GPLv2 license and all copyright is transferred to them for
+ # all posterity and eternity, wherever such transfer is possible.  Where it is
+ # not, then this file is released under the GPLv2 by myself.
++CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0)
+ PROJECT(libsword CXX C)
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0)
+ SET(SWORD_VERSION 1.9.0)
+ 
+ # Make sure it's an out-of-stream build

--- a/app-text/sword/metadata.xml
+++ b/app-text/sword/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>nicolas.parlant@parhuet.fr</email>
+		<name>Nicolas PARLANT</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
 The SWORD Project is the CrossWire Bible Society's free Bible software
 project. Its purpose is to create tools that allow programmers and Bible

--- a/app-text/sword/sword-1.9.0-r2.ebuild
+++ b/app-text/sword/sword-1.9.0-r2.ebuild
@@ -29,6 +29,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.9.0-cflags.patch
+	"${FILESDIR}"/${PN}-1.9.0-cmake4.patch
 )
 
 DOCS=( AUTHORS CODINGSTYLE ChangeLog README examples/ samples/ )


### PR DESCRIPTION
Upstream-support has been notified by email for cmake.

Add myself as a maintainer, like bibletime, its main rdep.

Closes: https://bugs.gentoo.org/953945

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
