### PR TITLE
media-sound/apulse: fix build with cmake 4

### DIFF
--- a/media-sound/apulse/apulse-0.1.13-r4.ebuild
+++ b/media-sound/apulse/apulse-0.1.13-r4.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib multiprocessing
+
+DESCRIPTION="PulseAudio emulation for ALSA"
+HOMEPAGE="https://github.com/i-rinat/apulse"
+SRC_URI="https://github.com/i-rinat/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+
+IUSE="debug sdk test"
+RESTRICT="!test? ( test )"
+
+DEPEND="dev-libs/glib:2[${MULTILIB_USEDEP}]
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
+	sdk? ( !media-libs/libpulse !media-sound/pulseaudio ) "
+RDEPEND="${DEPEND}
+	!media-plugins/alsa-plugins[pulseaudio]"
+
+PATCHES=(
+	"${FILESDIR}/sdk.patch"
+	"${FILESDIR}/check-key-before-remove.patch"
+	"${FILESDIR}/man.patch"
+	"${FILESDIR}/apulse-0.1.13-libgen.patch"
+	"${FILESDIR}/apulse-0.1.13-cmakever.patch"
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	if ! use sdk; then
+		# Ensure all relevant libdirs are added, to support all ABIs
+		DIRS=
+		_add_dir() { DIRS="${EPREFIX}/usr/$(get_libdir)/apulse${DIRS:+:${DIRS}}"; }
+		multilib_foreach_abi _add_dir
+		sed -e "s#@@DIRS@@#${DIRS}#g" "${FILESDIR}"/apulse > "${T}"/apulse || die
+	fi
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		"-DINSTALL_SDK=$(usex sdk)"
+		"-DLOG_TO_STDERR=$(usex debug)"
+		"-DWITH_TRACE=$(usex debug)"
+	)
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	_test() {
+		cmake --build . --target check
+	}
+	multilib_foreach_abi _test
+}
+
+multilib_src_install_all() {
+	if ! use sdk; then
+		_install_wrapper() { newbin "${BUILD_DIR}/apulse" "${CHOST}-apulse"; }
+		multilib_foreach_abi _install_wrapper
+		dobin "${T}/apulse"
+	fi
+	einstalldocs
+}

--- a/media-sound/apulse/files/apulse-0.1.13-cmakever.patch
+++ b/media-sound/apulse/files/apulse-0.1.13-cmakever.patch
@@ -1,0 +1,11 @@
+https://github.com/i-rinat/apulse/pull/128
+https://bugs.gentoo.org/953973
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+ project(apulse)
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 2.8...4.0)
+ 
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -fPIC -fvisibility=hidden")


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/953973

<!-- Please put the pull request description above -->

```diff
--- apulse-0.1.13-r3.ebuild	2025-04-17 23:18:55.563908557 +0100
+++ apulse-0.1.13-r4.ebuild	2025-04-17 23:19:17.644321580 +0100
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/i-rinat/${PN
 
 LICENSE="MIT LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~ppc64 x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 
 IUSE="debug sdk test"
 RESTRICT="!test? ( test )"
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}/check-key-before-remove.patch"
 	"${FILESDIR}/man.patch"
 	"${FILESDIR}/apulse-0.1.13-libgen.patch"
+	"${FILESDIR}/apulse-0.1.13-cmakever.patch"
 )
 
 src_prepare() {
@@ -52,12 +53,7 @@ multilib_src_configure() {
 
 multilib_src_test() {
 	_test() {
-		pushd tests || die
-		cmake -S "${S}/tests" -B . || die
-		emake test_ringbuffer
-		ctest -j "$(makeopts_jobs "${MAKEOPTS}" 999)" \
-			--test-load "$(makeopts_loadavg)" || die
-		popd || die
+		cmake --build . --target check
 	}
 	multilib_foreach_abi _test
 }
```


---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
