### PR TITLE
media-sound/playerctl: enable py3.13 for tests

### DIFF
--- a/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
+++ b/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit bash-completion-r1 meson python-any-r1 virtualx xdg-utils
 
 DESCRIPTION="A CLI utility to control media players over MPRIS"

--- a/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
+++ b/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit bash-completion-r1 meson python-any-r1 virtualx xdg-utils
+inherit meson python-any-r1 shell-completion virtualx xdg-utils
 
 DESCRIPTION="A CLI utility to control media players over MPRIS"
 HOMEPAGE="https://github.com/acrisci/playerctl"
@@ -93,7 +93,6 @@ src_install() {
 	dodoc -r "${S}"/examples/.
 	docompress -x "/usr/share/doc/${PF}/examples"
 
-	newbashcomp data/playerctl.bash "${PN}"
-	insinto /usr/share/zsh/site-functions
-	newins data/playerctl.zsh _playerctl
+	newbashcomp data/playerctl.bash playerctl
+	newzshcomp data/playerctl.zsh _playerctl
 }


### PR DESCRIPTION
<!-- Please put the pull request description above -->

arm64 needs to be stabled separately for the newer version before dropping the old one.

https://bugs.gentoo.org/908611

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
