### PR TITLE
dev-debug/valgrind: keyword 3.25.0_rc1 for ~riscv

### DIFF
--- a/dev-debug/valgrind/valgrind-3.25.0_rc1.ebuild
+++ b/dev-debug/valgrind/valgrind-3.25.0_rc1.ebuild
@@ -42,7 +42,7 @@ else
 	S="${WORKDIR}"/${MY_P}
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+		KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 	fi
 fi
 

--- a/dev-debug/valgrind/valgrind-9999.ebuild
+++ b/dev-debug/valgrind/valgrind-9999.ebuild
@@ -42,7 +42,7 @@ else
 	S="${WORKDIR}"/${MY_P}
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+		KEYWORDS="-* ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 	fi
 fi
 


### PR DESCRIPTION
Known test failure documented here: https://sourceforge.net/p/valgrind/mailman/message/59153566/
Runtime tested some basic features: memcheck, gdbserver, callgrind, helgrind and massif, all of which are working. Given this, we can proceed to keyword for riscv.

Thanks-to: Sam James <sam@gentoo.org>

