### PR TITLE
x11-plugins/wmnetload: update EAPI 7 -> 8, port to C23

### DIFF
--- a/x11-plugins/wmnetload/files/wmnetload-1.3-C23.patch
+++ b/x11-plugins/wmnetload/files/wmnetload-1.3-C23.patch
@@ -1,0 +1,23 @@
+Correct size of variables that are passed to library and then discarded.
+Also replace sed that corrects path for library.
+https://bugs.gentoo.org/919443
+--- a/src/wmnetload.c
++++ b/src/wmnetload.c
+@@ -37,7 +37,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/time.h>
+ #include <unistd.h>
+-#include <dockapp.h>
++#include <libdockapp/dockapp.h>
+ #ifdef HAVE_SYS_SOCKIO_H
+ #include <sys/sockio.h>
+ #endif
+@@ -1051,7 +1051,7 @@
+ setshape(void)
+ {
+ 	Pixmap mask, pixmap;
+-	unsigned int h, w;
++	unsigned short int h, w;
+ 
+ 	if (DAMakePixmapFromData(backlight_off_xpm, &pixmap, &mask, &h, &w)) {
+ 		DASetShape(mask);

--- a/x11-plugins/wmnetload/wmnetload-1.3-r7.ebuild
+++ b/x11-plugins/wmnetload/wmnetload-1.3-r7.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Network interface monitor dockapp"
+HOMEPAGE="https://github.com/bbidulock/wmnetload"
+SRC_URI="https://github.com/bbidulock/wmnetload/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+DEPEND=">=x11-libs/libdockapp-0.7:="
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-r4-configure.patch"
+	"${FILESDIR}/${P}-C23.patch"
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919443

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
