### PR TITLE
app-emulation/faudio: add multilib to both ebuilds

### DIFF
--- a/app-emulation/faudio/faudio-25.04.ebuild
+++ b/app-emulation/faudio/faudio-25.04.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake flag-o-matic
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="Accuracy-focused XAudio reimplementation for open platforms"
 HOMEPAGE="https://fna-xna.github.io/"
@@ -17,8 +17,8 @@ IUSE="debug dumpvoices sdl3 test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	sdl3? ( media-libs/libsdl3 )
-	!sdl3? ( media-libs/libsdl2[sound] )
+	sdl3? ( media-libs/libsdl3[${MULTILIB_USEDEP}] )
+	!sdl3? ( media-libs/libsdl2[${MULTILIB_USEDEP},sound] )
 "
 DEPEND="${RDEPEND}"
 
@@ -32,7 +32,7 @@ src_configure() {
 		-DDUMP_VOICES="$(usex dumpvoices)"
 	)
 
-	cmake_src_configure
+	cmake-multilib_src_configure
 }
 
 src_test() {


### PR DESCRIPTION
<!-- Please put the pull request description above -->
- app-emulation/faudio: Added Multilib ABIs to the ebuilds (testing 25.04 and 25.03)
---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
