### PR TITLE
app-containers/podman: add OpenRC user service for podman

### DIFF
--- a/app-containers/podman/files/podman-5.0.0_rc4.user.confd
+++ b/app-containers/podman/files/podman-5.0.0_rc4.user.confd
@@ -1,0 +1,6 @@
+# Config file for /etc/user/init.d/podman
+
+# Sets the API service daemon log level
+# valid levels: debug, info, warn, error, fatal or panic
+#LOG_LEVEL="error"
+

--- a/app-containers/podman/files/podman-5.0.0_rc4.user.initd
+++ b/app-containers/podman/files/podman-5.0.0_rc4.user.initd
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+# Copyright 2015-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+supervisor=supervise-daemon
+description="Podman API Service"
+
+RUN_PATH="${XDG_RUNTIME_DIR}/podman"
+LOG_PATH="${RUN_PATH}/log"
+output_log="${LOG_PATH}/${RC_SVCNAME}.log"
+error_log="${LOG_PATH}/${RC_SVCNAME}.log"
+pidfile="${RUN_PATH}/${RC_SVCNAME}.pid"
+socket="unix://${RUN_PATH}/${RC_SVCNAME}.sock"
+
+# command_user="${RUN_AS_USER:=root:root}"
+command="/usr/bin/podman"
+command_args="--log-level ${LOG_LEVEL:-error} system service --time 0 ${socket}"
+command_background="true"
+
+start() {
+	checkpath -o $USER -d "${RUN_PATH}" "${LOG_PATH}"
+	default_start
+}

--- a/app-containers/podman/podman-5.4.2.ebuild
+++ b/app-containers/podman/podman-5.4.2.ebuild
@@ -123,6 +123,9 @@ src_install() {
 
 		insinto /etc/logrotate.d
 		newins "${FILESDIR}/podman.logrotated" podman
+
+		exeinto /etc/user/init.d
+		newexe "${FILESDIR}/podman-5.0.0_rc4.user.initd"
 	fi
 
 	keepdir /var/lib/containers

--- a/app-containers/podman/podman-5.4.2.ebuild
+++ b/app-containers/podman/podman-5.4.2.ebuild
@@ -126,6 +126,9 @@ src_install() {
 
 		exeinto /etc/user/init.d
 		newexe "${FILESDIR}/podman-5.0.0_rc4.user.initd"
+
+		insinto /etc/user/conf.d
+		newins "${FILESDIR}/podman-5.0.0_rc4.user.confd"
 	fi
 
 	keepdir /var/lib/containers

--- a/app-containers/podman/podman-9999.ebuild
+++ b/app-containers/podman/podman-9999.ebuild
@@ -123,6 +123,9 @@ src_install() {
 
 		insinto /etc/logrotate.d
 		newins "${FILESDIR}/podman.logrotated" podman
+
+		exeinto /etc/user/init.d
+		newexe "${FILESDIR}/podman-5.0.0_rc4.user.initd"
 	fi
 
 	keepdir /var/lib/containers

--- a/app-containers/podman/podman-9999.ebuild
+++ b/app-containers/podman/podman-9999.ebuild
@@ -126,6 +126,9 @@ src_install() {
 
 		exeinto /etc/user/init.d
 		newexe "${FILESDIR}/podman-5.0.0_rc4.user.initd"
+
+		insinto /etc/user/conf.d
+		newins "${FILESDIR}/podman-5.0.0_rc4.user.confd"
 	fi
 
 	keepdir /var/lib/containers


### PR DESCRIPTION
Add a script for a per-user podman service in OpenRC (see https://github.com/OpenRC/openrc/pull/573)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
