### PR TITLE
app-emulation/qemu: add pycotap test dep for >=qemu-9.2.0

### DIFF
--- a/app-emulation/qemu/qemu-9.2.2.ebuild
+++ b/app-emulation/qemu/qemu-9.2.2.ebuild
@@ -288,8 +288,9 @@ BDEPEND="
 	)
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (
-		dev-libs/glib[utils]
 		app-alternatives/bc
+		dev-libs/glib[utils]
+		dev-python/pycotap[${PYTHON_USEDEP}]
 	)
 "
 CDEPEND="

--- a/app-emulation/qemu/qemu-9.2.3-r1.ebuild
+++ b/app-emulation/qemu/qemu-9.2.3-r1.ebuild
@@ -288,8 +288,9 @@ BDEPEND="
 	)
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (
-		dev-libs/glib[utils]
 		app-alternatives/bc
+		dev-libs/glib[utils]
+		dev-python/pycotap[${PYTHON_USEDEP}]
 	)
 "
 CDEPEND="

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -288,8 +288,9 @@ BDEPEND="
 	)
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (
-		dev-libs/glib[utils]
 		app-alternatives/bc
+		dev-libs/glib[utils]
+		dev-python/pycotap[${PYTHON_USEDEP}]
 	)
 "
 CDEPEND="


### PR DESCRIPTION
Required for >=qemu-9.2.0 functional tests.
https://gitlab.com/qemu-project/qemu/-/blob/stable-9.2/docs/devel/testing/functional.rst
https://gitlab.com/qemu-project/qemu/-/commit/5ec1eec11000ef118b2a87c330245ffaa475f5ee
https://gitlab.com/qemu-project/qemu/-/commit/fa32a634329f4b2cdab8e380d5ccf263b1491daa

Bug: https://bugs.gentoo.org/949902
See-Also: https://github.com/gentoo/gentoo/pull/40630

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
