### PR TITLE
dev-qt/qtwebengine: Allow to use libatomic-stub instead of gcc

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-6.9.0-r2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.9.0-r2.ebuild
@@ -109,6 +109,11 @@ PATCHES=( "${WORKDIR}"/patches/${PN} )
 
 PATCHES+=(
 	# add extras as needed here, may merge in set if carries across versions
+	"${FILESDIR}"/${PN}-6.8.2-glibc2.41.patch
+	"${FILESDIR}"/${PN}-6.8.3-pipewire1.4.patch
+	"${FILESDIR}"/${PN}-6.8.3-gperf3.2.patch
+	"${FILESDIR}"/${PN}-6.9.0-x11-pixmap-leak.patch
+	"${FILESDIR}"/${PN}-6.9.0-QTBUG-133570.patch
 )
 
 python_check_deps() {

--- a/dev-qt/qtwebengine/qtwebengine-6.9.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.9.9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 "
 
 # dlopen: krb5, libva, pciutils
-# gcc: for -latomic
+# gcc or libatomic-stub: for -latomic
 RDEPEND="
 	app-arch/snappy:=
 	dev-libs/expat
@@ -53,7 +53,10 @@ RDEPEND="
 	media-libs/tiff:=
 	sys-apps/dbus
 	sys-apps/pciutils
-	sys-devel/gcc:*
+	|| (
+		sys-devel/gcc:*
+		llvm-runtimes/libatomic-stub
+	)
 	sys-libs/zlib:=[minizip]
 	virtual/libudev:=
 	x11-libs/libX11


### PR DESCRIPTION
llvm-runtimes/libatomic-stub provides libatomic.a, so there is no reason to hard depend on gcc anymore.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
