### PR TITLE
app-editors/vscode: add L10N use flag support

### DIFF
--- a/app-editors/vscode/vscode-1.99.3.ebuild
+++ b/app-editors/vscode/vscode-1.99.3.ebuild
@@ -3,7 +3,11 @@
 
 EAPI=8
 
-inherit desktop pax-utils xdg optfeature
+CHROMIUM_LANGS="af am ar bg bn ca cs da de el en-GB es es-419 et fa fi fil fr gu he
+	hi hr hu id it ja kn ko lt lv ml mr ms nb nl pl pt-BR pt-PT ro ru sk sl sr
+	sv sw ta te th tr uk ur vi zh-CN zh-TW"
+
+inherit chromium-2 desktop pax-utils xdg optfeature
 
 DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
 HOMEPAGE="https://code.visualstudio.com"
@@ -72,17 +76,29 @@ RDEPEND="
 "
 
 QA_PREBUILT="*"
+VSC_HOME="vscode"
+
+src_unpack() {
+	default
+	use amd64 || use arm || use arm64 \
+		|| die "Visual Studio Code only supports amd64, arm and arm64"
+	mv "${S}"/VSCode-linux-* "${S}/${VSC_HOME}" || die
+}
+
+src_configure() {
+	default
+	chromium_suid_sandbox_check_kernel_config
+}
+
+src_prepare() {
+	default
+	pushd "${VSC_HOME}/locales" > /dev/null || die
+	chromium_remove_language_paks
+	popd > /dev/null || die
+}
 
 src_install() {
-	if use amd64; then
-		cd "${WORKDIR}/VSCode-linux-x64" || die
-	elif use arm; then
-		cd "${WORKDIR}/VSCode-linux-armhf" || die
-	elif use arm64; then
-		cd "${WORKDIR}/VSCode-linux-arm64" || die
-	else
-		die "Visual Studio Code only supports amd64, arm and arm64"
-	fi
+	pushd "${VSC_HOME}" > /dev/null || die
 
 	# Cleanup
 	rm -r ./resources/app/ThirdPartyNotices.txt || die


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/954170

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
