### PR TITLE
sys-sys-power/nut: Support for Python 13 and fix init scripts to use /run/nut

### DIFF
--- a/sys-power/nut/files/nut-2.2.2-init.d-upsdrv
+++ b/sys-power/nut/files/nut-2.2.2-init.d-upsdrv
@@ -21,6 +21,10 @@ stop() {
 	_dostop "$UPSNAME" "$msgtext"
 }
 
+start_pre() {
+	checkpath -q -d -m 0700 -o nut:nut /run/nut
+}
+
 startall() {
 	_dostart "" "$msgtext"
 }
@@ -39,5 +43,5 @@ _dostop() {
 	# Not in our control at all
 	ebegin "Stopping UPS $msgtext"
 	/usr/sbin/upsdrvctl stop $UPSNAME
-	eend $? "Failed to stop UPS $msgtext!"
+	ewarn $? "Failed to stop UPS $msgtext!"
 }

--- a/sys-power/nut/files/nut-2.6.5-init.d-upslog
+++ b/sys-power/nut/files/nut-2.6.5-init.d-upslog
@@ -4,12 +4,16 @@
 
 extra_started_commands="reload"
 
-pidfile=/var/run/upslog.pid
+pidfile=/run/nut/upslog.pid
 bin=/usr/bin/upslog
 
 depend() {
 	use upsdrv
 	after upsdrv
+}
+
+start_pre() {
+	checkpath -q -d -m 0700 -o nut:nut /run/nut
 }
 
 start() {

--- a/sys-power/nut/files/nut-2.6.5-init.d-upsmon
+++ b/sys-power/nut/files/nut-2.6.5-init.d-upsmon
@@ -11,6 +11,10 @@ depend() {
 	use net
 }
 
+start_pre() {
+	checkpath -q -d -m 0700 -o nut:nut /run/nut
+}
+
 start() {
 	ebegin "Starting upsmon"
 	start-stop-daemon --start --quiet --exec ${bin}

--- a/sys-power/nut/files/nut-2.8.0-init.d-upsd
+++ b/sys-power/nut/files/nut-2.8.0-init.d-upsd
@@ -13,6 +13,10 @@ depend() {
 	after upsdrv
 }
 
+start_pre() {
+	checkpath -q -d -m 0700 -o nut:nut /run/nut
+}
+
 start() {
 	ebegin "Starting upsd"
 	# clean up first

--- a/sys-power/nut/nut-2.8.2-r2.ebuild
+++ b/sys-power/nut/nut-2.8.2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit bash-completion-r1 desktop linux-info optfeature
 inherit python-single-r1 systemd tmpfiles toolchain-funcs udev wrapper xdg
 
@@ -123,7 +123,7 @@ src_configure() {
 		--with-group=nut
 		--with-htmlpath=/usr/share/nut/html
 		--with-logfacility=LOG_DAEMON
-		--with-statepath=/var/lib/nut
+		--with-statepath=/run/nut
 		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
 		--with-systemdtmpfilesdir="/usr/lib/tmpfiles.d"
 		--with-udev-dir="$(get_udevdir)"

--- a/sys-power/nut/nut-9999.ebuild
+++ b/sys-power/nut/nut-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit bash-completion-r1 desktop linux-info optfeature
 inherit python-single-r1 systemd tmpfiles toolchain-funcs udev wrapper xdg
 
@@ -123,7 +123,7 @@ src_configure() {
 		--with-group=nut
 		--with-htmlpath=/usr/share/nut/html
 		--with-logfacility=LOG_DAEMON
-		--with-statepath=/var/lib/nut
+		--with-statepath=/run/nut
 		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
 		--with-systemdtmpfilesdir="/usr/lib/tmpfiles.d"
 		--with-udev-dir="$(get_udevdir)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952749

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
