### PR TITLE
media-tv/kodi: Don't need wayland enabled on libxkbcommon

### DIFF
--- a/media-tv/kodi/kodi-21.9999.ebuild
+++ b/media-tv/kodi/kodi-21.9999.ebuild
@@ -220,7 +220,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		)
 	)
 	wayland? (
-		>=x11-libs/libxkbcommon-0.4.1[wayland]
+		>=x11-libs/libxkbcommon-0.4.1
 	)
 	webserver? (
 		>=net-libs/libmicrohttpd-0.9.77:=

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -220,7 +220,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		)
 	)
 	wayland? (
-		>=x11-libs/libxkbcommon-0.4.1[wayland]
+		>=x11-libs/libxkbcommon-0.4.1
 	)
 	webserver? (
 		>=net-libs/libmicrohttpd-0.9.77:=


### PR DESCRIPTION
wayland is only used with the tools flag to build the xkbcli utility.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
