### PR TITLE
dev-lisp/sbcl: system-bootstrap on musl via ecl

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.5.0.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.5.0.ebuild
@@ -50,7 +50,10 @@ CDEPEND=">=dev-lisp/asdf-3.3:= \
 BDEPEND="${CDEPEND}
 		dev-debug/strace
 		doc? ( sys-apps/texinfo >=media-gfx/graphviz-2.26.0 )
-		system-bootstrap? ( || ( dev-lisp/clisp dev-lisp/sbcl ) )"
+		system-bootstrap? ( || (
+			!elibc_musl? ( dev-lisp/clisp )
+			elibc_musl?  ( >=dev-lisp/ecl-24.5.10 )
+			dev-lisp/sbcl ) )"
 RDEPEND="${CDEPEND}
 		zstd? ( app-arch/zstd )
 		!prefix? ( elibc_glibc? ( >=sys-libs/glibc-2.6 ) )"
@@ -178,6 +181,8 @@ src_compile() {
 	if use system-bootstrap ; then
 		if has_version "dev-lisp/sbcl" ; then
 			bootstrap_lisp="sbcl --no-sysinit --no-userinit --disable-debugger"
+		elif use elibc_musl ; then
+			bootstrap_lisp="ecl"
 		else
 			bootstrap_lisp="clisp"
 		fi

--- a/dev-lisp/sbcl/sbcl-2.5.2.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.5.2.ebuild
@@ -50,7 +50,10 @@ CDEPEND=">=dev-lisp/asdf-3.3:= \
 BDEPEND="${CDEPEND}
 		dev-debug/strace
 		doc? ( sys-apps/texinfo >=media-gfx/graphviz-2.26.0 )
-		system-bootstrap? ( || ( dev-lisp/clisp dev-lisp/sbcl ) )"
+		system-bootstrap? ( || (
+			!elibc_musl? ( dev-lisp/clisp )
+			elibc_musl?  ( >=dev-lisp/ecl-24.5.10 )
+			dev-lisp/sbcl ) )"
 RDEPEND="${CDEPEND}
 		zstd? ( app-arch/zstd )
 		!prefix? ( elibc_glibc? ( >=sys-libs/glibc-2.6 ) )"
@@ -178,6 +181,8 @@ src_compile() {
 	if use system-bootstrap ; then
 		if has_version "dev-lisp/sbcl" ; then
 			bootstrap_lisp="sbcl --no-sysinit --no-userinit --disable-debugger"
+		elif use elibc_musl ; then
+			bootstrap_lisp="ecl"
 		else
 			bootstrap_lisp="clisp"
 		fi

--- a/dev-lisp/sbcl/sbcl-2.5.3.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.5.3.ebuild
@@ -50,7 +50,10 @@ CDEPEND=">=dev-lisp/asdf-3.3:= \
 BDEPEND="${CDEPEND}
 		dev-debug/strace
 		doc? ( sys-apps/texinfo >=media-gfx/graphviz-2.26.0 )
-		system-bootstrap? ( || ( dev-lisp/clisp dev-lisp/sbcl ) )"
+		system-bootstrap? ( || (
+			!elibc_musl? ( dev-lisp/clisp )
+			elibc_musl?  ( >=dev-lisp/ecl-24.5.10 )
+			dev-lisp/sbcl ) )"
 RDEPEND="${CDEPEND}
 		zstd? ( app-arch/zstd )
 		!prefix? ( elibc_glibc? ( >=sys-libs/glibc-2.6 ) )"
@@ -178,6 +181,8 @@ src_compile() {
 	if use system-bootstrap ; then
 		if has_version "dev-lisp/sbcl" ; then
 			bootstrap_lisp="sbcl --no-sysinit --no-userinit --disable-debugger"
+		elif use elibc_musl ; then
+			bootstrap_lisp="ecl"
 		else
 			bootstrap_lisp="clisp"
 		fi


### PR DESCRIPTION
It is now possible to bootstrap sbcl via ecl on musl. The restriction to >=dev-lisp/ecl-24.5.10 is because that is what has been tested, earlier versions of ecl might work.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
