### PR TITLE
*/*: Fix build with CMake 4.x

### DIFF
--- a/dev-cpp/gflags/gflags-2.2.2-r1.ebuild
+++ b/dev-cpp/gflags/gflags-2.2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,13 @@ SLOT="0/2.2"
 IUSE="static-libs test"
 RESTRICT="!test? ( test )"
 
+RDEPEND="
+	>=dev-build/cmake-4.0.0
+"
+DEPEND="
+	${RDEPEND}
+"
+
 # AUTHORS.txt only links the google group
 DOCS=( ChangeLog.txt README.md )
 
@@ -28,6 +35,7 @@ multilib_src_configure() {
 	append-lfs-flags
 
 	local mycmakeargs=(
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 		-DBUILD_STATIC_LIBS=$(usex static-libs)
 		-DBUILD_TESTING=$(usex test)
 		# avoid installing .cmake/packages, e.g.:

--- a/dev-cpp/glog/glog-0.6.0.ebuild
+++ b/dev-cpp/glog/glog-0.6.0.ebuild
@@ -30,6 +30,7 @@ RDEPEND="gflags? ( dev-cpp/gflags:0=[${MULTILIB_USEDEP}] )
 		llvm-libunwind? ( llvm-runtimes/libunwind:0=[${MULTILIB_USEDEP}] )
 		!llvm-libunwind? ( sys-libs/libunwind:0=[${MULTILIB_USEDEP}] )
 	)
+	>=dev-build/cmake-4.0.0
 "
 DEPEND="${RDEPEND}
 	test? ( >=dev-cpp/gtest-1.8.0[${MULTILIB_USEDEP}] )
@@ -42,6 +43,7 @@ PATCHES=(
 
 src_configure() {
 	local mycmakeargs=(
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 		-DBUILD_TESTING=$(usex test ON OFF)
 		-DWITH_GFLAGS=$(usex gflags ON OFF)
 		-DWITH_GTEST=$(usex test ON OFF)

--- a/sci-physics/bullet/bullet-3.21.ebuild
+++ b/sci-physics/bullet/bullet-3.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,11 +23,15 @@ RDEPEND="
 	virtual/opengl
 	media-libs/freeglut
 	tbb? ( <dev-cpp/tbb-2021.4.0:= )
+	>=dev-build/cmake-4.0.0
 "
 DEPEND="${RDEPEND}"
 BDEPEND="doc? ( app-text/doxygen[dot] )"
 
-PATCHES=( "${FILESDIR}"/${PN}-2.85-soversion.patch )
+PATCHES=( 
+	"${FILESDIR}"/${PN}-2.85-soversion.patch
+	"${FILESDIR}"/${PN}-3.21-cmake-version.patch
+	)
 
 DOCS=( AUTHORS.txt LICENSE.txt README.md )
 
@@ -63,6 +67,8 @@ src_configure() {
 	filter-lto
 
 	local mycmakeargs=(
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+		-DOpenGL_GL_PREFERENCE=GLVND
 		-DBUILD_CPU_DEMOS=OFF
 		-DBUILD_OPENGL3_DEMOS=OFF
 		-DBUILD_BULLET2_DEMOS=OFF
@@ -76,6 +82,7 @@ src_configure() {
 		-DBULLET2_MULTITHREADING=$(usex threads)
 		-DBULLET2_USE_OPEN_MP_MULTITHREADING=$(usex openmp)
 		-DBULLET2_USE_TBB_MULTITHREADING=$(usex tbb)
+		-DBUILD_BULLET_ROBOTICS_GUI_EXTRA=ON
 	)
 	cmake_src_configure
 }

--- a/sci-physics/bullet/files/bullet-3.21-cmake-version.patch
+++ b/sci-physics/bullet/files/bullet-3.21-cmake-version.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt	2025-04-23 11:40:55.509033306 +0300
++++ b/CMakeLists.txt	2025-04-23 11:41:16.355325420 +0300
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4.3)
++cmake_minimum_required(VERSION 3.5.0)
+ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
+ cmake_policy(SET CMP0017 NEW)
+ #this line has to appear before 'PROJECT' in order to be able to disable incremental linking


### PR DESCRIPTION
Fix build with CMake 4.x for dev-cpp/gflags
Closes: https://bugs.gentoo.org/951895

Fix build with CMake 4.x for dev-cpp/glog
Closes: https://bugs.gentoo.org/954083

Fix build with CMake 4.x for sci-physics/bullet
No bug found though the problem exists.

This 3 commits make posible to build blender with CMake 4.x as the only cmake in a system.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
