### PR TITLE
net-vpn/tor: rename `tor-hardening` USE flag to just `hardening`, improve metadata a bit

### DIFF
--- a/net-vpn/tor/metadata.xml
+++ b/net-vpn/tor/metadata.xml
@@ -12,6 +12,5 @@
 	<use>
 		<flag name="scrypt">Use <pkg>app-crypt/libscrypt</pkg> for the scrypt algorithm</flag>
 		<flag name="server">Enable tor's relay module so it can operate as a relay/bridge/authority</flag>
-		<flag name="tor-hardening">Compile tor with hardening on vanilla compilers/linkers</flag>
 	</use>
 </pkgmetadata>

--- a/net-vpn/tor/metadata.xml
+++ b/net-vpn/tor/metadata.xml
@@ -13,4 +13,8 @@
 		<flag name="scrypt">Use <pkg>app-crypt/libscrypt</pkg> for the scrypt algorithm</flag>
 		<flag name="server">Enable tor's relay module so it can operate as a relay/bridge/authority</flag>
 	</use>
+	<upstream>
+		<bugs-to>https://support.torproject.org/misc/bug-or-feedback/</bugs-to>
+		<changelog>https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog</changelog>
+	</upstream>
 </pkgmetadata>

--- a/net-vpn/tor/tor-0.4.8.14.ebuild
+++ b/net-vpn/tor/tor-0.4.8.14.ebuild
@@ -39,7 +39,7 @@ fi
 # that's different from the actual binary.
 LICENSE="BSD GPL-2 GPL-3"
 SLOT="0"
-IUSE="caps doc lzma +man scrypt seccomp selinux +server systemd tor-hardening test zstd"
+IUSE="caps doc hardened lzma +man scrypt seccomp selinux +server systemd test zstd"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -140,6 +140,8 @@ src_configure() {
 		--enable-gpl
 		--enable-module-pow
 
+		$(use_enable hardened gcc-hardening)
+		$(use_enable hardened linker-hardening)
 		$(use_enable man asciidoc)
 		$(use_enable man manpage)
 		$(use_enable lzma)
@@ -147,8 +149,6 @@ src_configure() {
 		$(use_enable seccomp)
 		$(use_enable server module-relay)
 		$(use_enable systemd)
-		$(use_enable tor-hardening gcc-hardening)
-		$(use_enable tor-hardening linker-hardening)
 		$(use_enable test unittests)
 		$(use_enable zstd)
 	)

--- a/net-vpn/tor/tor-0.4.8.16.ebuild
+++ b/net-vpn/tor/tor-0.4.8.16.ebuild
@@ -39,7 +39,7 @@ fi
 # that's different from the actual binary.
 LICENSE="BSD GPL-2 GPL-3"
 SLOT="0"
-IUSE="caps doc lzma +man scrypt seccomp selinux +server systemd tor-hardening test zstd"
+IUSE="caps doc hardened lzma +man scrypt seccomp selinux +server systemd test zstd"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -140,6 +140,8 @@ src_configure() {
 		--enable-gpl
 		--enable-module-pow
 
+		$(use_enable hardened gcc-hardening)
+		$(use_enable hardened linker-hardening)
 		$(use_enable man asciidoc)
 		$(use_enable man manpage)
 		$(use_enable lzma)
@@ -147,8 +149,6 @@ src_configure() {
 		$(use_enable seccomp)
 		$(use_enable server module-relay)
 		$(use_enable systemd)
-		$(use_enable tor-hardening gcc-hardening)
-		$(use_enable tor-hardening linker-hardening)
 		$(use_enable test unittests)
 		$(use_enable zstd)
 	)

--- a/net-vpn/tor/tor-9999.ebuild
+++ b/net-vpn/tor/tor-9999.ebuild
@@ -39,7 +39,7 @@ fi
 # that's different from the actual binary.
 LICENSE="BSD GPL-2 GPL-3"
 SLOT="0"
-IUSE="caps doc lzma +man scrypt seccomp selinux +server systemd tor-hardening test zstd"
+IUSE="caps doc hardened lzma +man scrypt seccomp selinux +server systemd test zstd"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -140,6 +140,8 @@ src_configure() {
 		--enable-gpl
 		--enable-module-pow
 
+		$(use_enable hardened gcc-hardening)
+		$(use_enable hardened linker-hardening)
 		$(use_enable man asciidoc)
 		$(use_enable man manpage)
 		$(use_enable lzma)
@@ -147,8 +149,6 @@ src_configure() {
 		$(use_enable seccomp)
 		$(use_enable server module-relay)
 		$(use_enable systemd)
-		$(use_enable tor-hardening gcc-hardening)
-		$(use_enable tor-hardening linker-hardening)
 		$(use_enable test unittests)
 		$(use_enable zstd)
 	)


### PR DESCRIPTION
Global USE flags FTW!

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
