### PR TITLE
app-crypt/certbot: QA, fix broken README, #954283

### DIFF
--- a/app-crypt/certbot/certbot-3.2.0-r103.ebuild
+++ b/app-crypt/certbot/certbot-3.2.0-r103.ebuild
@@ -174,6 +174,11 @@ src_prepare() {
 
 	# Used to build documentation
 	mkdir "${CERTBOT_DOCS}" || die
+
+	# Remove "broken" symbolic link used as documentation.
+	# Copy actual file, removing source breaks wheel building.
+	rm -f "${S}/README.rst"
+	cp "${S}/certbot/README.rst" "${S}/README.rst" || die
 }
 
 python_compile() {

--- a/app-crypt/certbot/certbot-3.3.0-r3.ebuild
+++ b/app-crypt/certbot/certbot-3.3.0-r3.ebuild
@@ -174,6 +174,11 @@ src_prepare() {
 
 	# Used to build documentation
 	mkdir "${CERTBOT_DOCS}" || die
+
+	# Remove "broken" symbolic link used as documentation.
+	# Copy actual file, removing source breaks wheel building.
+	rm -f "${S}/README.rst"
+	cp "${S}/certbot/README.rst" "${S}/README.rst" || die
 }
 
 python_compile() {

--- a/app-crypt/certbot/certbot-4.0.0-r2.ebuild
+++ b/app-crypt/certbot/certbot-4.0.0-r2.ebuild
@@ -173,6 +173,11 @@ src_prepare() {
 
 	# Used to build documentation
 	mkdir "${CERTBOT_DOCS}" || die
+
+	# Remove "broken" symbolic link used as documentation.
+	# Copy actual file, removing source breaks wheel building.
+	rm -f "${S}/README.rst"
+	cp "${S}/certbot/README.rst" "${S}/README.rst" || die
 }
 
 python_compile() {

--- a/app-crypt/certbot/certbot-9999.ebuild
+++ b/app-crypt/certbot/certbot-9999.ebuild
@@ -173,6 +173,11 @@ src_prepare() {
 
 	# Used to build documentation
 	mkdir "${CERTBOT_DOCS}" || die
+
+	# Remove "broken" symbolic link used as documentation.
+	# Copy actual file, removing source breaks wheel building.
+	rm -f "${S}/README.rst"
+	cp "${S}/certbot/README.rst" "${S}/README.rst" || die
 }
 
 python_compile() {


### PR DESCRIPTION
Note: I consider creating a new revision was not necessary, specially considering stable is in process, [bug 952978](https://bugs.gentoo.org/952978).

Closes: https://bugs.gentoo.org/954283

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
