### PR TITLE
dev-cpp/fbthrift: add missing mvfst dependency

### DIFF
--- a/dev-cpp/fbthrift/fbthrift-2025.04.14.00-r1.ebuild
+++ b/dev-cpp/fbthrift/fbthrift-2025.04.14.00-r1.ebuild
@@ -30,6 +30,7 @@ RESTRICT="test"
 DEPEND="
 	~dev-cpp/fizz-${PV}:=
 	~dev-cpp/folly-${PV}:=
+	~dev-cpp/mvfst-${PV}:=
 	~dev-cpp/wangle-${PV}:=
 	dev-cpp/gflags:=
 	dev-cpp/glog:=[gflags]


### PR DESCRIPTION
Misread the qa-vdb output, oops. This should be an RDEPEND since the CMake files Thrift installs depend on mvfst being present.

Closes: https://bugs.gentoo.org/954273

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
