### PR TITLE
net-libs/paho-mqtt-c: enable py3.13, pypy3, pypy3_11

### DIFF
--- a/net-libs/paho-mqtt-c/paho-mqtt-c-1.3.13.ebuild
+++ b/net-libs/paho-mqtt-c/paho-mqtt-c-1.3.13.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
 
 inherit cmake python-any-r1 toolchain-funcs
 


### PR DESCRIPTION
porting to Python 3.13; tested with pypy on amd64
Closes: https://bugs.gentoo.org/952598

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
