### PR TITLE
media-libs/mesa: Fix `video_cards_panfrost` cross-compile and add Apple silicon drivers

### DIFF
--- a/dev-util/mesa_clc/mesa_clc-9999.ebuild
+++ b/dev-util/mesa_clc/mesa_clc-9999.ebuild
@@ -26,7 +26,7 @@ fi
 LICENSE="MIT"
 SLOT="0"
 
-VIDEO_CARDS="panfrost"
+VIDEO_CARDS="asahi panfrost"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -68,6 +68,7 @@ pkg_setup() {
 }
 
 src_configure() {
+	tools_enable video_cards_asahi asahi
 	tools_enable video_cards_panfrost panfrost
 
 	tools_list() {
@@ -108,6 +109,7 @@ src_configure() {
 src_install() {
 	dobin "${BUILD_DIR}"/src/compiler/clc/mesa_clc
 	dobin "${BUILD_DIR}"/src/compiler/spirv/vtn_bindgen2
+	use video_cards_asahi && dobin "${BUILD_DIR}"/src/asahi/clc/asahi_clc
 	use video_cards_panfrost && dobin "${BUILD_DIR}"/src/panfrost/clc/panfrost_compile
 }
 

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -159,7 +159,7 @@ DEPEND="${RDEPEND}
 "
 
 CLC_DEPSTRING="
-	~dev-util/mesa_clc-${PV}
+	~dev-util/mesa_clc-${PV}[video_cards_panfrost?]
 	llvm-core/libclc[spirv(-)]
 "
 BDEPEND="
@@ -439,6 +439,10 @@ multilib_src_configure() {
 	   use video_cards_nvk ||
 	   use video_cards_panfrost; then
 	   emesonargs+=(-Dmesa-clc=system)
+	fi
+
+	if use video_cards_panfrost; then
+	    emesonargs+=(-Dprecomp-compiler=system)
 	fi
 
 	use debug && EMESON_BUILDTYPE=debug

--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -148,6 +148,9 @@
 -video_cards_vmware
 -video_cards_qxl
 
+# unmask video_cards with virtgpu DRM native-context support
+-video_cards_asahi
+
 # Simon Stelling <blubb@gentoo.org> (2007-02-16)
 # Since this profile forces >=portage-2.1.2, we can unmask all
 # SIMD assembler flags

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -123,6 +123,7 @@ snapcast
 
 # Unmask ARM-only video-cards
 -video_cards_amdgpu
+-video_cards_asahi
 -video_cards_d3d12
 -video_cards_exynos
 -video_cards_freedreno

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -279,6 +279,10 @@ dev-util/diffoscope haskell
 # gui-libs/egl-wayland with nvidia-drivers is only usable on some arches.
 x11-wm/mutter video_cards_nvidia
 
+# dev-util/mesa_clc with video_cards_panfrost is required to cross-compile
+# dev-libs/mesa with video_cards_panfrost
+dev-util/mesa_clc -video_cards_panfrost
+
 # Michael Orlitzky <mjo@gentoo.org> (2021-03-27)
 # The clozurecl and clozurecl64 flags are now arch-specific in maxima,
 # so we mask them both by default beginning with v5.44.0-r5 where

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -279,9 +279,9 @@ dev-util/diffoscope haskell
 # gui-libs/egl-wayland with nvidia-drivers is only usable on some arches.
 x11-wm/mutter video_cards_nvidia
 
-# dev-util/mesa_clc with video_cards_panfrost is required to cross-compile
-# dev-libs/mesa with video_cards_panfrost
-dev-util/mesa_clc -video_cards_panfrost
+# dev-util/mesa_clc with video_cards_{asahi,panfrost} is required to
+# cross-compile dev-libs/mesa with video_cards_{asahi,panfrost}
+dev-util/mesa_clc -video_cards_asahi -video_cards_panfrost
 
 # Michael Orlitzky <mjo@gentoo.org> (2021-03-27)
 # The clozurecl and clozurecl64 flags are now arch-specific in maxima,

--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -207,6 +207,11 @@ video_cards_vivante
 # linux-only drivers
 video_cards_qxl
 
+# drivers with virtgpu DRM native-context support
+# these could be unmasked on all architectures with qemu system target but
+# unmasking only tested and actually used ones is a sane default.
+video_cards_asahi
+
 # not needed on non-x86, non-amd64, non-ppc systems
 input_devices_synaptics
 input_devices_wacom

--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -6,6 +6,7 @@
 # Keep it sorted.
 
 amdgpu - VIDEO_CARDS setting to build driver for AMDGPU video cards
+asahi - VIDEO_CARDS setting to build support for Apple AGX GPUs
 ast - VIDEO_CARDS setting to build driver for ASpeedTech video cards
 d3d12 - VIDEO_CARDS seeting to build driver for Microsoft WSL video cards
 dummy - VIDEO_CARDS setting to build driver for dummy video cards


### PR DESCRIPTION
This depends on https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34693 (merged in main on 2025-04-25) but not yet backported to mesa-25.1.0-rc3 

- dev-util/mesa_clc: Build panfrost tools / precomp-compiler
- media-libs/mesa: Fix panfrost cross compilation
- profiles: add asahi VIDEO_CARDS value and add arch use masks
- dev-util/mesa_clc: Build asahi tools / precomp-compiler
- media-libs/mesa: Enable support for asahi and HoneyKrisp drivers

Replaces #41546

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
