### PR TITLE
Properly handle liburing in Facebook packages

### DIFF
--- a/dev-cpp/fbthrift/fbthrift-2025.04.14.00-r2.ebuild
+++ b/dev-cpp/fbthrift/fbthrift-2025.04.14.00-r2.ebuild
@@ -22,14 +22,14 @@ SRC_URI="https://github.com/facebook/fbthrift/archive/refs/tags/v${PV}.tar.gz ->
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
 KEYWORDS="~amd64 ~arm64"
-IUSE="test"
+IUSE="io-uring test"
 
 # See https://github.com/facebook/fbthrift/issues/628
 RESTRICT="test"
 
 DEPEND="
 	~dev-cpp/fizz-${PV}:=
-	~dev-cpp/folly-${PV}:=
+	~dev-cpp/folly-${PV}:=[io-uring(+)=]
 	~dev-cpp/mvfst-${PV}:=
 	~dev-cpp/wangle-${PV}:=
 	dev-cpp/gflags:=

--- a/dev-cpp/folly/files/folly-2025.04.14.00-CMake-Avoid-finding-liburing.patch
+++ b/dev-cpp/folly/files/folly-2025.04.14.00-CMake-Avoid-finding-liburing.patch
@@ -1,0 +1,30 @@
+From a0d86ed3bc2150ddfad50ab1b2eb09bea7a277d2 Mon Sep 17 00:00:00 2001
+From: sin-ack <sin-ack@protonmail.com>
+Date: Thu, 24 Apr 2025 20:59:06 +0000
+Subject: [PATCH] CMake: Avoid finding liburing
+
+Otherwise, Folly will unconditionally add it to the list of libraries to
+link even if io_uring support is otherwise disabled, creating an
+implicit dependency on it that can't be tracked by package managers.
+---
+ CMake/folly-deps.cmake | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/CMake/folly-deps.cmake b/CMake/folly-deps.cmake
+index 6ce4c679a..b1e20a901 100644
+--- a/CMake/folly-deps.cmake
++++ b/CMake/folly-deps.cmake
+@@ -139,10 +139,6 @@ find_package(LibAIO)
+ list(APPEND FOLLY_LINK_LIBRARIES ${LIBAIO_LIBRARIES})
+ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBAIO_INCLUDE_DIRS})
+ 
+-find_package(LibUring)
+-list(APPEND FOLLY_LINK_LIBRARIES ${LIBURING_LIBRARIES})
+-list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBURING_INCLUDE_DIRS})
+-
+ find_package(Libsodium)
+ list(APPEND FOLLY_LINK_LIBRARIES ${LIBSODIUM_LIBRARIES})
+ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${LIBSODIUM_INCLUDE_DIRS})
+-- 
+2.49.0
+

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,14 @@
 
 # New entries go on top.
 
+# sin-ack <sin-ack@protonmail.com> (2025-04-24)
+# Folly's support for io_uring depends on as-of-yet unreleased liburing
+# features. All Facebook packages that depend on this support are masked.
+# Can be dropped once liburing 2.10 is released.
+# Bug #954335
+dev-cpp/folly io-uring
+dev-cpp/fbthrift io-uring
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2025-04-21)
 # Prepare cleanup of dev-qt/qtwebengine:5
 app-i18n/fcitx-chinese-addons webengine


### PR DESCRIPTION
There are three different problems being addressed here:

1. Recent Folly versions depend on liburing features that have not yet been released.
2. Folly has no build system configuration option to disable io_uring support.
3. Folly's CMake build system will unconditionally add liburing as a library to link against, which downstream Facebook libraries rely on.

The third one creates an implicit dependency between Folly and liburing which means if liburing gets depcleaned or otherwise unmerged, other Facebook packages will fail to build.

We solve this by conditionally patching out io_uring support based on USE=io-uring and having a (currently technically invalid) dependency on the yet-unreleased liburing-2.10, which will make it automagically start working once we do have that release in ::gentoo.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
