### PR TITLE
media-gfx/photoqt: delete source /etc/env.d/02locale for LC_COLLATE

### DIFF
--- a/media-gfx/photoqt/photoqt-4.8.1.ebuild
+++ b/media-gfx/photoqt/photoqt-4.8.1.ebuild
@@ -93,12 +93,11 @@ src_configure() {
 src_test() {
 	local -x QT_QPA_PLATFORM=offscreen
 	# QCollator::setNumericMode is not supported w/ POSIX/C locale or w/o icu
-	# Unset and source LC_COLLATE from the current system locale.
+	# Set LC_COLLATE=en_US.utf8 if available.
 	# Required for PQCTest::getFoldersIn()
 	unset LC_COLLATE
-	source "${EPREFIX}"/etc/env.d/02locale
-	[[ -n "${LC_COLLATE}" ]] && export LC_COLLATE
-	"${BUILD_DIR}"/photoqt_test || die
+	locale -a | grep -iq "en_US.utf8" || die "locale en_US.utf8 not available, testsuite not launched"
+	LC_COLLATE="en_US.utf8" "${BUILD_DIR}"/photoqt_test || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
set LC_COLLATE=en_US.utf-8 if available for testsuite
C, C.utf-8 or POSIX don't support natural sorting here

Closes: https://bugs.gentoo.org/954370

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
