### PR TITLE
app-crypt/yubikey-manager: lock pyscard RDEPEND

### DIFF
--- a/app-crypt/yubikey-manager/yubikey-manager-5.5.1-r1.ebuild
+++ b/app-crypt/yubikey-manager/yubikey-manager-5.5.1-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+DISTUTILS_USE_PEP517=poetry
+
+inherit distutils-r1 verify-sig
+
+MY_PN="${PN/-/_}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Python library and command line tool for configuring a YubiKey"
+HOMEPAGE="https://developers.yubico.com/yubikey-manager/"
+# According to https://github.com/Yubico/yubikey-manager/issues/518 the release
+# tarballs on Yubico Web site and on GitHub should be identical, and at least
+# for recent releases the latter are signed as well. Only the automatically
+# generated "Source code (tar.gz)" tarballs should not be used.
+# Still, prefer the former if available.
+SRC_URI="https://developers.yubico.com/${PN}/Releases/${MY_P}.tar.gz
+	verify-sig? ( https://developers.yubico.com/${PN}/Releases/${MY_P}.tar.gz.sig )"
+
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv x86"
+IUSE="ssl"
+VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/yubico.com.asc"
+
+# app-crypt/ccid required for
+# - 'ykman oath'
+# - 'ykman openpgp'
+# - 'ykman piv'
+RDEPEND="
+	app-crypt/ccid
+	>=dev-python/click-8.0[${PYTHON_USEDEP}]
+	<dev-python/cryptography-45[${PYTHON_USEDEP}]
+	dev-python/fido2:0/1.0[${PYTHON_USEDEP}]
+	dev-python/keyring[${PYTHON_USEDEP}]
+	>=dev-python/pyscard-2.0[${PYTHON_USEDEP}]
+	<dev-python/pyscard-2.2.2[${PYTHON_USEDEP}]
+	ssl? ( >=dev-python/pyopenssl-0.15.1[${PYTHON_USEDEP}] )"
+BDEPEND="
+	test? ( dev-python/makefun[${PYTHON_USEDEP}] )
+	verify-sig? ( >=sec-keys/openpgp-keys-yubico-20240628 )"
+
+distutils_enable_tests pytest
+
+python_install_all() {
+	distutils-r1_python_install_all
+	doman man/ykman.1
+}

--- a/app-crypt/yubikey-manager/yubikey-manager-5.6.1-r1.ebuild
+++ b/app-crypt/yubikey-manager/yubikey-manager-5.6.1-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+DISTUTILS_USE_PEP517=poetry
+
+inherit distutils-r1 verify-sig
+
+MY_PN="${PN/-/_}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Python library and command line tool for configuring a YubiKey"
+HOMEPAGE="https://developers.yubico.com/yubikey-manager/"
+# According to https://github.com/Yubico/yubikey-manager/issues/518 the release
+# tarballs on Yubico Web site and on GitHub should be identical, and at least
+# for recent releases the latter are signed as well. Only the automatically
+# generated "Source code (tar.gz)" tarballs should not be used.
+# Still, prefer the former if available.
+SRC_URI="https://developers.yubico.com/${PN}/Releases/${MY_P}.tar.gz
+	verify-sig? ( https://developers.yubico.com/${PN}/Releases/${MY_P}.tar.gz.sig )"
+
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/yubico.com.asc"
+
+# app-crypt/ccid required for
+# - 'ykman oath'
+# - 'ykman openpgp'
+# - 'ykman piv'
+RDEPEND="
+	app-crypt/ccid
+	>=dev-python/click-8.0[${PYTHON_USEDEP}]
+	<dev-python/cryptography-45[${PYTHON_USEDEP}]
+	dev-python/fido2:0/1.0[${PYTHON_USEDEP}]
+	dev-python/keyring[${PYTHON_USEDEP}]
+	>=dev-python/pyscard-2.0[${PYTHON_USEDEP}]
+	<dev-python/pyscard-2.2.2[${PYTHON_USEDEP}]"
+BDEPEND="
+	test? ( dev-python/makefun[${PYTHON_USEDEP}] )
+	verify-sig? ( >=sec-keys/openpgp-keys-yubico-20240628 )"
+
+distutils_enable_tests pytest
+
+python_install_all() {
+	distutils-r1_python_install_all
+	doman man/ykman.1
+}


### PR DESCRIPTION
Lock pyscard to <2.2.2, new version not compatible: https://github.com/Yubico/yubikey-manager/commit/b951fcd0c6e916a5ccf751307b8dcdf71149b38a

Closes: https://bugs.gentoo.org/953840

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
