### PR TITLE
www-apps/tt-rss: drop mysql support, rm no-chmod patch for live, update PHP_USE

### DIFF
--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -10,11 +10,10 @@ HOMEPAGE="https://tt-rss.org/"
 EGIT_REPO_URI="https://git.tt-rss.org/fox/${PN}.git"
 LICENSE="GPL-3"
 SLOT="${PV}" # Single live slot.
-IUSE="+acl daemon gd +mysqli postgres"
-REQUIRED_USE="|| ( mysqli postgres )"
+IUSE="+acl daemon gd"
 
 PHP_SLOTS="8.4 8.3 8.2" # Check with: grep PHP_VERSION classes/Config.php
-PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
+PHP_USE="gd?,postgres,ctype,curl,fileinfo,filter,intl,pdo,tokenizer,unicode,xml"
 
 php_rdepend() {
 	local slot
@@ -50,9 +49,39 @@ DEPEND="
 
 need_httpd_cgi # From webapp.eclass
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-no-chmod.patch
-)
+pkg_pretend() {
+	if has_version www-apps/tt-rss[mysqli]; then
+		ewarn
+		ewarn "You are currently using tt-rss with mysql backend."
+		ewarn
+		ewarn "THIS IS NOT SUPPORTED ANYMORE."
+		ewarn
+		ewarn "Since 2025-04-14 tt-rss has dropped support for MySQL."
+		ewarn
+		ewarn "To upgrade, you need to migrate to PostgreSQL first."
+		ewarn
+		ewarn "Migrating between different tt-rss versions might work but is not recommended."
+		ewarn "It's recommended to switch to =www-apps/tt-rss-20250414 for migration."
+		ewarn
+		ewarn "Export/Import articles could be done with an official plugin:"
+		ewarn "ttrss-data-migration"
+		ewarn "For plugin installation and export/import, see:"
+		ewarn "https://gitlab.tt-rss.org/tt-rss/plugins/ttrss-data-migration"
+		ewarn
+		ewarn "Example of migration steps:"
+		ewarn "0. Setup PostgreSQL (dev-db/postgresql)"
+		ewarn "1. Backup !"
+		ewarn "2. Export settings/feeds (OPML)"
+		ewarn "3. Export articles (JSON) via ttrss-data-migration"
+		ewarn "4. Migrate to PostgreSQL backend changing USE flag mysqli to postgres"
+		ewarn "5. Emerge www-apps/tt-rss with new USE flag"
+		ewarn "6. Setup fresh install of tt-rss with PostgreSQL backend"
+		ewarn "7. Import settings/feeds (OPML)"
+		ewarn "8. Import articles"
+		ewarn
+		die "MySQL backend not supported anymore"
+	fi
+}
 
 src_install() {
 	webapp_src_preinst


### PR DESCRIPTION
chmod removed by upstream :
https://gitlab.tt-rss.org/tt-rss/tt-rss/-/commit/be82663ac9b59de8a135178a519efe9f7ebae213

update PHP_USE (from composer.lock) :
json is no longer an useflag since dev-lang/php-8
add ctype, filter, tokenizer

drop mysql support

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
