### PR TITLE
x11-misc/sunflower: enable py3.13

### DIFF
--- a/x11-misc/sunflower/sunflower-0.5-r3.ebuild
+++ b/x11-misc/sunflower/sunflower-0.5-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="sqlite"
 DISTUTILS_USE_PEP517="setuptools"
 inherit distutils-r1 xdg
@@ -16,6 +16,7 @@ HOMEPAGE="https://github.com/MeanEYE/Sunflower
 	https://sunflower-fm.org/"
 SRC_URI="https://github.com/MeanEYE/${MY_PN}/archive/refs/tags/${MY_PV}.tar.gz"
 
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 x86"
@@ -30,8 +31,6 @@ RDEPEND="${DEPEND}
 	dev-python/pycairo[${PYTHON_USEDEP}]
 	x11-libs/vte:2.91
 "
-
-S="${WORKDIR}/${MY_PN}-${MY_PV}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
No meaningful test suite, however passes runtime check.

Closes: https://bugs.gentoo.org/952777

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
