### PR TITLE
x11-misc/py3status: update EAPI 7 -> 8, Add  py3_13

### DIFF
--- a/x11-misc/py3status/py3status-3.61.ebuild
+++ b/x11-misc/py3status/py3status-3.61.ebuild
@@ -1,10 +1,12 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
-PYTHON_COMPAT=( python{3_9,3_10,3_11,3_12} )
+EAPI=8
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=hatchling
 
+DESCRIPTION="py3status is an extensible i3status wrapper written in python"
+HOMEPAGE="https://github.com/ultrabug/py3status"
 SRC_URI="https://github.com/ultrabug/py3status/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 inherit distutils-r1
@@ -12,9 +14,7 @@ inherit distutils-r1
 MY_PN="py3status"
 MY_P="${MY_PN}-${PV/_/-}"
 
-DESCRIPTION="py3status is an extensible i3status wrapper written in python"
-HOMEPAGE="https://github.com/ultrabug/py3status"
-
+S=${WORKDIR}/${MY_P}
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
@@ -29,5 +29,3 @@ RDEPEND="
 	udev? ( >=dev-python/pyudev-0.21.0[${PYTHON_USEDEP}] )
 "
 DEPEND="${RDEPEND}"
-
-S=${WORKDIR}/${MY_P}


### PR DESCRIPTION
Passes runtime test and general ebuild cleanup.

Closes: https://bugs.gentoo.org/952772

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
