### PR TITLE
app-arch/rpm: fix infodir and mandir macros

### DIFF
--- a/app-arch/rpm/rpm-4.20.1-r1.ebuild
+++ b/app-arch/rpm/rpm-4.20.1-r1.ebuild
@@ -105,6 +105,10 @@ src_configure() {
 		-DWITH_ZSTD=$(usex zstd)
 		-DWITH_LIBLZMA=$(usex lzma)
 		-DWITH_DOXYGEN=$(usex doc)
+		# Upstream expects these paths to be relative, but cmake.eclass
+		# sets them as absolute paths. bug #954379
+		-DCMAKE_INSTALL_INFODIR=share/info
+		-DCMAKE_INSTALL_MANDIR=share/man
 	)
 
 	# special handling for ASAN


### PR DESCRIPTION
By default, infodir and mandir macros are set to
`\${prefix}/${CMAKE_INSTALL_*DIR}`, assuming ${CMAKE_INSTALL_*DIR} are relative paths, but cmake.eclass sets them to absolute paths including prefix.

Closes: https://bugs.gentoo.org/954379

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
