### PR TITLE
games-arcade/asteroid: update EAPI 7 -> 8, fix build with gcc 15, cmake 4

### DIFF
--- a/games-arcade/asteroid/asteroid-1.2.1-r1.ebuild
+++ b/games-arcade/asteroid/asteroid-1.2.1-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Modern version of the arcade classic that uses OpenGL"
+HOMEPAGE="https://chazomaticus.github.io/asteroid/"
+SRC_URI="https://github.com/chazomaticus/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	media-libs/freeglut
+	media-libs/libsdl
+	media-libs/sdl-mixer
+	virtual/glu
+	virtual/opengl
+	x11-libs/gtk+:2
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libm.patch
+	"${FILESDIR}"/${P}-cmake4.patch
+	"${FILESDIR}"/${P}-gcc15.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DOpenGL_GL_PREFERENCE=GLVND
+	)
+	cmake_src_configure
+}

--- a/games-arcade/asteroid/files/asteroid-1.2.1-cmake4.patch
+++ b/games-arcade/asteroid/files/asteroid-1.2.1-cmake4.patch
@@ -1,0 +1,12 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,8 +1,8 @@
++cmake_minimum_required(VERSION 3.31)
+ project(Asteroid)
+ set(Asteroid_BUILD_VERSION "1.2.1")
+ 
+ # Dependencies
+-cmake_minimum_required(VERSION 2.6)
+ find_package(OpenGL REQUIRED)
+ if(NOT OPENGL_FOUND)
+    message(FATAL_ERROR "Error: OpenGL not found")

--- a/games-arcade/asteroid/files/asteroid-1.2.1-gcc15.patch
+++ b/games-arcade/asteroid/files/asteroid-1.2.1-gcc15.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/944250
+
+--- a/src/main.c
++++ b/src/main.c
+@@ -244,7 +244,7 @@ void GameTimer(int v)
+ }
+ 
+ #ifdef CFG_GTK
+-static gboolean DisplayDialog()
++static gboolean DisplayDialog(void* a)
+ {
+    GtkWidget * dialog = gtk_message_dialog_new(NULL,
+       GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK, ASTEROIDS_ABOUT);


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/944250

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
