### PR TITLE
media-fonts/terminus-font: enable py3.13

### DIFF
--- a/media-fonts/terminus-font/terminus-font-4.49.1-r2.ebuild
+++ b/media-fonts/terminus-font/terminus-font-4.49.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit font python-any-r1
 


### PR DESCRIPTION
No test suites are included but font package installs and runs correctly at runtime.

Closes: https://bugs.gentoo.org/946301

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
