### PR TITLE
dev-libs/nss: fix calling shlibsign from pkg_postinst

### DIFF
--- a/dev-libs/nss/nss-3.101.2.ebuild
+++ b/dev-libs/nss/nss-3.101.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -395,6 +395,20 @@ multilib_src_install() {
 }
 
 pkg_postinst() {
+	if [[ -n "${ROOT}" ]]; then
+		elog "You appear to to be installing in a seperate \$ROOT"
+		elog "to complete the setup and re-sign libraries please run:"
+		elog "emerge --config '=${CATEGORY}/${PF}'"
+	else
+		sign_libraries
+	fi
+}
+
+pkg_config() {
+	sign_libraries
+}
+
+sign_libraries() {
 	multilib_pkg_postinst() {
 		# We must re-sign the libraries AFTER they are stripped.
 		local shlibsign="${EROOT}/usr/bin/shlibsign"

--- a/dev-libs/nss/nss-3.101.3.ebuild
+++ b/dev-libs/nss/nss-3.101.3.ebuild
@@ -396,6 +396,20 @@ multilib_src_install() {
 }
 
 pkg_postinst() {
+	if [[ -n "${ROOT}" ]]; then
+		elog "You appear to to be installing in a seperate \$ROOT"
+		elog "to complete the setup and re-sign libraries please run:"
+		elog "emerge --config '=${CATEGORY}/${PF}'"
+	else
+		sign_libraries
+	fi
+}
+
+pkg_config() {
+	sign_libraries
+}
+
+sign_libraries() {
 	multilib_pkg_postinst() {
 		# We must re-sign the libraries AFTER they are stripped.
 		local shlibsign="${EROOT}/usr/bin/shlibsign"

--- a/dev-libs/nss/nss-3.110.ebuild
+++ b/dev-libs/nss/nss-3.110.ebuild
@@ -406,6 +406,20 @@ multilib_src_install() {
 }
 
 pkg_postinst() {
+	if [[ -n "${ROOT}" ]]; then
+		elog "You appear to to be installing in a seperate \$ROOT"
+		elog "to complete the setup and re-sign libraries please run:"
+		elog "emerge --config '=${CATEGORY}/${PF}'"
+	else
+		sign_libraries
+	fi
+}
+
+pkg_config() {
+	sign_libraries
+}
+
+sign_libraries() {
 	multilib_pkg_postinst() {
 		# We must re-sign the libraries AFTER they are stripped.
 		local shlibsign="${EROOT}/usr/bin/shlibsign"


### PR DESCRIPTION
Fixes [954224](https://bugs.gentoo.org/954224)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

dev-libs/nss
  UnstableOnly: for arch: [ hppa ], all versions are unstable: [ 3.101.2, 3.101.3, 3.110 ]
  StaticSrcUri: version 3.101.2: '3.101' in SRC_URI, replace with $(ver_cut 1-2)
  VariableOrderWrong: version 3.101.2: variable S should occur before RESTRICT
  LaggingStable: version 3.101.3: slot(0), stabled arches: [ amd64, arm, arm64, ppc, ppc64, x86 ], lagging: [ ~sparc ]
  PotentialStable: version 3.101.3: slot(0), stabled arches: [ amd64, arm, arm64, ppc, ppc64, x86 ], potential: [ ~hppa ]
  StaticSrcUri: version 3.101.3: '3.101' in SRC_URI, replace with $(ver_cut 1-2)
  VariableOrderWrong: version 3.101.3: variable S should occur before RESTRICT
  VariableOrderWrong: version 3.110: variable S should occur before RESTRICT
  RedirectedUrl: version 3.110: HOMEPAGE: permanently redirected: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS -> https://firefox-source-docs.mozilla.org/security/nss/index.html
  IncorrectCopyright: version 3.101.2: incorrect copyright year 2024: '# Copyright 1999-2024 Gentoo Authors'
