### PR TITLE
gstreamer-meson.eclass: enable py3.13

### DIFF
--- a/eclass/gstreamer-meson.eclass
+++ b/eclass/gstreamer-meson.eclass
@@ -35,7 +35,7 @@ case "${EAPI:-0}" in
 		;;
 esac
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 [[ ${EAPI} == 8 ]] && inherit python-any-r1
 
 # multilib-minimal goes last


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951610

Tested by running test+builds on all users. Only encountered unrelated test failures (media-libs/gst-rtsp-server, media-plugins/gst-plugins-libav, media-libs/gst-plugins-good, media-libs/gst-plugins-bad and media-libs/gst-plugins-base)

I don't think this needs mailing list review?

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
