### PR TITLE
net-news/yydecode: fix build with gcc 15

### DIFF
--- a/net-news/yydecode/files/yydecode-0.2.10-gcc15.patch
+++ b/net-news/yydecode/files/yydecode-0.2.10-gcc15.patch
@@ -1,0 +1,12 @@
+https://bugs.gentoo.org/944985
+
+--- a/src/error.c
++++ b/src/error.c
+@@ -56,7 +56,6 @@ void exit ();
+ extern char *program_name;
+ 
+ #ifdef HAVE_STRERROR
+-char *strerror ();
+ #else
+ extern char *sys_errlist[];
+ extern int sys_nerr;

--- a/net-news/yydecode/yydecode-0.2.10-r4.ebuild
+++ b/net-news/yydecode/yydecode-0.2.10-r4.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="A decoder for yENC format, popular on Usenet"
+HOMEPAGE="https://yydecode.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/yydecode/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.2.10-fix-strcmp-not-found.patch
+	"${FILESDIR}"/${PN}-0.2.10-gcc15.patch
+)
+
+src_prepare() {
+	default
+
+	# https://bugs.gentoo.org/277307
+	sed -e "s/t3.sh//" -e "s/t7.sh//" -i checks/Makefile.in checks/Makefile.am || die
+
+	eautoreconf
+}
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/898078
+	#
+	# Upstream has been dead since 2003. No bug reported.
+	filter-lto
+	default
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/944985

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
