### PR TITLE
app-text/sword: skip cppcheck tests

### DIFF
--- a/app-text/sword/sword-1.9.0-r2.ebuild
+++ b/app-text/sword/sword-1.9.0-r2.ebuild
@@ -36,6 +36,8 @@ DOCS=( AUTHORS CODINGSTYLE ChangeLog README examples/ samples/ )
 
 src_configure() {
 	local mycmakeargs=(
+		# skip unnecessary tests, bug #954771
+		-DCMAKE_DISABLE_FIND_PACKAGE_cppcheck="ON"
 		-DCMAKE_SKIP_RPATH="ON"
 		# default is shared and static
 		-DLIBSWORD_LIBRARY_TYPE="Shared"


### PR DESCRIPTION
cppcheck fails to run :
arg "--template gcc" should be "--template=gcc" in cmake/Findcppcheck.cmake

But we don't really want such tests, so let's skip it.

Closes: https://bugs.gentoo.org/954771

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
