### PR TITLE
dev-java/tapestry-json: Depend '--build-only' on slf4j-api #954809

### DIFF
--- a/dev-java/tapestry-json/tapestry-json-5.8.7-r1.ebuild
+++ b/dev-java/tapestry-json/tapestry-json-5.8.7-r1.ebuild
@@ -35,7 +35,7 @@ JAVA_SRC_DIR="tapestry-json/src/main/java"
 src_compile() {
 	# build classes needed for compilation
 	ejavac -d target/deps \
-		-cp "$(java-pkg_getjars slf4j-api)" \
+		-cp "$(java-pkg_getjars --build-only slf4j-api)" \
 		$(find \
 			commons/src/main/java \
 			plastic-asm/src/main/java \


### PR DESCRIPTION
The wrong line in /usr/share/tapestry-json/package.env was caused by calling java-pkg_getjars without the '--build-only' option.

Closes: https://bugs.gentoo.org/954809

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
