### PR TITLE
dev-libs/blazesym_c: address QA warning regarding LDFLAGS

### DIFF
--- a/dev-libs/blazesym_c/blazesym_c-0.1.1.ebuild
+++ b/dev-libs/blazesym_c/blazesym_c-0.1.1.ebuild
@@ -38,12 +38,17 @@ LICENSE+="
 SLOT="0"
 KEYWORDS="~amd64"
 
-# many failures (WIP)
+# Currently suffers from (at least):
+# - problems with crate tarball
+# - hardcoded/hand-rolled multilib assumptions
+# - possibly sandbox
 RESTRICT="test"
 
 BDEPEND="
 	dev-util/cargo-c
 "
+
+QA_FLAGS_IGNORED="usr/lib64/libblazesym_c.so.${PV}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Also clarify comment about test restrictions.

Closes: https://bugs.gentoo.org/954808
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
