### PR TITLE
sci-chemistry/molsketch: fix build with openbabel-3.1.1_p20241221

### DIFF
--- a/sci-chemistry/molsketch/files/molsketch-0.8.1-obabel_namespace.patch
+++ b/sci-chemistry/molsketch/files/molsketch-0.8.1-obabel_namespace.patch
@@ -1,0 +1,37 @@
+https://github.com/hvennekate/Molsketch/pull/17.patch
+
+From b3ecbef4766591dea4f8349c70f14cfb67d7400b Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Mon, 28 Apr 2025 19:25:24 +0000
+Subject: [PATCH] fix namespace for obabeliface
+
+openbabel has changed namespaces :
+https://github.com/openbabel/openbabel/commit/a0ec8c96554d4ee4f9bf80b00165b1ce554c8621
+
+> Molsketch-0.8.1/obabeliface/obabeliface.cpp:199:5: error: use of undeclared identifier 'impl'; did you mean 'OpenBabel::impl'?
+>  199 |     FOR_ATOMS_OF_MOL(obatom, molecule) {
+>      |     ^
+> /usr/include/openbabel3/openbabel/obiter.h:417:49: note: expanded from macro 'FOR_ATOMS_OF_MOL'
+>  417 | #define FOR_ATOMS_OF_MOL(a,m)     for (auto a : impl::MolGetAtoms(m))
+>      |                                                 ^
+> /usr/include/openbabel3/openbabel/obiter.h:401:13: note: 'OpenBabel::impl' declared here
+>  401 |   namespace impl {
+>      |             ^
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+---
+ obabeliface/obabeliface.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/obabeliface/obabeliface.cpp b/obabeliface/obabeliface.cpp
+index 029f4e3..fad553a 100644
+--- a/obabeliface/obabeliface.cpp
++++ b/obabeliface/obabeliface.cpp
+@@ -190,6 +190,7 @@ namespace Molsketch
+ 
+   // TODO should be const, but OpenBabel iterator methods do not support const
+   bool hasCoordinates(OpenBabel::OBMol &molecule) {
++    using namespace OpenBabel;
+     FOR_ATOMS_OF_MOL(obatom, molecule) {
+       if (obatom->GetVector() != OpenBabel::VZero)
+         return true;

--- a/sci-chemistry/molsketch/molsketch-0.8.1.ebuild
+++ b/sci-chemistry/molsketch/molsketch-0.8.1.ebuild
@@ -25,6 +25,8 @@ BDEPEND="dev-qt/qttools:6[linguist]"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.3.0-_DEFAULT_SOURCE.patch
+	# bug #955047, https://github.com/hvennekate/Molsketch/pull/17
+	"${FILESDIR}"/${PN}-0.8.1-obabel_namespace.patch
 )
 
 src_configure() {


### PR DESCRIPTION
it occurs only with openbabel-3.1.1_p20241221, because openbabel has changed namespaces :
https://github.com/openbabel/openbabel/commit/a0ec8c96554d4ee4f9bf80b00165b1ce554c8621

Closes: https://bugs.gentoo.org/955047

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
