### PR TITLE
app-editors/pyvim: enable py3.13

### DIFF
--- a/app-editors/pyvim/pyvim-3.0.3.ebuild
+++ b/app-editors/pyvim/pyvim-3.0.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 edo
 
@@ -13,8 +13,8 @@ HOMEPAGE="https://pypi.org/project/pyvim/ https://github.com/prompt-toolkit/pyvi
 SRC_URI="https://github.com/prompt-toolkit/${PN}/archive/${COMMIT}.tar.gz -> ${P}.gh.tar.gz"
 S="${WORKDIR}/${PN}-${COMMIT}"
 
-SLOT="0"
 LICENSE="BSD"
+SLOT="0"
 KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="


### PR DESCRIPTION
Minor QA fixes to ebuild included and added py3_13 with test suite pass.

Closes: https://bugs.gentoo.org/952191

```
tests/test_substitute.py::test_substitute_current_line PASSED                   [ 1/13]
tests/test_substitute.py::test_substitute_single_line PASSED                    [ 2/13]
tests/test_substitute.py::test_substitute_range PASSED                          [ 3/13]
tests/test_substitute.py::test_substitute_range_boundaries PASSED               [ 4/13]
tests/test_substitute.py::test_substitute_from_search_history PASSED            [ 5/13]
tests/test_substitute.py::test_substitute_from_substitute_search_history PASSED [ 6/13]
tests/test_substitute.py::test_substitute_with_repeat_last_substitution PASSED  [ 7/13]
tests/test_substitute.py::test_substitute_without_replacement_text PASSED       [ 8/13]
tests/test_substitute.py::test_substitute_with_repeat_last_substitution_without_previous_substitution PASSED [ 9/13]
tests/test_substitute.py::test_substitute_flags_empty_flags PASSED              [10/13]
tests/test_substitute.py::test_substitute_flags_g PASSED                        [11/13]
tests/test_window_arrangements.py::test_initial PASSED                          [12/13]
tests/test_window_arrangements.py::test_vsplit PASSED                           [13/13]
```

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
