### PR TITLE
app-emacs/emacs-ipython-notebook: enable py3.13

### DIFF
--- a/app-emacs/emacs-ipython-notebook/emacs-ipython-notebook-0.17.1_pre20230826.ebuild
+++ b/app-emacs/emacs-ipython-notebook/emacs-ipython-notebook-0.17.1_pre20230826.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # NOTICE: Check package version in "lisp/ein-pkg.el".
@@ -7,7 +7,7 @@
 EAPI=8
 
 [[ "${PV}" == *20230826 ]] && COMMIT=998ba22660be2035cd23bed1555e47748c4da8a2
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit elisp readme.gentoo-r1 python-single-r1
 
@@ -17,8 +17,8 @@ SRC_URI="https://github.com/millejoh/${PN}/archive/${COMMIT}.tar.gz -> ${P}.tar.
 S="${WORKDIR}"/${PN}-${COMMIT}
 
 LICENSE="GPL-3+"
-KEYWORDS="~amd64 ~x86"
 SLOT="0"
+KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"


### PR DESCRIPTION
Minor QA clean up and enabled py3.13 with passed test suite tests.

Closes: https://bugs.gentoo.org/952195

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
