### PR TITLE
dev-tex/biblatex: missing texlive-luatex dependency for doc use flag

### DIFF
--- a/dev-tex/biblatex/biblatex-3.20-r1.ebuild
+++ b/dev-tex/biblatex/biblatex-3.20-r1.ebuild
@@ -28,6 +28,7 @@ PDEPEND="biber? ( ~dev-tex/biber-2.$(ver_cut 2) )"
 # corefonts for "Courier New"
 BDEPEND="
 	doc? (
+		dev-texlive/texlive-luatex
 		media-fonts/corefonts
 		virtual/latex-base
 	)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951127
Fixes: 42c855fd2687e39bd37635ad639dfa36f4c7a88f

CC: @Flowdalic 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
