### PR TITLE
games-strategy/hedgewars: various fixes

### DIFF
--- a/games-strategy/hedgewars/files/hedgewars-1.0.2-clang-15.patch
+++ b/games-strategy/hedgewars/files/hedgewars-1.0.2-clang-15.patch
@@ -1,0 +1,21 @@
+
+# HG changeset patch
+# User LocutusOfBorg
+# Date 1663951667 14400
+# Node ID 6cb7330113d8960151c1f5db396859c539079e34
+# Parent  1878d95d6e15a655a4fa06848987b5c032c8c692
+Fix clang-15 compile error
+
+diff -r 1878d95d6e15 -r 6cb7330113d8 project_files/hwc/rtl/sysutils.c
+--- a/project_files/hwc/rtl/sysutils.c	Fri Sep 23 02:45:49 2022 +0300
++++ b/project_files/hwc/rtl/sysutils.c	Fri Sep 23 12:47:47 2022 -0400
+@@ -83,7 +83,7 @@
+ // Semi-dummy implementation of FormatDateTime
+ string255 fpcrtl_formatDateTime(string255 FormatStr, TDateTime DateTime)
+ {
+-    string255 buffer = STRINIT(FormatStr.str);
++    string255 buffer = FormatStr;
+     time_t rawtime;
+     struct tm* my_tm;
+ 
+

--- a/games-strategy/hedgewars/files/hedgewars-1.0.2-ffmpeg-6.patch
+++ b/games-strategy/hedgewars/files/hedgewars-1.0.2-ffmpeg-6.patch
@@ -1,0 +1,455 @@
+
+# HG changeset patch
+# User Pekka Ristola <pekkarr@protonmail.com>
+# Date 1738001285 -3600
+# Node ID dbdb98dafd804263cc271628433015bd59b8adeb
+# Parent  b68e513d14160683f8c8d4b85031b12af3fac45b
+Add support for ffmpeg 6.0
+- Use the new send_frame/receive_packet API for encoding
+- Use the new channel layout API for audio
+- Fix audio recording
+  - Copy codec parameters to the stream parameters
+  - Set correct pts for audio frames
+- Read audio samples from file directly to the refcounted AVFrame buffer instead of the `g_pSamples` buffer
+- Use global AVPackets allocated with `av_packet_alloc`
+- Stop trying to write more audio frames when `WriteAudioFrame` fails with a negative error code
+- Fix segfault with `g_pContainer->url`. The field has to be allocated with `av_malloc` before writing to it. It's set to `NULL` by default.
+- Properly free allocations with `avcodec_free_context` and `avformat_free_context`
+
+diff -r b68e513d1416 -r dbdb98dafd80 hedgewars/avwrapper/avwrapper.c
+--- a/hedgewars/avwrapper/avwrapper.c	Mon Jan 13 11:39:58 2025 +0100
++++ b/hedgewars/avwrapper/avwrapper.c	Mon Jan 27 19:08:05 2025 +0100
+@@ -42,15 +42,19 @@
+ #define UNUSED(x) (void)(x)
+ 
+ static AVFormatContext* g_pContainer;
+-static AVOutputFormat* g_pFormat;
++static const AVOutputFormat* g_pFormat;
+ static AVStream* g_pAStream;
+ static AVStream* g_pVStream;
+ static AVFrame* g_pAFrame;
+ static AVFrame* g_pVFrame;
+-static AVCodec* g_pACodec;
+-static AVCodec* g_pVCodec;
++static const AVCodec* g_pACodec;
++static const AVCodec* g_pVCodec;
+ static AVCodecContext* g_pAudio;
+ static AVCodecContext* g_pVideo;
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++static AVPacket* g_pAPacket;
++static AVPacket* g_pVPacket;
++#endif
+ 
+ static int g_Width, g_Height;
+ static uint32_t g_Frequency, g_Channels;
+@@ -58,8 +62,13 @@
+ static AVRational g_Framerate;
+ 
+ static FILE* g_pSoundFile;
++#if LIBAVUTIL_VERSION_MAJOR < 53
+ static int16_t* g_pSamples;
++#endif
+ static int g_NumSamples;
++#if LIBAVCODEC_VERSION_MAJOR >= 53
++static int64_t g_NextAudioPts;
++#endif
+ 
+ 
+ // compatibility section
+@@ -93,6 +102,8 @@
+     if (pkt->duration > 0)
+         pkt->duration = av_rescale_q(pkt->duration, ctb, stb);
+ }
++
++#define avcodec_free_context(ctx)           do { avcodec_close(*ctx); av_freep(ctx); } while (0)
+ #endif
+ 
+ #ifndef AV_CODEC_CAP_DELAY
+@@ -165,8 +176,42 @@
+     AddFileLogRaw(Buffer);
+ }
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++static int EncodeAndWriteFrame(
++        const AVStream* pStream,
++        AVCodecContext* pCodecContext,
++        const AVFrame* pFrame,
++        AVPacket* pPacket)
++{
++    int ret;
++
++    ret = avcodec_send_frame(pCodecContext, pFrame);
++    if (ret < 0)
++        return FatalError("avcodec_send_frame failed: %d", ret);
++    while (1)
++    {
++        ret = avcodec_receive_packet(pCodecContext, pPacket);
++        if (ret == AVERROR(EAGAIN))
++            return 1;
++        else if (ret == AVERROR_EOF)
++            return 0;
++        else if (ret < 0)
++            return FatalError("avcodec_receive_packet failed: %d", ret);
++
++        av_packet_rescale_ts(pPacket, pCodecContext->time_base, pStream->time_base);
++
++        // Write the compressed frame to the media file.
++        pPacket->stream_index = pStream->index;
++        ret = av_interleaved_write_frame(g_pContainer, pPacket);
++        if (ret != 0)
++            return FatalError("Error while writing frame: %d", ret);
++    }
++}
++#endif
++
+ static void AddAudioStream()
+ {
++    int ret;
+     g_pAStream = avformat_new_stream(g_pContainer, g_pACodec);
+     if(!g_pAStream)
+     {
+@@ -176,20 +221,44 @@
+     g_pAStream->id = 1;
+ 
+ #if LIBAVCODEC_VERSION_MAJOR >= 59
+-    const AVCodec *audio_st_codec = avcodec_find_decoder(g_pAStream->codecpar->codec_id);
+-    g_pAudio = avcodec_alloc_context3(audio_st_codec);
+-    avcodec_parameters_to_context(g_pAudio, g_pAStream->codecpar);
++    g_pAudio = avcodec_alloc_context3(g_pACodec);
+ #else
+     g_pAudio = g_pAStream->codec;
+-#endif
+ 
+     avcodec_get_context_defaults3(g_pAudio, g_pACodec);
+     g_pAudio->codec_id = g_pACodec->id;
++#endif
+ 
+     // put parameters
+     g_pAudio->sample_fmt = AV_SAMPLE_FMT_S16;
+     g_pAudio->sample_rate = g_Frequency;
++#if LIBAVCODEC_VERSION_MAJOR >= 60
++    const AVChannelLayout* pChLayout = g_pACodec->ch_layouts;
++    if (pChLayout)
++    {
++        for (; pChLayout->nb_channels; pChLayout++)
++        {
++            if (pChLayout->nb_channels == g_Channels)
++            {
++                ret = av_channel_layout_copy(&g_pAudio->ch_layout, pChLayout);
++                if (ret != 0)
++                {
++                    Log("Channel layout copy failed: %d\n", ret);
++                    return;
++                }
++                break;
++            }
++        }
++    }
++    if (!g_pAudio->ch_layout.nb_channels)
++    {
++        // no suitable layout found
++        g_pAudio->ch_layout.order = AV_CHANNEL_ORDER_UNSPEC;
++        g_pAudio->ch_layout.nb_channels = g_Channels;
++    }
++#else
+     g_pAudio->channels = g_Channels;
++#endif
+ 
+     // set time base as invers of sample rate
+     g_pAudio->time_base.den = g_pAStream->time_base.den = g_Frequency;
+@@ -213,6 +282,15 @@
+         return;
+     }
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    ret = avcodec_parameters_from_context(g_pAStream->codecpar, g_pAudio);
++    if (ret < 0)
++    {
++        Log("Could not copy parameters from codec context: %d\n", ret);
++        return;
++    }
++#endif
++
+ #if LIBAVCODEC_VERSION_MAJOR >= 54
+     if (g_pACodec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE)
+ #else
+@@ -221,13 +299,46 @@
+         g_NumSamples = 4096;
+     else
+         g_NumSamples = g_pAudio->frame_size;
+-    g_pSamples = (int16_t*)av_malloc(g_NumSamples*g_Channels*sizeof(int16_t));
+     g_pAFrame = av_frame_alloc();
+     if (!g_pAFrame)
+     {
+         Log("Could not allocate frame\n");
+         return;
+     }
++#if LIBAVUTIL_VERSION_MAJOR >= 53
++#if LIBAVCODEC_VERSION_MAJOR >= 60
++    ret = av_channel_layout_copy(&g_pAFrame->ch_layout, &g_pAudio->ch_layout);
++    if (ret != 0)
++    {
++        Log("Channel layout copy for frame failed: %d\n", ret);
++        return;
++    }
++#else
++    g_pAFrame->channels = g_pAudio->channels;
++#endif
++    g_pAFrame->format = g_pAudio->sample_fmt;
++    g_pAFrame->sample_rate = g_pAudio->sample_rate;
++    g_pAFrame->nb_samples = g_NumSamples;
++    ret = av_frame_get_buffer(g_pAFrame, 1);
++    if (ret < 0)
++    {
++        Log("Failed to allocate frame buffer: %d\n", ret);
++        return;
++    }
++#else
++    g_pSamples = (int16_t*)av_malloc(g_NumSamples*g_Channels*sizeof(int16_t));
++#endif
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    g_pAPacket = av_packet_alloc();
++    if (!g_pAPacket)
++    {
++        Log("Could not allocate audio packet\n");
++        return;
++    }
++#endif
++#if LIBAVCODEC_VERSION_MAJOR >= 53
++    g_NextAudioPts = 0;
++#endif
+ }
+ 
+ // returns non-zero if there is more sound, -1 in case of error
+@@ -236,22 +347,46 @@
+     if (!g_pAStream)
+         return 0;
+ 
+-    AVPacket Packet;
+-    av_init_packet(&Packet);
+-    Packet.data = NULL;
+-    Packet.size = 0;
++    int ret;
++    int16_t* pData;
++#if LIBAVUTIL_VERSION_MAJOR >= 53
++    ret = av_frame_make_writable(g_pAFrame);
++    if (ret < 0)
++        return FatalError("Could not make audio frame writable: %d", ret);
++    pData = (int16_t*) g_pAFrame->data[0];
++#else
++    pData = g_pSamples;
++#endif
+ 
+-    int NumSamples = fread(g_pSamples, 2*g_Channels, g_NumSamples, g_pSoundFile);
++    int NumSamples = fread(pData, 2*g_Channels, g_NumSamples, g_pSoundFile);
+ 
+ #if LIBAVCODEC_VERSION_MAJOR >= 53
+     AVFrame* pFrame = NULL;
+     if (NumSamples > 0)
+     {
+         g_pAFrame->nb_samples = NumSamples;
++        g_pAFrame->pts = g_NextAudioPts;
++        g_NextAudioPts += NumSamples;
++#if LIBAVUTIL_VERSION_MAJOR < 53
+         avcodec_fill_audio_frame(g_pAFrame, g_Channels, AV_SAMPLE_FMT_S16,
+-                                 (uint8_t*)g_pSamples, NumSamples*2*g_Channels, 1);
++                                 (uint8_t*)pData, NumSamples*2*g_Channels, 1);
++#endif
+         pFrame = g_pAFrame;
+     }
++#endif
++
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    ret = EncodeAndWriteFrame(g_pAStream, g_pAudio, pFrame, g_pAPacket);
++    if (ret < 0)
++        return FatalError("Audio frame processing failed");
++    return ret;
++#else
++    AVPacket Packet;
++    av_init_packet(&Packet);
++    Packet.data = NULL;
++    Packet.size = 0;
++
++#if LIBAVCODEC_VERSION_MAJOR >= 53
+     // when NumSamples == 0 we still need to call encode_audio2 to flush
+     int got_packet;
+     if (avcodec_encode_audio2(g_pAudio, &Packet, pFrame, &got_packet) != 0)
+@@ -266,7 +401,7 @@
+     int BufferSize = OUTBUFFER_SIZE;
+     if (g_pAudio->frame_size == 0)
+         BufferSize = NumSamples*g_Channels*2;
+-    Packet.size = avcodec_encode_audio(g_pAudio, g_OutBuffer, BufferSize, g_pSamples);
++    Packet.size = avcodec_encode_audio(g_pAudio, g_OutBuffer, BufferSize, pData);
+     if (Packet.size == 0)
+         return 1;
+     if (g_pAudio->coded_frame && g_pAudio->coded_frame->pts != AV_NOPTS_VALUE)
+@@ -280,25 +415,25 @@
+     if (av_interleaved_write_frame(g_pContainer, &Packet) != 0)
+         return FatalError("Error while writing audio frame");
+     return 1;
++#endif
+ }
+ 
+ // add a video output stream
+ static int AddVideoStream()
+ {
++    int ret;
+     g_pVStream = avformat_new_stream(g_pContainer, g_pVCodec);
+     if (!g_pVStream)
+         return FatalError("Could not allocate video stream");
+ 
+ #if LIBAVCODEC_VERSION_MAJOR >= 59
+-    const AVCodec *video_st_codec = avcodec_find_decoder(g_pVStream->codecpar->codec_id);
+-    g_pVideo = avcodec_alloc_context3(video_st_codec);
+-    avcodec_parameters_to_context(g_pVideo, g_pVStream->codecpar);
++    g_pVideo = avcodec_alloc_context3(g_pVCodec);
+ #else
+     g_pVideo = g_pVStream->codec;
+-#endif
+ 
+     avcodec_get_context_defaults3(g_pVideo, g_pVCodec);
+     g_pVideo->codec_id = g_pVCodec->id;
++#endif
+ 
+     // put parameters
+     // resolution must be a multiple of two
+@@ -361,6 +496,12 @@
+     if (avcodec_open2(g_pVideo, g_pVCodec, NULL) < 0)
+         return FatalError("Could not open video codec %s", g_pVCodec->long_name);
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    ret = avcodec_parameters_from_context(g_pVStream->codecpar, g_pVideo);
++    if (ret < 0)
++        return FatalError("Could not copy parameters from codec context: %d", ret);
++#endif
++
+     g_pVFrame = av_frame_alloc();
+     if (!g_pVFrame)
+         return FatalError("Could not allocate frame");
+@@ -370,6 +511,12 @@
+     g_pVFrame->height = g_Height;
+     g_pVFrame->format = AV_PIX_FMT_YUV420P;
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    g_pVPacket = av_packet_alloc();
++    if (!g_pVPacket)
++        return FatalError("Could not allocate packet");
++#endif
++
+     return avcodec_default_get_buffer2(g_pVideo, g_pVFrame, 0);
+ }
+ 
+@@ -380,6 +527,10 @@
+     // write interleaved audio frame
+     if (g_pAStream)
+     {
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++        if (!g_pAPacket)
++            return FatalError("Error while writing video frame: g_pAPacket does not exist");
++#endif
+         VideoTime = (double)g_pVFrame->pts * g_pVStream->time_base.num/g_pVStream->time_base.den;
+         do
+         {
+@@ -388,7 +539,7 @@
+             AudioTime = (double)g_pAFrame->pts * g_pAStream->time_base.num/g_pAStream->time_base.den;
+             ret = WriteAudioFrame();
+         }
+-        while (AudioTime < VideoTime && ret);
++        while (AudioTime < VideoTime && ret > 0);
+         if (ret < 0)
+             return ret;
+     }
+@@ -396,13 +547,18 @@
+     if (!g_pVStream)
+         return 0;
+ 
++    g_pVFrame->pts++;
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++    ret = EncodeAndWriteFrame(g_pVStream, g_pVideo, pFrame, g_pVPacket);
++    if (ret < 0)
++        return FatalError("Video frame processing failed");
++    return ret;
++#else
+     AVPacket Packet;
+     av_init_packet(&Packet);
+     Packet.data = NULL;
+     Packet.size = 0;
+ 
+-    g_pVFrame->pts++;
+-#if LIBAVCODEC_VERSION_MAJOR < 58
+     if (g_pFormat->flags & AVFMT_RAWPICTURE)
+     {
+         /* raw video case. The API will change slightly in the near
+@@ -417,7 +573,6 @@
+         return 0;
+     }
+     else
+-#endif
+     {
+ #if LIBAVCODEC_VERSION_MAJOR >= 54
+         int got_packet;
+@@ -447,6 +602,7 @@
+ 
+         return 1;
+     }
++#endif
+ }
+ 
+ AVWRAP_DECL int AVWrapper_WriteFrame(uint8_t *buf)
+@@ -539,9 +695,13 @@
+     char ext[16];
+     strncpy(ext, g_pFormat->extensions, 16);
+     ext[15] = 0;
+-    ext[strcspn(ext,",")] = 0;
++    size_t extLen = strcspn(ext, ",");
++    ext[extLen] = 0;
+ #if LIBAVCODEC_VERSION_MAJOR >= 59
+-    snprintf(g_pContainer->url, sizeof(g_pContainer->url), "%s.%s", pFilename, ext);
++    // pFilename + dot + ext + null byte
++    size_t urlLen = strlen(pFilename) + 1 + extLen + 1;
++    g_pContainer->url = av_malloc(urlLen);
++    snprintf(g_pContainer->url, urlLen, "%s.%s", pFilename, ext);
+ #else
+     snprintf(g_pContainer->filename, sizeof(g_pContainer->filename), "%s.%s", pFilename, ext);
+ #endif
+@@ -636,21 +796,33 @@
+     // free everything
+     if (g_pVStream)
+     {
+-        avcodec_close(g_pVideo);
+-        av_free(g_pVideo);
+-        av_free(g_pVStream);
++        avcodec_free_context(&g_pVideo);
+         av_frame_free(&g_pVFrame);
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++        av_packet_free(&g_pVPacket);
++#endif
+     }
+     if (g_pAStream)
+     {
+-        avcodec_close(g_pAudio);
+-        av_free(g_pAudio);
+-        av_free(g_pAStream);
++        avcodec_free_context(&g_pAudio);
+         av_frame_free(&g_pAFrame);
++#if LIBAVCODEC_VERSION_MAJOR >= 58
++        av_packet_free(&g_pAPacket);
++#endif
++#if LIBAVUTIL_VERSION_MAJOR < 53
+         av_free(g_pSamples);
++#endif
+         fclose(g_pSoundFile);
+     }
+ 
++#if LIBAVCODEC_VERSION_MAJOR >= 59
++    avformat_free_context(g_pContainer);
++#else
++    if (g_pVStream)
++        av_free(g_pVStream);
++    if (g_pAStream)
++        av_free(g_pAStream);
+     av_free(g_pContainer);
++#endif
+     return 0;
+ }
+

--- a/games-strategy/hedgewars/files/hedgewars-1.0.2-glext-prototypes.patch
+++ b/games-strategy/hedgewars/files/hedgewars-1.0.2-glext-prototypes.patch
@@ -1,0 +1,14 @@
+Description: Add definition to use older prototypes until upstream fixes the pas2c build
+Author: Gianfranco Costamagna <locutusofborg@debian.org>
+Last-Update: 2024-01-02
+
+--- hedgewars-1.0.2.orig/project_files/hwc/rtl/GL.h
++++ hedgewars-1.0.2/project_files/hwc/rtl/GL.h
+@@ -3,6 +3,7 @@
+ #if defined(__APPLE__) && !defined(EMSCRIPTEN)
+ #include <OpenGL/gl.h>
+ #else
++#define GL_GLEXT_PROTOTYPES
+ #include "GL/gl.h"
+ #endif
+ 

--- a/games-strategy/hedgewars/files/hedgewars-1.0.2-metainfo.patch
+++ b/games-strategy/hedgewars/files/hedgewars-1.0.2-metainfo.patch
@@ -1,0 +1,32 @@
+From 3cd2cc671b2bebc447451e1be09824ca332c1be8 Mon Sep 17 00:00:00 2001
+From: Lars Wendler <polynomial-c@gmx.de>
+Date: Mon, 23 Jan 2023 09:56:08 +0100
+Subject: [PATCH] Rename appdata to metainfo
+
+See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html
+chapter 2.1.2 "Filesystem locations"
+
+Signed-off-by: Lars Wendler <polynomial-c@gmx.de>
+---
+ share/CMakeLists.txt                                    | 4 ++--
+ share/{hedgewars.appdata.xml => hedgewars.metainfo.xml} | 0
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+ rename share/{hedgewars.appdata.xml => hedgewars.metainfo.xml} (100%)
+
+diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
+index 849624df1a..5af0c6c2f0 100644
+--- a/share/CMakeLists.txt
++++ b/share/CMakeLists.txt
+@@ -19,6 +19,6 @@ if(APPLE)
+     install(PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/dsa_pub.pem"
+             DESTINATION ../Resources/)
+ elseif(UNIX)
+-    install(PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/hedgewars.appdata.xml"
+-            DESTINATION ${CMAKE_INSTALL_PREFIX}/share/appdata/)
++    install(PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/hedgewars.metainfo.xml"
++            DESTINATION ${CMAKE_INSTALL_PREFIX}/share/metainfo/)
+ endif()
+diff --git a/share/hedgewars.appdata.xml b/share/hedgewars.metainfo.xml
+similarity index 100%
+rename from share/hedgewars.appdata.xml
+rename to share/hedgewars.metainfo.xml

--- a/games-strategy/hedgewars/files/hedgewars-1.0.2-respect-cc.patch
+++ b/games-strategy/hedgewars/files/hedgewars-1.0.2-respect-cc.patch
@@ -1,0 +1,37 @@
+FPC alignment bug has been fixed:
+https://gitlab.com/freepascal.org/fpc/source/-/commit/fb918994574fec69e44b9868e0147510473b5aae
+
+diff '--color=auto' -urpN hedgewars-src-1.0.2.orig/CMakeLists.txt hedgewars-src-1.0.2/CMakeLists.txt
+--- hedgewars-src-1.0.2.orig/CMakeLists.txt	2022-09-13 01:33:59.000000000 +0300
++++ hedgewars-src-1.0.2/CMakeLists.txt	2025-04-28 23:43:49.771904474 +0300
+@@ -79,10 +79,6 @@ if(BUILD_ENGINE_JS)
+     set(target_library_install_dir "lib" CACHE PATH "install dest for libs")
+ endif()
+ 
+-if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4" AND UNIX AND NOT APPLE)
+-    set(BUILD_ENGINE_C ON CACHE STRING "PAS2C force-enabled due to a freepascal 32 bit alignment bug" FORCE)
+-endif()
+-
+ #system paths for finding required fonts (see share/hedgewars/Data/fonts)
+ #subdirectories will NOT be searched.
+ #all fonts that can't be found will be bundled with hedgewars
+@@ -180,19 +176,6 @@ else()
+ endif()
+ 
+ 
+-#build engine without freepascal
+-if(BUILD_ENGINE_C AND NOT BUILD_ENGINE_JS)
+-    find_package(Clang REQUIRED)
+-
+-    if(${CLANG_VERSION} VERSION_LESS "3.0")
+-        message(FATAL_ERROR "LLVM/Clang compiler required version is 3.0 but version ${CLANG_VERSION} was found!")
+-    endif()
+-
+-    set(CMAKE_C_COMPILER ${CLANG_EXECUTABLE})
+-    set(CMAKE_CXX_COMPILER ${CLANG_EXECUTABLE})
+-endif()
+-
+-
+ #server
+ if(NOT NOSERVER)
+     add_subdirectory(gameServer)

--- a/games-strategy/hedgewars/hedgewars-1.0.2-r1.ebuild
+++ b/games-strategy/hedgewars/hedgewars-1.0.2-r1.ebuild
@@ -1,0 +1,124 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CMAKE_MAKEFILE_GENERATOR=emake
+LUA_COMPAT=( lua5-1 )
+
+inherit cmake flag-o-matic lua-single toolchain-funcs xdg-utils
+
+MY_P=${PN}-src-${PV}
+
+DESCRIPTION="A turn-based strategy, artillery, action and comedy game"
+HOMEPAGE="https://www.hedgewars.org/"
+SRC_URI="https://www.hedgewars.org/download/releases/${MY_P}.tar.bz2"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="GPL-2 Apache-2.0 FDL-1.3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="ffmpeg pas2c server"
+
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+QA_FLAGS_IGNORED="/usr/bin/hwengine" # pascal sucks
+QA_PRESTRIPPED="/usr/bin/hwengine" # pascal sucks
+
+# qtcore:5= - depends on private header
+DEPEND="${LUA_DEPS}
+	>=dev-games/physfs-3.0.1
+	dev-qt/qtcore:5=
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtwidgets:5
+	media-libs/libpng:0=
+	media-libs/libsdl2:=[opengl]
+	media-libs/sdl2-image:=[png]
+	media-libs/sdl2-mixer:=[vorbis]
+	media-libs/sdl2-net:=
+	media-libs/sdl2-ttf:=
+	sys-libs/zlib
+	!pas2c? ( ffmpeg? ( media-video/ffmpeg:= ) )
+	"
+RDEPEND="${DEPEND}
+	app-arch/xz-utils
+	>=media-fonts/dejavu-2.28
+	media-fonts/wqy-zenhei"
+BDEPEND="
+	dev-qt/linguist-tools:5
+	!pas2c? ( dev-lang/fpc )
+	pas2c? (
+		>=dev-lang/ghc-6.10
+		dev-haskell/parsec
+		llvm-core/clang
+	)
+	server? (
+		>=dev-lang/ghc-6.10
+		dev-haskell/entropy
+		dev-haskell/hslogger
+		>=dev-haskell/mtl-2
+		>=dev-haskell/network-2.3
+		dev-haskell/random
+		dev-haskell/regex-tdfa
+		dev-haskell/sandi
+		dev-haskell/sha
+		dev-haskell/vector
+		dev-haskell/utf8-string
+		dev-haskell/yaml
+		>=dev-haskell/zlib-0.5.3
+	)"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.0.0-cmake_lua_version.patch"
+	"${FILESDIR}/${PN}-1.0.2-respect-cc.patch"
+	"${FILESDIR}/${PN}-1.0.2-metainfo.patch"
+	"${FILESDIR}/${P}-glext-prototypes.patch"
+	"${FILESDIR}/${P}-clang-15.patch"
+	"${FILESDIR}/${P}-ffmpeg-6.patch"
+)
+
+src_configure() {
+	if use pas2c && ! tc-is-clang; then
+		# Follow upstream and build with clang
+		export CC=${CHOST}-clang
+		export CXX=${CHOST}-clang++
+		# Filter out flags not implemented by clang
+		strip-unsupported-flags
+	fi
+
+	local mycmakeargs=(
+		-DMINIMAL_FLAGS=ON
+		-DDATA_INSTALL_DIR="${EPREFIX}/usr/share/${PN}"
+		-Dtarget_binary_install_dir="${EPREFIX}/usr/bin"
+		-Dtarget_library_install_dir="${EPREFIX}/usr/$(get_libdir)"
+		-DNOSERVER=$(usex !server)
+		-DBUILD_ENGINE_C=$(usex pas2c)
+		-DNOVIDEOREC=$(usex ffmpeg $(usex pas2c) ON)
+		-DCMAKE_VERBOSE_MAKEFILE=TRUE
+		# Need to tell the build system where the fonts are located
+		# as it uses PhysFS' symbolic link protection mode which
+		# prevents us from symlinking the fonts into the right directory
+		#   https://hg.hedgewars.org/hedgewars/rev/76ad55807c24
+		#   https://icculus.org/physfs/docs/html/physfs_8h.html#aad451d9b3f46f627a1be8caee2eef9b7
+		-DFONTS_DIRS="${EPREFIX}/usr/share/fonts/wqy-zenhei;${EPREFIX}/usr/share/fonts/dejavu"
+		# upstream sets RPATH that leads to weird breakage
+		# https://bugzilla.redhat.com/show_bug.cgi?id=1200193
+		-DCMAKE_SKIP_RPATH=ON
+		-DLUA_VERSION=$(lua_get_version)
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	doman man/${PN}.6
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+}

--- a/games-strategy/hedgewars/metadata.xml
+++ b/games-strategy/hedgewars/metadata.xml
@@ -6,6 +6,8 @@
 	<name>Gentoo Games Project</name>
 </maintainer>
 <use>
+	<flag name="ffmpeg">Enable video recording feature</flag>
+	<flag name="pas2c">Translate Pascal sources to C and build with clang</flag>
 	<flag name="server">Enable local server</flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
* Fix build with clang-15.
* Fix build with ffmpeg-6.
* Fix SDL dependencies: png and opengl are required.
* Fix ffmpeg dependency: it is actually not suported when building with pas2c. Also make it optional via USE-flag.
* Allow building with fpc on 32-bit arches instead of pas2c+clang. Alignment bug has been fixed in fpc long time ago.
* Introduce pas2c USE-flag to still allow building with pas2c+clang.
* Rename appdata to metainfo.

Closes: https://bugs.gentoo.org/750515

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
