### PR TITLE
sci-physics/thepeg: allow Java higher than 1.8

### DIFF
--- a/sci-physics/thepeg/files/thepeg-1.8.3-java.patch
+++ b/sci-physics/thepeg/files/thepeg-1.8.3-java.patch
@@ -1,6 +1,29 @@
+
+We are changing the javac -soure value from 1.4 to 1.8 which is supported by all
+Java versions presently available in ::gentoo.
+
+TODO: configure.ac
+Replace '1.8' with a variable to be set with $(java-pkg_get-source) in the ebuild.
+
+TODO java/Makefile.am
+Replace fixed values in
+	$(JAVAC) -source 1.8 -target 1.8 `for file in $(JAVASOURCES); do echo ThePEG/$$file; done`
+with values from java-pkg_get-source and java-pkg_get-target
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -123,7 +123,7 @@ AC_ARG_WITH(javagui,
+             [  --with-javagui          Compile and install the java-based GUI.])
+ 
+ if test "x$with_javagui" != "xno"; then
+-  THEPEG_HAS_JAVA([1.4], [], [with_javagui=no; AC_MSG_NOTICE([Java GUI disabled])])
++  THEPEG_HAS_JAVA([1.8], [], [with_javagui=no; AC_MSG_NOTICE([Java GUI disabled])])
+ fi
+ 
+ AM_CONDITIONAL([JAVAGUI], [test "x$with_javagui" != "xno"])
 --- a/java/Makefile.am
 +++ b/java/Makefile.am
-@@ -11,8 +12,7 @@
+@@ -11,8 +12,7 @@ JAVASOURCES = SetupThePEG.java ObjectFrame.java \
  
  CLEANFILES = ThePEG.jar thepeg.sh
  
@@ -10,7 +33,16 @@
  
  dist_noinst_DATA = $(JAVASOURCES) jar-manifest
  
-@@ -34,7 +34,7 @@
+@@ -27,14 +27,14 @@ clean-local:
+ ThePEG:
+ 	mkdir -p ThePEG
+ 	for file in $(JAVASOURCES) jar-manifest; do \
+-           cd ThePEG; $(LN_S) ../$(srcdir)/$$file $$file; cd ..; done
++           cd ThePEG; cp ../$(srcdir)/$$file $$file; cd ..; done
+ 
+ ThePEG.jar: ThePEG $(JAVASOURCES)
+-	$(JAVAC) `for file in $(JAVASOURCES); do echo ThePEG/$$file; done`
++	$(JAVAC) -source 1.8 -target 1.8 `for file in $(JAVASOURCES); do echo ThePEG/$$file; done`
  	$(JAR) cmf ThePEG/jar-manifest ThePEG.jar ThePEG/*.class
  
  thepeg.sh: thepeg.install Makefile

--- a/sci-physics/thepeg/thepeg-2.2.2-r2.ebuild
+++ b/sci-physics/thepeg/thepeg-2.2.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,10 +8,10 @@ inherit autotools elisp-common java-pkg-opt-2
 MY_P=ThePEG-${PV}
 
 DESCRIPTION="Toolkit for High Energy Physics Event Generation"
-HOMEPAGE="http://home.thep.lu.se/ThePEG/"
+HOMEPAGE="https://thepeg.hepforge.org/"
 
-TEST_URI="https://www.hepforge.org/archive/lhapdf/pdfsets/current"
-SRC_URI="https://www.hepforge.org/archive/thepeg/${MY_P}.tar.bz2
+TEST_URI="https://www.hepforge.org/downloads/lhapdf/pdfsets/current"
+SRC_URI="https://www.hepforge.org/downloads/thepeg/${MY_P}.tar.bz2
 	test? ( hepmc? (
 		${TEST_URI}/cteq6ll.LHpdf
 		${TEST_URI}/cteq5l.LHgrid
@@ -22,7 +22,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="GPL-3"
 SLOT="0/20"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="emacs fastjet hepmc java lhapdf static-libs test zlib"
+IUSE="emacs fastjet hepmc lhapdf static-libs test zlib"
 RESTRICT="!test? ( test )"
 
 CDEPEND="
@@ -33,13 +33,14 @@ CDEPEND="
 	lhapdf? ( >=sci-physics/lhapdf-6.0:0= )
 	zlib? ( sys-libs/zlib:0= )"
 DEPEND="${CDEPEND}
-	java? ( virtual/jdk:1.8 )
+	java? ( >=virtual/jdk-1.8:*[-headless-awt] )
 	test? ( sys-process/time )"
 RDEPEND="${CDEPEND}
-	java? ( virtual/jre:1.8 )"
+	java? ( >=virtual/jre-1.8:* )
+"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.8.3-java.patch
+	"${FILESDIR}"/${PN}-1.8.3-java.patch # there are todo items in the patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
 )
 
@@ -57,6 +58,13 @@ src_prepare() {
 }
 
 src_configure() {
+	if use java; then
+		local -x JAVAC="$(java-pkg_get-javac)"
+		local -x JAVA="$(java-config -J)"
+		local -x JAR="$(java-config -j)"
+		local -x JAVAC_SOURCE="$(java-pkg_get-source)"
+		local -x JAVAC_TARGET="$(java-pkg_get-target)"
+	fi
 	econf \
 		$(use_enable static-libs static) \
 		$(use_with fastjet fastjet "${EPREFIX}"/usr) \

--- a/sci-physics/thepeg/thepeg-2.2.3-r2.ebuild
+++ b/sci-physics/thepeg/thepeg-2.2.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,57 +8,48 @@ inherit autotools elisp-common java-pkg-opt-2
 MY_P=ThePEG-${PV}
 
 DESCRIPTION="Toolkit for High Energy Physics Event Generation"
-HOMEPAGE="
-	http://home.thep.lu.se/ThePEG/
-	https://thepeg.hepforge.org/
-"
+HOMEPAGE="https://thepeg.hepforge.org/"
 
-TEST_URI="https://www.hepforge.org/archive/lhapdf/pdfsets/current"
-SRC_URI="https://www.hepforge.org/archive/thepeg/${MY_P}.tar.bz2
-	test? (
-		hepmc3? (
-			${TEST_URI}/cteq6ll.LHpdf
-			${TEST_URI}/cteq5l.LHgrid
-			${TEST_URI}/GRV98nlo.LHgrid
-			${TEST_URI}/MRST2001nlo.LHgrid )
-	)"
+TEST_URI="https://www.hepforge.org/downloads/lhapdf/pdfsets/current"
+SRC_URI="https://www.hepforge.org/downloads/thepeg/${MY_P}.tar.bz2
+	test? ( hepmc3? (
+		${TEST_URI}/cteq6ll.LHpdf
+		${TEST_URI}/cteq5l.LHgrid
+		${TEST_URI}/GRV98nlo.LHgrid
+		${TEST_URI}/MRST2001nlo.LHgrid ) )"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-3"
 SLOT="0/30"
-KEYWORDS="~amd64"
-IUSE="emacs fastjet +hepmc3 lhapdf static-libs test zlib rivet"
+KEYWORDS="~amd64 ~x86"
+IUSE="emacs fastjet +hepmc3 lhapdf static-libs test zlib"
 RESTRICT="!test? ( test )"
 
 CDEPEND="
 	sci-libs/gsl:0=
 	emacs? ( >=app-editors/emacs-23.1:* )
 	fastjet? ( sci-physics/fastjet:0= )
-	rivet? ( sci-physics/rivet:3=[hepmc3] )
 	hepmc3? ( sci-physics/hepmc:3= )
 	lhapdf? ( >=sci-physics/lhapdf-6.0:0= )
 	zlib? ( sys-libs/zlib:0= )"
 DEPEND="${CDEPEND}
-	sci-libs/gsl:=
-	java? ( virtual/jdk:1.8 )
+	java? ( >=virtual/jdk-1.8:*[-headless-awt] )
 	test? (
 		sys-process/time
 		dev-libs/boost
 	)"
 RDEPEND="${CDEPEND}
-	java? ( virtual/jre:1.8 )
+	java? ( >=virtual/jre-1.8:* )
 "
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.8.3-java.patch
+	"${FILESDIR}"/${PN}-1.8.3-java.patch # there are todo items in the patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
-	"${FILESDIR}"/${PN}-2.3.0-rivet.patch # properly support rivet/yoda weights in thepeg, reported to upstream by mail.
-	"${FILESDIR}"/${PN}-2.3.0-functional.patch # https://bugs.gentoo.org/941477
 )
 
 src_prepare() {
 	find -name 'Makefile.am' -exec \
-		sed -i -e '1ipkgdatadir=$(datadir)/ThePEG' {} \; || die
+		sed -i -e '1ipkgdatadir=$(datadir)/thepeg' {} \; || die
 	# trick to force c++ linking
 	sed -i \
 		-e '1inodist_EXTRA_libThePEG_la_SOURCES = dummy.cxx' \
@@ -70,17 +61,23 @@ src_prepare() {
 }
 
 src_configure() {
-	local -x CONFIG_SHELL=/bin/bash
+	if use java; then
+		local -x JAVAC="$(java-pkg_get-javac)"
+		local -x JAVA="$(java-config -J)"
+		local -x JAR="$(java-config -j)"
+		local -x JAVAC_SOURCE="$(java-pkg_get-source)"
+		local -x JAVAC_TARGET="$(java-pkg_get-target)"
+	fi
 	econf \
 		$(use_enable static-libs static) \
-		$(use_with fastjet fastjet "${ESYSROOT}"/usr) \
-		$(use_with hepmc3 hepmc "${ESYSROOT}"/usr) \
+		$(use_with fastjet fastjet "${EPREFIX}"/usr) \
+		$(use_with hepmc3 hepmc "${EPREFIX}"/usr) \
 		$(use_with hepmc3 hepmcversion 3) \
 		$(use_with java javagui) \
-		$(use_with lhapdf lhapdf "${ESYSROOT}"/usr) \
-		$(use_with test boost "${ESYSROOT}"/usr) \
-		$(use_with rivet rivet "${ESYSROOT}"/usr) \
-		$(use_with zlib zlib "${ESYSROOT}"/usr)
+		$(use_with lhapdf lhapdf "${EPREFIX}"/usr) \
+		$(use_with test boost "${EPREFIX}"/usr) \
+		--without-rivet \
+		$(use_with zlib zlib "${EPREFIX}"/usr)
 }
 
 src_compile() {
@@ -97,7 +94,7 @@ src_install() {
 	use emacs && elisp-install ${PN} lib/ThePEG.el{,c}
 	use java && java-pkg_newjar java/ThePEG.jar
 
-	cat <<-EOF > "${T}"/50${PN} || die
+	cat <<-EOF > "${T}"/50${PN}
 	LDPATH="${EPREFIX}/usr/$(get_libdir)/ThePEG"
 	EOF
 	doenvd "${T}"/50${PN}

--- a/sci-physics/thepeg/thepeg-2.3.0-r1.ebuild
+++ b/sci-physics/thepeg/thepeg-2.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,47 +8,54 @@ inherit autotools elisp-common java-pkg-opt-2
 MY_P=ThePEG-${PV}
 
 DESCRIPTION="Toolkit for High Energy Physics Event Generation"
-HOMEPAGE="http://home.thep.lu.se/ThePEG/"
+HOMEPAGE="https://thepeg.hepforge.org/"
 
-TEST_URI="https://www.hepforge.org/archive/lhapdf/pdfsets/current"
-SRC_URI="https://www.hepforge.org/archive/thepeg/${MY_P}.tar.bz2
-	test? ( hepmc3? (
-		${TEST_URI}/cteq6ll.LHpdf
-		${TEST_URI}/cteq5l.LHgrid
-		${TEST_URI}/GRV98nlo.LHgrid
-		${TEST_URI}/MRST2001nlo.LHgrid ) )"
+TEST_URI="https://www.hepforge.org/downloads/lhapdf/pdfsets/current"
+SRC_URI="https://www.hepforge.org/downloads/thepeg/${MY_P}.tar.bz2
+	test? (
+		hepmc3? (
+			${TEST_URI}/cteq6ll.LHpdf
+			${TEST_URI}/cteq5l.LHgrid
+			${TEST_URI}/GRV98nlo.LHgrid
+			${TEST_URI}/MRST2001nlo.LHgrid )
+	)"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-3"
 SLOT="0/30"
-KEYWORDS="~amd64 ~x86"
-IUSE="emacs fastjet +hepmc3 java lhapdf static-libs test zlib"
+KEYWORDS="~amd64"
+IUSE="emacs fastjet +hepmc3 lhapdf static-libs test zlib rivet"
 RESTRICT="!test? ( test )"
 
 CDEPEND="
 	sci-libs/gsl:0=
 	emacs? ( >=app-editors/emacs-23.1:* )
 	fastjet? ( sci-physics/fastjet:0= )
+	rivet? ( sci-physics/rivet:3=[hepmc3] )
 	hepmc3? ( sci-physics/hepmc:3= )
 	lhapdf? ( >=sci-physics/lhapdf-6.0:0= )
 	zlib? ( sys-libs/zlib:0= )"
 DEPEND="${CDEPEND}
-	java? ( virtual/jdk:1.8 )
+	sci-libs/gsl:=
+	java? ( >=virtual/jdk-1.8:*[-headless-awt] )
 	test? (
 		sys-process/time
 		dev-libs/boost
 	)"
 RDEPEND="${CDEPEND}
-	java? ( virtual/jre:1.8 )"
+	java? ( >=virtual/jre-1.8:* )
+"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.8.3-java.patch
+	"${FILESDIR}"/${PN}-1.8.3-java.patch # there are todo items in the patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
+	"${FILESDIR}"/${PN}-2.3.0-rivet.patch # properly support rivet/yoda weights in thepeg, reported to upstream by mail.
+	"${FILESDIR}"/${PN}-2.3.0-functional.patch # https://bugs.gentoo.org/941477
 )
 
 src_prepare() {
 	find -name 'Makefile.am' -exec \
-		sed -i -e '1ipkgdatadir=$(datadir)/thepeg' {} \; || die
+		sed -i -e '1ipkgdatadir=$(datadir)/ThePEG' {} \; || die
 	# trick to force c++ linking
 	sed -i \
 		-e '1inodist_EXTRA_libThePEG_la_SOURCES = dummy.cxx' \
@@ -60,16 +67,24 @@ src_prepare() {
 }
 
 src_configure() {
+	local -x CONFIG_SHELL=/bin/bash
+	if use java; then
+		local -x JAVAC="$(java-pkg_get-javac)"
+		local -x JAVA="$(java-config -J)"
+		local -x JAR="$(java-config -j)"
+		local -x JAVAC_SOURCE="$(java-pkg_get-source)"
+		local -x JAVAC_TARGET="$(java-pkg_get-target)"
+	fi
 	econf \
 		$(use_enable static-libs static) \
-		$(use_with fastjet fastjet "${EPREFIX}"/usr) \
-		$(use_with hepmc3 hepmc "${EPREFIX}"/usr) \
+		$(use_with fastjet fastjet "${ESYSROOT}"/usr) \
+		$(use_with hepmc3 hepmc "${ESYSROOT}"/usr) \
 		$(use_with hepmc3 hepmcversion 3) \
 		$(use_with java javagui) \
-		$(use_with lhapdf lhapdf "${EPREFIX}"/usr) \
-		$(use_with test boost "${EPREFIX}"/usr) \
-		--without-rivet \
-		$(use_with zlib zlib "${EPREFIX}"/usr)
+		$(use_with lhapdf lhapdf "${ESYSROOT}"/usr) \
+		$(use_with test boost "${ESYSROOT}"/usr) \
+		$(use_with rivet rivet "${ESYSROOT}"/usr) \
+		$(use_with zlib zlib "${ESYSROOT}"/usr)
 }
 
 src_compile() {
@@ -86,7 +101,7 @@ src_install() {
 	use emacs && elisp-install ${PN} lib/ThePEG.el{,c}
 	use java && java-pkg_newjar java/ThePEG.jar
 
-	cat <<-EOF > "${T}"/50${PN}
+	cat <<-EOF > "${T}"/50${PN} || die
 	LDPATH="${EPREFIX}/usr/$(get_libdir)/ThePEG"
 	EOF
 	doenvd "${T}"/50${PN}


### PR DESCRIPTION
This commit lifts the javac -source value from 1.4 to 1.8 so that the package can be built vith higher Java versions including 25. Leaves a todo item in thepeg-2.3.0-javac_source.patch.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
