### PR TITLE
dev-cpp/opentelemetry-cpp: remove patch for clang template

### DIFF
--- a/dev-cpp/opentelemetry-cpp/opentelemetry-cpp-1.20.0.ebuild
+++ b/dev-cpp/opentelemetry-cpp/opentelemetry-cpp-1.20.0.ebuild
@@ -38,7 +38,6 @@ PATCHES=(
 	# remove tests the need network
 	"${FILESDIR}/${PN}-1.5.0-tests.patch"
 	"${FILESDIR}/${PN}-1.16.1-cstdint.patch"
-	"${FILESDIR}/${PN}-1.16.1-fix-clang-template.patch"
 )
 
 src_configure() {


### PR DESCRIPTION
which was wrongly added back during the rebase of the last PR

Closes: https://bugs.gentoo.org/955103

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
