### PR TITLE
net-libs/pjproject: avoid libyuv requirement with libyuv disabled

### DIFF
--- a/net-libs/pjproject/pjproject-2.15.1-r1.ebuild
+++ b/net-libs/pjproject/pjproject-2.15.1-r1.ebuild
@@ -97,6 +97,9 @@ src_configure() {
 
 	[ "${videnable}" = "--enable-video" ] && _pj_set_define PJMEDIA_HAS_VIDEO 1 || _pj_set_define PJMEDIA_HAS_VIDEO 0
 
+	# bug 955077 and bug 955129
+	use libyuv && myconf+=( --with-external-yuv )
+
 	LD="$(tc-getCXX)" econf \
 		--enable-shared \
 		${videnable} \
@@ -116,7 +119,6 @@ src_configure() {
 		$(use_with portaudio external-pa) \
 		$(use_with speex external-speex) \
 		$(usex srtp --with-external-srtp --disable-libsrtp) \
-		--with-external-yuv \
 		"${myconf[@]}"
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955129
Fixes: 1e0a5ae70d5a1995b7761f946c0ac0f95e64d3b5

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
