### PR TITLE
sci-chemistry/gnome-chemistry-utils: fix build adding BDEPS

### DIFF
--- a/sci-chemistry/gnome-chemistry-utils/files/gnome-chemistry-utils-disable_tests_man.patch
+++ b/sci-chemistry/gnome-chemistry-utils/files/gnome-chemistry-utils-disable_tests_man.patch
@@ -1,0 +1,26 @@
+Disable tests for manpages, useless and it causes failures
+diff --git a/docs/man/Makefile.am b/docs/man/Makefile.am
+index eb8e3f5..fcddc85 100644
+--- a/docs/man/Makefile.am
++++ b/docs/man/Makefile.am
+@@ -40,20 +40,3 @@ if HAVE_XSLTPROC
+ else
+ 	echo "***** Cannot update the XML sources without `xsltproc'."
+ endif
+-
+-
+-check-local:
+-	@echo "***** Correct any errors before making a distribution."
+-if HAVE_XMLLINT
+-	$(XMLLINT) $(XMLLINT_FLAGS) $(gcu_man_src)
+-else
+-	@echo "***** Cannot check the XML sources without `xmllint'."
+-endif
+-if HAVE_MAN
+-	@for man in $(man_MANS) ; do \
+-		LANG=C MANWIDTH=80 $(MAN) $(srcdir)/$${man} > /dev/null ; \
+-	done
+-else
+-	@echo "***** Cannot check the manpages without `man'."
+-endif	
+-

--- a/sci-chemistry/gnome-chemistry-utils/gnome-chemistry-utils-0.14.17_p6-r3.ebuild
+++ b/sci-chemistry/gnome-chemistry-utils/gnome-chemistry-utils-0.14.17_p6-r3.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit autotools flag-o-matic xdg
+inherit autotools flag-o-matic toolchain-funcs xdg
 
 DESCRIPTION="Programs and library containing GTK widgets and C++ classes related to chemistry"
-HOMEPAGE="http://gchemutils.nongnu.org/"
+HOMEPAGE="https://gchemutils.nongnu.org/"
 SRC_URI="
-	http://download.savannah.gnu.org/releases/gchemutils/$(ver_cut 1-2)/${P/_p*}.tar.xz
+	https://download.savannah.gnu.org/releases/gchemutils/$(ver_cut 1-2)/${P/_p*}.tar.xz
 	mirror://debian/pool/main/${PN:0:1}/${PN}/${PN}_${PV/_p*}-${PV/*_p}.debian.tar.xz
 "
 S="${WORKDIR}/${P/_p*}"
@@ -20,22 +20,26 @@ IUSE="gnumeric"
 RDEPEND="
 	>=dev-libs/glib-2.36.0:2
 	>=dev-libs/libxml2-2.4.16:2
-	>=gnome-extra/libgsf-1.14.9
+	>=gnome-extra/libgsf-1.14.9:=
+	media-libs/libglvnd[X]
 	>=sci-chemistry/bodr-5
 	>=sci-chemistry/chemical-mime-data-0.1.94
 	>=sci-chemistry/openbabel-2.3.0:0=
 	>=x11-libs/cairo-1.6.0
-	>=x11-libs/gdk-pixbuf-2.22.0
-	>=x11-libs/goffice-0.10.12
+	>=x11-libs/gdk-pixbuf-2.22.0:2
+	>=x11-libs/goffice-0.10.12:0.10
 	x11-libs/gtk+:3[X]
 	>=x11-libs/libX11-1.0.0
-	virtual/glu
-	gnumeric? ( >=app-office/gnumeric-1.12.42:= )
+	x11-libs/pango
+	gnumeric? ( >=app-office/gnumeric-1.12.42 )
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	virtual/glu"
 BDEPEND="
 	app-text/doxygen
 	app-text/yelp-tools
+	dev-util/glib-utils
+	dev-util/intltool
 	virtual/pkgconfig
 "
 
@@ -53,6 +57,12 @@ src_prepare() {
 
 	# From Fedora
 	eapply "${FILESDIR}"/${PN}-fix_pointer_types.patch
+
+	# Disable tests for manpages
+	eapply "${FILESDIR}"/${PN}-disable_tests_man.patch
+
+	sed -e "s:pkg-config:$(tc-getPKG_CONFIG):g" \
+		-i configure.ac || die
 
 	eautoreconf
 }


### PR DESCRIPTION
> \* Running 'intltoolize --automake --copy --force' ... [ !! ]
> \* Failed running 'intltoolize'!

> make[3]: Entering directory '/var/tmp/portage/sci-chemistry/gnome-chemistry-utils-0.14.17_p6-r2/work/gnome-chemistry-utils-0.14.17/libs/gcugtk'
> prefix=gcu_ --header marshalers.list >marshalers.h
> /bin/sh: line 1: --header: command not found
> make[3]: [Makefile:994: marshalers.h] Error 127 (ignored)

BDEP (above errors) :
add dev-util/intltool
add dev-util/glib-utils (GLIB_GENMARSHAL)

update subslot operator :=

R/DEP :
add x11-libs/pango
add media-libs/libglvnd
virtual/glu is only required on build-time

set pkg-config without native-symlinks

skip tests for manpages, useless and it causes failures

set HTTP+S

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
