### PR TITLE
sys-apps/lssbus: Force gnustd89

### DIFF
--- a/sys-apps/lssbus/lssbus-0.1-r1.ebuild
+++ b/sys-apps/lssbus/lssbus-0.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit toolchain-funcs
+inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="Small utility for Linux/SPARC that list devices on SBUS"
 HOMEPAGE="https://people.redhat.com/tcallawa/lssbus/"
@@ -14,6 +14,8 @@ SLOT="0"
 KEYWORDS="-* sparc"
 
 src_compile() {
+	append-cflags -std=gnu89 # Bug #951330
+
 	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
 }
 


### PR DESCRIPTION
Package seems no longer supported by upstream, so using the workaround fix to allow users to use it on Gentoo before a better solution is found.

This is also fixes the issue with SPARC installcd not building for Releng.

Closes: https://bugs.gentoo.org/951330

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
