### PR TITLE
games-util/gamemode: drop MULTILIB_COMPAT

### DIFF
--- a/games-util/gamemode/gamemode-1.8.2.ebuild
+++ b/games-util/gamemode/gamemode-1.8.2.ebuild
@@ -1,9 +1,7 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit meson-multilib systemd
 

--- a/games-util/gamemode/gamemode-9999.ebuild
+++ b/games-util/gamemode/gamemode-9999.ebuild
@@ -1,9 +1,7 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-
-MULTILIB_COMPAT=( abi_x86_{32,64} )
 
 inherit meson-multilib systemd
 


### PR DESCRIPTION
As per multilib-build.eclass:
"This variable is intended for use in prebuilt multilib packages that can provide binaries only for a limited set of ABIs." Gamemode builds from source, and works perfectly fine on architectures that are not amd64 or x86, so all this MUILTILIB_COMPAT is doing currently is preventing it from being built on other architectures.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
