### PR TITLE
dot-a.eclass: new eclass for handling LTO in static archives

### DIFF
--- a/dev-libs/glib/glib-2.78.6.ebuild
+++ b/dev-libs/glib/glib-2.78.6.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 PYTHON_REQ_USE="xml(+)"
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
+inherit dot-a gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -173,6 +173,11 @@ src_prepare() {
 	# TODO: python_name sedding for correct python shebang? Might be relevant mainly for glib-utils only
 }
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	# TODO: figure a way to pass appropriate values for all cross properties
 	# that glib uses (search for get_cross_property)
@@ -245,6 +250,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps
 	# and removals, and test depend on glib-utils instead; revisit now with

--- a/dev-libs/glib/glib-2.80.5-r1.ebuild
+++ b/dev-libs/glib/glib-2.80.5-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 PYTHON_REQ_USE="xml(+)"
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
+inherit dot-a gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -210,6 +210,11 @@ src_prepare() {
 	# TODO: python_name sedding for correct python shebang? Might be relevant mainly for glib-utils only
 }
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	# TODO: figure a way to pass appropriate values for all cross properties
 	# that glib uses (search for get_cross_property)
@@ -388,6 +393,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps
 	# and removals, and test depend on glib-utils instead; revisit now with

--- a/dev-libs/glib/glib-2.82.5.ebuild
+++ b/dev-libs/glib/glib-2.82.5.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 PYTHON_REQ_USE="xml(+)"
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
+inherit dot-a eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -198,6 +198,11 @@ src_prepare() {
 	# TODO: python_name sedding for correct python shebang? Might be relevant mainly for glib-utils only
 }
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	# TODO: figure a way to pass appropriate values for all cross properties
 	# that glib uses (search for get_cross_property)
@@ -376,6 +381,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps
 	# and removals, and test depend on glib-utils instead; revisit now with

--- a/dev-libs/glib/glib-2.84.0.ebuild
+++ b/dev-libs/glib/glib-2.84.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 PYTHON_REQ_USE="xml(+)"
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
+inherit dot-a eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -202,6 +202,11 @@ src_prepare() {
 	# TODO: python_name sedding for correct python shebang? Might be relevant mainly for glib-utils only
 }
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	# TODO: figure a way to pass appropriate values for all cross properties
 	# that glib uses (search for get_cross_property)
@@ -380,6 +385,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps
 	# and removals, and test depend on glib-utils instead; revisit now with

--- a/dev-libs/glib/glib-2.84.1.ebuild
+++ b/dev-libs/glib/glib-2.84.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 PYTHON_REQ_USE="xml(+)"
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
+inherit dot-a eapi9-ver gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -203,6 +203,11 @@ src_prepare() {
 	# TODO: python_name sedding for correct python shebang? Might be relevant mainly for glib-utils only
 }
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	# TODO: figure a way to pass appropriate values for all cross properties
 	# that glib uses (search for get_cross_property)
@@ -381,6 +386,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps
 	# and removals, and test depend on glib-utils instead; revisit now with

--- a/dev-util/sysprof-capture/sysprof-capture-3.48.0.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-3.48.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 GNOME_ORG_MODULE="sysprof"
 
-inherit gnome.org meson-multilib systemd
+inherit dot-a gnome.org meson-multilib systemd
 
 DESCRIPTION="Static library for sysprof capture data generation"
 HOMEPAGE="http://sysprof.com/"
@@ -20,6 +20,11 @@ BDEPEND="
 	>=sys-kernel/linux-headers-2.6.32
 	virtual/pkgconfig
 "
+
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
 
 multilib_src_configure() {
 	local emesonargs=(
@@ -37,4 +42,9 @@ multilib_src_configure() {
 		-Dagent=false
 	)
 	meson_src_configure
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	strip-lto-bytecode
 }

--- a/dev-util/sysprof-capture/sysprof-capture-46.0.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-46.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 GNOME_ORG_MODULE="sysprof"
 
-inherit gnome.org meson-multilib systemd
+inherit dot-a gnome.org meson-multilib systemd
 
 DESCRIPTION="Static library for sysprof capture data generation"
 HOMEPAGE="http://sysprof.com/"
@@ -21,6 +21,11 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	local emesonargs=(
 		-Dgtk=false
@@ -35,4 +40,9 @@ multilib_src_configure() {
 		-Dexamples=false
 	)
 	meson_src_configure
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	strip-lto-bytecode
 }

--- a/dev-util/sysprof-capture/sysprof-capture-47.2.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-47.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 GNOME_ORG_MODULE="sysprof"
 
-inherit gnome.org meson-multilib systemd
+inherit dot-a gnome.org meson-multilib systemd
 
 DESCRIPTION="Static library for sysprof capture data generation"
 HOMEPAGE="http://sysprof.com/"
@@ -21,6 +21,11 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+src_configure() {
+	lto-guarantee-fat
+	meson-multilib_src_configure
+}
+
 multilib_src_configure() {
 	local emesonargs=(
 		-Dgtk=false
@@ -35,4 +40,9 @@ multilib_src_configure() {
 		-Dexamples=false
 	)
 	meson_src_configure
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	strip-lto-bytecode
 }

--- a/eclass/dot-a.eclass
+++ b/eclass/dot-a.eclass
@@ -1,0 +1,117 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: dot-a.eclass
+# @MAINTAINER:
+# Toolchain Ninjas <toolchain@gentoo.org>
+# @AUTHOR:
+# Sam James <sam@gentoo.org>
+# Eli Schwartz <eschwartz@gentoo.org>
+# @SUPPORTED_EAPIS: 8
+# @BLURB: Functions to handle stripping LTO bytecode out of static archives.
+# @DESCRIPTION:
+# This eclass provides functions to strip LTO bytecode out of static archives
+# (.a files).
+#
+# Static libraries when built with LTO will contain LTO bytecode which is
+# not portable across compiler versions or compiler vendors. To avoid pessimising
+# the library and always filtering LTO, we can build it with -ffat-lto-objects
+# instead, which builds some components twice. The installed part will then
+# have the LTO contents stripped out, leaving the regular objects in the
+# static archive.
+#
+# Use should be passing calling lto-guarantee-fat before configure-time
+# and calling strip-lto-bytecode after installation.
+#
+# Most packages installing static libraries should be using this eclass,
+# though it's not strictly necessary if the package filters LTO.
+#
+# @EXAMPLE:
+# @CODE
+#
+# inherit dot-a
+#
+# src_configure() {
+#     lto-guarantee-fat
+#     econf
+# }
+#
+# src_install() {
+#     default
+#     strip-lto-bytecode
+# }
+case ${EAPI} in
+	8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+if [[ -z ${_DOT_A_ECLASS} ]] ; then
+_DOT_A_ECLASS=1
+
+inherit flag-o-matic toolchain-funcs
+
+# TODO: QA check
+
+# @FUNCTION: lto-guarantee-fat
+# @DESCRIPTION:
+# If LTO is enabled, appends -ffat-lto-objects or any other flags needed
+# to provide fat LTO objects.
+lto-guarantee-fat() {
+	tc-is-lto || return
+
+	# We add this for all languages as LTO obviously can't be done
+	# if different compilers are used for e.g. C vs C++ anyway.
+	append-flags $(test-flags-CC -ffat-lto-objects)
+}
+
+# @FUNCTION: strip-lto-bytecode
+# @USAGE: [library|directory] [...]
+# @DESCRIPTION:
+# Strips LTO bytecode from libraries (static archives) passed as arguments.
+# Defaults to operating on ${ED} as a whole if no arguments are passed.
+#
+# As an optimisation, if USE=static-libs exists for a package and is disabled,
+# the default-searching behaviour with no arguments is suppressed.
+strip-lto-bytecode() {
+	tc-is-lto || return
+
+	local files=()
+
+	if [[ ${#} -eq 0 ]]; then
+		if ! in_iuse static-libs || use static-libs ; then
+			# maybe we are USE=static-libs. Alternatively, maybe the ebuild doesn't
+			# offer such a choice. In both cases, the user specified the function,
+			# so we expect to be called on *something*, but nothing was explicitly
+			# passed. Try scanning ${ED} automatically.
+			set -- "${ED}"
+		fi
+	fi
+
+	mapfile -t -d '' files < <(find -H "${@}" -type f \( -name '*.a' -or -name '*.o' \) -print0)
+
+	toolchain_type=
+	tc-is-gcc && toolchain_type=gnu
+	tc-is-clang && toolchain_type=llvm
+
+	local file
+	for file in "${files[@]}" ; do
+		case ${toolchain_type} in
+			gnu)
+				$(tc-getSTRIP) \
+					-R .gnu.lto_* \
+					-R .gnu.debuglto_* \
+					-N __gnu_lto_v1 \
+					"${file}" || die "Stripping bytecode in ${file} failed"
+				;;
+			llvm)
+				llvm-bitcode-strip \
+					-r "${file}" \
+					-o "${file}" || die "Stripping bytecode in ${file} failed"
+				;;
+			*)
+				;;
+		esac
+	done
+}
+
+fi

--- a/eclass/tests/dot-a.sh
+++ b/eclass/tests/dot-a.sh
@@ -1,0 +1,511 @@
+#!/bin/bash
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+source tests-common.sh || exit
+source version-funcs.sh || exit
+
+inherit dot-a
+
+_strip_is_gnu() {
+	local name=$($(tc-getSTRIP) --version 2>&1 | head -n 1)
+
+	if ! [[ ${name} =~ ^GNU.*strip ]] ; then
+		return 1
+	fi
+
+	return 0
+}
+
+_check_binutils_version() {
+	local tool=$1
+	# Convert this:
+	# ```
+	# GNU ld (Gentoo 2.38 p4) 2.38
+	# Copyright (C) 2022 Free Software Foundation, Inc.
+	# This program is free software; you may redistribute it under the terms of
+	# the GNU General Public License version 3 or (at your option) a later version.
+	# This program has absolutely no warranty.
+	# ```
+	#
+	# into...
+	# ```
+	# 2.38
+	# ```
+	local ver=$(${tool} --version 2>&1 | head -n 1 | rev | cut -d' ' -f1 | rev)
+
+	if ! [[ ${ver} =~ [0-9].[0-9][0-9](.[0-9]?) ]] ; then
+		# Skip if unrecognised format so we don't pass something
+		# odd into ver_cut.
+		return
+	fi
+
+	ver_major=$(ver_cut 1 "${ver}")
+	ver_minor=$(ver_cut 2 "${ver}")
+	ver_extra=$(ver_cut 3 "${ver}")
+	echo ${ver_major}.${ver_minor}${ver_extra:+.${ver_extra}}
+}
+
+_create_test_progs() {
+	cat <<-EOF > a.c
+	int foo();
+
+	int foo() {
+		return 42;
+	}
+	EOF
+
+	cat <<-EOF > main.c
+	#include <stdio.h>
+	int foo();
+
+	int main() {
+		printf("Got magic number: %d\n", foo());
+		return 0;
+	}
+	EOF
+}
+
+test_lto_guarantee_fat() {
+	# Check whether lto-guarantee-fat adds -ffat-lto-objects and it
+	# results in a successful link (and a failed link without it).
+	LDFLAGS="-fuse-ld=${linker}"
+
+	$(tc-getCC) ${CFLAGS} -flto a.c -o a.o -c || die
+	$(tc-getCC) ${CFLAGS} ${LDFLAGS} -flto main.c a.o -o main || die
+	if ./main | grep -q "Got magic number: 42" ; then
+		:;
+	else
+		die "Pure LTO check failed"
+	fi
+
+	tbegin "lto-guarantee-fat (CC=$(tc-getCC), linker=${linker}): check linking w/ fat LTO object w LTO"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+		lto-guarantee-fat
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c a.o 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking LTO executable w/ fat object failed"
+
+	tbegin "lto-guarantee-fat (CC=$(tc-getCC), linker=${linker}): check linking w/ fat LTO object w/o LTO"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+		lto-guarantee-fat
+
+		# Linking here will fail if a.o isn't a fat object, as there's nothing
+		# to fall back on with -fno-lto.
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} -fno-lto main.c a.o 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking non-LTO executable w/ fat object failed"
+
+	tbegin "lto-guarantee-fat (CC=$(tc-getCC), linker=${linker}): check linking w/ fat LTO archive w LTO"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+		lto-guarantee-fat
+
+		rm test.a 2>/dev/null
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) r test.a a.o 2>/dev/null || return 1
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c test.a 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking LTO executable w/ fat archive failed"
+
+	tbegin "lto-guarantee-fat (CC=$(tc-getCC), linker=${linker}): check linking w/ fat LTO archive w/o LTO"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+		lto-guarantee-fat
+
+		rm test.a 2>/dev/null
+
+		# Linking here will fail if a.o (-> test.a) isn't a fat object, as there's nothing
+		# to fall back on with -fno-lto.
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) r test.a a.o 2>/dev/null || return 1
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} -fno-lto main.c test.a 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking non-LTO executable w/ fat archive failed"
+}
+
+test_strip_lto_bytecode() {
+	# Check whether strip-lto-bytecode does its job on a single argument, but
+	# focus of this test is more basic, not checking all possible option
+	# handling.
+	#
+	# i.e. If we use strip-lto-bytecode, does it remove the LTO bytecode
+	# and allow linking? If we use it w/o -ffat-lto-objects, do we get
+	# a failed link as we expect?
+	LDFLAGS="-fuse-ld=${linker}"
+
+	tbegin "strip-lto-bytecode (CC=$(tc-getCC), linker=${linker}): check that linking w/ stripped non-fat object breaks"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		# strip-lto-bytecode will error out early with LLVM,
+		# so stop the test here.
+		tc-is-clang && return 0
+		# strip with >= GNU Binutils 2.45 won't corrupt the archive:
+		# https://sourceware.org/PR21479
+		_strip_is_gnu && ver_test $(_check_binutils_version $(tc-getSTRIP)) -gt 2.44 && return 0
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+
+		# This should corrupt a.o and make linking below fail.
+		strip-lto-bytecode a.o
+
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Linking corrupted non-fat object unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC=$(tc-getCC), linker=${linker}): check that linking w/ stripped fat object works"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		lto-guarantee-fat
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+
+		# This should NOT corrupt a.o, so linking below should succeed.
+		strip-lto-bytecode a.o
+
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking stripped fat object failed"
+
+	tbegin "strip-lto-bytecode (CC=$(tc-getCC), linker=${linker}): check that linking w/ stripped non-fat archive breaks"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		# strip-lto-bytecode will error out early with LLVM,
+		# so stop the test here.
+		tc-is-clang && return 0
+		# strip with >= GNU Binutils 2.45 won't corrupt the archive:
+		# https://sourceware.org/PR21479
+		_strip_is_gnu && ver_test $(_check_binutils_version $(tc-getSTRIP)) -gt 2.44 && return 0
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) q test.a a.o 2>/dev/null || return 1
+
+		# This should corrupt a.o and make linking below fail.
+		strip-lto-bytecode test.a
+
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Linking corrupted non-fat object unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC=$(tc-getCC), linker=${linker}): check that linking w/ stripped fat archive works"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		lto-guarantee-fat
+
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) q test.a a.o 2>/dev/null || return 1
+
+		# This should NOT corrupt a.o, so linking below should succeed.
+		strip-lto-bytecode test.a
+
+		$(tc-getCC) ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Linking stripped fat archive failed"
+}
+
+test_mixed_objects_after_stripping() {
+	# Check whether mixing objects from two compilers (${CC_1} and ${CC_2})
+	# fails without lto-guarantee-fat and strip-lto-bytecode and works
+	# once they're used.
+	LDFLAGS="-fuse-ld=${linker}"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that unstripped LTO objects from ${CC_1} fail w/ ${CC_2}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		${CC_1} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		# Using CC_1 IR with CC_2 should fail.
+		${CC_2} ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Mixing unstripped objects unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that unstripped LTO objects from ${CC_2} fail w/ ${CC_1}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		${CC_2} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		# Using CC_2 IR with CC_1 should fail.
+		${CC_1} ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Mixing unstripped objects unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that stripped LTO objects from ${CC_1} work w/ ${CC_2}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		lto-guarantee-fat
+		${CC_1} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		# The object should now be "vendor-neutral" and work.
+		CC=${CC_1} strip-lto-bytecode a.o
+		${CC_2} ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Mixing stripped objects failed"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that stripped LTO objects from ${CC_2} work w/ ${CC_1}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		lto-guarantee-fat
+		${CC_2} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		# The object should now be "vendor-neutral" and work.
+		CC=${CC_2} strip-lto-bytecode a.o
+		${CC_1} ${CFLAGS} ${LDFLAGS} main.c a.o -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Mixing stripped objects failed"
+}
+
+test_mixed_archives_after_stripping() {
+	# Check whether mixing archives from two compilers (${CC_1} and ${CC_2})
+	# fails without lto-guarantee-fat and strip-lto-bytecode and works
+	# once they're used.
+	LDFLAGS="-fuse-ld=${linker}"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that unstripped LTO archives from ${CC_1} fail w/ ${CC_2}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		${CC_1} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		${AR_1} r test.a a.o 2>/dev/null || return 1
+		# Using CC_1 IR with CC_2 should fail.
+		${CC_2} ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Mixing unstripped archives unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that unstripped LTO archives from ${CC_2} fail w/ ${CC_1}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		${CC_2} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		${AR_2} r test.a a.o 2>/dev/null || return 1
+		# Using CC_2 IR with CC_1 should fail.
+		${CC_1} ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Mixing unstripped archives unexpectedly worked"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that stripped LTO archives from ${CC_1} work w/ ${CC_2}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		lto-guarantee-fat
+		${CC_1} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		${AR_1} r test.a a.o 2>/dev/null || return 1
+		# The object should now be "vendor-neutral" and work.
+		CC=${CC_1} strip-lto-bytecode test.a
+		${CC_2} ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Mixing stripped archives failed"
+
+	tbegin "strip-lto-bytecode (CC_1=${CC_1}, CC_2=${CC_2}, linker=${linker}): check that stripped LTO archives from ${CC_2} work w/ ${CC_1}"
+	ret=0
+	(
+		export CFLAGS="-O2 -flto"
+
+		rm test.a 2>/dev/null
+
+		lto-guarantee-fat
+		${CC_2} ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		${AR_2} r test.a a.o 2>/dev/null || return 1
+		# The object should now be "vendor-neutral" and work.
+		CC=${CC_2} strip-lto-bytecode test.a
+		${CC_1} ${CFLAGS} ${LDFLAGS} main.c test.a -o main 2>/dev/null || return 1
+	) || ret=1
+	tend ${ret} "Mixing stripped archives failed"
+}
+
+_check_if_lto_object() {
+	# Adapted from tc-is-lto
+	local ret=1
+	case $(tc-get-compiler-type) in
+		clang)
+			# If LTO is used, clang will output bytecode and llvm-bcanalyzer
+			# will run successfully.  Otherwise, it will output plain object
+			# file and llvm-bcanalyzer will exit with error.
+			llvm-bcanalyzer "$1" &>/dev/null && ret=0
+			;;
+		gcc)
+			[[ $($(tc-getREADELF) -S "$1") == *.gnu.lto* ]] && ret=0
+			;;
+	esac
+	return "${ret}"
+}
+
+test_search_recursion() {
+	# Test whether the argument handling and logic of strip-lto-bytecode
+	# works as expected.
+	tbegin "whether default search behaviour of \${ED} works"
+	ret=0
+	(
+		CC=gcc
+		CFLAGS="-O2 -flto"
+
+		rm foo.a 2>/dev/null
+
+		_create_test_progs
+		lto-guarantee-fat
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) q foo.a a.o 2>/dev/null || return 1
+
+		_check_if_lto_object "${tmpdir}/lto/foo.a" || return 1
+		# It should search ${ED} if no arguments are passed, find
+		# the LTO'd foo.o, and strip it.
+		ED="${tmpdir}/lto" strip-lto-bytecode
+		# foo.a should be a regular object here.
+		_check_if_lto_object "${tmpdir}/lto/foo.a" && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Unexpected LTO object found"
+
+	tbegin "whether a single file argument works"
+	ret=0
+	(
+		CC=gcc
+		CFLAGS="-O2 -flto"
+
+		rm foo.a 2>/dev/null
+
+		_create_test_progs
+		lto-guarantee-fat
+		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
+		$(tc-getAR) r foo.a a.o 2>/dev/null || return 1
+
+		_check_if_lto_object "${tmpdir}/lto/foo.a" || return 1
+		# It should search ${ED} if no arguments are passed, find
+		# the LTO'd foo.o, and strip it.
+		ED="${tmpdir}/lto" strip-lto-bytecode "${tmpdir}/lto/foo.a"
+		# foo.a should be a regular object here.
+		_check_if_lto_object "${tmpdir}/lto/foo.a" && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Unexpected LTO object found"
+
+	tbegin "whether a directory and file argument works"
+	ret=0
+	(
+		mkdir "${tmpdir}"/lto2 || die
+
+		CC=gcc
+		CFLAGS="-O2 -flto"
+
+		rm foo.a 2>/dev/null
+
+		_create_test_progs
+		lto-guarantee-fat
+		$(tc-getCC) ${CFLAGS} "${tmpdir}"/lto/a.c -o "${tmpdir}"/lto/a.o -c 2>/dev/null || return 1
+		$(tc-getAR) q foo.a a.o 2>/dev/null || return 1
+		$(tc-getAR) q "${tmpdir}"/lto2/foo.a a.o 2>/dev/null || return 1
+
+		_check_if_lto_object "${tmpdir}/lto/foo.a" || return 1
+		_check_if_lto_object "${tmpdir}/lto2/foo.a" || return 1
+		# It should search ${ED} if no arguments are passed, find
+		# the LTO'd foo.o, and strip it.
+		ED="${tmpdir}/lto" strip-lto-bytecode "${tmpdir}/lto/foo.a" "${tmpdir}/lto2/foo.a"
+		# foo.a should be a regular object here.
+		_check_if_lto_object "${tmpdir}/lto/foo.a" && return 1
+		_check_if_lto_object "${tmpdir}/lto2/foo.a" && return 1
+
+		return 0
+	) || ret=1
+	tend ${ret} "Unexpected LTO object found"
+}
+
+_repeat_tests_with_compilers() {
+	# Call test_lto_guarantee_fat and test_strip_lto_bytecode with
+	# various compilers and linkers.
+	for toolchain in gcc:ar clang:llvm-ar ; do
+		CC=${toolchain%:*}
+		AR=${toolchain#*:}
+		type -P ${CC} &>/dev/null || continue
+		type -P ${AR} &>/dev/null || continue
+
+		for linker in gold bfd lld mold gold ; do
+			# lld doesn't support GCC LTO: https://github.com/llvm/llvm-project/issues/41791
+			[[ ${CC} == gcc && ${linker} == lld ]] && continue
+			# Make sure the relevant linker is actually installed and usable.
+			LDFLAGS="-fuse-ld=${linker}" tc-ld-is-${linker} || continue
+			LDFLAGS="-fuse-ld=${linker}" test-compile 'c+ld' 'int main() { return 0; }' || continue
+
+			test_lto_guarantee_fat
+			test_strip_lto_bytecode
+		done
+	done
+}
+
+_repeat_mixed_tests_with_linkers() {
+	# Call test_mixed_objects_after_stripping with various linkers.
+	#
+	# Needs both GCC and Clang to test mixing their outputs.
+	if type -P gcc &>/dev/null && type -P clang &>/dev/null ; then
+		for linker in bfd lld mold gold ; do
+			# lld doesn't support GCC LTO: https://github.com/llvm/llvm-project/issues/41791
+			[[ ${CC} == gcc && ${linker} == lld ]] && continue
+			# Make sure the relevant linker is actually installed and usable.
+			LDFLAGS="-fuse-ld=${linker}" tc-ld-is-${linker} || continue
+			LDFLAGS="-fuse-ld=${linker}" test-compile 'c+ld' 'int main() { return 0; }' || continue
+
+			CC_1=gcc AR_1=ar
+			CC_2=clang AR_2=llvm-ar
+			test_mixed_objects_after_stripping
+			test_mixed_archives_after_stripping
+		done
+	fi
+}
+
+# TODO: maybe test several files
+mkdir -p "${tmpdir}/lto" || die
+pushd "${tmpdir}/lto" >/dev/null || die
+_create_test_progs
+_repeat_tests_with_compilers
+_repeat_mixed_tests_with_linkers
+test_search_recursion
+texit

--- a/eclass/tests/dot-a.sh
+++ b/eclass/tests/dot-a.sh
@@ -9,45 +9,6 @@ source version-funcs.sh || exit
 
 inherit dot-a
 
-_strip_is_gnu() {
-	local name=$($(tc-getSTRIP) --version 2>&1 | head -n 1)
-
-	if ! [[ ${name} =~ ^GNU.*strip ]] ; then
-		return 1
-	fi
-
-	return 0
-}
-
-_check_binutils_version() {
-	local tool=$1
-	# Convert this:
-	# ```
-	# GNU ld (Gentoo 2.38 p4) 2.38
-	# Copyright (C) 2022 Free Software Foundation, Inc.
-	# This program is free software; you may redistribute it under the terms of
-	# the GNU General Public License version 3 or (at your option) a later version.
-	# This program has absolutely no warranty.
-	# ```
-	#
-	# into...
-	# ```
-	# 2.38
-	# ```
-	local ver=$(${tool} --version 2>&1 | head -n 1 | rev | cut -d' ' -f1 | rev)
-
-	if ! [[ ${ver} =~ [0-9].[0-9][0-9](.[0-9]?) ]] ; then
-		# Skip if unrecognised format so we don't pass something
-		# odd into ver_cut.
-		return
-	fi
-
-	ver_major=$(ver_cut 1 "${ver}")
-	ver_minor=$(ver_cut 2 "${ver}")
-	ver_extra=$(ver_cut 3 "${ver}")
-	echo ${ver_major}.${ver_minor}${ver_extra:+.${ver_extra}}
-}
-
 _create_test_progs() {
 	cat <<-EOF > a.c
 	int foo();
@@ -154,9 +115,6 @@ test_strip_lto_bytecode() {
 		# strip-lto-bytecode will error out early with LLVM,
 		# so stop the test here.
 		tc-is-clang && return 0
-		# strip with >= GNU Binutils 2.45 won't corrupt the archive:
-		# https://sourceware.org/PR21479
-		_strip_is_gnu && ver_test $(_check_binutils_version $(tc-getSTRIP)) -gt 2.44 && return 0
 
 		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
 
@@ -195,9 +153,6 @@ test_strip_lto_bytecode() {
 		# strip-lto-bytecode will error out early with LLVM,
 		# so stop the test here.
 		tc-is-clang && return 0
-		# strip with >= GNU Binutils 2.45 won't corrupt the archive:
-		# https://sourceware.org/PR21479
-		_strip_is_gnu && ver_test $(_check_binutils_version $(tc-getSTRIP)) -gt 2.44 && return 0
 
 		$(tc-getCC) ${CFLAGS} a.c -o a.o -c 2>/dev/null || return 1
 		$(tc-getAR) q test.a a.o 2>/dev/null || return 1

--- a/sys-devel/flex/flex-2.6.4-r6.ebuild
+++ b/sys-devel/flex/flex-2.6.4-r6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit flag-o-matic libtool multilib-minimal toolchain-funcs
+inherit dot-a flag-o-matic libtool multilib-minimal toolchain-funcs
 
 DESCRIPTION="The Fast Lexical Analyzer"
 HOMEPAGE="https://github.com/westes/flex"
@@ -53,7 +53,7 @@ src_prepare() {
 
 src_configure() {
 	use static && append-ldflags -static
-
+	lto-guarantee-fat
 	multilib-minimal_src_configure
 }
 
@@ -86,6 +86,7 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
 	einstalldocs
 	dodoc ONEWS
 	find "${ED}" -name '*.la' -type f -delete || die

--- a/sys-libs/zlib/zlib-1.3.1-r1.ebuild
+++ b/sys-libs/zlib/zlib-1.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 # Worth keeping an eye on 'develop' branch upstream for possible backports.
 AUTOTOOLS_AUTO_DEPEND="no"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/madler.asc
-inherit autotools edo multilib-minimal flag-o-matic verify-sig
+inherit autotools dot-a edo multilib-minimal flag-o-matic verify-sig
 
 DESCRIPTION="Standard (de)compression library"
 HOMEPAGE="https://zlib.net/"
@@ -66,6 +66,11 @@ src_prepare() {
 
 			;;
 	esac
+}
+
+src_configure() {
+	lto-guarantee-fat
+	multilib-minimal_src_configure
 }
 
 multilib_src_configure() {
@@ -164,6 +169,8 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
+	strip-lto-bytecode
+
 	dodoc FAQ README ChangeLog doc/*.txt
 
 	if use minizip ; then


### PR DESCRIPTION
This needs more testing still as well as some decisions on where to put QA checks (and they should be opt-in as well).

---

Introduce a new eclass with utility functions for handling LTO bytecode (or internal representation, IR) inside static archives (.a files).

Static libraries when built with LTO will contain LTO bytecode which is not portable across compiler versions or compiler vendors. To avoid pessimising the library and always filtering LTO, we can build it with -ffat-lto-objects instead, which builds some components twice. The installed part will then have the LTO contents stripped out, leaving the regular objects in the static archive.

It's not feasible to make these work otherwise, as we'd need tracking for whether a library was built by a specific compiler and its version, and that compatibility can vary based on other factors (e.g. with gcc, sys-devel/gcc[zstd] controls if it supports zstd compression for LTO). We also discourage static libraries anyway.

Provide two functions:

* lto-guarantee-fat

  If LTO is currently enabled (as determined by `tc-is-lto`, added in 2aea6c3ff2181ad96187e456a3307609fd288d4c), add `-ffat-lto-objects` to CFLAGS and CXXFLAGS if supported.

  This guarantees that produced archives are "fat" (contain both IR and regular object files) for later pruning.

* strip-lto-bytecode

  Process a given static archive (.a file) and remove its IR component, leaving a regular object.

This approach is also taken by Fedora, openSUSE, and Debian/Ubuntu.

We did consider an alternative approach where we'd relink objects using the driver in src_install (or some hook afterwards), but this would be more brittle, as we'd need to extract the right arguments to use (see e.g. the recent Wireshark issues in fad8ff8a45afc83559f8df695cf96dfec51d3e8a for how this can be subtle) and not PM-agnostic given we don't have portable hooks right now (and even if we did, suspect they wouldn't work in a way that facilitated this). It's also not clear if such an approach would've worked for Clang.

All of this wasn't worth pursuing until H. J. Lu's patches for binutils
landed, which they have now in binutils-2.44 [0], which made bfd's handling
of mixed objects much more robust.

[0] https://inbox.sourceware.org/binutils/20250112220244.597636-1-hjl.tools@gmail.com/

Bug: https://bugs.gentoo.org/926120
Thanks-to: Arsen Arsenović <arsen@gentoo.org>
Thanks-to: Eli Schwartz <eschwartz@gentoo.org>
