### PR TITLE
dev-db/mariadb:  apply libxml2 patch & musl largefile workaround

### DIFF
--- a/dev-db/mariadb/mariadb-10.11.11.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.11.ebuild
@@ -299,6 +299,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-10.11.12.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.12.ebuild
@@ -290,6 +290,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-10.6.15.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.15.ebuild
@@ -299,6 +299,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-10.6.15.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.15.ebuild
@@ -223,6 +223,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-10.6.11-gssapi.patch
 	eapply "${FILESDIR}"/${PN}-10.6.11-include.patch
 	eapply "${FILESDIR}"/${PN}-10.6.12-gcc-13.patch
+	eapply "${FILESDIR}"/${PN}-10.6.17-libxml-2.12.patch
 	eapply "${WORKDIR}"/${PN}-10.6-columnstore-with-boost-1.85.patch
 
 	eapply_user

--- a/dev-db/mariadb/mariadb-10.6.20.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.20.ebuild
@@ -301,6 +301,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-10.6.21.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.21.ebuild
@@ -301,6 +301,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-10.6.22.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.22.ebuild
@@ -301,6 +301,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-11.4.5-r1.ebuild
+++ b/dev-db/mariadb/mariadb-11.4.5-r1.ebuild
@@ -294,6 +294,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 

--- a/dev-db/mariadb/mariadb-11.4.6.ebuild
+++ b/dev-db/mariadb/mariadb-11.4.6.ebuild
@@ -285,6 +285,8 @@ src_configure() {
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# It fails on alpha without this
 	use alpha && append-ldflags "-Wl,--no-relax"
 


### PR DESCRIPTION
fix many errors like bellow:

> mysql/storage/connect/filamfix.cpp:698:7: error: use of undeclared identifier 'lseek64'; did you mean 'lseek'?

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
