### PR TITLE
dev-python/jaraco-context: add missing cond dep for pypy3*

### DIFF
--- a/dev-python/jaraco-context/jaraco-context-6.0.1.ebuild
+++ b/dev-python/jaraco-context/jaraco-context-6.0.1.ebuild
@@ -23,7 +23,7 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 
 RDEPEND="
 	$(python_gen_cond_dep '
 		dev-python/backports-tarfile[${PYTHON_USEDEP}]
-	' 3.10 3.11)
+	' 3.10 3.11 'pypy3*')
 "
 BDEPEND="
 	test? (


### PR DESCRIPTION
The missing cond dep can result in build failures for setuptools since jaraco-context does not pull in backports for pypy3*.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
