### PR TITLE
virtual/ldb: add 2.9.2

### DIFF
--- a/virtual/ldb/ldb-2.9.2.ebuild
+++ b/virtual/ldb/ldb-2.9.2.ebuild
@@ -1,0 +1,11 @@
+# Copyright 2024-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Virtual for samba project's ldb"
+
+SLOT="0/2.9.2"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
+
+RDEPEND="sys-libs/ldb:${SLOT}"


### PR DESCRIPTION
Adding missing virtual/ldb-2.9.2

This missing virtual package is causing us to not be able to build sys-auth/sssd-2.9.6-r3

Since sys-auth/sssd-2.9.6-r3 depends on virtual/ldb
We have samba flag enabled so it pulls net-fs/samba

This causes dependency conflict since because of missing virtual/ldb-2.9.2,
virtual/ldb-2.9.1 pulls sys-libs/ldb-2.9.1
and
net-fs/samba-4.20.7 pulls sys-libs/ldb-2.9.2

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
