### PR TITLE
dev-lang/ghc: fixing for RAP and gcc-15

### DIFF
--- a/dev-lang/ghc/files/ghc-9.2.8-use-stdlib.patch
+++ b/dev-lang/ghc/files/ghc-9.2.8-use-stdlib.patch
@@ -1,0 +1,25 @@
+Use stdlib's malloc and realloc instead of extern to avoid conflict
+Reference: https://src.fedoraproject.org/rpms/ghc9.12/blob/12ecf74c5a603b552da365829135e5b62e252db1/f/hp2ps-C-gnu17.patch
+===================================================================
+--- ghc-9.2.8.orig/utils/hp2ps/Utilities.c
++++ ghc-9.2.8/utils/hp2ps/Utilities.c
+@@ -1,10 +1,9 @@
+ #include "Main.h"
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include "Error.h"
+ 
+-extern void* malloc();
+-
+ char*
+ Basename(char *name)
+ {
+@@ -89,7 +88,6 @@ void *
+ xrealloc(void *p, size_t n)
+ {
+     void *r;
+-    extern void *realloc();
+ 
+     r = realloc(p, n);
+     if (!r) {

--- a/dev-lang/ghc/ghc-9.0.2-r4.ebuild
+++ b/dev-lang/ghc/ghc-9.0.2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -148,6 +148,7 @@ RDEPEND="
 #    utils/ghc-pkg_HC_OPTS += -DBOOTSTRAPPING
 PREBUILT_BINARY_DEPENDS="
 	!prefix? ( elibc_glibc? ( >=sys-libs/glibc-2.17 ) )
+	prefix? ( dev-util/patchelf )
 "
 # This set of dependencies is needed to install
 # ghc[binary] in system. terminfo package is linked
@@ -407,6 +408,14 @@ relocate_ghc() {
 
 	if use prefix; then
 		hprefixify "${bin_libpath}"/${PN}*/settings
+		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${P}/bin"
+		find "${bin_libpath}"/${PN}*/bin -type f -print0 | \
+			while IFS=  read -r -d '' filename; do
+				einfo "${filename}'s interpreter changed to ${interpreter}"
+				patchelf ${filename} --set-interpreter ${interpreter} || die
+			done
+		eend $?
 	fi
 
 	# regenerate the binary package cache

--- a/dev-lang/ghc/ghc-9.2.8.ebuild
+++ b/dev-lang/ghc/ghc-9.2.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -700,6 +700,10 @@ src_prepare() {
 		pushd "${S}/libraries/Win32"
 			eapply "${FILESDIR}"/${PN}-8.2.1_rc1-win32-cross-2-hack.patch # bad workaround
 		popd
+
+		# https://bugs.gentoo.org/946695
+		# Fix for gnu17 (gcc-15)
+		eapply "${FILESDIR}/${PN}-9.2.8-use-stdlib.patch"
 
 		bump_libs
 

--- a/dev-lang/ghc/ghc-9.2.8.ebuild
+++ b/dev-lang/ghc/ghc-9.2.8.ebuild
@@ -166,6 +166,7 @@ RDEPEND="
 #    utils/ghc-pkg_HC_OPTS += -DBOOTSTRAPPING
 PREBUILT_BINARY_DEPENDS="
 	!prefix? ( elibc_glibc? ( >=sys-libs/glibc-2.17 ) )
+	prefix? ( dev-util/patchelf )
 "
 # This set of dependencies is needed to install
 # ghc[binary] in system. terminfo package is linked
@@ -426,6 +427,14 @@ relocate_ghc() {
 
 	if use prefix; then
 		hprefixify "${bin_libpath}"/${PN}*/settings
+		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${P}/bin"
+		find "${bin_libpath}"/${PN}*/bin -type f -print0 | \
+			while IFS=  read -r -d '' filename; do
+				einfo "${filename}'s interpreter changed to ${interpreter}"
+				patchelf ${filename} --set-interpreter ${interpreter} || die
+			done
+		eend $?
 	fi
 
 	# regenerate the binary package cache


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

src_test result on RAP:

```
SUMMARY for test run started at Fri May  2 21:04:27 2025 
0:06:17.372938 spent to go through
    8342 total tests, which gave rise to
   32697 test cases, of which
   21527 were skipped

      44 had missing libraries
    8502 expected passes
     175 expected failures

       0 caused framework failures
       0 caused framework warnings
       0 unexpected passes
      11 unexpected failures
       0 unexpected stat failures
      14 fragile tests

Unexpected failures:
   concurrent/should_run/hs_try_putmvar001.run       hs_try_putmvar001 [exit code non-0] (threaded1)
   rts/keep-cafs.run                                 keep-cafs [bad stderr] (normal)
   driver/linkwhole/linkwhole.run                    linkwhole [bad stderr] (normal)
   rts/pause-resume/list_threads_and_misc_roots.run  list_threads_and_misc_roots [exit code non-0] (threaded1)
   driver/recomp015/recomp015.run                    recomp015 [bad stderr] (normal)
   hsc2hs/T12504.run                                 T12504 [bad stderr] (normal)
   simplCore/should_compile/T13340.run               T13340 [bad stderr] (normal)
   codeGen/should_compile/T14999.run                 T14999 [bad stderr] (normal)
   dynlibs/T3807.run                                 T3807 [bad exit code (2)] (normal)
   numeric/should_run/T7014.run                      T7014 [bad stderr] (normal)
   rts/testwsdeque.run                               testwsdeque [exit code non-0] (threaded1)

Fragile test passes:
   concurrent/prog001/concprog001.run              concprog001 [fragile] (threaded2)
   libraries/base/tests/CPUTime001.run             CPUTime001 [fragile] (normal)
   concurrent/should_run/foreignInterruptible.run  foreignInterruptible [fragile] (ghci)
   concurrent/should_run/hs_try_putmvar003.run     hs_try_putmvar003 [fragile] (threaded1)
   runghc/T-signals-child.run                      T-signals-child [fragile] (threaded1)
   ghci/should_run/T3171.run                       T3171 [fragile] (normal)
   concurrent/should_run/T5611.run                 T5611 [fragile] (normal)
   concurrent/should_run/T5611a.run                T5611a [fragile] (normal)

Fragile test failures:
   profiling/should_run/heapprof001.run  heapprof001 [fragile] (ghci-ext-prof)
   profiling/should_run/heapprof001.run  heapprof001 [fragile] (prof)
   ghci/linking/T11531.run               T11531 [fragile] (normal)
   profiling/should_run/T15897.run       T15897 [fragile] (profasm)
   profiling/should_run/T5559.run        T5559 [fragile] (ghci-ext-prof)
   profiling/should_run/T5559.run        T5559 [fragile] (prof)
```
