### PR TITLE
net-fs/cifs-utils: fix build in musl

### DIFF
--- a/net-fs/cifs-utils/cifs-utils-7.0-r1.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-7.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-6.12-ln_in_destdir.patch" #766594
 	"${FILESDIR}/${PN}-6.15-musl.patch"
 	"${FILESDIR}/${PN}-7.0-no-clobber-fortify-source.patch"
+	"${FILESDIR}/${PN}-7.0-musl.patch"
 )
 
 pkg_setup() {

--- a/net-fs/cifs-utils/cifs-utils-7.3.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-7.3.ebuild
@@ -44,6 +44,7 @@ DOCS="doc/linux-cifs-client-guide.odt"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-7.3-no-clobber-fortify-source.patch"
+	"${FILESDIR}/${PN}-7.0-musl.patch"
 )
 
 pkg_setup() {

--- a/net-fs/cifs-utils/files/cifs-utils-7.0-musl.patch
+++ b/net-fs/cifs-utils/files/cifs-utils-7.0-musl.patch
@@ -1,0 +1,39 @@
+https://lore.kernel.org/linux-cifs/CALMA0xaVdk3qwkb-92QqF2+6z+=oxbBWDR1hYEoE2WUc7jVGkw@mail.gmail.com/T/#u
+
+From abd3d9a2d4f8a5dc4d90daddc7cf0c62d954f03a Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Fri, 2 May 2025 23:08:41 +0800
+Subject: [PATCH] getcifsacl, setcifsacl: use <libgen.h> for basename
+
+basename() is defined in <libgen.h> only in musl, while glibc defines it
+in <string.h> too, which is not standard behavior.
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/getcifsacl.c b/getcifsacl.c
+index 97471e9..6c6356f 100644
+--- a/getcifsacl.c
++++ b/getcifsacl.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #include <stddef.h>
+ #include <errno.h>
++#include <libgen.h>
+ #include <limits.h>
+ #include <ctype.h>
+ #include <linux/limits.h>
+diff --git a/setcifsacl.c b/setcifsacl.c
+index b199118..3cb603c 100644
+--- a/setcifsacl.c
++++ b/setcifsacl.c
+@@ -47,6 +47,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <errno.h>
++#include <libgen.h>
+ #include <limits.h>
+ #include <ctype.h>
+ #include <linux/limits.h>
+-- 
+2.45.2
+


### PR DESCRIPTION
basename() is defined in <libgen.h> in standard

Closes: https://bugs.gentoo.org/936928

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
