### PR TITLE
dev-util/bpftool: prevent attribute warning with bpf-toolchain

### DIFF
--- a/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
+++ b/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
@@ -94,6 +94,11 @@ src_prepare() {
 	sed -i 's/-fno-stack-protector/& -std=gnu11/g' src/Makefile || die
 
 	if ! use clang; then
+		# prevent attribute warning about preserve_access_index
+		# since gcc does not support '#pragma clang attribute push':
+		# https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=675b4e2
+		sed -i 's/std=gnu11/& -DBPF_NO_PRESERVE_ACCESS_INDEX/g' src/Makefile || die
+
 		# remove bpf target & add assembly annotations to fix CO-RE feature detection
 		sed -i -e 's/-target bpf/-dA/' src/Makefile.feature || die
 

--- a/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
+++ b/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
@@ -94,6 +94,11 @@ src_prepare() {
 	sed -i 's/-fno-stack-protector/& -std=gnu11/g' src/Makefile || die
 
 	if ! use clang; then
+		# make people aware of what they are doing
+		ewarn "Using bpf-toolchain instead of clang due to USE=-clang."
+		ewarn "Please report any odd behaviours you observe, since using gcc for BPF"
+		ewarn "is still under development in both the Linux kernel and gcc itself."
+
 		# prevent attribute warning about preserve_access_index
 		# since gcc does not support '#pragma clang attribute push':
 		# https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=675b4e2

--- a/dev-util/bpftool/bpftool-9999.ebuild
+++ b/dev-util/bpftool/bpftool-9999.ebuild
@@ -92,6 +92,11 @@ src_prepare() {
 	sed -i 's/-fno-stack-protector/& -std=gnu11/g' src/Makefile || die
 
 	if ! use clang; then
+		# prevent attribute warning about preserve_access_index
+		# since gcc does not support '#pragma clang attribute push':
+		# https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=675b4e2
+		sed -i 's/std=gnu11/& -DBPF_NO_PRESERVE_ACCESS_INDEX/g' src/Makefile || die
+
 		# remove bpf target & add assembly annotations to fix CO-RE feature detection
 		sed -i -e 's/-target bpf/-dA/' src/Makefile.feature || die
 

--- a/dev-util/bpftool/bpftool-9999.ebuild
+++ b/dev-util/bpftool/bpftool-9999.ebuild
@@ -92,6 +92,11 @@ src_prepare() {
 	sed -i 's/-fno-stack-protector/& -std=gnu11/g' src/Makefile || die
 
 	if ! use clang; then
+		# make people aware of what they are doing
+		ewarn "Using bpf-toolchain instead of clang due to USE=-clang."
+		ewarn "Please report any odd behaviours you observe, since using gcc for BPF"
+		ewarn "is still under development in both the Linux kernel and gcc itself."
+
 		# prevent attribute warning about preserve_access_index
 		# since gcc does not support '#pragma clang attribute push':
 		# https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=675b4e2


### PR DESCRIPTION
The bpf-generated kernel headers currently use a clang-specific pragma to annotate data structures with the preserve_access_index attribute; since this does not work with gcc, the attribute will be ignored. Luckily the BPF test suite already has a macro guard called BPF_NO_PRESERVE_ACCESS_INDEX for this case, so just define that for the bpftool build as well.

Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
