### PR TITLE
app-accessibility/flite: don't call ar directly

### DIFF
--- a/app-accessibility/flite/files/flite-2.2-no-native-ar.patch
+++ b/app-accessibility/flite/files/flite-2.2-no-native-ar.patch
@@ -1,0 +1,22 @@
+From 54c65164840777326bbb83517568e38a128122ef Mon Sep 17 00:00:00 2001
+From: Rick van Schijndel <rol3517@gmail.com>
+Date: Sat, 27 Feb 2021 11:47:09 +0100
+Subject: [PATCH] common_make_rules: use  instead of the native ar command
+
+
+diff --git a/config/common_make_rules b/config/common_make_rules
+index 9dfe994..1a45b43 100644
+--- a/config/common_make_rules
++++ b/config/common_make_rules
+@@ -122,7 +122,7 @@ $(LIBDIR)/%.so: $(LIBDIR)/%.shared.a
+ 	@ echo making $@
+ 	@ rm -rf shared_os && mkdir shared_os
+ 	@ rm -f $@ $@.${PROJECT_VERSION} $@.${PROJECT_SHLIB_VERSION} 
+-	@ (cd shared_os && ar x ../$<)
++	@ (cd shared_os && $(AR) x ../$<)
+ 	@ (cd shared_os && $(CC) -shared -Wl,-soname,`basename $@`.${PROJECT_SHLIB_VERSION} -o ../$@.${PROJECT_VERSION} *.os $(LDFLAGS))
+ 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_VERSION}` `basename $@.${PROJECT_SHLIB_VERSION}` )
+ 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_SHLIB_VERSION}` `basename $@` )
+-- 
+2.45.2
+

--- a/app-accessibility/flite/flite-2.2-r1.ebuild
+++ b/app-accessibility/flite/flite-2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -59,6 +59,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.4-audio-interface.patch
 	"${FILESDIR}"/${PN}-2.2-backport-pr30.patch
 	"${FILESDIR}"/${PN}-2.2-make-4.4.patch
+	"${FILESDIR}"/${PN}-2.2-no-native-ar.patch
 )
 
 get_audio() {

--- a/app-accessibility/flite/flite-2.2-r2.ebuild
+++ b/app-accessibility/flite/flite-2.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2-backport-pr30.patch
 	"${FILESDIR}"/${PN}-2.2-make-4.4.patch
 	"${FILESDIR}"/${PN}-2.2-backport-pr66.patch
+	"${FILESDIR}"/${PN}-2.2-no-native-ar.patch
 )
 
 get_audio() {

--- a/app-accessibility/flite/flite-2.2-r3.ebuild
+++ b/app-accessibility/flite/flite-2.2-r3.ebuild
@@ -61,6 +61,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2-make-4.4.patch
 	"${FILESDIR}"/${PN}-2.2-backport-pr66.patch
 	"${FILESDIR}"/${PN}-2.2-remove-const-cast.patch
+	"${FILESDIR}"/${PN}-2.2-no-native-ar.patch
 )
 
 get_audio() {


### PR DESCRIPTION
apply patch from upstream

Closes: https://bugs.gentoo.org/718048

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
