### PR TITLE
net-p2p/deluge: add USE=appindicator

### DIFF
--- a/net-p2p/deluge/deluge-2.1.1-r7.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r7.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.deluge-torrent.org/${PN}"
 else
 	SRC_URI="http://download.deluge-torrent.org/source/$(ver_cut 1-2)/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~riscv"
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
 fi
 
 LICENSE="GPL-2"
@@ -63,6 +63,15 @@ RDEPEND="
 		libnotify? ( x11-libs/libnotify )
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-twisted-22.10.patch"
+	# https://dev.deluge-torrent.org/ticket/3598
+	"${FILESDIR}/${P}-ayatana.patch"
+	# https://dev.deluge-torrent.org/ticket/3582
+	"${FILESDIR}/${P}-consoleui-deferred.patch"
+	"${FILESDIR}/${P}-email-module-replace.patch"
+)
 
 distutils_enable_tests pytest
 
@@ -131,7 +140,7 @@ python_install_all() {
 	if use webinterface; then
 		newinitd "${FILESDIR}/deluge-web.init-2" deluge-web
 		newconfd "${FILESDIR}/deluge-web.conf" deluge-web
-		systemd_newunit "${FILESDIR}/deluge-web.service-3" deluge-web.service
+		systemd_newunit "${FILESDIR}/deluge-web.service-4" deluge-web.service
 		systemd_install_serviced "${FILESDIR}/deluge-web.service.conf"
 	else
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/web/" || die
@@ -156,7 +165,9 @@ pkg_postinst() {
 	elog
 	elog "To start the daemon either run 'deluged' as user"
 	elog "or modify /etc/conf.d/deluged and run"
-	elog "/etc/init.d/deluged start as root"
+	elog "'/etc/init.d/deluged start' as root if you use OpenRC"
+	elog "or"
+	elog "'systemctl start deluged.service' as root if you use systemd"
 	elog "You can still use deluge the old way"
 	elog
 	elog "Systemd unit files for deluged and deluge-web no longer source"


### PR DESCRIPTION
Add the `appindicator` USE flag along with the `dev-libs/libayatana-appindicator` `RDEPEND`.

See https://git.deluge-torrent.org/deluge/commit/?h=develop&id=d5af32802f7ec7cdb8b741812f1e2b0cebbb3bc6.

Closes: https://bugs.gentoo.org/939078

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
