### PR TITLE
net-libs/nodejs: disable -O3 option in V8 dependency that cause compi…

### DIFF
--- a/net-libs/nodejs/nodejs-22.13.1.ebuild
+++ b/net-libs/nodejs/nodejs-22.13.1.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-22.14.0.ebuild
+++ b/net-libs/nodejs/nodejs-22.14.0.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-22.15.0.ebuild
+++ b/net-libs/nodejs/nodejs-22.15.0.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-99999999.ebuild
+++ b/net-libs/nodejs/nodejs-99999999.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then


### PR DESCRIPTION
Just removed '-O3' substring from file tools/v8_gypfiles/toolchain.gypi that used when comile 'deps/v8/...' folder to set CXXFLAGS.
added line 
`sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi` to prepare phase for every ebuild from 22.13.1 version to 9999

Bug: https://bugs.gentoo.org/930099
Bug: https://bugs.gentoo.org/931150

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
