### PR TITLE
net-analyzer/pktstat: update EAPI 7 -> 8, fix for gcc15

### DIFF
--- a/net-analyzer/pktstat/files/pktstat-1.8.5-gcc15.patch
+++ b/net-analyzer/pktstat/files/pktstat-1.8.5-gcc15.patch
@@ -1,0 +1,24 @@
+https://github.com/dleonard0/pktstat/pull/6
+https://bugs.gentoo.org/945321
+
+--- a/resize.c
++++ b/resize.c
+@@ -36,7 +36,7 @@
+ #include "compat.h"
+ 
+ #ifdef SIGWINCH
+-static RETSIGTYPE sigwinch();
++static RETSIGTYPE sigwinch(int sig);
+ #endif
+ 
+ static volatile int sigwinch_seen;
+@@ -44,8 +44,7 @@ static volatile int sigwinch_seen;
+ #ifdef SIGWINCH
+ /* Set the flag when the window size changes */
+ static RETSIGTYPE
+-sigwinch(sig)
+-	int sig;
++sigwinch(int sig)
+ {
+ 	sigwinch_seen = 1;
+ }

--- a/net-analyzer/pktstat/metadata.xml
+++ b/net-analyzer/pktstat/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>netmon@gentoo.org</email>
-	<name>Gentoo network monitoring and analysis project</name>
-</maintainer>
+	<maintainer type="project">
+		<email>netmon@gentoo.org</email>
+		<name>Gentoo network monitoring and analysis project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">dleonard0/pktstat</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/net-analyzer/pktstat/pktstat-1.8.5-r2.ebuild
+++ b/net-analyzer/pktstat/pktstat-1.8.5-r2.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A network monitoring tool with bandwidth tracking"
+HOMEPAGE="https://github.com/dleonard0/pktstat http://www.adaptive-enterprises.com.au/~d/software/pktstat/"
+SRC_URI="http://www.adaptive-enterprises.com.au/~d/software/pktstat/${P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+BDEPEND="virtual/pkgconfig"
+RDEPEND="
+	net-libs/libpcap
+	>=sys-libs/ncurses-5.3-r1
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-tinfo.patch
+	"${FILESDIR}"/${P}-smtp_line.patch
+	"${FILESDIR}"/${P}-gcc15.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_install() {
+	dosbin pktstat
+	doman pktstat.1
+	dodoc ChangeLog NEWS README TODO
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/945321

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
