### PR TITLE
media-libs/libtgvoip: fix missing cstdint for gcc-15

### DIFF
--- a/media-libs/libtgvoip/files/libtgvoip-2.4.4_p20240706-fix-missing-cstdint-for-gcc-15.patch
+++ b/media-libs/libtgvoip/files/libtgvoip-2.4.4_p20240706-fix-missing-cstdint-for-gcc-15.patch
@@ -1,0 +1,37 @@
+https://bugs.gentoo.org/938332
+https://github.com/telegramdesktop/libtgvoip/pull/38
+
+From ddfb667ba17c31898949dcbf07c863e268e5c85a Mon Sep 17 00:00:00 2001
+From: Blackteahamburger <blackteahamburger@outlook.com>
+Date: Fri, 30 Aug 2024 20:02:12 +0800
+Subject: [PATCH] Fix missing cstdint for GCC 15
+
+---
+ TgVoip.h   | 1 +
+ json11.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/TgVoip.h b/TgVoip.h
+index 9ad06155..6ea64b47 100755
+--- a/TgVoip.h
++++ b/TgVoip.h
+@@ -1,6 +1,7 @@
+ #ifndef __TGVOIP_H
+ #define __TGVOIP_H
+ 
++#include <cstdint>
+ #include <functional>
+ #include <vector>
+ #include <string>
+diff --git a/json11.cpp b/json11.cpp
+index 812e6103..1818db3f 100755
+--- a/json11.cpp
++++ b/json11.cpp
+@@ -22,6 +22,7 @@
+ #include "json11.hpp"
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>

--- a/media-libs/libtgvoip/libtgvoip-2.4.4_p20240706.ebuild
+++ b/media-libs/libtgvoip/libtgvoip-2.4.4_p20240706.ebuild
@@ -30,6 +30,10 @@ REQUIRED_USE="
 	|| ( alsa pulseaudio )
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-fix-missing-cstdint-for-gcc-15.patch"
+)
+
 src_prepare() {
 	# Will be controlled by us
 	sed -i -e '/^CFLAGS += -DTGVOIP_NO_DSP/d' Makefile.am || die


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938332

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
