### PR TITLE
sys-boot/woeusb-ng: add app-arch/7zip as an alternative

### DIFF
--- a/sys-boot/woeusb-ng/woeusb-ng-0.2.12-r1.ebuild
+++ b/sys-boot/woeusb-ng/woeusb-ng-0.2.12-r1.ebuild
@@ -22,7 +22,10 @@ IUSE="gui"
 
 RDEPEND="
 	!sys-boot/woeusb
-	app-arch/p7zip
+	|| (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	)
 	sys-apps/util-linux
 	sys-block/parted
 	sys-boot/grub:2


### PR DESCRIPTION
It's just using `7z e` command.
https://github.com/WoeUSB/WoeUSB-ng/blob/18e8918f75af26c0258a5b5f7bdb13acb76611eb/WoeUSB/workaround.py#L100

Closes: https://bugs.gentoo.org/955161

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
