### PR TITLE
net-p2p/syncthing: port missing patch

### DIFF
--- a/net-p2p/syncthing/files/syncthing-1.29.5-remove_race_in_tests.patch
+++ b/net-p2p/syncthing/files/syncthing-1.29.5-remove_race_in_tests.patch
@@ -1,0 +1,15 @@
+This patch removes conditional appending of "-race" flag.
+It is needed as we build in PIE mode and race is incompatible with that.
+
+https://bugs.gentoo.org/955442
+--- a/build.go
++++ b/build.go
+@@ -396,7 +396,7 @@
+ 	}
+ 	args = append(args, "-timeout", timeout)
+ 
+-	if runtime.GOARCH == "amd64" {
++	if false {
+ 		switch runtime.GOOS {
+ 		case buildpkg.Darwin, buildpkg.Linux, buildpkg.FreeBSD: // , "windows": # See https://github.com/golang/go/issues/27089
+ 			args = append(args, "-race")

--- a/net-p2p/syncthing/syncthing-1.29.5.ebuild
+++ b/net-p2p/syncthing/syncthing-1.29.5.ebuild
@@ -31,6 +31,7 @@ DOCS=( AUTHORS {GOALS,README}.md )
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.3.4-TestIssue5063_timeout.patch
 	"${FILESDIR}"/${PN}-1.18.4-tool_users.patch
+	"${FILESDIR}"/${PN}-1.29.5-remove_race_in_tests.patch #955442
 )
 
 src_prepare() {


### PR DESCRIPTION
I feel like `sed` here is the better choice as we never want to have `-race`, but I am not the mainainer so I went with the preexisting solution.

Is the description within the patch good enough?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
