### PR TITLE
 media-libs/nvidia-vaapi-driver: Nvidia vaapi driver make "gstream" dependency optional #41925e

### DIFF
--- a/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.13.ebuild
+++ b/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.13.ebuild
@@ -12,8 +12,9 @@ SRC_URI="https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v${PV}
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
+IUSE="+gstreamer"
 
-RDEPEND="media-libs/gst-plugins-bad
+RDEPEND="gstreamer? ( media-libs/gst-plugins-bad )
 	media-libs/libglvnd
 	>=media-libs/libva-1.8.0
 	>=x11-libs/libdrm-2.4.60"

--- a/net-libs/nodejs/nodejs-22.13.1.ebuild
+++ b/net-libs/nodejs/nodejs-22.13.1.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-22.14.0.ebuild
+++ b/net-libs/nodejs/nodejs-22.14.0.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-22.15.0.ebuild
+++ b/net-libs/nodejs/nodejs-22.15.0.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then

--- a/net-libs/nodejs/nodejs-99999999.ebuild
+++ b/net-libs/nodejs/nodejs-99999999.ebuild
@@ -99,6 +99,7 @@ src_prepare() {
 	sed -i -e "/DEPFLAGS =/d" tools/gyp/pylib/gyp/generator/make.py || die
 
 	sed -i -e "/'-O3'/d" common.gypi node.gypi || die
+	sed -i -e "/'-O3'/d" tools/v8_gypfiles/toolchain.gypi
 
 	# debug builds. change install path, remove optimisations and override buildtype
 	if use debug; then


### PR DESCRIPTION
I was unable to build "media-libs/gst-plugins-bad" without multilib because it was required "gstream".
I made this dependency optional with IUSE=gst flag that I added, very simple.
I added description to metadata file but I don't know how to generate Manifest for that, add info to WIKI.

Bug: https://bugs.gentoo.org/955370
---

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.