### PR TITLE
media-libs/nvidia-vaapi-driver: Nvidia vaapi driver make "gstreamer" dependency optional #41925

### DIFF
--- a/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.13.ebuild
+++ b/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.13.ebuild
@@ -12,8 +12,9 @@ SRC_URI="https://github.com/elFarto/nvidia-vaapi-driver/archive/refs/tags/v${PV}
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
+IUSE="+gstreamer"
 
-RDEPEND="media-libs/gst-plugins-bad
+RDEPEND="gstreamer? ( media-libs/gst-plugins-bad )
 	media-libs/libglvnd
 	>=media-libs/libva-1.8.0
 	>=x11-libs/libdrm-2.4.60"


### PR DESCRIPTION
I was unable to build "media-libs/gst-plugins-bad" without multilib because it was required "gstream".
I made this dependency optional with IUSE=gst flag that I added, very simple.

I added description to metadata file but I don't know how to generate Manifest for that, add info to WIKI.

Bug: https://bugs.gentoo.org/955370

---
- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
