### PR TITLE
x11-libs/cairo: python interpeter required for build time scripts

### DIFF
--- a/x11-libs/cairo/cairo-1.18.4-r1.ebuild
+++ b/x11-libs/cairo/cairo-1.18.4-r1.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit meson-multilib
+PYTHON_COMPAT=( python3_{11..13} )
+inherit meson-multilib python-any-r1
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -45,6 +46,7 @@ DEPEND="${RDEPEND}
 	)
 	X? ( x11-base/xorg-proto )"
 BDEPEND="
+	${PYTHON_DEPS}
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gtk-doc )"
 

--- a/x11-libs/cairo/cairo-1.18.4.ebuild
+++ b/x11-libs/cairo/cairo-1.18.4.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit meson-multilib
+PYTHON_COMPAT=( python3_{11..13} )
+inherit meson-multilib python-any-r1
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -45,6 +46,7 @@ DEPEND="${RDEPEND}
 	)
 	X? ( x11-base/xorg-proto )"
 BDEPEND="
+	${PYTHON_DEPS}
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gtk-doc )"
 

--- a/x11-libs/cairo/cairo-9999.ebuild
+++ b/x11-libs/cairo/cairo-9999.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit meson-multilib
+PYTHON_COMPAT=( python3_{11..13} )
+inherit meson-multilib python-any-r1
 
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
@@ -45,6 +46,7 @@ DEPEND="${RDEPEND}
 	)
 	X? ( x11-base/xorg-proto )"
 BDEPEND="
+	${PYTHON_DEPS}
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gtk-doc )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/892786

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
