### PR TITLE
dev-java/ant-ivy: destabilize 2.5.0-r4 and friends for ~ppc64 in order to allow dropping ~dev-java/{libg,bnd-util,bnd-annotation}-7.0.0

### DIFF
--- a/dev-java/ant-contrib/ant-contrib-1.0_beta6_pre20201123-r3.ebuild
+++ b/dev-java/ant-contrib/ant-contrib-1.0_beta6_pre20201123-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,7 +17,7 @@ S="${WORKDIR}/${PN}-${MY_COMMIT}/${PN}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ppc64"
+KEYWORDS="amd64 ~ppc64"
 
 # Too many tests fail
 RESTRICT="test"

--- a/dev-java/ant-ivy/ant-ivy-2.5.0-r4.ebuild
+++ b/dev-java/ant-ivy/ant-ivy-2.5.0-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ S="${WORKDIR}/apache-ivy-${PV}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ppc64"
+KEYWORDS="amd64 ~ppc64"
 
 PROPERTIES="test_network"
 RESTRICT="test"

--- a/dev-java/bnd-util/bnd-util-7.0.0.ebuild
+++ b/dev-java/bnd-util/bnd-util-7.0.0.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/bnd-${PV}"
 
 LICENSE="Apache-2.0 EPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 arm64 ~ppc64"
+KEYWORDS="amd64 ~arm64 ~ppc64"
 
 CP_DEPEND="dev-java/osgi-annotation:0"
 

--- a/dev-java/bnd-util/bnd-util-7.0.0.ebuild
+++ b/dev-java/bnd-util/bnd-util-7.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ S="${WORKDIR}/bnd-${PV}"
 
 LICENSE="Apache-2.0 EPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 arm64 ppc64"
+KEYWORDS="amd64 arm64 ~ppc64"
 
 CP_DEPEND="dev-java/osgi-annotation:0"
 

--- a/dev-java/bndlib/bndlib-7.0.0.ebuild
+++ b/dev-java/bndlib/bndlib-7.0.0.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/bnd-${PV}"
 
 LICENSE="Apache-2.0 EPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 ppc64"
+KEYWORDS="amd64 ~ppc64"
 
 CP_DEPEND="
 	~dev-java/bnd-annotation-${PV}:0

--- a/dev-java/commons-vfs/commons-vfs-2.0-r4.ebuild
+++ b/dev-java/commons-vfs/commons-vfs-2.0-r4.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${P}/core"
 
 LICENSE="Apache-2.0"
 SLOT="2"
-KEYWORDS="amd64 ppc64 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~ppc64 ~amd64-linux ~x86-linux"
 
 CP_DEPEND="
 	>=dev-java/ant-1.10.14-r3:0

--- a/dev-java/jackrabbit-webdav/jackrabbit-webdav-2.10.1-r3.ebuild
+++ b/dev-java/jackrabbit-webdav/jackrabbit-webdav-2.10.1-r3.ebuild
@@ -16,7 +16,7 @@ SRC_URI="mirror://apache/${MY_PN}/${PV}/${MY_PN}-${PV}-src.zip"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ppc64"
+KEYWORDS="amd64 ~ppc64"
 
 S="${WORKDIR}/${MY_PN}-${PV}/${PN}"
 

--- a/dev-java/libg/libg-7.0.0.ebuild
+++ b/dev-java/libg/libg-7.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ S="${WORKDIR}/bnd-${PV}"
 
 LICENSE="Apache-2.0 EPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 arm64 ppc64"
+KEYWORDS="amd64 arm64 ~ppc64"
 # aQute.bnd.test.jupiter does not exist
 # org.assertj.core.api.junit.jupiter does not exist
 RESTRICT="test" #839681

--- a/dev-java/libg/libg-7.0.0.ebuild
+++ b/dev-java/libg/libg-7.0.0.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/bnd-${PV}"
 
 LICENSE="Apache-2.0 EPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 arm64 ~ppc64"
+KEYWORDS="amd64 ~arm64 ~ppc64"
 # aQute.bnd.test.jupiter does not exist
 # org.assertj.core.api.junit.jupiter does not exist
 RESTRICT="test" #839681


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
