### PR TITLE
Update Rdep's for zram-init-9999.ebuild

### DIFF
--- a/sys-block/zram-init/zram-init-9999.ebuild
+++ b/sys-block/zram-init/zram-init-9999.ebuild
@@ -23,6 +23,7 @@ RESTRICT="binchecks strip test"
 BDEPEND="sys-devel/gettext"
 
 RDEPEND="
+	>=sys-apps/util-linux-2.41
 	>=app-shells/push-2.0
 	virtual/libintl
 	|| ( sys-apps/openrc sys-apps/systemd )


### PR DESCRIPTION
As per https://github.com/vaeth/zram-init/pull/47 
>=sys-apps/util-linux-2.41 is now required for latest.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
