### PR TITLE
media-gfx/gimp: Revert -std=gnu17

### DIFF
--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -164,9 +164,6 @@ _adjust_sandbox() {
 src_configure() {
 	_adjust_sandbox
 
-	# bug #944284 (https://gitlab.gnome.org/GNOME/gimp/-/issues/12843)
-	append-cflags -std=gnu17
-
 	use vala && vala_setup
 
 	local emesonargs=(


### PR DESCRIPTION
Gimp have merged c23 enforcing compiler support into master which means we can revert forcing -std=gnu17 on the live ebuild now.

Upstream have also said this will be in 3.0.4 release as well.

Bug: https://bugs.gentoo.org/944284

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
