### PR TITLE
Greenbone Vulnerability Management - disable py3.10, remove dependency on dev-python/tomli

### DIFF
--- a/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-23.10.0-r1.ebuild
+++ b/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-23.10.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..13} )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 
@@ -11,8 +11,8 @@ DESCRIPTION="New script for syncing the Greenbone Community Feed"
 HOMEPAGE="https://github.com/greenbone/greenbone-feed-sync"
 SRC_URI="https://github.com/greenbone/greenbone-feed-sync/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
 
-SLOT="0"
 LICENSE="GPL-3+"
+SLOT="0"
 KEYWORDS="amd64 ~x86"
 IUSE="cron"
 RESTRICT="test"
@@ -21,7 +21,6 @@ DEPEND="
 	acct-user/gvm
 	net-misc/rsync
 	>=net-analyzer/gvmd-22.5.0
-	dev-python/tomli[${PYTHON_USEDEP}]
 	>=dev-python/rich-13.2.0[${PYTHON_USEDEP}]
 "
 

--- a/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-24.3.0-r2.ebuild
+++ b/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-24.3.0-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 
@@ -20,9 +20,6 @@ COMMON_DEPEND="
 	acct-user/gvm
 	net-misc/rsync
 	>=net-analyzer/gvmd-22.5.0
-	$(python_gen_cond_dep '
-		>dev-python/tomli-2.0.1[${PYTHON_USEDEP}]
-	' 3.10)
 	>=dev-python/rich-13.2.0[${PYTHON_USEDEP}]
 	>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]
 "

--- a/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-24.9.0.ebuild
+++ b/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-24.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 
@@ -20,9 +20,6 @@ COMMON_DEPEND="
 	acct-user/gvm
 	net-misc/rsync
 	>=net-analyzer/gvmd-22.5.0
-	$(python_gen_cond_dep '
-		>dev-python/tomli-2.0.1[${PYTHON_USEDEP}]
-	' 3.10)
 	>=dev-python/rich-13.2.0[${PYTHON_USEDEP}]
 	>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]
 "

--- a/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-25.1.0.ebuild
+++ b/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-25.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 
@@ -20,9 +20,6 @@ COMMON_DEPEND="
 	acct-user/gvm
 	net-misc/rsync
 	>=net-analyzer/gvmd-22.5.0
-	$(python_gen_cond_dep '
-		>dev-python/tomli-2.0.1[${PYTHON_USEDEP}]
-	' 3.10)
 	>=dev-python/rich-13.2.0[${PYTHON_USEDEP}]
 	>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]
 "

--- a/net-analyzer/gvm-tools/gvm-tools-24.12.1.ebuild
+++ b/net-analyzer/gvm-tools/gvm-tools-24.12.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1
 

--- a/net-analyzer/gvm-tools/gvm-tools-24.8.0-r1.ebuild
+++ b/net-analyzer/gvm-tools/gvm-tools-24.8.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1
 

--- a/net-analyzer/gvm-tools/gvm-tools-25.3.0.ebuild
+++ b/net-analyzer/gvm-tools/gvm-tools-25.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1
 

--- a/net-analyzer/notus-scanner/notus-scanner-22.6.3-r4.ebuild
+++ b/net-analyzer/notus-scanner/notus-scanner-22.6.3-r4.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
-inherit distutils-r1 greadme systemd
+inherit distutils-r1 readme.gentoo-r1 systemd
 
 DESCRIPTION="Notus is a vulnerability scanner for creating results from local security checks"
 HOMEPAGE="https://github.com/greenbone/notus-scanner"
@@ -13,16 +13,15 @@ SRC_URI="https://github.com/greenbone/notus-scanner/archive/refs/tags/v${PV}.tar
 
 LICENSE="AGPL-3 AGPL-3+"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="amd64 ~x86"
 
 DEPEND="
 	acct-user/gvm
 	net-libs/paho-mqtt-c
-	>=dev-python/psutil-6.1[${PYTHON_USEDEP}]
-	>=dev-python/python-gnupg-0.5.3[${PYTHON_USEDEP}]
+	>=dev-python/psutil-5.9[${PYTHON_USEDEP}]
+	>=dev-python/python-gnupg-0.5.1[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	>=dev-python/paho-mqtt-1.5.1[${PYTHON_USEDEP}]
-	<dev-python/tomli-3[${PYTHON_USEDEP}]
 "
 
 RDEPEND="
@@ -34,30 +33,48 @@ PATCHES=(
 	"${FILESDIR}"/notus-scanner-22.6.2-remove-tests.patch
 )
 
-GREADME_DISABLE_AUTOFORMAT=1
+DOC_CONTENTS="
+For validating the feed content, a GnuPG keychain with the Greenbone Community Feed integrity key needs to be created.
+Please, read here on how to create it:
+https://greenbone.github.io/docs/latest/22.4/source-build/index.html#feed-validation
+https://wiki.gentoo.org/wiki/Greenbone_Vulnerability_Management#Notus_Scanner
+
+To enable feed validation, edit /etc/gvm/${PN}.toml
+and set
+disable-hashsum-verification = false"
+DISABLE_AUTOFORMATTING=true
 
 distutils_enable_tests unittest
+
+python_compile() {
+	distutils-r1_python_compile
+}
 
 python_install() {
 	distutils-r1_python_install
 
 	insinto /etc/gvm
+	use prefix || fowners -R gvm:gvm /etc/gvm
 	newins "${FILESDIR}/${PN}.toml" "${PN}.toml"
+	use prefix || fowners gvm:gvm "/etc/gvm/${PN}.toml"
 
 	# Set proper permissions on required files/directories
 	keepdir /var/lib/notus
 	keepdir /var/lib/notus/products
 	keepdir /var/lib/notus/advisories
-	keepdir /var/log/gvm
 	if ! use prefix; then
-		fowners -R gvm:gvm /etc/gvm
 		fowners -R gvm:gvm /var/lib/notus
-		fowners -R gvm:gvm /var/log/gvm
 	fi
 
 	# Adding notus-scanner.log to logrotate
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" "${PN}"
+
+	# Set proper permissions on required files/directories
+	keepdir /var/log/gvm
+	if ! use prefix; then
+		fowners -R gvm:gvm /var/log/gvm
+	fi
 
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 
@@ -65,14 +82,9 @@ python_install() {
 
 	systemd_install_serviced "${FILESDIR}/notus-scanner.service.conf" \
 			${PN}.service
+	readme.gentoo_create_doc
+}
 
-	greadme_stdin <<-EOF
-For validating the feed content, a GnuPG keychain with the Greenbone Community Feed
-integrity key needs to be created. Please, read here on how to create it:
-  - https://greenbone.github.io/docs/latest/22.4/source-build/index.html#feed-validation
-  - https://wiki.gentoo.org/wiki/Greenbone_Vulnerability_Management#Notus_Scanner
-
-To enable feed validation, edit /etc/gvm/${PN}.toml and set
-  disable-hashsum-verification = false
-EOF
+pkg_postinst() {
+	readme.gentoo_print_elog
 }

--- a/net-analyzer/notus-scanner/notus-scanner-22.6.4-r3.ebuild
+++ b/net-analyzer/notus-scanner/notus-scanner-22.6.4-r3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
-inherit distutils-r1 readme.gentoo-r1 systemd
+inherit distutils-r1 greadme systemd
 
 DESCRIPTION="Notus is a vulnerability scanner for creating results from local security checks"
 HOMEPAGE="https://github.com/greenbone/notus-scanner"
@@ -13,18 +13,15 @@ SRC_URI="https://github.com/greenbone/notus-scanner/archive/refs/tags/v${PV}.tar
 
 LICENSE="AGPL-3 AGPL-3+"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 
 DEPEND="
 	acct-user/gvm
 	net-libs/paho-mqtt-c
-	>=dev-python/psutil-5.9[${PYTHON_USEDEP}]
+	>=dev-python/psutil-6.0[${PYTHON_USEDEP}]
 	>=dev-python/python-gnupg-0.5.1[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	>=dev-python/paho-mqtt-1.5.1[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep '
-		<dev-python/tomli-3[${PYTHON_USEDEP}]
-	' 3.10)
 "
 
 RDEPEND="
@@ -36,48 +33,30 @@ PATCHES=(
 	"${FILESDIR}"/notus-scanner-22.6.2-remove-tests.patch
 )
 
-DOC_CONTENTS="
-For validating the feed content, a GnuPG keychain with the Greenbone Community Feed integrity key needs to be created.
-Please, read here on how to create it:
-https://greenbone.github.io/docs/latest/22.4/source-build/index.html#feed-validation
-https://wiki.gentoo.org/wiki/Greenbone_Vulnerability_Management#Notus_Scanner
-
-To enable feed validation, edit /etc/gvm/${PN}.toml
-and set
-disable-hashsum-verification = false"
-DISABLE_AUTOFORMATTING=true
+GREADME_DISABLE_AUTOFORMAT=1
 
 distutils_enable_tests unittest
-
-python_compile() {
-	distutils-r1_python_compile
-}
 
 python_install() {
 	distutils-r1_python_install
 
 	insinto /etc/gvm
-	use prefix || fowners -R gvm:gvm /etc/gvm
 	newins "${FILESDIR}/${PN}.toml" "${PN}.toml"
-	use prefix || fowners gvm:gvm "/etc/gvm/${PN}.toml"
 
 	# Set proper permissions on required files/directories
 	keepdir /var/lib/notus
 	keepdir /var/lib/notus/products
 	keepdir /var/lib/notus/advisories
+	keepdir /var/log/gvm
 	if ! use prefix; then
+		fowners -R gvm:gvm /etc/gvm
 		fowners -R gvm:gvm /var/lib/notus
+		fowners -R gvm:gvm /var/log/gvm
 	fi
 
 	# Adding notus-scanner.log to logrotate
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" "${PN}"
-
-	# Set proper permissions on required files/directories
-	keepdir /var/log/gvm
-	if ! use prefix; then
-		fowners -R gvm:gvm /var/log/gvm
-	fi
 
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 
@@ -85,9 +64,14 @@ python_install() {
 
 	systemd_install_serviced "${FILESDIR}/notus-scanner.service.conf" \
 			${PN}.service
-	readme.gentoo_create_doc
-}
 
-pkg_postinst() {
-	readme.gentoo_print_elog
+	greadme_stdin <<-EOF
+For validating the feed content, a GnuPG keychain with the Greenbone Community Feed
+integrity key needs to be created. Please, read here on how to create it:
+  - https://greenbone.github.io/docs/latest/22.4/source-build/index.html#feed-validation
+  - https://wiki.gentoo.org/wiki/Greenbone_Vulnerability_Management#Notus_Scanner
+
+To enable feed validation, edit /etc/gvm/${PN}.toml and set
+  disable-hashsum-verification = false
+EOF
 }

--- a/net-analyzer/notus-scanner/notus-scanner-22.6.5-r1.ebuild
+++ b/net-analyzer/notus-scanner/notus-scanner-22.6.5-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 greadme systemd
 
@@ -13,16 +13,15 @@ SRC_URI="https://github.com/greenbone/notus-scanner/archive/refs/tags/v${PV}.tar
 
 LICENSE="AGPL-3 AGPL-3+"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64"
 
 DEPEND="
 	acct-user/gvm
 	net-libs/paho-mqtt-c
-	>=dev-python/psutil-6.0[${PYTHON_USEDEP}]
-	>=dev-python/python-gnupg-0.5.1[${PYTHON_USEDEP}]
+	>=dev-python/psutil-6.1[${PYTHON_USEDEP}]
+	>=dev-python/python-gnupg-0.5.3[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	>=dev-python/paho-mqtt-1.5.1[${PYTHON_USEDEP}]
-	<dev-python/tomli-3[${PYTHON_USEDEP}]
 "
 
 RDEPEND="

--- a/net-analyzer/notus-scanner/notus-scanner-22.7.1-r1.ebuild
+++ b/net-analyzer/notus-scanner/notus-scanner-22.7.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 greadme systemd
 
@@ -22,7 +22,6 @@ DEPEND="
 	>=dev-python/python-gnupg-0.5.4[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	>=dev-python/paho-mqtt-1.5.1[${PYTHON_USEDEP}]
-	<dev-python/tomli-3[${PYTHON_USEDEP}]
 "
 
 RDEPEND="

--- a/net-analyzer/ospd-openvas/ospd-openvas-22.7.1-r1.ebuild
+++ b/net-analyzer/ospd-openvas/ospd-openvas-22.7.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 

--- a/net-analyzer/ospd-openvas/ospd-openvas-22.8.2.ebuild
+++ b/net-analyzer/ospd-openvas/ospd-openvas-22.8.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 inherit distutils-r1 systemd
 

--- a/net-analyzer/pontos/pontos-24.3.2-r1.ebuild
+++ b/net-analyzer/pontos/pontos-24.3.2-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1
@@ -17,8 +17,8 @@ HOMEPAGE="
 
 SRC_URI="https://github.com/greenbone/pontos/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
 
-SLOT="0"
 LICENSE="GPL-3+"
+SLOT="0"
 KEYWORDS="amd64 ~x86"
 
 RDEPEND="

--- a/net-analyzer/pontos/pontos-24.9.0.ebuild
+++ b/net-analyzer/pontos/pontos-24.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1

--- a/net-analyzer/pontos/pontos-25.3.3.ebuild
+++ b/net-analyzer/pontos/pontos-25.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1

--- a/net-analyzer/python-gvm/python-gvm-24.12.0.ebuild
+++ b/net-analyzer/python-gvm/python-gvm-24.12.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1

--- a/net-analyzer/python-gvm/python-gvm-24.8.0-r1.ebuild
+++ b/net-analyzer/python-gvm/python-gvm-24.8.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1

--- a/net-analyzer/python-gvm/python-gvm-26.1.1.ebuild
+++ b/net-analyzer/python-gvm/python-gvm-26.1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} pypy3 pypy3_11 )
+PYTHON_COMPAT=( python3_{11..13} pypy3_11 )
 DISTUTILS_USE_PEP517=poetry
 
 inherit distutils-r1


### PR DESCRIPTION
Disable historical Python implementations (3.9, 3.10)
Enable pypy3_11
Remove dependency on dev-python/tomli

---
- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
