### PR TITLE
sci-electronics/kicad: Add dev-python/pytest as test dependency

### DIFF
--- a/sci-electronics/kicad/kicad-9.0.0-r1.ebuild
+++ b/sci-electronics/kicad/kicad-9.0.0-r1.ebuild
@@ -94,7 +94,8 @@ RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu
 "
 BDEPEND=">=dev-lang/swig-4.0
-	doc? ( app-text/doxygen )"
+	doc? ( app-text/doxygen )
+	test? ( $(python_gen_cond_dep 'dev-python/pytest[${PYTHON_USEDEP}]') )"
 
 if [[ ${PV} == 9999 ]] ; then
 	# x11-misc-util/macros only required on live ebuilds

--- a/sci-electronics/kicad/kicad-9999.ebuild
+++ b/sci-electronics/kicad/kicad-9999.ebuild
@@ -91,7 +91,8 @@ RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu
 "
 BDEPEND=">=dev-lang/swig-4.0
-	doc? ( app-text/doxygen )"
+	doc? ( app-text/doxygen )
+	test? ( $(python_gen_cond_dep 'dev-python/pytest[${PYTHON_USEDEP}]') )"
 
 if [[ ${PV} == 9999 ]] ; then
 	# x11-misc-util/macros only required on live ebuilds


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/946360
