### PR TITLE
dev-util/mesa_clc: Add forgotten ~arm/~arm64 keywords

### DIFF
--- a/dev-util/mesa_clc/mesa_clc-25.1.0.ebuild
+++ b/dev-util/mesa_clc/mesa_clc-25.1.0.ebuild
@@ -20,7 +20,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	S="${WORKDIR}/mesa-${MY_PV}"
 	SRC_URI="https://archive.mesa3d.org/mesa-${MY_PV}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/dev-util/mesa_clc/mesa_clc-9999.ebuild
+++ b/dev-util/mesa_clc/mesa_clc-9999.ebuild
@@ -20,7 +20,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	S="${WORKDIR}/mesa-${MY_PV}"
 	SRC_URI="https://archive.mesa3d.org/mesa-${MY_PV}.tar.xz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
https://github.com/gentoo/gentoo/pull/41727 added a build dependency for mesa_clc to media-libs/mesa for asahi and panfrost VIDEO_CARDS. It missed to add keywords for arm/arm64 making it hard to compile mesa for systems with these video cards natively. The same code was previously compiled within media-libs/mesa so there are little concerns that it builds.

<!-- Please put the pull request description above -->
dev-util/mesa_clc-25.1.0 / media-libs/mesa-25.1.0 is build/runtime tested for `video_cards_asahi` on arm64 
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
