### PR TITLE
dev-lang/spidermonkey: Support for Python 3.13+

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-128.10.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-128.10.0.ebuild
@@ -9,7 +9,7 @@ SPIDERMONKEY_PATCHSET="spidermonkey-128-patches-03.tar.xz"
 LLVM_COMPAT=( 17 18 19 )
 RUST_NEEDS_LLVM=1
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,ssl,xml(+)"
 
 WANT_AUTOCONF="2.1"

--- a/dev-lang/spidermonkey/spidermonkey-128.8.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-128.8.0.ebuild
@@ -9,7 +9,7 @@ SPIDERMONKEY_PATCHSET="spidermonkey-128-patches-03.tar.xz"
 LLVM_COMPAT=( 17 18 19 )
 RUST_NEEDS_LLVM=1
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,ssl,xml(+)"
 
 WANT_AUTOCONF="2.1"

--- a/dev-lang/spidermonkey/spidermonkey-128.9.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-128.9.0.ebuild
@@ -9,7 +9,7 @@ SPIDERMONKEY_PATCHSET="spidermonkey-128-patches-03.tar.xz"
 LLVM_COMPAT=( 17 18 19 )
 RUST_NEEDS_LLVM=1
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,ssl,xml(+)"
 
 WANT_AUTOCONF="2.1"


### PR DESCRIPTION
I compiled without problems with python 3.13, and everything seems to work correctly

closes: https://bugs.gentoo.org/952299

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
