### PR TITLE
media-sound/beets: add python-3.13 support

### DIFF
--- a/media-sound/beets/beets-2.2.0-r1.ebuild
+++ b/media-sound/beets/beets-2.2.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=poetry
 # Passes tests with python3_13 but dev-python/audioread is problematic
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 PYTHON_REQ_USE="sqlite"
 
 # These envvars are used to treat github tarball builds differently

--- a/media-sound/beets/beets-9999.ebuild
+++ b/media-sound/beets/beets-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=poetry
 # Passes tests with python3_13 but dev-python/audioread is problematic
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 PYTHON_REQ_USE="sqlite"
 
 # These envvars are used to treat github tarball builds differently


### PR DESCRIPTION
Tested-by: Andrés Becerra <andres.becerra@gmail.com>
Bug: https://bugs.gentoo.org/952541
Closes: https://bugs.gentoo.org/952541

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [*] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [*] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [*] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [*] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
