### PR TITLE
app-containers/lxc: added patch lxc/lxc#4536

### DIFF
--- a/app-containers/lxc/files/lxc-6.0.4-start-Re-introduce-first-SET_DUMPABLE-call.patch
+++ b/app-containers/lxc/files/lxc-6.0.4-start-Re-introduce-first-SET_DUMPABLE-call.patch
@@ -1,0 +1,34 @@
+From 2663712e8fa8f37e0bb873185e2d4526dc644764 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Graber?= <stgraber@stgraber.org>
+Date: Sat, 5 Apr 2025 01:11:18 -0400
+Subject: [PATCH] start: Re-introduce first SET_DUMPABLE call
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without it, we're running into issues with complex hooks like nvidia.
+
+Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
+---
+ src/lxc/start.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/lxc/start.c b/src/lxc/start.c
+index f28bceaba..ee4bf4003 100644
+--- a/src/lxc/start.c
++++ b/src/lxc/start.c
+@@ -1125,6 +1125,11 @@ static int do_start(void *data)
+ 		if (!lxc_switch_uid_gid(nsuid, nsgid))
+ 			goto out_warn_father;
+ 
++		ret = prctl(PR_SET_DUMPABLE, prctl_arg(1), prctl_arg(0),
++			    prctl_arg(0), prctl_arg(0));
++		if (ret < 0)
++			goto out_warn_father;
++
+ 		/* set{g,u}id() clears deathsignal */
+ 		ret = lxc_set_death_signal(SIGKILL, handler->monitor_pid, status_fd);
+ 		if (ret < 0) {
+-- 
+2.48.1
+

--- a/app-containers/lxc/lxc-6.0.4.ebuild
+++ b/app-containers/lxc/lxc-6.0.4.ebuild
@@ -37,6 +37,10 @@ BDEPEND="virtual/pkgconfig
 	man? ( app-text/docbook2X )
 	verify-sig? ( sec-keys/openpgp-keys-linuxcontainers )"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-start-Re-introduce-first-SET_DUMPABLE-call.patch
+)
+
 RESTRICT="!test? ( test )"
 
 CONFIG_CHECK="~!NETPRIO_CGROUP
@@ -74,6 +78,10 @@ DOCS=( AUTHORS CONTRIBUTING MAINTAINERS README.md doc/FAQ.txt )
 
 pkg_setup() {
 	linux-info_pkg_setup
+}
+
+src_prepare() {
+	default
 }
 
 src_configure() {


### PR DESCRIPTION
Added since LXC containers will not start without, when using LXC 6.0.4.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
