### PR TITLE
sci-libs/vtk: fix minimal for 9.4.2

### DIFF
--- a/sci-libs/vtk/vtk-9.4.2.ebuild
+++ b/sci-libs/vtk/vtk-9.4.2.ebuild
@@ -55,8 +55,8 @@ REQUIRED_USE="
 	)
 	cuda? ( video_cards_nvidia vtkm )
 	java? ( rendering )
-	minimal? ( !rendering )
-	!minimal? ( rendering )
+	minimal? ( !gdal !rendering )
+	!minimal? ( cgns netcdf rendering )
 	python? ( ${PYTHON_REQUIRED_USE} )
 	qt6? ( rendering )
 	tk? ( python rendering )
@@ -646,6 +646,7 @@ src_configure() {
 			-DVTK_MODULE_ENABLE_VTK_CommonSystem="YES"
 			-DVTK_MODULE_ENABLE_VTK_CommonTransforms="YES"
 
+			-DVTK_MODULE_ENABLE_VTK_FiltersCellGrid="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersCore="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersExtraction="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersGeneral="YES"
@@ -653,10 +654,12 @@ src_configure() {
 			-DVTK_MODULE_ENABLE_VTK_FiltersGeometry="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersHybrid="NO"
 			-DVTK_MODULE_ENABLE_VTK_FiltersHyperTree="YES"
+			-DVTK_MODULE_ENABLE_VTK_FiltersReduction="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersSources="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersStatistics="YES"
 			-DVTK_MODULE_ENABLE_VTK_FiltersVerdict="YES"
 
+			-DVTK_MODULE_ENABLE_VTK_IOCellGrid="YES"
 			-DVTK_MODULE_ENABLE_VTK_IOCore="YES"
 			-DVTK_MODULE_ENABLE_VTK_IOGeometry="NO"
 			-DVTK_MODULE_ENABLE_VTK_IOLegacy="YES"


### PR DESCRIPTION
Don't think this needs a bump because "minimal" and the relevant USE flag combinations could not have been emerged.

Additional modules required for minimal:

```
CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::IOLegacy module (enabled via a `YES` setting (via
  `VTK_MODULE_ENABLE_VTK_IOLegacy`)) requires the disabled module
  VTK::IOCellGrid (disabled via a `NO` setting (via
  `VTK_GROUP_ENABLE_StandAlone`)).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)

CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::IOCellGrid module (enabled via a `YES` setting (via
  `VTK_MODULE_ENABLE_VTK_IOCellGrid`)) requires the disabled module
  VTK::FiltersCellGrid (disabled via a `NO` setting (via
  `VTK_GROUP_ENABLE_StandAlone`)).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)

CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::FiltersCore module (enabled via a `YES` setting (via
  `VTK_MODULE_ENABLE_VTK_FiltersCore`)) requires the disabled module
  VTK::FiltersReduction (disabled via a `NO` setting (via
  `VTK_GROUP_ENABLE_StandAlone`)).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)
```

The REQUIRED_USE from 9.3.1-r1 are still needed:

USE="gdal minimal"

```
CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::IOGDAL module (enabled via a `YES` setting (via
  `VTK_MODULE_ENABLE_VTK_IOGDAL`)) requires the disabled module VTK::IOImage
  (disabled via a `NO` setting (via `VTK_GROUP_ENABLE_StandAlone`)).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)
 ```
 
USE="-minimal rendering truetype views"
 
```
 CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::IOMINC module (enabled via a `YES` setting (via
  `VTK_GROUP_ENABLE_StandAlone`)) requires the disabled module VTK::netcdf
  (disabled via a `NO` setting (via `VTK_MODULE_ENABLE_VTK_netcdf`)).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)
 ```

USE="-minimal rendering truetype views netcdf"
 
```
  CMake Error at CMake/vtkModule.cmake:1151 (message):
  The VTK::IOIOSS module (enabled via a `YES` setting (via
  `VTK_GROUP_ENABLE_StandAlone`)) requires the disabled module VTK::ioss
  (disabled due to the VTK::cgns module not being available (via a `NO`
  setting (via `VTK_MODULE_ENABLE_VTK_cgns`))).
Call Stack (most recent call first):
  CMakeLists.txt:481 (vtk_module_scan)
 ```


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`


Please note that all boxes must be checked for the pull request to be merged.
