### PR TITLE
net-analyzer/nload: add .desktop file

### DIFF
--- a/net-analyzer/nload/files/nload.desktop
+++ b/net-analyzer/nload/files/nload.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=nload
+GenericName=Network monitor
+Comment=Show per-interface network usage
+Exec=nload -t 250
+Terminal=true
+Categories=System;Network;Monitor;ConsoleOnly

--- a/net-analyzer/nload/metadata.xml
+++ b/net-analyzer/nload/metadata.xml
@@ -14,6 +14,8 @@
     <name>Proxy Maintainers</name>
   </maintainer>
   <upstream>
+    <bugs-to>https://github.com/rolandriegel/nload/issues</bugs-to>
+    <changelog>https://www.roland-riegel.de/nload/changelog</changelog>
     <remote-id type="github">rolandriegel/nload</remote-id>
   </upstream>
 </pkgmetadata>

--- a/net-analyzer/nload/nload-0.7.5_pre20180309.ebuild
+++ b/net-analyzer/nload/nload-0.7.5_pre20180309.ebuild
@@ -1,15 +1,18 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools
+# We avoid xdg.eclass here because it'll pull in glib & desktop utils
+# Headless machines do not need them. Related: #787470
+inherit autotools desktop xdg-utils
 
 GIT_REV="8f92dc04fad283abdd2a4538cd4c2093d957d9da"
 
 DESCRIPTION="Real time network traffic monitor for the command line interface"
-HOMEPAGE="http://www.roland-riegel.de/nload/index.html https://github.com/rolandriegel/nload"
+HOMEPAGE="https://www.roland-riegel.de/nload/ https://github.com/rolandriegel/nload"
 SRC_URI="https://github.com/rolandriegel/nload/archive/${GIT_REV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-${GIT_REV}"
 
 LICENSE="GPL-2+"
 SLOT="0"
@@ -24,8 +27,6 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.7.5_pre-Makefile-spec-don-t-compress-man-page.patch
 )
 
-S="${WORKDIR}/${PN}-${GIT_REV}"
-
 src_prepare() {
 	default
 	sed -i \
@@ -33,4 +34,19 @@ src_prepare() {
 		configure.ac \
 		|| die "Failed to patch configure.ac"
 	eautoreconf
+}
+
+src_install() {
+	default
+	domenu "${FILESDIR}"/${PN}.desktop
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
 }


### PR DESCRIPTION
Based on htop's.

Diff:
```diff
--- nload-0.7.5_pre20180309.ebuild	2026-02-24 08:21:02.164284217 +0100
+++ nload-0.7.5_pre20180309-r1.ebuild	2026-07-18 12:30:04.670118660 +0200
@@ -1,19 +1,22 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools
+# We avoid xdg.eclass here because it'll pull in glib & desktop utils
+# Headless machines do not need them. Related: #787470
+inherit autotools desktop xdg-utils
 
 GIT_REV="8f92dc04fad283abdd2a4538cd4c2093d957d9da"
 
-DESCRIPTION="Real time network traffic monitor for the command line interface"
-HOMEPAGE="http://www.roland-riegel.de/nload/index.html https://github.com/rolandriegel/nload"
+DESCRIPTION="TUI realtime network traffic monitor"
+HOMEPAGE="https://www.roland-riegel.de/nload/"
 SRC_URI="https://github.com/rolandriegel/nload/archive/${GIT_REV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-${GIT_REV}"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 arm ~mips ppc x86"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~x86"
 
 RDEPEND=">=sys-libs/ncurses-5.2:0="
 DEPEND="${RDEPEND}"
@@ -24,8 +27,6 @@
 	"${FILESDIR}"/${PN}-0.7.5_pre-Makefile-spec-don-t-compress-man-page.patch
 )
 
-S="${WORKDIR}/${PN}-${GIT_REV}"
-
 src_prepare() {
 	default
 	sed -i \
@@ -34,3 +35,18 @@
 		|| die "Failed to patch configure.ac"
 	eautoreconf
 }
+
+src_install() {
+	default
+	domenu "${FILESDIR}"/${PN}.desktop
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
