### PR TITLE
dev-libs/libnl: Add cpe_uri for libnl package.

### DIFF
--- a/dev-libs/libnl/metadata.xml
+++ b/dev-libs/libnl/metadata.xml
@@ -11,5 +11,6 @@
 	</use>
 	<upstream>
 		<remote-id type="github">thom311/libnl</remote-id>
+		<remote-id type="cpe">cpe:/a:libnl_project:libnl</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Adding CPE for dev-libs/libnl that our automation found existed in the CPE Dictionary so it can be covered by security scanning.

Signed-off-by: Michael Kochera kochera@google.com
Bug: https://bugs.gentoo.org/955255

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
