### PR TITLE
dev-lang/rust: require lld or mold if USE="lto", ignore system-llvm

### DIFF
--- a/dev-lang/rust/rust-1.84.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.0-r1.ebuild
@@ -68,12 +68,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.84.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.84.1-r1.ebuild
@@ -68,12 +68,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.85.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.85.0-r1.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.85.0.ebuild
+++ b/dev-lang/rust/rust-1.85.0.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.85.1.ebuild
+++ b/dev-lang/rust/rust-1.85.1.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.86.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.86.0-r1.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.87.0_beta20250420.ebuild
+++ b/dev-lang/rust/rust-1.87.0_beta20250420.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-1.87.0_beta20250430.ebuild
+++ b/dev-lang/rust/rust-1.87.0_beta20250430.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja

--- a/dev-lang/rust/rust-9999.ebuild
+++ b/dev-lang/rust/rust-9999.ebuild
@@ -94,12 +94,12 @@ BDEPEND="${PYTHON_DEPS}
 		>=sys-devel/gcc-4.7[cxx]
 		>=llvm-core/clang-3.5
 	)
-	lto? ( system-llvm? (
+	lto? (
 		|| (
 			$(llvm_gen_dep 'llvm-core/lld:${LLVM_SLOT}')
 			sys-devel/mold
 		)
-	) )
+	)
 	!system-llvm? (
 		>=dev-build/cmake-3.13.4
 		app-alternatives/ninja


### PR DESCRIPTION
Build failed with USE="lto -system-llvm" if without llvm-core/lld or mold is installed. It used to succeed, IIRC.

Reverts: 6106eb119ee77a916c9c47f5055e1bba06cf176d

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
