### PR TITLE
sci-libs/vtk: ensure ANARI Rendering Module is disabled

### DIFF
--- a/sci-libs/vtk/vtk-9.4.2.ebuild
+++ b/sci-libs/vtk/vtk-9.4.2.ebuild
@@ -737,6 +737,7 @@ src_configure() {
 			-DVTK_ENABLE_OSPRAY=OFF
 
 			-DVTK_MODULE_ENABLE_VTK_IOExportGL2PS="YES"
+			-DVTK_MODULE_ENABLE_VTK_RenderingAnari="NO"  # no package in ::gentoo
 			-DVTK_MODULE_ENABLE_VTK_RenderingAnnotation="YES"
 			-DVTK_MODULE_ENABLE_VTK_RenderingContext2D="YES"
 			-DVTK_MODULE_ENABLE_VTK_RenderingContextOpenGL2="YES"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955676

This is the default setting. enabled by USE="all-modules"

No bump as current ebuild does not emerge with USE="all-modules".

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
