### PR TITLE
dev-libs/boost: exclude dodgy test in boost::system, remove python-3.10

### DIFF
--- a/dev-libs/boost/boost-1.85.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.85.0-r1.ebuild
@@ -11,7 +11,7 @@ EAPI=8
 
 # FIXME: cleanup subslot after 1.85.0
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit dot-a flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/dev-libs/boost/boost-1.86.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.86.0-r1.ebuild
@@ -9,7 +9,7 @@ EAPI=8
 # (e.g. https://www.boost.org/users/history/version_1_83_0.html)
 # Note that the latter may sometimes feature patches not on the former too.
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit dot-a flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/dev-libs/boost/boost-1.87.0-r3.ebuild
+++ b/dev-libs/boost/boost-1.87.0-r3.ebuild
@@ -9,7 +9,7 @@ EAPI=8
 # (e.g. https://www.boost.org/users/history/version_1_83_0.html)
 # Note that the latter may sometimes feature patches not on the former too.
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit dot-a flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/dev-libs/boost/boost-1.88.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.88.0-r1.ebuild
@@ -54,6 +54,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.88.0-bind-no-Werror.patch
 	"${FILESDIR}"/${PN}-1.88.0-mysql-cstdint.patch
 	"${FILESDIR}"/${PN}-1.88.0-range-any_iterator.patch
+	"${FILESDIR}"/${PN}-1.88.0-system-crashing-test.patch
 	"${FILESDIR}"/${PN}-1.88.0-yap-cstdint.patch
 )
 

--- a/dev-libs/boost/boost-1.88.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.88.0-r1.ebuild
@@ -9,7 +9,7 @@ EAPI=8
 # (e.g. https://www.boost.org/users/history/version_1_83_0.html)
 # Note that the latter may sometimes feature patches not on the former too.
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit dot-a edo flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/dev-libs/boost/files/boost-1.88.0-system-crashing-test.patch
+++ b/dev-libs/boost/files/boost-1.88.0-system-crashing-test.patch
@@ -1,0 +1,16 @@
+Do not build a supposed-to-crash test which may or may not even compile
+correctly any longer.
+
+Bug: https://bugs.gentoo.org/955831
+
+--- boost_1_88_0/libs/system/test/Jamfile.v2~	2025-04-03 13:37:30.000000000 +0200
++++ boost_1_88_0/libs/system/test/Jamfile.v2	2025-05-11 14:28:16.187753266 +0200
+@@ -68,7 +68,7 @@ system-run before_main_test.cpp ;
+ 
+ run-fail throws_assign_fail.cpp : : :
+     # GCC 12 catches this at compile time with a warning
+-    <toolset>gcc,<variant>release:<build>no ;
++    <toolset>gcc:<build>no ;
+ 
+ system-run constexpr_test.cpp ;
+ system-run win32_hresult_test.cpp ;


### PR DESCRIPTION
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
Closes: https://bugs.gentoo.org/955831

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
