### PR TITLE
dev-libs/libnfc: require `sys-apps/which` as BDEPEND

### DIFF
--- a/dev-libs/libnfc/libnfc-1.8.0-r1.ebuild
+++ b/dev-libs/libnfc/libnfc-1.8.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,6 +18,7 @@ RDEPEND="
 	usb? ( virtual/libusb:0 )"
 DEPEND="${RDEPEND}"
 BDEPEND="
+	sys-apps/which
 	virtual/pkgconfig
 	doc? ( app-text/doxygen )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955591

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
