### PR TITLE
sys-cluster/glusterfs: enable py3.13

### DIFF
--- a/sys-cluster/glusterfs/glusterfs-11.1-r2.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-11.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools elisp-common python-single-r1 tmpfiles systemd bash-completion-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952731

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
