### PR TITLE
sci-physics/{yoda,rivet,hepmc}: various updates

### DIFF
--- a/sci-physics/hepmc/hepmc-3.2.7.ebuild
+++ b/sci-physics/hepmc/hepmc-3.2.7.ebuild
@@ -25,7 +25,7 @@ LICENSE="GPL-3+"
 SLOT="3"
 IUSE="doc test examples python root"
 RESTRICT="!test? ( test )"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 RDEPEND="
 	python? (
@@ -45,6 +45,10 @@ BDEPEND="
 		dev-texlive/texlive-latexrecommended
 	)
 "
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	filter-lto # 941937 941936

--- a/sci-physics/hepmc/hepmc-3.3.1.ebuild
+++ b/sci-physics/hepmc/hepmc-3.3.1.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3+"
 SLOT="3"
 IUSE="doc test examples python root static-libs"
 RESTRICT="!test? ( test )"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 RDEPEND="
 	python? (
@@ -59,6 +59,10 @@ BDEPEND="
 		app-arch/zstd
 	)
 "
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	filter-lto # 941937 941936

--- a/sci-physics/hepmc/hepmc-9999.ebuild
+++ b/sci-physics/hepmc/hepmc-9999.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3+"
 SLOT="3"
 IUSE="doc test examples python root static-libs"
 RESTRICT="!test? ( test )"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 RDEPEND="
 	python? (
@@ -59,6 +59,10 @@ BDEPEND="
 		app-arch/zstd
 	)
 "
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
 
 src_configure() {
 	filter-lto # 941937 941936

--- a/sci-physics/rivet/files/rivet-3.1.10-uint16.patch
+++ b/sci-physics/rivet/files/rivet-3.1.10-uint16.patch
@@ -1,0 +1,22 @@
+From b52b246eadeb92ca0f1301061f8c757e1bdc377c Mon Sep 17 00:00:00 2001
+From: Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
+Date: Wed, 11 Dec 2024 18:35:50 +0000
+Subject: [PATCH] yamlcpp: Explicitly include <cstdint>
+
+---
+ src/Core/yamlcpp/emitterutils.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Core/yamlcpp/emitterutils.cpp b/src/Core/yamlcpp/emitterutils.cpp
+index c033427e17..4943267206 100644
+--- a/src/Core/yamlcpp/emitterutils.cpp
++++ b/src/Core/yamlcpp/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 
+-- 
+GitLab
+

--- a/sci-physics/rivet/rivet-3.1.10-r2.ebuild
+++ b/sci-physics/rivet/rivet-3.1.10-r2.ebuild
@@ -1,0 +1,120 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit python-single-r1 flag-o-matic autotools optfeature bash-completion-r1
+
+MY_PN="Rivet"
+MY_PF=${MY_PN}-${PV}
+
+DESCRIPTION="Rivet toolkit (Robust Independent Validation of Experiment and Theory)"
+HOMEPAGE="
+	https://rivet.hepforge.org/
+	https://gitlab.com/hepcedar/rivet
+"
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.com/hepcedar/rivet"
+else
+	SRC_URI="https://www.hepforge.org/archive/rivet/${MY_PF}.tar.gz -> ${P}.tar.gz"
+	S=${WORKDIR}/${MY_PF}
+	KEYWORDS="~amd64"
+fi
+
+LICENSE="GPL-3+"
+SLOT="3"
+IUSE="+hepmc3 hepmc2 +zlib +python"
+REQUIRED_USE="
+	^^ ( hepmc3 hepmc2 )
+	python? ( ${PYTHON_REQUIRED_USE} )
+"
+
+RDEPEND="
+	>=sci-physics/fastjet-3.4.0[plugins]
+	>=sci-physics/fastjet-contrib-1.048
+	hepmc2? ( sci-physics/hepmc:2=[-cm(-),gev(+)] )
+	hepmc3? ( <sci-physics/hepmc-3.3.0:3=[-cm(-),gev(+)] )
+
+	sci-libs/gsl
+	zlib? ( sys-libs/zlib )
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-python/matplotlib[${PYTHON_USEDEP}]
+		')
+		>=sci-physics/yoda-1.9.8[${PYTHON_SINGLE_USEDEP}]
+		<sci-physics/yoda-2[${PYTHON_SINGLE_USEDEP}]
+	)
+	!python? (
+		>=sci-physics/yoda-1.9.8
+		<sci-physics/yoda-2
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-shells/bash
+	python? (
+		$(python_gen_cond_dep '
+			>=dev-python/cython-0.29.24[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.1.6-binreloc.patch
+	"${FILESDIR}"/${PN}-3.1.9-pythontests.patch
+	# https://gitlab.com/hepcedar/rivet/-/merge_requests/844
+	"${FILESDIR}"/${PN}-3.1.10-ref_cin.patch
+	# https://gitlab.com/hepcedar/rivet/-/merge_requests/979
+	"${FILESDIR}"/${PN}-3.1.10-versions.patch
+	# https://gitlab.com/hepcedar/rivet/-/merge_requests/985
+	"${FILESDIR}"/${PN}-3.1.10-uint16.patch
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# Eigen complains about alignment (see https://gitlab.com/libeigen/eigen/-/issues/2523).
+	# does this affect more cpus?
+	replace-cpu-flags znver1 x86-64
+	# not posix compatible, only bash
+	CONFIG_SHELL=${ESYSROOT}/bin/bash econf \
+		$(use_with zlib zlib "${ESYSROOT}/usr") \
+		$(usex hepmc2 "--with-hepmc=${ESYSROOT}/usr" "") \
+		$(usex hepmc3 "--with-hepmc3=${ESYSROOT}/usr" "") \
+		--with-yoda="${ESYSROOT}/usr" \
+		--with-fastjet="${ESYSROOT}/usr" \
+		$(use_enable python pyext) \
+		$(usex python CYTHON="${ESYSROOT}/usr/bin/cython")
+}
+
+src_install() {
+	default
+	use python && python_optimize
+	find "${ED}" -name '*.la' -delete || die
+	if use python ; then
+		newbashcomp "${ED}"/etc/bash_completion.d/${PN}-completion ${PN}
+		bashcomp_alias ${PN} ${PN}-config \
+			${PN}-build \
+			${PN}-buildplugin \
+			${PN}-cmphistos \
+			make-plots \
+			${PN}-mkhtml \
+			${PN}-mkhtml-mpl
+		rm "${ED}"/etc/bash_completion.d/${PN}-completion || die
+	fi
+}
+
+pkg_postinstall() {
+	optfeature "plotting support" virtual/latex-base media-gfx/imagemagick app-text/ghostscript-gpl
+}

--- a/sci-physics/yoda/yoda-1.9.10.ebuild
+++ b/sci-physics/yoda/yoda-1.9.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit bash-completion-r1 autotools python-single-r1 optfeature
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/946280

I just wanted to fix 946280, but that resulted in a few more improvemnts:

- Enabled python3.13 in old yoda-1 and rivet-3
- No python_required_use in hepmc w/o python (similar to yoda & rivet's single python setup)
- Inclusion of merged patch from upstream https://gitlab.com/hepcedar/rivet/-/merge_requests/985.patch to fix the bug