### PR TITLE
sys-apps/sdparm: bump EAPI

### DIFF
--- a/sys-apps/sdparm/sdparm-1.12-r1.ebuild
+++ b/sys-apps/sdparm/sdparm-1.12-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Utility to output and modify parameters on a SCSI device, like hdparm"
+HOMEPAGE="https://sg.danny.cz/sg/sdparm.html"
+SRC_URI="https://sg.danny.cz/sg/p/${P}.tgz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+# Older releases contain a conflicting sas_disk_blink
+RDEPEND=">=sys-apps/sg3_utils-1.45:0="
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS ChangeLog CREDITS README notes.txt )
+
+src_configure() {
+	# sdparm ships with a local copy of this lib, but will use the system copy if it
+	# detects it (see the README file).  Force the use of the system lib.  #479578
+	export ac_cv_lib_sgutils2_sg_ll_inquiry=yes
+	default
+}
+
+src_install() {
+	default
+
+	# These don't exist yet. Someone wanna copy hdparm's and make them work? :)
+	#newinitd ${FILESDIR}/sdparm-init-1 sdparm
+	#newconfd ${FILESDIR}/sdparm-conf.d-1 sdparm
+}


### PR DESCRIPTION
used to be a part of https://github.com/gentoo/gentoo/pull/38053

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
