### PR TITLE
net-fs/cifs-utils: fix build in musl with USE="creds"

### DIFF
--- a/net-fs/cifs-utils/files/cifs-utils-7.0-musl.patch
+++ b/net-fs/cifs-utils/files/cifs-utils-7.0-musl.patch
@@ -37,3 +37,27 @@ index b199118..3cb603c 100644
 -- 
 2.45.2
 
+From ae644b56a4446f520a75217f9288775e127ab2c8 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Tue, 13 May 2025 07:31:46 +0800
+Subject: [PATCH] cifscreds: use <libgen.h> for basename
+
+fix another implicit declaration of function 'basename' in musl
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/cifscreds.c b/cifscreds.c
+index f552bc8..295059f 100644
+--- a/cifscreds.c
++++ b/cifscreds.c
+@@ -29,6 +29,7 @@
+ #include <keyutils.h>
+ #include <getopt.h>
+ #include <errno.h>
++#include <libgen.h>
+ #include "cifskey.h"
+ #include "mount.h"
+ #include "resolve_host.h"
+-- 
+2.45.2
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936928
Fixes: fcde99ccaa5d4dc30a1e21f0438fb57d8f886759

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
