### PR TITLE
Start elogind before display-manager

### DIFF
--- a/sys-auth/elogind/files/elogind.init-r1
+++ b/sys-auth/elogind/files/elogind.init-r1
@@ -5,8 +5,8 @@
 depend() {
 	need dbus
 
-	# Make sure elogind is up before xdm starts any dm
-	before xdm
+	# Make sure elogind is up before display-manager starts any dm
+	before display-manager
 
 	use logger
 }


### PR DESCRIPTION
I believe this was missed when the switch to unified `display-manager` init script was made. Without it, openrc users can have issues with seats (preventing eg `loginctl reboot` from working) or with pulseaudio (eg having a system wide daemon started as root, preventing bluetooth devices from showing as available outputs once paired/connected ; or worse, sometimes audio will simply not work without re-logging into the DM, showing a "dummy output" in `pamix`).

Of course, there could be a few more things in this PR - do I need to update the copyright notice to 1999-2025, do I need to write a elogind.init-r2 file instead, etc? Whatever the case may be, this change seems to have a positive impact on the aforementioned issues, so I'm putting it out there.

Thanks to `navi` and `negril` on IRC for encouraging me to make the PR :-) and thank you for reading!

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

(I have not currently run `pkgcheck scan` as I currently didn't change my main portage URL to the fork that was created for this PR, having made it through the GH web UI ; I will proceed to do that later on, but in the meantime, do tell if there's some other issues, eg the copyright thing or whether I need to make a different init file)

Please note that all boxes must be checked for the pull request to be merged.
