### PR TITLE
sys-process/runit: fix ewarn messages

### DIFF
--- a/sys-process/runit/runit-2.1.2-r7.ebuild
+++ b/sys-process/runit/runit-2.1.2-r7.ebuild
@@ -133,20 +133,23 @@ pkg_postinst() {
 		migrate_from_211
 	fi
 
+	ewarn "To make sure sv works correctly in your currently open"
+	ewarn "shells, please run the following command:"
+	ewarn
+	ewarn "source /etc/profile"
+	ewarn
+
 	if use scripts; then
-		ewarn "To make sure sv works correctly in your currently open"
-		ewarn "shells, please run the following command:"
-		ewarn
-		ewarn "source /etc/profile"
-		ewarn
 		ewarn "Currently, no task(s) will run in stage 1 & 3, you're on your own"
 		ewarn "to put script(s) into /etc/runit/rc/, please see /etc/runit/rc.sh"
 		ewarn "for name in different stages."
+		ewarn
 	else
 		ewarn "This build with USE=\"-scripts\" doesn\'t include any boot scripts"
 		ewarn "into /etc/runit, you are on your own to put the scripts."
 		ewarn "Also, /sbin/runsvdir-start is a broken symlink to /etc/runit/2, you will"
 		ewarn "need to create script /etc/runit/2 before use it."
+		ewarn
 	fi
 
 	if [[ -L "${EROOT}"/var/service ]]; then

--- a/sys-process/runit/runit-2.2.0-r1.ebuild
+++ b/sys-process/runit/runit-2.2.0-r1.ebuild
@@ -125,20 +125,23 @@ pkg_postinst() {
 		migrate_from_211
 	fi
 
+	ewarn "To make sure sv works correctly in your currently open"
+	ewarn "shells, please run the following command:"
+	ewarn
+	ewarn "source /etc/profile"
+	ewarn
+
 	if use scripts; then
-		ewarn "To make sure sv works correctly in your currently open"
-		ewarn "shells, please run the following command:"
-		ewarn
-		ewarn "source /etc/profile"
-		ewarn
 		ewarn "Currently, no task(s) will run in stage 1 & 3, you're on your own"
 		ewarn "to put script(s) into /etc/runit/rc/, please see /etc/runit/rc.sh"
 		ewarn "for name in different stages."
+		ewarn
 	else
 		ewarn "This build with USE=\"-scripts\" doesn\'t include any boot scripts"
 		ewarn "into /etc/runit, you are on your own to put the scripts."
 		ewarn "Also, /sbin/runsvdir-start is a broken symlink to /etc/runit/2, you will"
 		ewarn "need to create script /etc/runit/2 before use it."
+		ewarn
 	fi
 
 	if [[ -L "${EROOT}"/var/service ]]; then

--- a/sys-process/runit/runit-2.2.0-r2.ebuild
+++ b/sys-process/runit/runit-2.2.0-r2.ebuild
@@ -132,20 +132,23 @@ pkg_postinst() {
 		migrate_from_211
 	fi
 
+	ewarn "To make sure sv works correctly in your currently open"
+	ewarn "shells, please run the following command:"
+	ewarn
+	ewarn "source /etc/profile"
+	ewarn
+
 	if use scripts; then
-		ewarn "To make sure sv works correctly in your currently open"
-		ewarn "shells, please run the following command:"
-		ewarn
-		ewarn "source /etc/profile"
-		ewarn
 		ewarn "Currently, no task(s) will run in stage 1 & 3, you're on your own"
 		ewarn "to put script(s) into /etc/runit/rc/, please see /etc/runit/rc.sh"
 		ewarn "for name in different stages."
+		ewarn
 	else
 		ewarn "This build with USE=\"-scripts\" doesn\'t include any boot scripts"
 		ewarn "into /etc/runit, you are on your own to put the scripts."
 		ewarn "Also, /sbin/runsvdir-start is a broken symlink to /etc/runit/2, you will"
 		ewarn "need to create script /etc/runit/2 before use it."
+		ewarn
 	fi
 
 	if [[ -L "${EROOT}"/var/service ]]; then


### PR DESCRIPTION
This fixes minor issue added since `runit-2.1.2-r7.ebuild`: first `ewarn` paragraph is related to unconditional `newenvd - 20runit` and thus should not be inside `if use scripts`.

@clan please review. BTW, it may worth to run `shfmt` tool on these ebuilds - it fixes some minor formatting issues (I had to disable auto-formatting in my editor to avoid such an unrelated changes in this PR).

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
