### PR TITLE
app-containers/incus: fix cross-compilation issue

### DIFF
--- a/app-containers/incus/incus-6.0.4-r1.ebuild
+++ b/app-containers/incus/incus-6.0.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit go-module linux-info optfeature systemd toolchain-funcs verify-sig
+inherit go-env go-module linux-info optfeature systemd toolchain-funcs verify-sig
 
 DESCRIPTION="Modern, secure and powerful system container and virtual machine manager"
 HOMEPAGE="https://linuxcontainers.org/incus/introduction/ https://github.com/lxc/incus"
@@ -153,7 +153,8 @@ src_test() {
 src_install() {
 	export GOPATH="${S}/_dist"
 
-	if tc-is-cross-compiler ; then
+	export GOHOSTARCH=$(go-env_goarch "${CBUILD}")
+	if [[ "${GOARCH}" != "${GOHOSTARCH}" ]]; then
 		local bindir="_dist/bin/linux_${GOARCH}"
 	else
 		local bindir="_dist/bin"

--- a/app-containers/incus/incus-6.12-r1.ebuild
+++ b/app-containers/incus/incus-6.12-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit go-module linux-info optfeature systemd toolchain-funcs verify-sig
+inherit go-env go-module linux-info optfeature systemd toolchain-funcs verify-sig
 
 DESCRIPTION="Modern, secure and powerful system container and virtual machine manager"
 HOMEPAGE="https://linuxcontainers.org/incus/introduction/ https://github.com/lxc/incus"
@@ -155,7 +155,8 @@ src_test() {
 src_install() {
 	export GOPATH="${S}/_dist"
 
-	if tc-is-cross-compiler ; then
+	export GOHOSTARCH=$(go-env_goarch "${CBUILD}")
+	if [[ "${GOARCH}" != "${GOHOSTARCH}" ]]; then
 		local bindir="_dist/bin/linux_${GOARCH}"
 	else
 		local bindir="_dist/bin"


### PR DESCRIPTION
Hi,

This PR has some history. We first proposed this change: https://github.com/gentoo/gentoo/pull/36323/files#diff-588171aa625435ebb07dcc80d1dd2598cf157d22da00e9daf74825e3bc0e47daR156 it was approved but it was causing issue: https://bugs.gentoo.org/930496 so it has been modified to the current version.

The current change is making Flatcar CI fails (with cross-compilation) during the installation phase:
```
117:54:49  !!! dosbin: _dist/bin/linux_amd64/incusd does not exist
```

This proposal has been tested on Flatcar CI with cross-compilation on `amd64` and `arm64`.

Thanks.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
