### PR TITLE
app-misc/screen: Fix wrong patch file path

### DIFF
--- a/app-misc/screen/files/screen-4.9.1-add-missing-pty.h-header.patch
+++ b/app-misc/screen/files/screen-4.9.1-add-missing-pty.h-header.patch
@@ -1,0 +1,10 @@
+--- a/pty.c
++++ b/pty.c
+@@ -29,6 +29,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#include <pty.h>
+ #include <signal.h>
+ 
+ #if defined(__OpenBSD__)

--- a/app-misc/screen/screen-4.9.1-r1.ebuild
+++ b/app-misc/screen/screen-4.9.1-r1.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	# Don't use utempter even if it is found on the system.
 	"${FILESDIR}"/${PN}-4.3.0-no-utempter.patch
 	"${FILESDIR}"/${PN}-4.9.1-utmp-exit.patch
+	"${FILESDIR}"/${PN}-4.9.1-add-missing-pty.h-header.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
When I made #42084 I used git version with v4.9.1 tag. But in tar it had different file structure. This will fix the build error.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
