### PR TITLE
profiles: last-rite media-gfx/transfig

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -36,6 +36,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Mario Haustein <mario.haustein@hrz.tu-chemnitz.de> (2025-05-15)
+# Deprecated and no longer maintained upstream. Open security
+# issues. Use media-gfx/fig2dev instead.
+# Removal on 2025-06-15. Bug #917279.
+media-gfx/transfig
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2025-05-15)
 # Very dead upstream, very many open bugs for years without anyone fixing.
 # Bugs #314835, #632432, #827131, #874429, #908830, #925513, #934808.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/917279

Remove `media-gfx/transfig` as all revdeps where replace by `media-gfx/fig2dev`.

Copy of #40756 which was unfortunately closed without merge.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.