### PR TITLE
app-crypt/certbot: ignore test for unsupported 64-bit time_t systems, #955713

### DIFF
--- a/app-crypt/certbot/certbot-4.0.0-r2.ebuild
+++ b/app-crypt/certbot/certbot-4.0.0-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit distutils-r1
+inherit distutils-r1 toolchain-funcs
 
 if [[ "${PV}" == *9999 ]]; then
 	inherit git-r3
@@ -220,6 +220,11 @@ python_compile_all() {
 
 python_test() {
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+	tc-has-64bit-time_t || EPYTEST_DESELECT+=(
+		'certbot/_internal/tests/storage_test.py::RenewableCertTests::test_time_interval_judgments'
+	)
+
 	# Change for pytest rootdir is required.
 	cd "${BUILD_DIR}/install$(python_get_sitedir)" || die
 	epytest

--- a/app-crypt/certbot/certbot-9999.ebuild
+++ b/app-crypt/certbot/certbot-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit distutils-r1
+inherit distutils-r1 toolchain-funcs
 
 if [[ "${PV}" == *9999 ]]; then
 	inherit git-r3
@@ -220,6 +220,11 @@ python_compile_all() {
 
 python_test() {
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+
+	tc-has-64bit-time_t || EPYTEST_DESELECT+=(
+		'certbot/_internal/tests/storage_test.py::RenewableCertTests::test_time_interval_judgments'
+	)
+
 	# Change for pytest rootdir is required.
 	cd "${BUILD_DIR}/install$(python_get_sitedir)" || die
 	epytest


### PR DESCRIPTION
~~WARNING:~~
~~I did NOT test this modification as I don’t have a working 32-bit environment, or simply not aware how to actually do it without relying on a dedicated virtual environment.~~

~~Please, execute some tests or provide feedback before merging.~~

EDIT: in fact I just tested the "faulty" test is correctly skipped, in the cases where the `tc-has-64bit-time_t` function returns true, so this is good to go.

Closes: https://bugs.gentoo.org/955713

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
