### PR TITLE
gui-apps/waybar: add media-fonts/fontawesome optfeature

### DIFF
--- a/gui-apps/waybar/waybar-0.12.0.ebuild
+++ b/gui-apps/waybar/waybar-0.12.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson optfeature
 
 DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
 HOMEPAGE="https://github.com/Alexays/Waybar"
@@ -98,4 +98,8 @@ src_configure() {
 		$(meson_use experimental)
 	)
 	meson_src_configure
+}
+
+pkg_postinst() {
+	optfeature "default icons support" "media-fonts/fontawesome"
 }

--- a/gui-apps/waybar/waybar-9999.ebuild
+++ b/gui-apps/waybar/waybar-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit meson
+inherit meson optfeature
 
 DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
 HOMEPAGE="https://github.com/Alexays/Waybar"
@@ -98,4 +98,8 @@ src_configure() {
 		$(meson_use experimental)
 	)
 	meson_src_configure
+}
+
+pkg_postinst() {
+	optfeature "default icons support" "media-fonts/fontawesome"
 }


### PR DESCRIPTION
Waybar requires fontawesome to display default icons https://github.com/Alexays/Waybar/wiki/FAQ#the-icons-from-the-default-configuration- arent-rendered

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
