### PR TITLE
eclass/rocm.eclass: add gfx1201 to rocm.eclass

### DIFF
--- a/eclass/rocm.eclass
+++ b/eclass/rocm.eclass
@@ -179,6 +179,7 @@ _rocm_set_globals() {
 				gfx803 gfx900 gfx940 gfx941
 				gfx1010 gfx1011 gfx1012
 				gfx1031 gfx1101 gfx1102
+				gfx1201
 			)
 			official_amdgpu_targets=(
 				gfx906 gfx908 gfx90a gfx942 gfx1030 gfx1100


### PR DESCRIPTION
This PR adds support for the AMD RX 9070 and RX 9070 XT for ROCm.
ROCm inofficially supports these since 6.3.3.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
