### PR TITLE
gnustep-base/gnustep-base: fix gdomap.c build with GCC 15

### DIFF
--- a/gnustep-base/gnustep-base/files/gnustep-base-1.30.0-fix-gcc15-compile.patch
+++ b/gnustep-base/gnustep-base/files/gnustep-base-1.30.0-fix-gcc15-compile.patch
@@ -1,0 +1,12 @@
+--- a/Tools/GNUmakefile
++++ b/Tools/GNUmakefile
+@@ -52,6 +52,9 @@
+ 
+ ADDITIONAL_CPPFLAGS = -DGNUSTEP_BASE_INTERNAL=1
+ 
++# Disable specifically the incompatible pointer type warnings for gdomap.c
++gdomap.c_FILE_FLAGS = -Wno-incompatible-pointer-types
++
+ # DTDs to install
+ dtddir = $(GNUSTEP_LIBRARY)/DTDs
+ DTD_FILES = plist-0_9.dtd \

--- a/gnustep-base/gnustep-base/gnustep-base-1.30.0.ebuild
+++ b/gnustep-base/gnustep-base/gnustep-base-1.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -34,6 +34,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.26.0-no_compress_man.patch
+	"${FILESDIR}"/${PN}-1.30.0-fix-gcc15-compile.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/956139

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
