### PR TITLE
java-utils-2.eclass: re-enable PORTAGE_QUIET

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2024 Gentoo Authors
+# Copyright 2004-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-utils-2.eclass
@@ -1298,7 +1298,7 @@ java-pkg_getjar() {
 	classpath=$(java-config --classpath=${pkg})
 	[[ $? != 0 ]] && die ${error_msg}
 
-	java-pkg_ensure-dep "${build_only}" "${pkg}"
+	[[ -z ${PORTAGE_QUIET} ]] && java-pkg_ensure-dep "${build_only}" "${pkg}"
 
 	# Record the package(Virtual) as a dependency and then set build_only
 	# So that individual jars are not recorded.
@@ -1318,7 +1318,7 @@ java-pkg_getjar() {
 
 		if [[ "$(basename ${jar})" == "${target_jar}" ]] ; then
 			# Only record jars that aren't build-only
-			if [[ -z "${record_jar}" ]]; then
+			if [[ -z "${record_jar}" && -z ${PORTAGE_QUIET} ]]; then
 				if [[ -z "${build_only}" ]]; then
 					java-pkg_record-jar_ "${pkg}" "${jar}"
 				else


### PR DESCRIPTION
There are packages like javacup and jflex which cannot be built from source without using a pre-built runtime version of itself. Re-emerging these packages using the installed instead of the bundled pre-built version was causing the java-pkg_getjar() function to trigger java-pkg_ensure-dep() to issue a "QA Notice: java-pkg_ensure-dep:" message.

This commit ports the PORTAGE_QUIET variable to java-pkg_getjar() so that it works again as it did in the past for ant-based ebuilds.

Bug: https://bugs.gentoo.org/937047

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
