### PR TITLE
games-puzzle/xtris: fix build with gcc15

### DIFF
--- a/games-puzzle/xtris/files/xtris-1.15-gcc15.patch
+++ b/games-puzzle/xtris/files/xtris-1.15-gcc15.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/943783
+
+--- a/xtris.c
++++ b/xtris.c
+@@ -2731,7 +2731,7 @@ void connect2server(char *h) {
+   }
+ }
+ 
+-void sigchld() {
++void sigchld(int a) {
+ #ifdef NeXT
+   while (wait3(NULL, WNOHANG|WUNTRACED, NULL) > 0);
+ #else

--- a/games-puzzle/xtris/xtris-1.15-r2.ebuild
+++ b/games-puzzle/xtris/xtris-1.15-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,8 @@ DEPEND="x11-libs/libX11"
 RDEPEND="${DEPEND}"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.15-implicit-function-decl-time.patch
+	"${FILESDIR}"/${P}-implicit-function-decl-time.patch
+	"${FILESDIR}"/${P}-gcc15.patch
 )
 
 src_compile() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/943783

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
