### PR TITLE
app-arch/dpkg: add --enable-static

### DIFF
--- a/app-arch/dpkg/dpkg-1.22.14.ebuild
+++ b/app-arch/dpkg/dpkg-1.22.14.ebuild
@@ -63,11 +63,17 @@ src_prepare() {
 src_configure() {
 	tc-export AR CC
 
+	# dpkg uses LT_INIT([disable-shared]) in configure.ac where GNU libtool
+	# enables static if both --disable-shared and --disable-static are set while
+	# slibtool disables both so explicitly set --enable-static until upstream
+	# supports shared libraries.
+	# https://bugs.gentoo.org/956332
 	local myconf=(
 		--disable-compiler-warnings
 		--disable-devel-docs
 		--disable-dselect
 		--disable-start-stop-daemon
+		--enable-static
 		--enable-unicode
 		--localstatedir="${EPREFIX}"/var
 		$(use_enable nls)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/956332
Upstream-Issue: https://dev.midipix.org/cross/slibtool/issue/79

dpkg currenty doesn't support shared libraries where GNU libtool will implicitly enable static libraries if both `--disable-shared` and `--disable-static` are used while slibtool will disable both.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
