### PR TITLE
sys-cluster/kubelet: add sane defaults for conf.d/kubelet

### DIFF
--- a/sys-cluster/kubelet/files/kubelet.confd
+++ b/sys-cluster/kubelet/files/kubelet.confd
@@ -1,4 +1,16 @@
 ###
 # Kubernetes Kubelet (worker) config
+# This configuration example is tuned for kubeadm
+# Feel free to modify
 
-command_args=""
+# If exists kubeadm-flags.env, then source it to get
+# environment variable ${KUBELET_KUBEADM_ARGS}
+if [ -e /var/lib/kubelet/kubeadm-flags.env ]; then
+  source /var/lib/kubelet/kubeadm-flags.env;
+fi
+
+# Pre-defined command-line args for kubeadm
+command_args="--config /var/lib/kubelet/config.yaml \
+	--kubeconfig=/etc/kubernetes/kubelet.conf \
+	--bootstrap-kubeconfig /etc/kubernetes/bootstrap-kubelet.conf \
+	${KUBELET_KUBEADM_ARGS}"


### PR DESCRIPTION
At this moment, as mentioned in https://bugs.gentoo.org/865505, there is no good default options for kubelet to start working out-of-the-box on openrc. Users has to figure out how to configure it on their own.
This PR fixes it by providing sane default option which tuned to be well with kubeadm.

Closes: https://bugs.gentoo.org/865505

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
