### PR TITLE
media-sound/mpd: metadata: make USE=zlib description non-generic

### DIFF
--- a/media-sound/mpd/metadata.xml
+++ b/media-sound/mpd/metadata.xml
@@ -44,6 +44,7 @@
     <flag name="webdav">Enable using music from a WebDAV share</flag>
     <flag name="wildmidi">Enable MIDI support via wildmidi</flag>
     <flag name="yajl">Enable JSON parsing via <pkg>dev-libs/yajl</pkg></flag>
+    <flag name="zlib">Enable database compression with <pkg>sys-libs/zlib</pkg></flag>
   </use>
   <upstream>
     <bugs-to>https://github.com/MusicPlayerDaemon/MPD/issues</bugs-to>


### PR DESCRIPTION
https://github.com/MusicPlayerDaemon/MPD/blob/8f9f69aa767bca8f3f651aca373456f9d1ade94f/meson_options.txt#L200

Just a small improvement

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
