### PR TITLE
app-containers/containerd: Fix cross by building gen-manpages for CBUILD

### DIFF
--- a/app-containers/containerd/containerd-2.1.0.ebuild
+++ b/app-containers/containerd/containerd-2.1.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit go-module systemd
+inherit go-env go-module systemd toolchain-funcs
 GIT_REVISION=061792f0ecf3684fb30a3a0eb006799b8c6638a7
 
 DESCRIPTION="A daemon to control runC"
@@ -65,9 +65,14 @@ src_compile() {
 		VERSION=v${PV}
 	)
 
-	# race condition in man target https://bugs.gentoo.org/765100
-	# we need to explicitly specify GOFLAGS for "go run" to use vendor source
-	emake "${myemakeargs[@]}" man -j1 #nowarn
+	# The Go env is already set, but reset it for CBUILD in a subshell to allow
+	# building the man pages when cross-compiling.
+	(
+		CHOST="${CBUILD}" go-env_set_compile_environment
+		# race condition in man target https://bugs.gentoo.org/765100
+		tc-env_build emake "${myemakeargs[@]}" man -j1 #nowarn
+	)
+
 	emake "${myemakeargs[@]}" all
 
 }


### PR DESCRIPTION
Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.