### PR TITLE
app-emulation/xen-tools: apply patch of 4.19.1

### DIFF
--- a/app-emulation/xen-tools/xen-tools-4.19.2-r1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.19.2-r1.ebuild
@@ -163,7 +163,9 @@ DEPEND="${COMMON_DEPEND}
 
 BDEPEND="dev-lang/perl
 	app-alternatives/yacc
-	sys-devel/gettext"
+	sys-devel/gettext
+	ipxe? ( sys-devel/gcc:* )
+	!system-seabios? ( sys-devel/gcc:* )"
 
 # hvmloader is used to bootstrap a fully virtualized kernel
 # Approved by QA team in bug #144032
@@ -280,7 +282,9 @@ src_prepare() {
 
 		# gcc 11
 		cp "${XEN_GENTOO_PATCHES_DIR}/ipxe/${PN}-4.15.0-ipxe-gcc11.patch" tools/firmware/etherboot/patches/ipxe-gcc11.patch || die
+		cp "${FILESDIR}/ipxe-force-gcc.patch" tools/firmware/etherboot/patches/ || die
 		echo ipxe-gcc11.patch >> tools/firmware/etherboot/patches/series || die
+		echo ipxe-force-gcc.patch >> tools/firmware/etherboot/patches/series || die
 	fi
 
 	# Fix texi2html build error with new texi2html, qemu.doc.html
@@ -403,6 +407,10 @@ src_prepare() {
 		# Use gnu17 because incompatible w/ C23
 		sed -i -e "s:-DZZLEXBUFSIZE=65536:-DZZLEXBUFSIZE=65536 -std=gnu17:" \
 			tools/firmware/ovmf-dir-remote/BaseTools/Source/C/VfrCompile/Pccts/*/makefile || die
+	fi
+
+	if ! use system-seabios ; then
+		sed -i "/^export HOSTCC/i override CC:=gcc" tools/firmware/seabios-dir/Makefile || die
 	fi
 
 	default


### PR DESCRIPTION
from commit 085af7dfb91c441435b7d5f2b0b387b6369baf68 to fix build failure if using clang

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
