### PR TITLE
net-dns/knot: fix undefined reference with eautoreconf, disable py3.10

### DIFF
--- a/net-dns/knot/knot-3.4.6.ebuild
+++ b/net-dns/knot/knot-3.4.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 inherit autotools python-single-r1 flag-o-matic systemd tmpfiles verify-sig
 
 # subslot: libknot major.libdnssec major.libzscanner major

--- a/net-dns/knot/knot-3.4.6.ebuild
+++ b/net-dns/knot/knot-3.4.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit python-single-r1 flag-o-matic systemd tmpfiles verify-sig
+inherit autotools python-single-r1 flag-o-matic systemd tmpfiles verify-sig
 
 # subslot: libknot major.libdnssec major.libzscanner major
 KNOT_SUBSLOT="15.9.4"
@@ -115,6 +115,11 @@ src_unpack() {
 		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.xz{,.asc}
 	fi
 	default
+}
+
+src_prepare() {
+	default
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
It fails to install with llvm-musl-20 :

>ld.lld: error: undefined reference: gnutls_priority_deinit
> \>>> referenced by ../src/.libs/libknot.so (disallowed by --no-allow-shlib-undefined)

call eautoreconf to fix it

disable py3.10
no python3_14 for now because knot-exporter uses 'return' inside a finally block

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
