### PR TITLE
dev-libs/nss: Don't call shlibsign during cross-builds

### DIFF
--- a/dev-libs/nss/nss-3.111.ebuild
+++ b/dev-libs/nss/nss-3.111.ebuild
@@ -214,13 +214,16 @@ multilib_src_compile() {
 
 	local d
 
+	# Disables calling shlibsign during the build #956431 and #436216
+	tc-is-cross-compiler && makeargs+=( CROSS_COMPILE=1 )
+
 	# Build the host tools first.
 	LDFLAGS="${BUILD_LDFLAGS}" \
 	XCFLAGS="${BUILD_CFLAGS} -D_FILE_OFFSET_BITS=64" \
 	NSPR_LIB_DIR="${T}/fakedir" \
 	emake -C coreconf \
 		CC="$(tc-getBUILD_CC)" \
-			${buildbits-${mybits}}
+		${buildbits-${mybits}}
 	makeargs+=( NSINSTALL="${PWD}/$(find -type f -name nsinstall)" )
 
 	# Then build the target tools.


### PR DESCRIPTION
Passing CROSS_COMPILE=1 to make prevents the build from calling shlibsign, which can fail in a cross-environment since CBUILD may not have dev-libs/nss installed.

Closes: https://bugs.gentoo.org/956431

I have only tested that building the package with a cross-emerge without having `dev-libs/nss` installed works and that the installed files stay the same.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
