### PR TITLE
x11-themes/experience: bump EAPI, fix variable order & empty IUSE

### DIFF
--- a/x11-themes/experience/experience-3.04-r2.ebuild
+++ b/x11-themes/experience/experience-3.04-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="GTK+2 themes which copy and improve the look of XP Luna"
+HOMEPAGE="https://web.archive.org/web/20130730053042/https://art.gnome.org/themes/gtk2/1058"
+SRC_URI="mirror://gnome/teams/art.gnome.org/themes/gtk2/GTK2-EXperience.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-themes/gtk-engines-experience"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	mv "eXperience - ice" eXperience-ice || die
+	mv "eXperience - olive" eXperience-olive || die
+
+	# Don't install index files, since this package doesn't provide the icon
+	# set. Remove cruft files also.
+	find . -name 'index.theme' -o -name '*~' | xargs rm || die
+}
+
+src_install() {
+	for dir in eXperience* ; do
+		insinto "/usr/share/themes/${dir}"
+		doins -r ${dir}/.
+	done
+
+	dodoc eXperience/README
+}


### PR DESCRIPTION
Was a part of https://github.com/gentoo/gentoo/pull/38116

The warning says that I have added a deprecated dependency.
I think it can be ignored as I am not adding a new package but improving what's already there.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
