### PR TITLE
net-proxy/squid: remove aclocal.m4

### DIFF
--- a/net-proxy/squid/squid-6.14.ebuild
+++ b/net-proxy/squid/squid-6.14.ebuild
@@ -140,7 +140,8 @@ src_prepare() {
 	sed -i -e 's:_LTDL_SETUP:LTDL_INIT([installable]):' \
 		libltdl/configure.ac || die
 
-	eautoreconf
+	# https://bugs.gentoo.org/956509
+	AT_NO_RECURSIVE="yes" eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
With slibtool and sltdl eautoreconf fails because the default aclocal.m4 contains references to the vendored libltdl. This is because upstream generates the sources with libltdl included in AC_CONFIG_SUBDIRS, but then comments the lines in configure.ac for release.

~~This can be fixed by using AT_NO_RECURSIVE="yes", but this reveals that --with-ltdl-lib fails with GNU libtool because it depends on libltdl.la existing which is not true for the Gentoo package. Additionally --with-ltdl-include doesn't work except in combination with --with-ltdl-lib.~~

Bug: https://bugs.gentoo.org/956509

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
