### PR TITLE
app-shells/bash: pass -std=gnu17 to CFLAGS_FOR_BUILD

### DIFF
--- a/app-shells/bash/bash-2.05b_p13.ebuild
+++ b/app-shells/bash/bash-2.05b_p13.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-2"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/${PN}-2.05b-destdir.patch

--- a/app-shells/bash/bash-2.05b_p13.ebuild
+++ b/app-shells/bash/bash-2.05b_p13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -104,6 +104,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-3.0_p22.ebuild
+++ b/app-shells/bash/bash-3.0_p22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -109,6 +109,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-3.0_p22.ebuild
+++ b/app-shells/bash/bash-3.0_p22.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-2"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/autoconf-mktime-2.53.patch

--- a/app-shells/bash/bash-3.1_p23.ebuild
+++ b/app-shells/bash/bash-3.1_p23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -104,6 +104,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-3.1_p23.ebuild
+++ b/app-shells/bash/bash-3.1_p23.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-2"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/autoconf-mktime-2.53.patch # bug #220040

--- a/app-shells/bash/bash-3.2_p57.ebuild
+++ b/app-shells/bash/bash-3.2_p57.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -106,6 +106,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-3.2_p57.ebuild
+++ b/app-shells/bash/bash-3.2_p57.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-2"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/autoconf-mktime-2.59.patch # bug #220040

--- a/app-shells/bash/bash-4.0_p44.ebuild
+++ b/app-shells/bash/bash-4.0_p44.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -100,6 +100,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-4.0_p44.ebuild
+++ b/app-shells/bash/bash-4.0_p44.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/${PN}-4.0-configure.patch # bug #304901

--- a/app-shells/bash/bash-4.1_p17.ebuild
+++ b/app-shells/bash/bash-4.1_p17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -95,6 +95,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-4.1_p17.ebuild
+++ b/app-shells/bash/bash-4.1_p17.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -50,8 +52,6 @@ LIB_DEPEND=">=sys-libs/ncurses-5.2-r2[static-libs(+)]
 RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )"
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/${PN}-4.1-fbsd-eaccess.patch #bug #303411

--- a/app-shells/bash/bash-4.2_p53.ebuild
+++ b/app-shells/bash/bash-4.2_p53.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -107,6 +107,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--with-installed-readline=.

--- a/app-shells/bash/bash-4.2_p53.ebuild
+++ b/app-shells/bash/bash-4.2_p53.ebuild
@@ -39,6 +39,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -52,8 +54,6 @@ DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
 # We only need bison (yacc) when the .y files get patched (bash42-005)
 BDEPEND="sys-devel/bison"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/${PN}-4.2-execute-job-control.patch # bug #383237

--- a/app-shells/bash/bash-4.3_p48-r2.ebuild
+++ b/app-shells/bash/bash-4.3_p48-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -116,6 +116,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--docdir='$(datarootdir)'/doc/${PF}

--- a/app-shells/bash/bash-4.3_p48-r2.ebuild
+++ b/app-shells/bash/bash-4.3_p48-r2.ebuild
@@ -43,6 +43,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
@@ -62,8 +64,6 @@ PATCHES=(
 	"${WORKDIR}"/${P}-r2-patches/${PN}-4.3-protos.patch
 	"${WORKDIR}"/${P}-r2-patches/${PN}-4.4-popd-offset-overflow.patch # bug #600174
 )
-
-S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {
 	# bug #7332

--- a/app-shells/bash/bash-4.4_p23-r2.ebuild
+++ b/app-shells/bash/bash-4.4_p23-r2.ebuild
@@ -52,6 +52,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
@@ -67,8 +69,6 @@ RDEPEND="
 "
 # We only need bison (yacc) when the .y files get patched (bash42-005)
 #BDEPEND="sys-devel/bison"
-
-S="${WORKDIR}/${MY_P}"
 
 pkg_setup() {
 	# bug #7332

--- a/app-shells/bash/bash-4.4_p23-r2.ebuild
+++ b/app-shells/bash/bash-4.4_p23-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -127,6 +127,10 @@ src_configure() {
 	# bash 5.3 drops unprototyped functions, earlier versions are
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
+
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
 
 	local myconf=(
 		--disable-profiling

--- a/app-shells/bash/bash-5.0_p18-r3.ebuild
+++ b/app-shells/bash/bash-5.0_p18-r3.ebuild
@@ -52,6 +52,8 @@ if [[ -n ${GENTOO_PATCH_VER} ]] ; then
 	SRC_URI+=" https://dev.gentoo.org/~${GENTOO_PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${GENTOO_PATCH_VER}-patches.tar.xz"
 fi
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="GPL-3"
 SLOT="${MY_PV}"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
@@ -67,8 +69,6 @@ RDEPEND="
 "
 # We only need bison (yacc) when the .y files get patched (bash42-005)
 BDEPEND="sys-devel/bison"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	# Patches from Chet sent to bashbug ml

--- a/app-shells/bash/bash-5.0_p18-r3.ebuild
+++ b/app-shells/bash/bash-5.0_p18-r3.ebuild
@@ -132,6 +132,10 @@ src_configure() {
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu89)
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	local myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.1_p16-r14.ebuild
+++ b/app-shells/bash/bash-5.1_p16-r14.ebuild
@@ -177,6 +177,10 @@ src_configure() {
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.2_p37-r3.ebuild
+++ b/app-shells/bash/bash-5.2_p37-r3.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.2_p37.ebuild
+++ b/app-shells/bash/bash-5.2_p37.ebuild
@@ -178,6 +178,10 @@ src_configure() {
 	# incompatible with C23.
 	append-cflags $(test-flags-CC -std=gnu17)
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.3_rc1.ebuild
+++ b/app-shells/bash/bash-5.3_rc1.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# may misbehave at runtime.
 	unset -v YACC
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.3_rc1_p20250430-r1.ebuild
+++ b/app-shells/bash/bash-5.3_rc1_p20250430-r1.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# may misbehave at runtime.
 	unset -v YACC
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.3_rc1_p20250504-r1.ebuild
+++ b/app-shells/bash/bash-5.3_rc1_p20250504-r1.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# may misbehave at runtime.
 	unset -v YACC
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-5.3_rc1_p20250519.ebuild
+++ b/app-shells/bash/bash-5.3_rc1_p20250519.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# may misbehave at runtime.
 	unset -v YACC
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 

--- a/app-shells/bash/bash-9999.ebuild
+++ b/app-shells/bash/bash-9999.ebuild
@@ -180,6 +180,10 @@ src_configure() {
 	# may misbehave at runtime.
 	unset -v YACC
 
+	if tc-is-cross-compiler; then
+		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
+	fi
+
 	myconf=(
 		--disable-profiling
 


### PR DESCRIPTION
Essential for cross compile even for >=bash-5.3

Build still fails on <=bash-4.4_p23-r2 (different issue)

Closes: https://bugs.gentoo.org/956318

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
