### PR TITLE
media-gfx/zbar: enable py3.13, py3.14 and fixup deps

### DIFF
--- a/media-gfx/zbar/zbar-0.23.93-r1.ebuild
+++ b/media-gfx/zbar/zbar-0.23.93-r1.ebuild
@@ -30,14 +30,15 @@ COMMON_DEPEND="
 	dbus? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
 	gtk? (
 		dev-libs/glib:2[${MULTILIB_USEDEP}]
-		x11-libs/gtk+:3[${MULTILIB_USEDEP}]
+		x11-libs/gdk-pixbuf:2[introspection?]
+		x11-libs/gtk+:3[${MULTILIB_USEDEP},introspection?]
 		introspection? ( dev-libs/gobject-introspection )
 	)
 	imagemagick? (
 		!graphicsmagick? ( media-gfx/imagemagick:=[png,jpeg?] )
 		graphicsmagick? ( media-gfx/graphicsmagick:=[png,jpeg?] )
 	)
-	jpeg? ( media-libs/libjpeg-turbo:0[${MULTILIB_USEDEP}] )
+	jpeg? ( media-libs/libjpeg-turbo:0=[${MULTILIB_USEDEP}] )
 	python? ( ${PYTHON_DEPS} )
 	qt5? (
 		dev-qt/qtcore:5


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
