### PR TITLE
dev-libs/qhotkey: fix build w/ cmake 4, drop Qt 5 support

### DIFF
--- a/dev-libs/qhotkey/files/qhotkey-1.5.0-cmake4.patch
+++ b/dev-libs/qhotkey/files/qhotkey-1.5.0-cmake4.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d34519e..727218e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(qhotkey
+     VERSION 1.5.0

--- a/dev-libs/qhotkey/files/qhotkey-1.5.0-wayland-crash.patch
+++ b/dev-libs/qhotkey/files/qhotkey-1.5.0-wayland-crash.patch
@@ -1,0 +1,29 @@
+commit bb630252684d3556b79ac7a521616692f348fcf7
+Author: Javier O. Cordero Pérez <javiercorderoperez@gmail.com>
+Date:   Mon May 20 15:13:12 2024 -0400
+
+    Fix: Prevent crash on Wayland when using Qt 6 (#97)
+
+diff --git a/QHotkey/qhotkey_x11.cpp b/QHotkey/qhotkey_x11.cpp
+index d3ac1d1..d9d73f7 100644
+--- a/QHotkey/qhotkey_x11.cpp
++++ b/QHotkey/qhotkey_x11.cpp
+@@ -132,13 +132,16 @@ quint32 QHotkeyPrivateX11::nativeKeycode(Qt::Key keycode, bool &ok)
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+ 	const QNativeInterface::QX11Application *x11Interface = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
+-	Display *display = x11Interface->display();
+ #else
+ 	const bool x11Interface = QX11Info::isPlatformX11();
+-	Display *display = QX11Info::display();
+ #endif
+ 
+ 	if(x11Interface) {
++#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
++		Display *display = x11Interface->display();
++#else
++		Display *display = QX11Info::display();
++#endif
+ 		auto res = XKeysymToKeycode(display, keysym);
+ 		if(res != 0)
+ 			ok = true;

--- a/dev-libs/qhotkey/qhotkey-1.5.0-r1.ebuild
+++ b/dev-libs/qhotkey/qhotkey-1.5.0-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="QHotkey"
+inherit cmake
+
+DESCRIPTION="A global shortcut/hotkey library for desktop Qt applications"
+HOMEPAGE="https://github.com/Skycoder42/QHotkey"
+SRC_URI="https://github.com/Skycoder42/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+LICENSE="BSD-with-attribution"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="
+	dev-qt/qtbase:6[X,gui]
+	x11-libs/libX11
+"
+
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-wayland-crash.patch
+	"${FILESDIR}"/${P}-cmake4.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DQT_DEFAULT_MAJOR_VERSION:STRING=6
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
Adds an upstream patch to fixes a crash on wayland with Qt 6.

Closes: https://bugs.gentoo.org/953982

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
