### PR TITLE
app-containers/containerd: allow customizing socket address

### DIFF
--- a/app-containers/containerd/files/containerd.confd
+++ b/app-containers/containerd/files/containerd.confd
@@ -1,3 +1,9 @@
 # This is the delay to be used in the start_post function to wait for
 # the socket to be active.
 #containerd_socket_delay=5
+
+# Configure containerd socket address
+#containerd_socket_address="/run/containerd/containerd.sock"
+
+# Configure parameters for containerd process. See `man containerd` for details
+#command_args="--root=/var/lib/containerd --state=/run/containerd --address=${containerd_socket_address:-/run/containerd/containerd.sock}"

--- a/app-containers/containerd/files/containerd.initd
+++ b/app-containers/containerd/files/containerd.initd
@@ -22,5 +22,5 @@ start_pre() {
 }
 
 start_post() {
-	ewaitfile ${containerd_socket_delay:-5} /run/containerd/containerd.sock
+	ewaitfile ${containerd_socket_delay:-5} ${containerd_socket_address:-/run/containerd/containerd.sock}
 }


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Allow customizing socket address. This should give possibility to run several instances of containerd by symlinking init.d script and editing respective conf.d file.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
