### PR TITLE
sys-process/htop: use relative path for fcap

### DIFF
--- a/sys-process/htop/htop-3.4.1-r1.ebuild
+++ b/sys-process/htop/htop-3.4.1-r1.ebuild
@@ -96,7 +96,7 @@ pkg_postinst() {
 	xdg_desktop_database_update
 	xdg_icon_cache_update
 
-	fcaps cap_sys_ptrace /usr/bin/${PN}
+	fcaps cap_sys_ptrace usr/bin/${PN}
 
 	optfeature "Viewing processes accessing certain files" sys-process/lsof
 }

--- a/sys-process/htop/htop-9999.ebuild
+++ b/sys-process/htop/htop-9999.ebuild
@@ -96,7 +96,7 @@ pkg_postinst() {
 	xdg_desktop_database_update
 	xdg_icon_cache_update
 
-	fcaps cap_sys_ptrace /usr/bin/${PN}
+	fcaps cap_sys_ptrace usr/bin/${PN}
 
 	optfeature "Viewing processes accessing certain files" sys-process/lsof
 }


### PR DESCRIPTION
htop ebuild uses absolute path which breaks fcaps when installing to alternate destinations (crossdev, etc.). fcaps.eclass only prefixes ROOT for relative paths.

Changes `/usr/bin/${PN}` to `usr/bin/${PN}`

Closes: https://bugs.gentoo.org/956638

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
