### PR TITLE
sys-libs/pam: make docs build respect doc use flag

### DIFF
--- a/sys-libs/pam/pam-1.7.0_p20241230-r4.ebuild
+++ b/sys-libs/pam/pam-1.7.0_p20241230-r4.ebuild
@@ -36,15 +36,14 @@ fi
 LICENSE="|| ( BSD GPL-2 )"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="audit berkdb elogind examples debug nis nls selinux systemd"
+IUSE="audit berkdb elogind examples debug nis nls selinux systemd +doc"
 REQUIRED_USE="?? ( elogind systemd )"
 
 # meson.build specifically checks for bison and then byacc
 # also requires xsltproc
 BDEPEND+="
 	|| ( sys-devel/bison dev-util/byacc )
-	app-text/docbook-xsl-ns-stylesheets
-	dev-libs/libxslt
+	doc? ( app-text/docbook-xsl-ns-stylesheets dev-libs/libxslt )
 	sys-devel/flex
 	virtual/pkgconfig
 	nls? ( sys-devel/gettext )
@@ -114,7 +113,7 @@ multilib_src_configure() {
 		-Dhtmldir="${EPREFIX}"/usr/share/doc/${PF}/html
 		-Dpdfdir="${EPREFIX}"/usr/share/doc/${PF}/pdf
 
-		$(meson_native_enabled docs)
+		$(meson_native_use_feature doc docs)
 
 		-Dpam_unix=enabled
 


### PR DESCRIPTION
sys-libs/pam: make docs build respect doc use flag
    
    This fixes the meson docs arg to depend on the doc use
    flag to be able to turn off documentation in the pam build.
    
    This is necessary because for reasons that aren't fully
    understood, on my system xsltproc fails to find the files
    installed by app-text/docbook-xsl-ns-stylesheets.
    
    As a result the build fails so making it optional via a
    doc USE flag allows to workaround the issue in case the
    docs are not required.
    
     <snip>
    
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
