### PR TITLE
sys-apps/openrc: remove os build option

### DIFF
--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -57,7 +57,6 @@ src_configure() {
 		$(meson_feature audit)
 		"-Dbranding=\"Gentoo Linux\""
 		$(meson_use newnet)
-		-Dos=Linux
 		$(meson_use pam)
 		-Dpam_libdir="$(getpam_mod_dir)"
 		$(meson_feature selinux)


### PR DESCRIPTION
removed upstream in favor of meson's host_machine.system() function.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
