### PR TITLE
sys-libs/libnvme: drop unnecessary glibc specific inlude

### DIFF
--- a/sys-libs/libnvme/files/libnvme-1.14-remove-glibc-include.patch
+++ b/sys-libs/libnvme/files/libnvme-1.14-remove-glibc-include.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/956710
+https://github.com/linux-nvme/libnvme/pull/1016
+https://github.com/linux-nvme/libnvme/commit/9b3ab852075f6da64648145b2d2e56e34354bf45
+
+From 9b3ab852075f6da64648145b2d2e56e34354bf45 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20N=C3=A9ri?= <dne+commits@rb67.eu>
+Date: Fri, 23 May 2025 12:36:44 +0200
+Subject: [PATCH] examples: remove unnecessary include of <bits/pthreadtypes.h>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The <bits/*.h> header files are GNU libc specific, and should not be
+used directly from application code. This one in particular is already
+included by <pthread.h> on glibc.
+
+Fixes build on musl.
+
+Signed-off-by: Daniel Néri <dne+commits@rb67.eu>
+--- a/examples/mi-mctp-csi-test.c
++++ b/examples/mi-mctp-csi-test.c
+@@ -21,7 +21,6 @@
+ 
+ #include <ccan/array_size/array_size.h>
+ #include <ccan/endian/endian.h>
+-#include <bits/pthreadtypes.h>
+ 
+ void fhexdump(FILE *fp, const unsigned char *buf, int len)
+ {

--- a/sys-libs/libnvme/libnvme-1.14.ebuild
+++ b/sys-libs/libnvme/libnvme-1.14.ebuild
@@ -44,6 +44,10 @@ BDEPEND="
 
 distutils_enable_tests unittest
 
+PATCHES=(
+	"${FILESDIR}"/libnvme-1.14-remove-glibc-include.patch
+)
+
 src_prepare() {
 	default
 	use python && distutils-r1_src_prepare


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/956710

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
