### PR TITLE
media-video/obs-studio: enable py3.14

### DIFF
--- a/media-video/obs-studio/obs-studio-31.0.3-r1.ebuild
+++ b/media-video/obs-studio/obs-studio-31.0.3-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 LUA_COMPAT=( luajit )
 # For the time being upstream supports up to Python 3.12 only.
-# Any issues found with 3.13 should be reported as a Gentoo bug.
-PYTHON_COMPAT=( python3_{10..13} )
+# Any issues found with 3.13+ should be reported as a Gentoo bug.
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 

--- a/media-video/obs-studio/obs-studio-31.0.3.ebuild
+++ b/media-video/obs-studio/obs-studio-31.0.3.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 LUA_COMPAT=( luajit )
 # For the time being upstream supports up to Python 3.12 only.
-# Any issues found with 3.13 should be reported as a Gentoo bug.
-PYTHON_COMPAT=( python3_{10..13} )
+# Any issues found with 3.13+ should be reported as a Gentoo bug.
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -7,7 +7,7 @@ CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 LUA_COMPAT=( luajit )
 # For the time being upstream supports up to Python 3.12 only.
 # Any issues found with 3.13 should be reported as a Gentoo bug.
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 


### PR DESCRIPTION
As with previous bump upstream only support py3.12 however py3.14 works with my python scripts so enabling with same rule as applied with py3.13.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
