### PR TITLE
sys-process/bpytop: enable py3.13

### DIFF
--- a/sys-process/bpytop/bpytop-1.0.68-r1.ebuild
+++ b/sys-process/bpytop/bpytop-1.0.68-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit distutils-r1
 
@@ -36,11 +36,4 @@ src_install() {
 	insinto "/usr/share/${PN}/themes"
 	doins bpytop-themes/*.theme
 	distutils-r1_src_install
-}
-
-python_test() {
-	EPYTEST_DESELECT=(
-		tests/test_functions.py::test_get_cpu_core_mapping
-	)
-	epytest
 }


### PR DESCRIPTION
Test suite passes and the program looks fine when ran. I also re-enabled a test which was previously disabled for some reason but passes for me.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
