### PR TITLE
sys-libs/binutils-libs: Prevent QA Notice for missing 'makeinfo'

### DIFF
--- a/sys-libs/binutils-libs/binutils-libs-2.44.ebuild
+++ b/sys-libs/binutils-libs/binutils-libs-2.44.ebuild
@@ -199,6 +199,9 @@ multilib_src_configure() {
 			"${S}"/opcodes/Makefile.in || die
 	fi
 
+	# Avoid a QA notice about missing makeinfo.
+	# bug #955546
+	export MAKEINFO=:
 	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 
 	# Prevent makeinfo from running as we don't build docs here.


### PR DESCRIPTION
Since we don't build docs here anyway.

Closes: https://bugs.gentoo.org/955546

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
