### PR TITLE
dev-vcs/git-tools: enable py3.13, py3.14

### DIFF
--- a/dev-vcs/git-tools/git-tools-2022.12.ebuild
+++ b/dev-vcs/git-tools/git-tools-2022.12.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..14} )
 inherit python-r1
 
 DESCRIPTION="Assorted git-related scripts"


### PR DESCRIPTION
Played around for a bit with git-restore-mtime which is the program that uses python in this package, and it seems to be working fine.

Closes: https://bugs.gentoo.org/952464

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
