### PR TITLE
net-libs/biblesync: fix build w/ cmake 4, EAPI 8

### DIFF
--- a/net-libs/biblesync/biblesync-2.1.0-r1.ebuild
+++ b/net-libs/biblesync/biblesync-2.1.0-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="A multicast protocol to support Bible software shared co-navigation"
+HOMEPAGE="https://wiki.crosswire.org/BibleSync"
+SRC_URI="https://github.com/karlkleinpaste/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64"
+
+PATCHES=( "${FILESDIR}"/${P}-cmake4.patch )
+
+src_configure() {
+	local mycmakeargs=(
+		# To prevent multilib-strict violations
+		-DLIBDIR="${EPREFIX}"/usr/$(get_libdir)
+	)
+	cmake_src_configure
+}

--- a/net-libs/biblesync/files/biblesync-2.1.0-cmake4.patch
+++ b/net-libs/biblesync/files/biblesync-2.1.0-cmake4.patch
@@ -1,0 +1,23 @@
+From 4b00f9fd3d0c858947eee18206ef44f9f6bd2283 Mon Sep 17 00:00:00 2001
+From: Karl Kleinpaste <karl@kleinpaste.org>
+Date: Wed, 26 Mar 2025 14:30:21 -0400
+Subject: [PATCH] fix #14 update cmake min version to 3.5 for cmake 4 min
+ permissible.
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7225bcb..8060d9c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,7 @@
+ PROJECT(libbiblesync CXX)
+ SET(BIBLESYNC_VERSION 2.1.0)
+ # A required CMake line
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+ # Where our custom Find* files are located
+ SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952093

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
