### PR TITLE
llvm-runtimes/libgcc: Allow cross-compilation

### DIFF
--- a/llvm-runtimes/libgcc/libgcc-19.1.7-r1.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-19.1.7-r1.ebuild
@@ -91,6 +91,24 @@ src_configure() {
 		)
 	fi
 
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# CMake compiler tests compile and run a test artifact. That works well on
+			# host targets, but doesn't work with cross wrappers, since the produced
+			# binary is of a foreign target, so executing it without an user-space
+			# emulator is impossible.
+			# Given that, let's just skip the compiler tests for cross targets.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+
+			-DCMAKE_ASM_COMPILER_TARGET="${CTARGET}"
+			-DCMAKE_C_COMPILER_TARGET="${CTARGET}"
+			-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+		)
+	fi
+
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libgcc/libgcc-20.1.5.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-20.1.5.ebuild
@@ -91,6 +91,24 @@ src_configure() {
 		)
 	fi
 
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# CMake compiler tests compile and run a test artifact. That works well on
+			# host targets, but doesn't work with cross wrappers, since the produced
+			# binary is of a foreign target, so executing it without an user-space
+			# emulator is impossible.
+			# Given that, let's just skip the compiler tests for cross targets.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+
+			-DCMAKE_ASM_COMPILER_TARGET="${CTARGET}"
+			-DCMAKE_C_COMPILER_TARGET="${CTARGET}"
+			-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+		)
+	fi
+
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libgcc/libgcc-21.0.0.9999.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.0.0.9999.ebuild
@@ -90,6 +90,24 @@ src_configure() {
 		)
 	fi
 
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# CMake compiler tests compile and run a test artifact. That works well on
+			# host targets, but doesn't work with cross wrappers, since the produced
+			# binary is of a foreign target, so executing it without an user-space
+			# emulator is impossible.
+			# Given that, let's just skip the compiler tests for cross targets.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+
+			-DCMAKE_ASM_COMPILER_TARGET="${CTARGET}"
+			-DCMAKE_C_COMPILER_TARGET="${CTARGET}"
+			-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+		)
+	fi
+
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libgcc/libgcc-21.0.0_pre20250523.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.0.0_pre20250523.ebuild
@@ -90,6 +90,24 @@ src_configure() {
 		)
 	fi
 
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# CMake compiler tests compile and run a test artifact. That works well on
+			# host targets, but doesn't work with cross wrappers, since the produced
+			# binary is of a foreign target, so executing it without an user-space
+			# emulator is impossible.
+			# Given that, let's just skip the compiler tests for cross targets.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+
+			-DCMAKE_ASM_COMPILER_TARGET="${CTARGET}"
+			-DCMAKE_C_COMPILER_TARGET="${CTARGET}"
+			-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+		)
+	fi
+
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libgcc/libgcc-21.0.0_pre20250528.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.0.0_pre20250528.ebuild
@@ -90,6 +90,24 @@ src_configure() {
 		)
 	fi
 
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# CMake compiler tests compile and run a test artifact. That works well on
+			# host targets, but doesn't work with cross wrappers, since the produced
+			# binary is of a foreign target, so executing it without an user-space
+			# emulator is impossible.
+			# Given that, let's just skip the compiler tests for cross targets.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+
+			-DCMAKE_ASM_COMPILER_TARGET="${CTARGET}"
+			-DCMAKE_C_COMPILER_TARGET="${CTARGET}"
+			-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+		)
+	fi
+
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"


### PR DESCRIPTION
CMake compiler tests compile and run a test artifact. That works well on host targets, but doesn't work with cross wrappers, since the produced binary is of a foreign target, so executing it without an user-space emulator is impossible.

Given that, let's just skip the compiler tests for cross targets.

Bug: https://bugs.gentoo.org/956749

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
