### PR TITLE
net-libs/libssh: use net-libs/mbedtls:3

### DIFF
--- a/net-libs/libssh/files/libssh-0.11.1-mbedtls-3.patch
+++ b/net-libs/libssh/files/libssh-0.11.1-mbedtls-3.patch
@@ -1,0 +1,55 @@
+From https://gitlab.com/libssh/libssh-mirror/-/commit/7712c7d0f97241c68e520d600b5857ebfcfd7439
+From: Davidwed <davidwe@posteo.de>
+Date: Tue, 3 Sep 2024 11:43:32 +0200
+Subject: [PATCH] cmake: Fixed compatibility issues with "CPM.cmake" in
+ combination with the libraries MBedTLS and libgcrypt.
+
+Signed-off-by: Davidwed <davidwe@posteo.de>
+Reviewed-by: Jakub Jelen <jjelen@redhat.com>
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ set(LIBSSH_PUBLIC_INCLUDE_DIRS ${libssh_SOURCE_DIR}/include)
+ 
+ set(LIBSSH_PRIVATE_INCLUDE_DIRS
++  ${libssh_BINARY_DIR}/include
+   ${libssh_BINARY_DIR}
+ )
+ 
+@@ -12,27 +13,13 @@ if (TARGET OpenSSL::Crypto)
+   list(APPEND LIBSSH_LINK_LIBRARIES OpenSSL::Crypto)
+ endif ()
+ 
+-if (MBEDTLS_CRYPTO_LIBRARY)
+-    set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-      ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-      ${MBEDTLS_INCLUDE_DIR}
+-    )
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${MBEDTLS_CRYPTO_LIBRARY}
+-  )
+-endif (MBEDTLS_CRYPTO_LIBRARY)
+-
+-if (GCRYPT_LIBRARIES)
+-  set(LIBSSH_PRIVATE_INCLUDE_DIRS
+-    ${LIBSSH_PRIVATE_INCLUDE_DIRS}
+-    ${GCRYPT_INCLUDE_DIR}
+-  )
++if (TARGET MbedTLS::mbedcrypto)
++  list(APPEND LIBSSH_LINK_LIBRARIES MbedTLS::mbedcrypto)
++endif ()
+ 
+-  set(LIBSSH_LINK_LIBRARIES
+-    ${LIBSSH_LINK_LIBRARIES}
+-    ${GCRYPT_LIBRARIES})
+-endif()
++if (TARGET libgcrypt::libgcrypt)
++  list(APPEND LIBSSH_LINK_LIBRARIES ${GCRYPT_LIBRARIES})
++endif ()
+ 
+ if (WITH_ZLIB)
+   list(APPEND LIBSSH_LINK_LIBRARIES ZLIB::ZLIB)
+-- 
+GitLab
+

--- a/net-libs/libssh/libssh-0.11.1-r2.ebuild
+++ b/net-libs/libssh/libssh-0.11.1-r2.ebuild
@@ -39,6 +39,11 @@ BDEPEND="doc? ( app-text/doxygen[dot] )"
 
 DOCS=( AUTHORS CHANGELOG README )
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.11.1-openssh-10.patch"
+	"${FILESDIR}/${PN}-0.11.1-mbedtls-3.patch"
+)
+
 src_prepare() {
 	# Remove custom find module to use system one
 	rm -fr cmake/Modules/FindMbedTLS.cmake
@@ -91,7 +96,7 @@ multilib_src_configure() {
 		-DWITH_GCRYPT=OFF
 		-DWITH_GSSAPI=$(usex gssapi)
 		-DWITH_MBEDTLS=$(usex mbedtls)
-		-DMBEDTLS_FOUND=$(usex mbedtls) # Enforce variable from custom find module
+		-DMBEDTLS_FOUND=$(usex mbedtls)	# Enforce variable from custom find module
 		-DWITH_PCAP=$(usex pcap)
 		-DWITH_SERVER=$(usex server)
 		-DWITH_SFTP=$(usex sftp)


### PR DESCRIPTION
Use net-libs/mbedtls:3 slot, specify required USE=threads.

Closes: https://bugs.gentoo.org/943343
Closes: https://bugs.gentoo.org/956764

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
