### PR TITLE
sys-cluster/drbd-utils: fix build with clang19

### DIFF
--- a/sys-cluster/drbd-utils/files/drbd-utils-9.25.0-missing-stdint.patch
+++ b/sys-cluster/drbd-utils/files/drbd-utils-9.25.0-missing-stdint.patch
@@ -33,3 +33,13 @@ Signed-off-by: Sam James <sam@gentoo.org>
  #include <string>
  
  class DisplayId
+--- a/user/drbdmon/terminal/DisplayStyleCollection.h
++++ b/user/drbdmon/terminal/DisplayStyleCollection.h
+@@ -1,6 +1,7 @@
+ #ifndef DISPLAYSTYLECOLLECTION_H
+ #define DISPLAYSTYLECOLLECTION_H
+ 
++#include <stdint.h>
+ #include <new>
+ #include <memory>
+ #include <stdexcept>


### PR DESCRIPTION
./terminal/DisplayStyleCollection.h:14:29: error: unknown type name 'uint16_t' ...

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
