### PR TITLE
sys-devel/m4: avoid build failures with -Werror=format-security

### DIFF
--- a/sys-devel/m4/m4-1.4.20.ebuild
+++ b/sys-devel/m4/m4-1.4.20.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/m4.asc
-inherit verify-sig
+inherit flag-o-matic verify-sig
 
 DESCRIPTION="GNU macro processor"
 HOMEPAGE="https://www.gnu.org/software/m4/m4.html"
@@ -57,6 +57,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# see https://bugs.gentoo.org/955947
+	append-flags -Wno-error=format-security
+
 	local -a myeconfargs=(
 		--enable-changeword
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955947
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
