### PR TITLE
sys-devel/gettext: avoid build failures with -Werror=format-security

### DIFF
--- a/sys-devel/gettext/gettext-0.23.1-r1.ebuild
+++ b/sys-devel/gettext/gettext-0.23.1-r1.ebuild
@@ -6,7 +6,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/gettext.asc
-inherit java-pkg-opt-2 libtool multilib-minimal verify-sig toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 libtool multilib-minimal verify-sig toolchain-funcs
 
 DESCRIPTION="GNU locale utilities"
 HOMEPAGE="https://www.gnu.org/software/gettext/"
@@ -102,6 +102,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# see https://bugs.gentoo.org/955689
+	append-flags -Wno-error=format-security
+
 	local myconf=(
 		# switches common to runtime and top-level
 		--cache-file="${BUILD_DIR}"/config.cache


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955689
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
