### PR TITLE
media-video/obs-studio: use net-libs/mbedtls:3

### DIFF
--- a/media-video/obs-studio/obs-studio-31.0.3-r2.ebuild
+++ b/media-video/obs-studio/obs-studio-31.0.3-r2.ebuild
@@ -82,7 +82,6 @@ DEPEND="
 	sys-apps/pciutils
 	sys-apps/util-linux
 	sys-libs/zlib:=
-	x11-libs/libdrm
 	x11-libs/libX11
 	x11-libs/libxcb:=
 	x11-libs/libXcomposite
@@ -100,6 +99,7 @@ DEPEND="
 		media-libs/mesa[gbm(+)]
 		net-print/cups
 		x11-libs/cairo
+		x11-libs/libdrm
 		x11-libs/libXcursor
 		x11-libs/libXdamage
 		x11-libs/libXext
@@ -186,6 +186,10 @@ src_prepare() {
 	use wayland && filter-lto
 
 	cmake_src_prepare
+
+	pushd deps/json11 &> /dev/null || die
+		eapply "${FILESDIR}/json11-1.0.0-include-cstdint.patch"
+	popd &> /dev/null || die
 }
 
 src_configure() {
@@ -248,8 +252,8 @@ src_install() {
 	cmake_src_install
 
 	# external plugins may need some things not installed by default, install them here
-	insinto /usr/include/obs/frontend/api
-	doins frontend/api/obs-frontend-api.h
+	insinto /usr/include/obs/UI/obs-frontend-api
+	doins UI/obs-frontend-api/obs-frontend-api.h
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Use net-libs/mbedtls:3, fix minor QA warning about deprecated dependencies.

Closes: https://bugs.gentoo.org/956807

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
