### PR TITLE
sys-devel/flex: patch to fix the malloc prototype

### DIFF
--- a/sys-devel/flex/files/flex-2.6.4-fix-malloc-prototype.patch
+++ b/sys-devel/flex/files/flex-2.6.4-fix-malloc-prototype.patch
@@ -1,0 +1,26 @@
+Bug: https://bugs.gentoo.org/956581
+https://github.com/westes/flex/pull/674
+https://github.com/westes/flex/commit/4b142954b54a57a9b0af0a9661056a9c39a8fa95
+
+From bf254c75b1e0d2641ebbd7fc85fb183f36a62ea7 Mon Sep 17 00:00:00 2001
+From: Richard Barnes <rbarnes@umn.edu>
+Date: Wed, 2 Oct 2024 10:35:09 -0700
+Subject: [PATCH] Match `malloc` signature to its use
+
+---
+ lib/malloc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/malloc.c b/lib/malloc.c
+index 75e8ef97c..701b9b39d 100755
+--- a/lib/malloc.c
++++ b/lib/malloc.c
+@@ -3,7 +3,7 @@
+      
+      #include <sys/types.h>
+      
+-     void *malloc ();
++     void *malloc (size_t n);
+      
+      /* Allocate an N-byte block of memory from the heap.
+         If N is zero, allocate a 1-byte block.  */

--- a/sys-devel/flex/flex-2.6.4-r6.ebuild
+++ b/sys-devel/flex/flex-2.6.4-r6.ebuild
@@ -29,6 +29,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-libobjdir.patch
 	"${FILESDIR}"/${P}-fix-build-with-glibc2.26.patch
 	"${FILESDIR}"/${P}-fix-apple-m1-crash-by-explicit-pointer-cast.patch
+	"${FILESDIR}"/${P}-fix-malloc-prototype.patch
 
 	"${WORKDIR}"/${P}-autotools-regenerate.patch
 )


### PR DESCRIPTION
Source: https://github.com/westes/flex/pull/674

Closes: https://bugs.gentoo.org/956581

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
