### PR TITLE
gui-wm/hyprland:

### DIFF
--- a/gui-wm/hyprland/hyprland-9999.ebuild
+++ b/gui-wm/hyprland/hyprland-9999.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="X legacy-renderer +qtutils systemd"
+IUSE="X +qtutils systemd"
 
 # hyprpm (hyprland plugin manager) requires the dependencies at runtime
 # so that it can clone, compile and install plugins.
@@ -91,7 +91,6 @@ pkg_setup() {
 
 src_configure() {
 	local emesonargs=(
-		$(meson_feature legacy-renderer legacy_renderer)
 		$(meson_feature systemd)
 		$(meson_feature X xwayland)
 	)


### PR DESCRIPTION
Hyprland has dropped the [legacy renderer](https://github.com/hyprwm/Hyprland/pull/10408), I've removed the corresponding USE flag.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
