### PR TITLE
Remove myself as a maintainer in two packages

### DIFF
--- a/dev-db/influxdb/metadata.xml
+++ b/dev-db/influxdb/metadata.xml
@@ -5,14 +5,6 @@
 		<email>williamh@gentoo.org</email>
 		<name>William Hubbs</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>davidroman96@gmail.com</email>
-		<name>David Roman</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<longdescription lang="en">
 		InfluxDB is an open source time series database with no external
 		dependencies. It is useful for recording metrics, events, and

--- a/sci-astronomy/wcslib/metadata.xml
+++ b/sci-astronomy/wcslib/metadata.xml
@@ -5,10 +5,6 @@
     <email>sci-astronomy@gentoo.org</email>
     <name>Gentoo Astronomy Project</name>
   </maintainer>
-  <maintainer type="person" proxied="yes">
-    <email>davidroman96@gmail.com</email>
-    <name>David Roman</name>
-  </maintainer>
   <longdescription lang="en">
   WCSLIB is a C library, supplied with a full set of Fortran wrappers,
   that implements the "World Coordinate System" (WCS) convention in FITS


### PR DESCRIPTION
For a bit of context:
 - wcslib: I didn't touch it for a lot of time as we don't use it at work anymore
- influxdb: is a PITA and the upstream decisions doesn't make it any easier to maintain. Wish luck to anyone willing to maintain it 
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
