### PR TITLE
net-libs/srt: fix build with cmake 4, allow LTO

### DIFF
--- a/net-libs/srt/files/srt-1.5.4-cmake4.patch
+++ b/net-libs/srt/files/srt-1.5.4-cmake4.patch
@@ -1,0 +1,25 @@
+https://bugs.gentoo.org/955894
+https://github.com/Haivision/srt/commit/0def1b1
+
+From 0def1b1a1094fc57752f241250e9a1aed71bbffd Mon Sep 17 00:00:00 2001
+From: Sam Umbach <samumbach@gmail.com>
+Date: Mon, 19 May 2025 08:39:46 -0400
+Subject: [PATCH] [build] Update for compatibility with CMake 4.x (#3167)
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 847b6f23f..847564d03 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ #
+ 
+-cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
++cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+ set (SRT_VERSION 1.5.4)
+ 
+ set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")

--- a/net-libs/srt/srt-1.5.4-r1.ebuild
+++ b/net-libs/srt/srt-1.5.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake-multilib flag-o-matic
+inherit cmake-multilib
 
 DESCRIPTION="Secure Reliable Transport (SRT) library and tools"
 HOMEPAGE="https://github.com/Haivision/srt"
@@ -39,10 +39,6 @@ PATCHES=(
 )
 
 src_configure() {
-	# ODR violations
-	# https://github.com/Haivision/srt/issues/2145 (bug #861584)
-	filter-lto
-
 	local mycmakeargs=(
 		-DUSE_CXX_STD=c++14 # Required for gtest
 		-DENABLE_STATIC=OFF

--- a/net-libs/srt/srt-1.5.4-r1.ebuild
+++ b/net-libs/srt/srt-1.5.4-r1.ebuild
@@ -1,0 +1,66 @@
+# Copyright 2018-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib flag-o-matic
+
+DESCRIPTION="Secure Reliable Transport (SRT) library and tools"
+HOMEPAGE="https://github.com/Haivision/srt"
+
+if [[ ${PV} == *9999 ]] ; then
+	EGIT_REPO_URI="https://github.com/Haivision/${PN}.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/Haivision/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv -sparc ~x86 ~ppc-macos ~x64-macos"
+fi
+
+LICENSE="MPL-2.0"
+SLOT="0/$(ver_cut 1-2)"
+IUSE="gnutls test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	gnutls? (
+		dev-libs/nettle:0=[${MULTILIB_USEDEP}]
+		net-libs/gnutls:0=[${MULTILIB_USEDEP}]
+	)
+	!gnutls? (
+		dev-libs/openssl:0=[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	test? ( >=dev-cpp/gtest-1.10[${MULTILIB_USEDEP}] )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.5.4-cmake4.patch
+)
+
+src_configure() {
+	# ODR violations
+	# https://github.com/Haivision/srt/issues/2145 (bug #861584)
+	filter-lto
+
+	local mycmakeargs=(
+		-DUSE_CXX_STD=c++14 # Required for gtest
+		-DENABLE_STATIC=OFF
+		# Bonding is experimental in 1.5, but works good and doesn't affect anything when not enabled with API calls
+		-DENABLE_BONDING=ON
+		-DENABLE_UNITTESTS=$(usex test)
+		-DENABLE_TESTING=OFF # Not installed developer/testing tools
+		-DUSE_GNUTLS=$(usex gnutls)
+	)
+	cmake-multilib_src_configure
+}
+
+multilib_src_test() {
+	cmake_src_test -j1
+}
+
+multilib_src_install() {
+	cmake_src_install
+	# remove old upstream temporary compatibility pc
+	rm "${ED}/usr/$(get_libdir)/pkgconfig/haisrt.pc" || die
+}


### PR DESCRIPTION
Backport patch [1] to fix building with cmake 4 and allow building with LTO since the ODR violations [2][3] have been fixed upstream [4]. The test suite passes fine with LTO on amd64.

[1] https://github.com/Haivision/srt/commit/0def1b1
[2] https://github.com/Haivision/srt/issues/2145
[3] https://bugs.gentoo.org/861584
[4] https://github.com/Haivision/srt/pull/3002

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
