### PR TITLE
profiles: Mask sys-boot/vboot-utils for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -36,6 +36,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Andreas Sturmlechner <asturm@gentoo.org> (2025-05-30)
+# Last updated >5 years ago, stuck on EAPI 7, imposes static-libs pressure
+# on its dependencies; many bugs. Removal on 2025-06-24.
+# Bugs #937435, #833111, #721504, #875593, #675726, #625122, #590616
+sys-boot/vboot-utils
+
 # Michael Orlitzky <mjo@gentoo.org> (2025-05-28)
 # I added this for SageMath, but in hindsight do not think anyone is
 # using it. It has code issues and upstream is not terribly interested


### PR DESCRIPTION
This is the only package blocking libzip[static-libs] cleanup. Which is cause for a lot of ebuild complexity and broken wrt deps anyway.

The alternative would be to drop IUSE static or limit it to !libzip, but I don't want to spend time on something that is potentially dead and unneeded.

@zmedico please let me know what to do.