### PR TITLE
gui-libs/libadwaita: Optionally build and install documentation

### DIFF
--- a/gui-libs/libadwaita/libadwaita-1.7.2-r1.ebuild
+++ b/gui-libs/libadwaita/libadwaita-1.7.2-r1.ebuild
@@ -13,8 +13,11 @@ LICENSE="LGPL-2.1+"
 SLOT="1"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
-IUSE="+introspection test +vala"
-REQUIRED_USE="vala? ( introspection )"
+IUSE="gtk-doc +introspection test +vala"
+REQUIRED_USE="
+	gtk-doc? ( introspection )
+	vala? ( introspection )
+"
 
 RDEPEND="
 	>=dev-libs/glib-2.80.0:2
@@ -27,6 +30,7 @@ DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
 BDEPEND="
 	${PYTHON_DEPS}
+	gtk-doc? ( dev-util/gi-docgen )
 	vala? ( $(vala_depend) )
 	dev-util/glib-utils
 	sys-devel/gettext
@@ -48,7 +52,7 @@ src_configure() {
 		-Dprofiling=false
 		$(meson_feature introspection)
 		$(meson_use vala vapi)
-		-Ddocumentation=false # we ship pregenerated docs
+		$(meson_use gtk-doc documentation)
 		$(meson_use test tests)
 		-Dexamples=false
 	)
@@ -63,5 +67,8 @@ src_test() {
 src_install() {
 	meson_src_install
 
-	insinto /usr/share/gtk-doc/html
+	if use gtk-doc; then
+		mkdir -p "${ED}"/usr/share/gtk-doc/html/ || die
+		mv "${ED}"/usr/share/doc/libadwaita-${SLOT} "${ED}"/usr/share/gtk-doc/html/ || die
+	fi
 }


### PR DESCRIPTION
Also a minor fix to switch from xdg to xdg-utils eclass - only xdg_environment_reset() is needed, not the pre/post functions or the DEPEND.

```diff
--- libadwaita-1.7.2.ebuild
+++ libadwaita-1.7.2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..12} python3_{13..14}{,t} )
-inherit gnome.org meson python-any-r1 vala virtualx xdg
+inherit gnome.org meson python-any-r1 vala virtualx xdg-utils
 
 DESCRIPTION="Building blocks for modern GNOME applications"
 HOMEPAGE="https://gnome.pages.gitlab.gnome.org/libadwaita/ https://gitlab.gnome.org/GNOME/libadwaita"
@@ -13,8 +13,11 @@
 SLOT="1"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
-IUSE="+introspection test +vala"
-REQUIRED_USE="vala? ( introspection )"
+IUSE="gtk-doc +introspection test +vala"
+REQUIRED_USE="
+	gtk-doc? ( introspection )
+	vala? ( introspection )
+"
 
 RDEPEND="
 	>=dev-libs/glib-2.80.0:2
@@ -27,6 +30,7 @@
 	x11-base/xorg-proto"
 BDEPEND="
 	${PYTHON_DEPS}
+	gtk-doc? ( dev-util/gi-docgen )
 	vala? ( $(vala_depend) )
 	dev-util/glib-utils
 	sys-devel/gettext
@@ -48,7 +52,7 @@
 		-Dprofiling=false
 		$(meson_feature introspection)
 		$(meson_use vala vapi)
-		-Ddocumentation=false # we ship pregenerated docs
+		$(meson_use gtk-doc documentation)
 		$(meson_use test tests)
 		-Dexamples=false
 	)
@@ -63,5 +67,8 @@
 src_install() {
 	meson_src_install
 
-	insinto /usr/share/gtk-doc/html
+	if use gtk-doc; then
+		mkdir -p "${ED}"/usr/share/gtk-doc/html/ || die
+		mv "${ED}"/usr/share/doc/libadwaita-${SLOT} "${ED}"/usr/share/gtk-doc/html/ || die
+	fi
 }
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
