### PR TITLE
app-text/xournalpp: fix unconditional enabling of gtest

### DIFF
--- a/app-text/xournalpp/xournalpp-1.2.5-r1.ebuild
+++ b/app-text/xournalpp/xournalpp-1.2.5-r1.ebuild
@@ -53,7 +53,7 @@ PATCHES=(
 src_configure() {
 	local mycmakeargs=(
 		-DLUA_VERSION="$(lua_get_version)"
-		-DENABLE_GTEST=ON
+		-DENABLE_GTEST=$(usex test)
 	)
 
 	cmake_src_configure

--- a/app-text/xournalpp/xournalpp-9999.ebuild
+++ b/app-text/xournalpp/xournalpp-9999.ebuild
@@ -53,7 +53,7 @@ PATCHES=(
 src_configure() {
 	local mycmakeargs=(
 		-DLUA_VERSION="$(lua_get_version)"
-		-DENABLE_GTEST=ON
+		-DENABLE_GTEST=$(usex test)
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/956765

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
