### PR TITLE
net-p2p/rtorrent: fix xmlrpc-c checking

### DIFF
--- a/net-p2p/rtorrent/rtorrent-0.15.3-r1.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.15.3-r1.ebuild
@@ -27,7 +27,7 @@ COMMON_DEPEND="
 	net-misc/curl
 	sys-libs/ncurses:0=
 	lua? ( ${LUA_DEPS} )
-	xmlrpc? ( dev-libs/xmlrpc-c:= )
+	xmlrpc? ( dev-libs/xmlrpc-c:=[libxml2] )
 "
 DEPEND="${COMMON_DEPEND}
 	dev-cpp/nlohmann_json


### PR DESCRIPTION
add dev-libs/xmlrpc-c[+libxml2]

Closes: https://bugs.gentoo.org/956759

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
