### PR TITLE
media-libs/intel-mediasdk: Update reference to media-libs/vpl-gpu-rt

### DIFF
--- a/media-libs/intel-mediasdk/intel-mediasdk-23.2.2.ebuild
+++ b/media-libs/intel-mediasdk/intel-mediasdk-23.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -94,5 +94,5 @@ multilib_src_configure() {
 }
 
 pkg_postinst() {
-	optfeature "Intel GPUs newer then, and including, Intel Xe" media-libs/oneVPL-intel-gpu
+	optfeature "Intel GPUs newer then, and including, Intel Xe" media-libs/vpl-gpu-rt
 }


### PR DESCRIPTION
In e21e3e247232 `media-libs/oneVPL-intel-gpu` was renamed to `media-libs/vpl-gpu-rt`.

cc @Nowa-Ammerlaan

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
