### PR TITLE
media-libs/assimp: disable automagic ccache

### DIFF
--- a/media-libs/assimp/assimp-5.4.3-r1.ebuild
+++ b/media-libs/assimp/assimp-5.4.3-r1.ebuild
@@ -75,6 +75,7 @@ src_configure() {
 		# -DASSIMP_BUILD_NONFREE_C4D_IMPORTER=no # Build the C4D importer, which relies on the non-free Cineware SDK.
 		-DASSIMP_BUILD_SAMPLES=$(usex samples) # If the official samples are built as well (needs Glut).
 		-DASSIMP_BUILD_TESTS=$(usex test) # If the test suite for Assimp is built in addition to the library.
+		-DASSIMP_BUILD_USE_CCACHE=off
 		-DASSIMP_BUILD_ZLIB=no # Build your own zlib
 		-DASSIMP_COVERALLS=$(usex test) # Enable this to measure test coverage.
 		# breaks tests


### PR DESCRIPTION
Users in Gentoo enable ccache with FEATURES="ccache" if required, it
shouldn't be enabled automagically by a project.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
