### PR TITLE
geeqie-2.6: Filter lto due to odr violations

### DIFF
--- a/media-gfx/geeqie/geeqie-2.6.ebuild
+++ b/media-gfx/geeqie/geeqie-2.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 LUA_COMPAT=( lua5-{3,4} )
 
-inherit lua-single meson optfeature xdg
+inherit flag-o-matic lua-single meson optfeature xdg
 
 DESCRIPTION="A lightweight GTK image viewer forked from GQview"
 HOMEPAGE="https://www.geeqie.org"
@@ -85,6 +85,8 @@ src_configure() {
 		$(meson_feature zip archive)
 	)
 
+	# Bug: https://bugs.gentoo.org/957023
+	filter-lto
 	meson_src_configure
 }
 

--- a/media-gfx/geeqie/geeqie-9999.ebuild
+++ b/media-gfx/geeqie/geeqie-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 LUA_COMPAT=( lua5-{3,4} )
 
-inherit git-r3 lua-single meson optfeature xdg
+inherit flag-o-matic git-r3 lua-single meson optfeature xdg
 
 DESCRIPTION="A lightweight GTK image viewer forked from GQview"
 HOMEPAGE="https://www.geeqie.org"
@@ -78,6 +78,8 @@ src_configure() {
 		$(meson_feature zip archive)
 	)
 
+	# Bug: https://bugs.gentoo.org/957023
+	filter-lto
 	meson_src_configure
 }
 


### PR DESCRIPTION
Closes gentoo bug [957023](https://bugs.gentoo.org/957023)

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
