### PR TITLE
dev-python/aiohttp: BDEPEND on multidict

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.11.14.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.11.14.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	' 3.10)
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		dev-python/cython[${PYTHON_USEDEP}]
 	)

--- a/dev-python/aiohttp/aiohttp-3.11.18.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.11.18.ebuild
@@ -44,6 +44,7 @@ RDEPEND="
 	' 3.10)
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		dev-python/cython[${PYTHON_USEDEP}]
 	)

--- a/dev-python/aiohttp/aiohttp-3.12.0.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.12.0.ebuild
@@ -40,6 +40,7 @@ RDEPEND="
 	>=dev-python/yarl-1.17.0[${PYTHON_USEDEP}]
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		>=dev-python/cython-3.1.1[${PYTHON_USEDEP}]
 		dev-python/pkgconfig[${PYTHON_USEDEP}]

--- a/dev-python/aiohttp/aiohttp-3.12.2.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.12.2.ebuild
@@ -40,6 +40,7 @@ RDEPEND="
 	>=dev-python/yarl-1.17.0[${PYTHON_USEDEP}]
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		>=dev-python/cython-3.1.1[${PYTHON_USEDEP}]
 		dev-python/pkgconfig[${PYTHON_USEDEP}]

--- a/dev-python/aiohttp/aiohttp-3.12.4.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.12.4.ebuild
@@ -40,6 +40,7 @@ RDEPEND="
 	>=dev-python/yarl-1.17.0[${PYTHON_USEDEP}]
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		>=dev-python/cython-3.1.1[${PYTHON_USEDEP}]
 		dev-python/pkgconfig[${PYTHON_USEDEP}]

--- a/dev-python/aiohttp/aiohttp-3.12.6.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.12.6.ebuild
@@ -40,6 +40,7 @@ RDEPEND="
 	>=dev-python/yarl-1.17.0[${PYTHON_USEDEP}]
 "
 BDEPEND="
+	>=dev-python/multidict-4.5.0[${PYTHON_USEDEP}]
 	native-extensions? (
 		>=dev-python/cython-3.1.1[${PYTHON_USEDEP}]
 		dev-python/pkgconfig[${PYTHON_USEDEP}]


### PR DESCRIPTION
Fix issue where aiohttp fails to emerge in cases where multidict is not installed for BDEPEND due to a call aiohttp-*/tools/gen.py during configure.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
