### PR TITLE
net-ftp/lftp: fix musl build if using clang

### DIFF
--- a/net-ftp/lftp/files/lftp-4.9.3-gnulib-stdlib.h.patch
+++ b/net-ftp/lftp/files/lftp-4.9.3-gnulib-stdlib.h.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/stdlib.in.h b/lib/stdlib.in.h
+index ed00a43..f37ff84 100644
+--- a/lib/stdlib.in.h
++++ b/lib/stdlib.in.h
+@@ -119,7 +119,7 @@ struct random_data
+ # include <unistd.h>
+ #endif
+ 
+-#if ((@GNULIB_STRTOL@ && @REPLACE_STRTOL@) || (@GNULIB_STRTOLL@ && @REPLACE_STRTOLL@) || (@GNULIB_STRTOUL@ && @REPLACE_STRTOUL@) || (@GNULIB_STRTOULL@ && @REPLACE_STRTOULL@)) && defined __cplusplus && !defined GNULIB_NAMESPACE && defined __GNUG__ && !defined __clang__
++#if ((@GNULIB_STRTOL@ && @REPLACE_STRTOL@) || (@GNULIB_STRTOLL@ && @REPLACE_STRTOLL@) || (@GNULIB_STRTOUL@ && @REPLACE_STRTOUL@) || (@GNULIB_STRTOULL@ && @REPLACE_STRTOULL@)) && defined __cplusplus && !defined GNULIB_NAMESPACE && defined __GNUG__
+ /* When strtol, strtoll, strtoul, or strtoull is going to be defined as a macro
+    below, this may cause compilation errors later in the libstdc++ header files
+    (that are part of GCC), such as:

--- a/net-ftp/lftp/lftp-4.9.3.ebuild
+++ b/net-ftp/lftp/lftp-4.9.3.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-4.9.1-libdir-readline.patch
 	"${FILESDIR}"/${PN}-4.9.2-socks.patch
 	"${FILESDIR}"/${PN}-4.9.3-gnulib.patch
+	"${FILESDIR}"/${PN}-4.9.3-gnulib-stdlib.h.patch
 )
 
 # Gnulib false positive #900064


### PR DESCRIPTION
otherwise build failed with:
> error: 'rpl_strtol' is not a member of 'std'

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
