### PR TITLE
dev-util/colm: fix for slibtool

### DIFF
--- a/dev-util/colm/colm-0.14.7-r4.ebuild
+++ b/dev-util/colm/colm-0.14.7-r4.ebuild
@@ -27,6 +27,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.14.7-drop-julia-check.patch
 	"${FILESDIR}"/${PN}-0.14.7-disable-static-lib.patch
 	"${FILESDIR}"/${PN}-0.14.7-solaris.patch
+	# https://bugs.gentoo.org/927974
+	"${FILESDIR}"/${PN}-0.14.7-slibtool.patch
 )
 
 src_prepare() {

--- a/dev-util/colm/files/colm-0.14.7-slibtool.patch
+++ b/dev-util/colm/files/colm-0.14.7-slibtool.patch
@@ -1,0 +1,59 @@
+https://bugs.gentoo.org/927974
+https://github.com/adrian-thurston/colm/pull/163
+
+From b433d0ff5ef8eb4263925eed2efc328d6434a52b Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Thu, 14 Mar 2024 14:48:29 -0700
+Subject: [PATCH] src: link with libcolm.la
+
+When linking internal dependencies created by libtool it is better to
+use the libtool archive (.la) file and this allows colm to build with
+slibtool in addition to GNU libtool.
+---
+ src/Makefile.am            | 2 +-
+ test/rlparse.d/Makefile.am | 2 +-
+ test/trans.d/Makefile.am   | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index c5fb6efa..3c763398 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -175,7 +175,7 @@ colm_CXXFLAGS = $(common_CFLAGS) -DLOAD_COLM
+ colm_CFLAGS = $(common_CFLAGS)
+ colm_SOURCES = main.cc loadcolm.cc loadfinal.h version.h
+ nodist_colm_SOURCES = gen/if3.h gen/if3.cc gen/parse3.c
+-colm_LDADD = libprog.a -lcolm
++colm_LDADD = libprog.a libcolm.la
+ 
+ # Listing if1.h in BUILT_SOURCES isn't sufficient because it depends on the
+ # building of bootstrap0. Automake wants to put all built sources into a list
+diff --git a/test/rlparse.d/Makefile.am b/test/rlparse.d/Makefile.am
+index 54a14639..9cdebc23 100644
+--- a/test/rlparse.d/Makefile.am
++++ b/test/rlparse.d/Makefile.am
+@@ -21,7 +21,7 @@ rlparse_SOURCES = parse.c if.h if.cc commit.cc \
+ 	svector.h
+ 
+ rlparse_CPPFLAGS = $(COLM_xCPPFLAGS)
+-rlparse_LDADD = -lcolm
++rlparse_LDADD = $(top_builddir)/src/libcolm.la
+ rlparse_LDFLAGS = $(COLM_xLDFLAGS)
+ 
+ EXTRA_DIST = \
+diff --git a/test/trans.d/Makefile.am b/test/trans.d/Makefile.am
+index 4a9d8798..d7a2d4b7 100644
+--- a/test/trans.d/Makefile.am
++++ b/test/trans.d/Makefile.am
+@@ -33,7 +33,7 @@ trans.c: trans.lm $(TRANS_DEPS) $(COLM_BIN)
+ 
+ trans_CPPFLAGS = $(COLM_xCPPFLAGS)
+ trans_SOURCES = actparams.cc trans.c main.c
+-trans_LDADD = -lcolm
++trans_LDADD = $(top_builddir)/src/libcolm.la
+ trans_LDFLAGS = $(COLM_xLDFLAGS)
+ 
+ CASES =  \
+-- 
+2.49.0
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927974
Upstream-PR: https://github.com/adrian-thurston/colm/pull/163

The `0.14.7` version requires additional changes not required in the upstream git repo.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
