### PR TITLE
app-arch/zopfli: fix build w/ cmake 4

### DIFF
--- a/app-arch/zopfli/files/zopfli-1.0.3-cmake4.patch
+++ b/app-arch/zopfli/files/zopfli-1.0.3-cmake4.patch
@@ -1,0 +1,17 @@
+https://github.com/google/zopfli/pull/207
+commit 15464520156b4bfceb417f86d86e5a00d7e11c15
+Author: Johannes Huber <johu@gmx.de>
+Date:   Mon Jun 2 20:27:25 2025 +0200
+
+    fix build w/ cmake4
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e56fd2f..bee4355 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.11)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(Zopfli)
+ 

--- a/app-arch/zopfli/zopfli-1.0.3-r1.ebuild
+++ b/app-arch/zopfli/zopfli-1.0.3-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Very good, but slow, deflate or zlib compression"
+HOMEPAGE="https://github.com/google/zopfli/"
+SRC_URI="https://github.com/google/zopfli/archive/${P}.tar.gz"
+S="${WORKDIR}/${PN}-${P}"
+
+LICENSE="Apache-2.0"
+SLOT="0/1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+DOCS=( CONTRIBUTORS README README.zopflipng )
+
+PATCHES=( "${FILESDIR}"/${P}-cmake4.patch )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/951805

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
