### PR TITLE
media-libs/libdvbpsi: fix for slibtool

### DIFF
--- a/media-libs/libdvbpsi/files/libdvbpsi-1.3.3-slibtool.patch
+++ b/media-libs/libdvbpsi/files/libdvbpsi-1.3.3-slibtool.patch
@@ -1,0 +1,95 @@
+https://code.videolan.org/videolan/libdvbpsi/-/merge_requests/14
+
+From d4bee7cf2d03cd30a189c8abf4b34165a17598e5 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Thu, 14 Mar 2024 17:34:59 -0700
+Subject: [PATCH] build: link with the libtool archive
+
+When linking an internal dependency it is better to use the libtool
+archive (.la) file which allows it to always link correctly with both
+GNU libtool and slibtool.
+
+Gentoo-Issue: https://bugs.gentoo.org/956827
+---
+ examples/Makefile.am         | 15 +++++++++------
+ examples/dvbinfo/Makefile.am |  4 ++--
+ misc/Makefile.am             |  6 +++---
+ 3 files changed, 14 insertions(+), 11 deletions(-)
+
+diff --git a/examples/Makefile.am b/examples/Makefile.am
+index 97f100a..e65ccd5 100644
+--- a/examples/Makefile.am
++++ b/examples/Makefile.am
+@@ -15,27 +15,30 @@ check_cc_pid_LDFLAGS =
+ 
+ decode_pat_SOURCES = decode_pat.c
+ decode_pat_CPPFLAGS = -DDVBPSI_DIST
+-decode_pat_LDFLAGS = -L../src -ldvbpsi
++decode_pat_LDADD = $(top_builddir)/src/libdvbpsi.la
+ 
+ decode_pmt_SOURCES = decode_pmt.c
+ decode_pmt_CPPFLAGS = -DDVBPSI_DIST
+-decode_pmt_LDFLAGS = -L../src -ldvbpsi -lm
++decode_pmt_LDADD = $(top_builddir)/src/libdvbpsi.la
++decode_pmt_LDFLAGS = -lm
+ 
+ get_pcr_pid_SOURCES = get_pcr_pid.c
+ get_pcr_pid_CPPFLAGS = -DDVBPSI_DIST
+-get_pcr_pid_LDFLAGS = -L../src -ldvbpsi -lm
++get_pcr_pid_LDADD = $(top_builddir)/src/libdvbpsi.la
++get_pcr_pid_LDFLAGS = -lm
+ 
+ decode_sdt_SOURCES = decode_sdt.c
+ decode_sdt_CPPFLAGS = -DDVBPSI_DIST
+-decode_sdt_LDFLAGS = -L../src -ldvbpsi
++decode_sdt_LDADD = $(top_builddir)/src/libdvbpsi.la
+ 
+ decode_mpeg_SOURCES = decode_mpeg.c
+ if HAVE_SYS_SOCKET_H
+ decode_mpeg_SOURCES += connect.c connect.h
+ endif
+ decode_mpeg_CPPFLAGS = -D_FILE_OFFSET_BITS=64 -DDVBPSI_DIST
+-decode_mpeg_LDFLAGS = -L../src -ldvbpsi -lm
++decode_mpeg_LDADD = $(top_builddir)/src/libdvbpsi.la
++decode_mpeg_LDFLAGS = -lm
+ 
+ decode_bat_SOURCES = decode_bat.c
+ decode_bat_CPPFLAGS = -DDVBPSI_DIST
+-decode_bat_LDFLAGS = -L../src -ldvbpsi
++decode_bat_LDADD = $(top_builddir)/src/libdvbpsi.la
+diff --git a/examples/dvbinfo/Makefile.am b/examples/dvbinfo/Makefile.am
+index b878676..7eb5835 100644
+--- a/examples/dvbinfo/Makefile.am
++++ b/examples/dvbinfo/Makefile.am
+@@ -7,5 +7,5 @@ if HAVE_SYS_SOCKET_H
+ dvbinfo_SOURCES += tcp.c tcp.h udp.c udp.h
+ endif
+ dvbinfo_CPPFLAGS = -D_FILE_OFFSET_BITS=64 -DDVBPSI_DIST
+-dvbinfo_LDFLAGS = -L../../src -ldvbpsi -pthread -lm
+-
++dvbinfo_LDADD = $(top_builddir)/src/libdvbpsi.la
++dvbinfo_LDFLAGS = -pthread -lm
+diff --git a/misc/Makefile.am b/misc/Makefile.am
+index cd25f60..59886e2 100644
+--- a/misc/Makefile.am
++++ b/misc/Makefile.am
+@@ -7,16 +7,16 @@ gen_crc_SOURCES = gen_crc.c
+ 
+ gen_pat_SOURCES = gen_pat.c
+ gen_pat_CPPFLAGS = -DDVBPSI_DIST
+-gen_pat_LDFLAGS = -L../src -ldvbpsi
++gen_pat_LDADD = $(top_builddir)/src/libdvbpsi.la
+ 
+ gen_pmt_SOURCES = gen_pmt.c
+ gen_pmt_CPPFLAGS = -DDVBPSI_DIST
+-gen_pmt_LDFLAGS = -L../src -ldvbpsi
++gen_pmt_LDADD = $(top_builddir)/src/libdvbpsi.la
+ 
+ 
+ test_dr_SOURCES = test_dr.c
+ test_dr_CPPFLAGS = -DDVBPSI_DIST
+-test_dr_LDFLAGS = -L../src -ldvbpsi
++test_dr_LDADD = $(top_builddir)/src/libdvbpsi.la
+ 
+ noinst_HEADERS = test_dr.h
+ 

--- a/media-libs/libdvbpsi/libdvbpsi-1.3.3-r1.ebuild
+++ b/media-libs/libdvbpsi/libdvbpsi-1.3.3-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library for MPEG TS/DVB PSI tables decoding and generation"
+HOMEPAGE="https://www.videolan.org/libdvbpsi"
+SRC_URI="https://download.videolan.org/pub/${PN}/${PV}/${P}.tar.bz2"
+
+LICENSE="LGPL-2.1"
+# Sublot == libdvbpsi.so major
+SLOT="0/10"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc static-libs"
+
+BDEPEND="
+	doc? (
+		app-text/doxygen
+		>=media-gfx/graphviz-2.26
+	)"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+PATCHES=(
+	# https://bugs.gentoo.org/956827
+	"${FILESDIR}"/${PN}-1.3.3-slibtool.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable static-libs static) \
+		--enable-release
+}
+
+src_compile() {
+	default
+	use doc && emake doc
+}
+
+src_install() {
+	use doc && local HTML_DOCS=( doc/doxygen/html/. )
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
* Fixes the build system for slibtool
* update EAPI 7 -> 8
* Removes pointless sed

The patch was rebased for the 1.3.3 version.

-O2 is not used if $CFLAGS is set, -O6 is not used anywhere in the build system and -Werror is only for --enable-debug which Gentoo doesn't use.

Closes: https://bugs.gentoo.org/956827
Upstream-PR: https://code.videolan.org/videolan/libdvbpsi/-/merge_requests/14

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
