### PR TITLE
dev-util/android-tools: fix building with gcc 16

### DIFF
--- a/dev-util/android-tools/android-tools-35.0.2.ebuild
+++ b/dev-util/android-tools/android-tools-35.0.2.ebuild
@@ -50,6 +50,7 @@ DOCS=()
 src_prepare() {
 	eapply "${DISTDIR}/${PN}-31.0.3-no-gtest.patch"
 	eapply "${FILESDIR}/android-tools-35.0.2-protobuf.patch"
+	eapply "${FILESDIR}/android-tools-35.0.2-gcc-16.patch"
 
 	cd "${S}/vendor/core" || die
 	eapply "${S}/patches/core/0011-Remove-the-useless-dependency-on-gtest.patch"

--- a/dev-util/android-tools/files/android-tools-35.0.2-gcc-16.patch
+++ b/dev-util/android-tools/files/android-tools-35.0.2-gcc-16.patch
@@ -1,0 +1,27 @@
+https://android-review.googlesource.com/c/platform/system/libbase/+/3555906
+https://android-review.googlesource.com/c/platform/system/libziparchive/+/3649395
+
+diff --git a/vendor/libbase/hex.cpp b/vendor/libbase/hex.cpp
+index a4b7715..85ba671 100644
+--- a/vendor/libbase/hex.cpp
++++ b/vendor/libbase/hex.cpp
+@@ -18,6 +18,8 @@
+ 
+ #include "android-base/logging.h"
+ 
++#include <stdint.h>
++
+ namespace android {
+ namespace base {
+ 
+diff --git a/vendor/libziparchive/include/ziparchive/zip_writer.h b/vendor/libziparchive/include/ziparchive/zip_writer.h
+index 268e8b6..aca7f4e 100644
+--- a/vendor/libziparchive/include/ziparchive/zip_writer.h
++++ b/vendor/libziparchive/include/ziparchive/zip_writer.h
+@@ -16,6 +16,7 @@
+
+ #pragma once
+
++#include <cstdint>
+ #include <cstdio>
+ #include <ctime>


### PR DESCRIPTION
More libstdc++ changes landed upstream which shuffled some things around again, so <cstdint> and <stdint.h> have to be explicitly included.

Links to upstream changes: 
https://android-review.googlesource.com/c/platform/system/libbase/+/3555906
https://android-review.googlesource.com/c/platform/system/libziparchive/+/3649395

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
