### PR TITLE
dev-cpp/libcmis: backport upstream fix sha1 computation

### DIFF
--- a/dev-cpp/libcmis/files/libcmis-0.6.2-fix-sha1-test.patch
+++ b/dev-cpp/libcmis/files/libcmis-0.6.2-fix-sha1-test.patch
@@ -1,0 +1,45 @@
+https://github.com/tdf/libcmis/pull/69
+https://github.com/tdf/libcmis/commit/0753091be57edae28655e43a9bae9e4c4e414117
+
+From 0753091be57edae28655e43a9bae9e4c4e414117 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Caol=C3=A1n=20McNamara?= <caolan.mcnamara@collabora.com>
+Date: Fri, 13 Sep 2024 16:02:13 +0100
+Subject: [PATCH] sha1 test fails with older boost
+
+<fridrich> 1) test: XmlTest::sha1Test (F) line: 588 test-xmlutils.cxx
+<fridrich> equality assertion failed
+<fridrich> - Expected: f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0
+<fridrich> - Actual  : 8b9efff79be0b27b5d5a9370c50c5e78f0abd0d9
+---
+ src/libcmis/xml-utils.cxx | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/libcmis/xml-utils.cxx b/src/libcmis/xml-utils.cxx
+index cdf088f..3568ec6 100644
+--- a/src/libcmis/xml-utils.cxx
++++ b/src/libcmis/xml-utils.cxx
+@@ -536,17 +536,19 @@ namespace libcmis
+         boost::uuids::detail::sha1::digest_type digest;
+         sha1.get_digest( digest );
+ 
+-        // by using a pointer to unsigned char, we can read the
+-        // object representation of either typedef.
+-        const unsigned char* ptr = reinterpret_cast<const unsigned char*>( digest );
+-
+         stringstream out;
+         // Setup writing mode. Every number must produce two
+         // hexadecimal digits, including possible leading 0s, or we get
+         // less than 40 digits as result.
+         out << hex << setfill('0') << right;
+-        for ( int i = 0; i < sizeof( digest ); ++ptr, ++i )
++#if BOOST_VERSION < 108600
++        for ( int i = 0; i < 5; ++i )
++            out << setw(8) << digest[i];
++#else
++        const unsigned char* ptr = reinterpret_cast<const unsigned char*>( digest );
++        for ( size_t i = 0; i < sizeof( digest ); ++ptr, ++i )
+             out << setw(2) << static_cast<int>( *ptr );
++#endif
+         return out.str();
+     }
+ 

--- a/dev-cpp/libcmis/libcmis-0.6.2-r2.ebuild
+++ b/dev-cpp/libcmis/libcmis-0.6.2-r2.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://github.com/tdf/libcmis.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/tdf/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+fi
+inherit autotools flag-o-matic
+
+DESCRIPTION="C++ client library for the CMIS interface"
+HOMEPAGE="https://github.com/tdf/libcmis"
+
+LICENSE="|| ( GPL-2 LGPL-2 MPL-1.1 )"
+SLOT="0/0.6"
+IUSE="man test tools"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	dev-libs/boost:=
+	dev-libs/libxml2:=
+	net-misc/curl
+"
+RDEPEND="
+	${DEPEND}
+	!dev-cpp/libcmis:0.5
+"
+BDEPEND="
+	virtual/pkgconfig
+	man? (
+		app-text/docbook2X
+		dev-libs/libxslt
+	)
+	test? (
+		dev-util/cppunit
+	)
+"
+
+PATCHES=(
+	# https://github.com/tdf/libcmis/pull/52
+	"${FILESDIR}"/${P}-libxml2-2.12.patch # bug 917523
+	# https://github.com/tdf/libcmis/pull/68
+	"${FILESDIR}"/${P}-boost-1.86.patch
+	# https://github.com/tdf/libcmis/pull/69
+	"${FILESDIR}"/${P}-fix-sha1-test.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# ODR issues in tests w/ curl
+	filter-lto
+
+	local myeconfargs=(
+		--disable-werror
+		$(use_with man)
+		$(use_enable test tests)
+		$(use_enable tools client)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Link: https://github.com/tdf/libcmis/pull/69
Link: https://github.com/tdf/libcmis/commit/0753091be57edae28655e43a9bae9e4c4e414117
Closes: https://bugs.gentoo.org/957018

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
