### PR TITLE
dev-libs/glib: ignore gschemas.compiled & giomodule.cache in pkg_preinst

### DIFF
--- a/dev-libs/glib/glib-2.82.5.ebuild
+++ b/dev-libs/glib/glib-2.82.5.ebuild
@@ -411,32 +411,6 @@ multilib_src_install_all() {
 
 pkg_preinst() {
 	xdg_pkg_preinst
-
-	# Make gschemas.compiled belong to glib alone
-	local cache="/usr/share/glib-2.0/schemas/gschemas.compiled"
-
-	if [[ -e ${EROOT}${cache} ]]; then
-		cp "${EROOT}"${cache} "${ED}"/${cache} || die
-	else
-		touch "${ED}"${cache} || die
-	fi
-
-	multilib_pkg_preinst() {
-		# Make giomodule.cache belong to glib alone
-		local cache="/usr/$(get_libdir)/gio/modules/giomodule.cache"
-
-		if [[ -e ${EROOT}${cache} ]]; then
-			cp "${EROOT}"${cache} "${ED}"${cache} || die
-		else
-			touch "${ED}"${cache} || die
-		fi
-	}
-
-	# Don't run the cache ownership when cross-compiling, as it would end up with an empty cache
-	# file due to inability to create it and GIO might not look at any of the modules there
-	if ! tc-is-cross-compiler ; then
-		multilib_foreach_abi multilib_pkg_preinst
-	fi
 }
 
 pkg_postinst() {

--- a/dev-libs/glib/glib-2.84.3.ebuild
+++ b/dev-libs/glib/glib-2.84.3.ebuild
@@ -407,32 +407,6 @@ multilib_src_install_all() {
 
 pkg_preinst() {
 	xdg_pkg_preinst
-
-	# Make gschemas.compiled belong to glib alone
-	local cache="/usr/share/glib-2.0/schemas/gschemas.compiled"
-
-	if [[ -e ${EROOT}${cache} ]]; then
-		cp "${EROOT}"${cache} "${ED}"/${cache} || die
-	else
-		touch "${ED}"${cache} || die
-	fi
-
-	multilib_pkg_preinst() {
-		# Make giomodule.cache belong to glib alone
-		local cache="/usr/$(get_libdir)/gio/modules/giomodule.cache"
-
-		if [[ -e ${EROOT}${cache} ]]; then
-			cp "${EROOT}"${cache} "${ED}"${cache} || die
-		else
-			touch "${ED}"${cache} || die
-		fi
-	}
-
-	# Don't run the cache ownership when cross-compiling, as it would end up with an empty cache
-	# file due to inability to create it and GIO might not look at any of the modules there
-	if ! tc-is-cross-compiler ; then
-		multilib_foreach_abi multilib_pkg_preinst
-	fi
 }
 
 pkg_postinst() {

--- a/dev-libs/glib/glib-2.84.4.ebuild
+++ b/dev-libs/glib/glib-2.84.4.ebuild
@@ -407,32 +407,6 @@ multilib_src_install_all() {
 
 pkg_preinst() {
 	xdg_pkg_preinst
-
-	# Make gschemas.compiled belong to glib alone
-	local cache="/usr/share/glib-2.0/schemas/gschemas.compiled"
-
-	if [[ -e ${EROOT}${cache} ]]; then
-		cp "${EROOT}"${cache} "${ED}"/${cache} || die
-	else
-		touch "${ED}"${cache} || die
-	fi
-
-	multilib_pkg_preinst() {
-		# Make giomodule.cache belong to glib alone
-		local cache="/usr/$(get_libdir)/gio/modules/giomodule.cache"
-
-		if [[ -e ${EROOT}${cache} ]]; then
-			cp "${EROOT}"${cache} "${ED}"${cache} || die
-		else
-			touch "${ED}"${cache} || die
-		fi
-	}
-
-	# Don't run the cache ownership when cross-compiling, as it would end up with an empty cache
-	# file due to inability to create it and GIO might not look at any of the modules there
-	if ! tc-is-cross-compiler ; then
-		multilib_foreach_abi multilib_pkg_preinst
-	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
both will be handled in pkg_postinst, otherwise `equery check` complains:

> !!! /usr/lib64/gio/modules/giomodule.cache does not exist
> !!! /usr/share/glib-2.0/schemas/gschemas.compiled does not exist

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
