### PR TITLE
net-analyzer/testssl: fix DNS tools dependencies

### DIFF
--- a/net-analyzer/testssl/testssl-3.0.9-r1.ebuild
+++ b/net-analyzer/testssl/testssl-3.0.9-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="${PN}.sh"
+MY_PV="${PV/_p/-}"
+
+DESCRIPTION="Tool to check TLS/SSL cipher support"
+HOMEPAGE="https://testssl.sh/"
+SRC_URI="https://github.com/drwetter/${MY_PN}/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+S=${WORKDIR}/${MY_PN}-${MY_PV}
+
+LICENSE="GPL-2 bundled-openssl? ( openssl )"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+IUSE="bundled-openssl kerberos"
+
+RDEPEND="
+	app-shells/bash[net]
+	sys-apps/util-linux
+	sys-libs/ncurses:0
+	sys-process/procps
+	|| (
+		net-dns/bind
+		net-libs/ldns
+	)
+	bundled-openssl? (
+		kerberos? (
+			sys-libs/zlib
+			virtual/krb5
+		)
+	)
+	!bundled-openssl? ( dev-libs/openssl:0 )
+"
+
+QA_PREBUILT="opt/${PN}/*"
+
+pkg_setup() {
+	if use amd64; then
+		if use kerberos; then
+			BUNDLED_OPENSSL="openssl.Linux.x86_64.krb"
+		else
+			BUNDLED_OPENSSL="openssl.Linux.x86_64"
+		fi
+	elif use x86; then
+		BUNDLED_OPENSSL="openssl.Linux.i686"
+	fi
+}
+
+src_prepare() {
+	default
+	sed -i ${PN}.sh \
+		-e 's|TESTSSL_INSTALL_DIR="${TESTSSL_INSTALL_DIR:-""}"|TESTSSL_INSTALL_DIR="/"|' \
+		-e 's|$TESTSSL_INSTALL_DIR/etc/|&testssl/|g' || die
+
+	if use bundled-openssl; then
+		sed -i ${PN}.sh \
+			-e "/find_openssl_binary()/a OPENSSL=\"/opt/${PN}/${BUNDLED_OPENSSL}\"" || die
+	fi
+}
+
+src_install() {
+	dodoc CHANGELOG.md CREDITS.md Readme.md
+	dodoc openssl-iana.mapping.html
+
+	dobin ${PN}.sh
+
+	insinto /etc/${PN}
+	doins etc/*
+
+	if use bundled-openssl; then
+		exeinto /opt/${PN}
+		use amd64 && doexe bin/${BUNDLED_OPENSSL}
+	fi
+}


### PR DESCRIPTION
testssl.sh could use dig, host or nslookup from net-dns/bind,
or drill from net-libs/ldns.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
