### PR TITLE
kde-plasma/plasma-workspace: fix building with gcc 16

### DIFF
--- a/kde-plasma/plasma-workspace/files/plasma-workspace-6.3.5-gcc-16.patch
+++ b/kde-plasma/plasma-workspace/files/plasma-workspace-6.3.5-gcc-16.patch
@@ -1,0 +1,30 @@
+https://invent.kde.org/plasma/plasma-workspace/-/commit/73e7404f
+
+From 73e7404f7da95c0e1be94fc49ffa7ea3e3b27312 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sun, 1 Jun 2025 03:45:34 +0100
+Subject: [PATCH] dataengines: add missing <mutex> include
+
+This shows up with recent GCC 16 trunk. It's fixed on master with
+fe0dbb13cd4263a75ff1c226f8a49ce8a09131e6 but that change is a bit big,
+so let's do the minimal thing here for the branch.
+---
+ dataengines/weather/ions/bbcukmet/ion_bbcukmet.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/dataengines/weather/ions/bbcukmet/ion_bbcukmet.cpp b/dataengines/weather/ions/bbcukmet/ion_bbcukmet.cpp
+index 32ec4b02e4f..c6140c572c5 100644
+--- a/dataengines/weather/ions/bbcukmet/ion_bbcukmet.cpp
++++ b/dataengines/weather/ions/bbcukmet/ion_bbcukmet.cpp
+@@ -11,6 +11,8 @@
+ 
+ #include "ion_bbcukmetdebug.h"
+ 
++#include <mutex>
++
+ #include <KIO/TransferJob>
+ #include <KLocalizedString>
+ #include <KUnitConversion/Converter>
+-- 
+GitLab
+

--- a/kde-plasma/plasma-workspace/plasma-workspace-6.3.5-r2.ebuild
+++ b/kde-plasma/plasma-workspace/plasma-workspace-6.3.5-r2.ebuild
@@ -157,6 +157,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-5.22.5-krunner-cwd-at-home.patch" # TODO upstream: KDE-bug 432975, bug 767478
 	"${WORKDIR}"/${PATCHSET}
+	"${FILESDIR}"/${PN}-6.3.5-gcc-16.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Backport patch [1] that adds an include for the mutex header, which has to be explicitly included with gcc 16.

[1] https://invent.kde.org/plasma/plasma-workspace/-/commit/73e7404f7

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
