### PR TITLE
dev-libs/libevent: migrate to mbedtls:3

### DIFF
--- a/dev-libs/libevent/files/libevent-2.2.1-cmake-install-paths.patch
+++ b/dev-libs/libevent/files/libevent-2.2.1-cmake-install-paths.patch
@@ -1,0 +1,68 @@
+From https://github.com/libevent/libevent/commit/7870e85ecbfa09d79c66d382301ecd0a1e441c19
+From: kurtliu <kurtliu@tencent.com>
+Date: Wed, 24 Jan 2024 13:19:23 +0800
+Subject: [PATCH] install DESTINATION use CMAKE_INSTALL_<dir>
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1683,12 +1683,12 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfigVersion.cmake.in
+ 
+ # Install compat headers
+ install(FILES ${HDR_COMPAT}
+-        DESTINATION "include"
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+         COMPONENT dev)
+ 
+ # Install public headers
+ install(FILES ${HDR_PUBLIC}
+-        DESTINATION "include/event2"
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/event2"
+         COMPONENT dev)
+ 
+ # Install the configs.
+@@ -1716,7 +1716,7 @@ endif()
+ # Install the scripts.
+ install(PROGRAMS
+        ${CMAKE_CURRENT_SOURCE_DIR}/event_rpcgen.py
+-       DESTINATION "bin"
++       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT runtime)
+ 
+ # Create documents with doxygen.
+--- a/cmake/AddEventLibrary.cmake
++++ b/cmake/AddEventLibrary.cmake
+@@ -36,9 +36,9 @@ endmacro()
+ macro(export_install_target TYPE LIB_NAME)
+     if("${LIB_NAME}" STREQUAL "event")
+         install(TARGETS "${LIB_NAME}_${TYPE}"
+-            LIBRARY DESTINATION "lib" COMPONENT lib
+-            ARCHIVE DESTINATION "lib" COMPONENT lib
+-            RUNTIME DESTINATION "lib" COMPONENT lib
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+             COMPONENT dev
+         )
+     else()
+@@ -62,9 +62,9 @@ macro(export_install_target TYPE LIB_NAME)
+         )
+         install(TARGETS "${LIB_NAME}_${TYPE}"
+             EXPORT LibeventTargets-${TYPE}
+-            LIBRARY DESTINATION "lib" COMPONENT lib
+-            ARCHIVE DESTINATION "lib" COMPONENT lib
+-            RUNTIME DESTINATION "lib" COMPONENT lib
++            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
++            RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
+             COMPONENT dev
+         )
+     endif()
+@@ -169,7 +169,7 @@ macro(add_event_library LIB_NAME)
+         if (NOT WIN32)
+             install(FILES
+                 "$<TARGET_FILE_DIR:${LIB_NAME}_shared>/${LIB_LINK_NAME}"
+-                DESTINATION "lib"
++                DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+                 COMPONENT lib)
+         endif()
+     endif()

--- a/dev-libs/libevent/libevent-2.2.1-r4.ebuild
+++ b/dev-libs/libevent/libevent-2.2.1-r4.ebuild
@@ -5,14 +5,22 @@ EAPI=8
 
 CMAKE_REMOVE_MODULES_LIST=( FindMbedTLS )
 
-inherit cmake-multilib git-r3
+inherit cmake-multilib verify-sig
 
+MY_P="${P}-alpha-dev"
 DESCRIPTION="Library to execute a function when a specific event occurs on a file descriptor"
 HOMEPAGE="
 	https://libevent.org/
 	https://github.com/libevent/libevent/
 "
-EGIT_REPO_URI="https://github.com/libevent/libevent.git"
+BASE_URI="https://github.com/libevent/libevent/releases/download/release-${PV}-alpha"
+SRC_URI="
+	${BASE_URI}/${MY_P}.tar.gz
+	verify-sig? (
+		${BASE_URI}/${MY_P}.tar.gz.asc
+	)
+"
+S=${WORKDIR}/${MY_P}
 
 LICENSE="BSD"
 SLOT="0/2.2.1-r2"
@@ -31,10 +39,23 @@ DEPEND="
 RDEPEND="
 	${DEPEND}
 "
+BDEPEND="
+	verify-sig? (
+		sec-keys/openpgp-keys-libevent
+	)
+"
 
-DOCS=( README.md ChangeLog{,-2.0,-2.1} whatsnew-2.{0,1}.txt )
+DOCS=( README.md ChangeLog{,-2.0} whatsnew-2.{0,1}.txt )
 MULTILIB_WRAPPED_HEADERS=(
 	/usr/include/event2/event-config.h
+)
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/libevent.asc
+
+PATCHES=(
+	# signalfd-by-default breaks at least app-misc/tmux
+	# https://github.com/libevent/libevent/pull/1486
+	"${FILESDIR}/${P}-disable-signalfd.patch"
+	"${FILESDIR}/${P}-cmake-install-paths.patch"
 )
 
 multilib_src_configure() {


### PR DESCRIPTION
Migrate ebuild to cmake buildsystem as autotools are deprecated.

Closes: https://bugs.gentoo.org/957135

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
