### PR TITLE
net-misc/ntp: fix ntp-client startup with networkmanager

### DIFF
--- a/net-misc/ntp/files/ntp-client.rc
+++ b/net-misc/ntp/files/ntp-client.rc
@@ -4,7 +4,7 @@
 
 depend() {
 	before cron portmap
-	after net
+	need net
 	use dns logger
 }
 


### PR DESCRIPTION
With openrc, when setting ntp-client service to the default runlevel, if net-misc/networkmanager is used on the system, the service fails to start. In /var/log/rc.log we can find :

> * Starting NetworkManager ...      [ ok ]
> Connexion......... 1s [offline]
>  * Marking NetworkManager as inactive. It will automatically be marked
>  * as started after a network connection has been established.
>  * WARNING: NetworkManager has started, but is inactive
>  * Starting acpid ...              [ ok ]
>  * Starting avahi-daemon ...       [ ok ]
>  * Starting bluetooth ...          [ ok ]
>  * Setting clock via the NTP client 'ntpdate' ...
> Exiting, name server cannot be used: Temporary failure in name resolution (-3)
> * Failed to set clock [ !! ]
>  * ERROR: ntp-client failed to start

After *need*ing the net script :
In /var/log/rc.log :
>  * WARNING: ntp-client will start when NetworkManager has started

And in /var/log/messages we can see that the problem is fixed :
> Jun  5 16:26:19 coreI5 /etc/init.d/ntp-client[2579]:
>            WARNING: ntp-client will start when NetworkManager has started
> [...]
> Jun  5 16:26:32 coreI5 ntpdate[3113]: step time server 109.190.177.203
>            offset -0.006526 sec

Closes: https://bugs.gentoo.org/930071

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
