### PR TITLE
docker-compose: depend on virtual package instead of docker-cli

### DIFF
--- a/app-containers/docker-compose/docker-compose-2.32.3-r1.ebuild
+++ b/app-containers/docker-compose/docker-compose-2.32.3-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 2018-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit eapi9-ver go-module
+MY_PV=${PV/_/-}
+
+DESCRIPTION="Multi-container orchestration for Docker"
+HOMEPAGE="https://github.com/docker/compose"
+SRC_URI="https://github.com/docker/compose/archive/v${MY_PV}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~williamh/dist/${P}-deps.tar.xz"
+
+S="${WORKDIR}/compose-${MY_PV}"
+
+LICENSE="Apache-2.0"
+SLOT="2"
+KEYWORDS="amd64 arm64"
+
+BDEPEND=">=dev-lang/go-1.21"
+RDEPEND="virtual/docker"
+
+RESTRICT="test"
+
+src_prepare() {
+	default
+	# do not strip
+	sed -i -e 's/-s -w//' Makefile || die
+}
+
+src_compile() {
+	emake VERSION=v${PV}
+}
+
+src_test() {
+	emake test
+}
+
+src_install() {
+	exeinto /usr/libexec/docker/cli-plugins
+	doexe bin/build/docker-compose
+	dodoc README.md
+}
+
+pkg_postinst() {
+	ver_replacing -ge 2 && return
+	ewarn
+	ewarn "docker-compose 2.x is a sub command of docker"
+	ewarn "Use 'docker compose' from the command line instead of"
+	ewarn "'docker-compose'"
+	ewarn "If you need to keep 1.x around, please run the following"
+	ewarn "command before your next --depclean"
+	ewarn "# emerge --noreplace docker-compose:0"
+}

--- a/app-containers/docker-compose/docker-compose-2.38.1-r1.ebuild
+++ b/app-containers/docker-compose/docker-compose-2.38.1-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 2018-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit eapi9-ver go-module
+MY_PV=${PV/_/-}
+
+DESCRIPTION="Multi-container orchestration for Docker"
+HOMEPAGE="https://github.com/docker/compose"
+SRC_URI="https://github.com/docker/compose/archive/v${MY_PV}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~williamh/dist/${P}-deps.tar.xz"
+
+S="${WORKDIR}/compose-${MY_PV}"
+
+LICENSE="Apache-2.0"
+SLOT="2"
+KEYWORDS="~amd64 ~arm64"
+
+RDEPEND="virtual/docker"
+
+RESTRICT="test"
+
+src_prepare() {
+	default
+	# do not strip
+	sed -i -e 's/-s -w//' Makefile || die
+}
+
+src_compile() {
+	emake VERSION=v${PV}
+}
+
+src_test() {
+	emake test
+}
+
+src_install() {
+	exeinto /usr/libexec/docker/cli-plugins
+	doexe bin/build/docker-compose
+	dodoc README.md
+}
+
+pkg_postinst() {
+	ver_replacing -ge 2 && return
+	ewarn
+	ewarn "docker-compose 2.x is a sub command of docker"
+	ewarn "Use 'docker compose' from the command line instead of"
+	ewarn "'docker-compose'"
+	ewarn "If you need to keep 1.x around, please run the following"
+	ewarn "command before your next --depclean"
+	ewarn "# emerge --noreplace docker-compose:0"
+}

--- a/virtual/docker/docker-0.ebuild
+++ b/virtual/docker/docker-0.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Virtual package for container engine"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv"
+
+RDEPEND="|| (
+	>=app-containers/docker-cli-23.0.0
+	app-containers/podman[wrapper(+)]
+)
+"
+
+pkg_postinst() {
+	if has_version "app-containers/podman[wrapper(+)]"; then
+		ewarn "podman may have compatibility issues with the docker api."
+		ewarn "Please ensure that any issues you face are not related to \
+issues with the podman api before filing bug reports in the gentoo bugzilla"
+	fi
+}

--- a/virtual/docker/metadata.xml
+++ b/virtual/docker/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person" proxied="yes">
+    <email>luna@nullrequest.com</email>
+    <name>Luna D Dragon</name>
+  </maintainer>
+  <maintainer type="project" proxied="proxy">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
<!-- Please put the pull request description above -->
`docker-compose` can be used with podman either via setting the `DOCKER_HOST` env var or [`podman compose`](https://docs.podman.io/en/stable/markdown/podman-compose.1.html)(which also sets the envvar) other distributions allow `docker-compose` to be installed without docker and gentoo should also allow the same. This pull request creates a virtual package `virutal/docker` and makes `docker-compose` v2 depend on it 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
