### PR TITLE
net-misc/smbc: force gcc

### DIFF
--- a/net-misc/smbc/smbc-1.2.2-r4.ebuild
+++ b/net-misc/smbc/smbc-1.2.2-r4.ebuild
@@ -34,6 +34,12 @@ PATCHES=(
 )
 
 src_prepare() {
+	if ! tc-is-gcc; then
+		ewarn "force gcc because too many nested functions which is unsupported by clang"
+		export CC=${CHOST}-gcc
+		tc-is-gcc || die "tc-is-gcc failed in spite of CC=${CC}"
+	fi
+
 	default
 	mv configure.{in,ac} || die
 	# for some reason some build 32bit x86 objects are bundled


### PR DESCRIPTION
too many nest functions to be fixed, it's not necessary to fix them unless absolutely needed, since current version is released at 2005.

Closes: https://bugs.gentoo.org/871594
Closes: https://bugs.gentoo.org/885881
Closes: https://bugs.gentoo.org/913559

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
