### PR TITLE
net-vpn/tor: improve init.d script a bit

### DIFF
--- a/net-vpn/tor/files/tor.initd-r10
+++ b/net-vpn/tor/files/tor.initd-r10
@@ -1,13 +1,18 @@
 #!/sbin/openrc-run
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 command=/usr/bin/tor
-pidfile=/run/tor/tor.pid
-command_args="--hush --runasdaemon 1 --pidfile \"${pidfile}\""
+pidfile=/run/tor/${RC_SVCNAME}.pid
+command_args="--hush"
+command_args_background="--runasdaemon 1 --pidfile \"${pidfile}\""
 retry=${GRACEFUL_TIMEOUT:-60}
 stopsig=INT
 command_progress=yes
+
+depend() {
+	after net
+}
 
 extra_commands="checkconfig"
 extra_started_commands="reload"
@@ -16,7 +21,7 @@ description_checkconfig="Check for valid config file"
 description_reload="Reload the configuration"
 
 checkconfig() {
-	${command} --verify-config --hush > /dev/null 2>&1
+	${command} ${command_args} --verify-config > /dev/null 2>&1
 	if [ $? -ne 0 ] ; then
 		eerror "Tor configuration (/etc/tor/torrc) is not valid."
 		eerror "Example is in /etc/tor/torrc.sample"

--- a/net-vpn/tor/tor-0.4.8.16.ebuild
+++ b/net-vpn/tor/tor-0.4.8.16.ebuild
@@ -186,7 +186,7 @@ src_install() {
 	readme.gentoo_create_doc
 
 	newconfd "${FILESDIR}"/tor.confd tor
-	newinitd "${FILESDIR}"/tor.initd-r9 tor
+	newinitd "${FILESDIR}"/tor.initd-r10 tor
 	systemd_dounit "${FILESDIR}"/tor.service
 
 	keepdir /var/lib/tor


### PR DESCRIPTION
- use $RC_SVCNAME in pidfile for genericness
- use command_args_background
  - use command_args in checkconfig()
- add depend() with `after net`

Bug: https://bugs.gentoo.org/756079
Closes: https://bugs.gentoo.org/956736

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
