### PR TITLE
app-text/sword: bump cmake_min to avoid QA-notice

### DIFF
--- a/app-text/sword/files/sword-1.9.0-cmake4.patch
+++ b/app-text/sword/files/sword-1.9.0-cmake4.patch
@@ -13,3 +13,16 @@ index c23f7fa..53104f6 100644
  SET(SWORD_VERSION 1.9.0)
  
  # Make sure it's an out-of-stream build
+diff --git a/bindings/Android/SWORD/app/src/main/cpp/CMakeLists.txt b/bindings/Android/SWORD/app/src/main/cpp/CMakeLists.txt
+index 41439c5..26d04a8 100644
+--- a/bindings/Android/SWORD/app/src/main/cpp/CMakeLists.txt
++++ b/bindings/Android/SWORD/app/src/main/cpp/CMakeLists.txt
+@@ -3,7 +3,7 @@
+ 
+ # Sets the minimum version of CMake required to build the native library.
+ 
+-cmake_minimum_required(VERSION 3.4.1)
++cmake_minimum_required(VERSION 3.10.0)
+ 
+ SET(CMAKE_C_FLAGS "-DBIBLESYNC ${CMAKE_C_FLAGS}")
+ 


### PR DESCRIPTION
QA-notice is a false positive because this CMakeLists.txt for Android bindings is never used.
Amend the patch in tree anyway to avoid the workaround.

Closes: https://bugs.gentoo.org/957415

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
