### PR TITLE
app-editors/vscodium,vscode: Correct typo in EGL USE flags 'rending' …

### DIFF
--- a/app-editors/vscode/metadata.xml
+++ b/app-editors/vscode/metadata.xml
@@ -14,7 +14,7 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="egl">Use EGL platform, enables smooth rending in high refresh rate monitors on X11/Xwayland</flag>
+		<flag name="egl">Use EGL platform, enables smooth rendering in high refresh rate monitors on X11/Xwayland</flag>
 		<flag name="wayland">Run in wayland mode under wayland sessions, xwayland otherwise. This flag doesn't affect x11 sessions.</flag>
 	</use>
 	<longdescription>

--- a/app-editors/vscodium/metadata.xml
+++ b/app-editors/vscodium/metadata.xml
@@ -14,7 +14,7 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="egl">Use EGL platform, enables smooth rending in high refresh rate monitors on X11/Xwayland</flag>
+		<flag name="egl">Use EGL platform, enables smooth rendering in high refresh rate monitors on X11/Xwayland</flag>
 		<flag name="wayland">Run in wayland mode under wayland sessions, xwayland otherwise. This flag doesn't affect x11 sessions.</flag>
 	</use>
 	<longdescription>


### PR DESCRIPTION
This commit corrects incorrect spelling of 'rendering' in USE flag documentation of vscode and vscodium.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
