### PR TITLE
sys-apps/accountsservice: remove REQUIRED_USE

### DIFF
--- a/sys-apps/accountsservice/accountsservice-23.13.9-r1.ebuild
+++ b/sys-apps/accountsservice/accountsservice-23.13.9-r1.ebuild
@@ -1,0 +1,106 @@
+# Copyright 2011-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{10..13} )
+inherit meson python-any-r1 systemd vala
+
+DESCRIPTION="D-Bus interfaces for querying and manipulating user account information"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/AccountsService/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/${P}.tar.xz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+IUSE="doc elogind gtk-doc +introspection selinux test vala"
+RESTRICT="!test? ( test )"
+
+CDEPEND="
+	>=dev-libs/glib-2.63.5:2
+	sys-auth/polkit
+	virtual/libcrypt:=
+	elogind? ( >=sys-auth/elogind-229.4 )
+	!elogind? ( >=sys-apps/systemd-186:0= )
+	introspection? ( >=dev-libs/gobject-introspection-0.9.12:= )
+"
+DEPEND="${CDEPEND}
+	sys-apps/dbus
+"
+BDEPEND="
+	dev-libs/libxslt
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	sys-devel/gettext
+	virtual/pkgconfig
+	doc? (
+		app-text/docbook-xml-dtd:4.1.2
+		app-text/xmlto
+	)
+	gtk-doc? (
+		dev-util/gtk-doc
+		app-text/docbook-xml-dtd:4.3
+	)
+	vala? ( $(vala_depend) )
+	test? (
+		$(python_gen_any_dep '
+			dev-python/python-dbusmock[${PYTHON_USEDEP}]
+		')
+	)
+"
+RDEPEND="${CDEPEND}
+	selinux? ( sec-policy/selinux-accountsd )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-22.04.62-gentoo-system-users.patch
+	"${FILESDIR}"/${PN}-23.13.9-generate-version.patch #905770
+	# From Alpine Linux
+	# https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/97
+	"${FILESDIR}"/${PN}-23.13.9-musl-fixes.patch
+	"${FILESDIR}"/${PN}-23.13.9-c99-fixes.patch #930715
+	"${FILESDIR}"/${PN}-23.13.9-test-fix.patch
+)
+
+python_check_deps() {
+	if use test; then
+		python_has_version "dev-python/python-dbusmock[${PYTHON_USEDEP}]"
+	fi
+}
+
+src_prepare() {
+	default
+
+	use vala && vala_setup
+}
+
+src_configure() {
+	# No option to disable tests
+	if ! use test; then
+		sed -e "/subdir('tests')/d" -i meson.build || die
+	fi
+
+	local emesonargs=(
+		--localstatedir="${EPREFIX}/var"
+		-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
+		-Dadmin_group="wheel"
+		$(meson_use elogind)
+		$(meson_use introspection)
+		$(meson_use doc docbook)
+		$(meson_use gtk-doc gtk_doc)
+		$(meson_use vala vapi)
+	)
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/90
+	if use doc; then
+		mv "${ED}/usr/share/doc/${PN}" "${ED}/usr/share/doc/${PF}" || die
+	fi
+
+	# This directories are created at runtime when needed
+	rm -r "${ED}"/var/lib || die
+}

--- a/sys-apps/accountsservice/metadata.xml
+++ b/sys-apps/accountsservice/metadata.xml
@@ -6,10 +6,11 @@
     <name>Gentoo GNOME Desktop</name>
   </maintainer>
   <use>
-    <flag name="elogind">Use <pkg>sys-auth/elogind</pkg> for session tracking</flag>
     <flag name="systemd">Use <pkg>sys-apps/systemd</pkg> for session tracking</flag>
   </use>
   <upstream>
+    <bugs-to>https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues</bugs-to>
+    <changelog>https://gitlab.freedesktop.org/accountsservice/accountsservice/-/releases</changelog>
     <remote-id type="freedesktop-gitlab">accountsservice/accountsservice</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Here's the file diff:
```diff
--- accountsservice-23.13.9.ebuild	2025-06-08 21:51:11.276143225 +0200
+++ accountsservice-23.13.9-r1.ebuild	2025-06-08 21:58:06.202824158 +0200
@@ -11,19 +11,18 @@
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~loong ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
-IUSE="doc elogind gtk-doc +introspection selinux systemd test vala"
+IUSE="doc elogind gtk-doc +introspection selinux test vala"
 RESTRICT="!test? ( test )"
-REQUIRED_USE="^^ ( elogind systemd )"
 
 CDEPEND="
 	>=dev-libs/glib-2.63.5:2
 	sys-auth/polkit
 	virtual/libcrypt:=
 	elogind? ( >=sys-auth/elogind-229.4 )
+	!elogind? ( >=sys-apps/systemd-186:0= )
 	introspection? ( >=dev-libs/gobject-introspection-0.9.12:= )
-	systemd? ( >=sys-apps/systemd-186:0= )
 "
 DEPEND="${CDEPEND}
 	sys-apps/dbus
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
