### PR TITLE
app-emulation/fex-xtajit: Ensure using vendored libfmt

### DIFF
--- a/app-emulation/fex-xtajit/fex-xtajit-2506.ebuild
+++ b/app-emulation/fex-xtajit/fex-xtajit-2506.ebuild
@@ -91,6 +91,7 @@ src_configure() {
 		-DBUILD_FEXCONFIG=FALSE \
 		-DMINGW_BUILD=1 \
 		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+		-DCMAKE_DISABLE_FIND_PACKAGE_fmt=true \
 		"${S}" || die
 	popd >/dev/null || die
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/957612

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
