### PR TITLE
mail-mta/proton-mail-bridge: fix bug

### DIFF
--- a/mail-mta/proton-mail-bridge/proton-mail-bridge-3.20.0-r1.ebuild
+++ b/mail-mta/proton-mail-bridge/proton-mail-bridge-3.20.0-r1.ebuild
@@ -42,7 +42,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.15.1-gui_gentoo.patch
 )
 
-DOCS=( {README,Changelog}.md )
+# $S is there for bug 957684
+DOCS=( "${S}"/{README,Changelog}.md )
 
 src_unpack() {
 	default


### PR DESCRIPTION
not closing as it is a workaround

Bug: https://bugs.gentoo.org/957684

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
