### PR TITLE
wine.eclass: warn about missing amd64 when ARM64 && WoW64

### DIFF
--- a/eclass/wine.eclass
+++ b/eclass/wine.eclass
@@ -423,6 +423,14 @@ wine_pkg_postinst() {
 		fi
 	fi
 
+	if use arm64 && use wow64; then
+		ewarn
+		ewarn "You have enabled x86 emulation via FEX-Emu's xtajit implementation."
+		ewarn "This currently *does not* include amd64/x86_64/x64 emulation. Only i386"
+		ewarn "and ARM64 Windows applications are supported at this time. Please do not"
+		ewarn "file bugs about amd64 applications."
+	fi
+
 	eselect wine update --if-unset || die
 }
 


### PR DESCRIPTION
Due to 40+ years of sloppy nomenclature in the Wintel ecosystem, folks are going to expect "x86 emulation" to include not only i386/x86/x32, but also amd64/x86_64/x64. Since we currently don't (and can't) build libarm64ecfex.dll or WINE's ARM64EC support, we cannot provide amd64 emulation yet.

Warn users about the lack of amd64 emulation and ask them not to file bugs about it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
