### PR TITLE
x11-plugins/pidgin-sipe: fix compilation with libxml2 >= 2.12, fix tests, update HOMEPAGE

### DIFF
--- a/x11-plugins/pidgin-sipe/files/pidgin-sipe-1.25.0-appstreamcli.patch
+++ b/x11-plugins/pidgin-sipe/files/pidgin-sipe-1.25.0-appstreamcli.patch
@@ -1,0 +1,27 @@
+
+https://repo.or.cz/siplcs.git/commit/cb7e7be214a03acb4348c65b0e2194e86c5d55f4
+Bug: https://bugs.gentoo.org/730118
+
+From: Stefan Becker <chemobejk@gmail.com>
+Date: Mon, 22 Jan 2024 22:53:54 +0200
+Subject: [PATCH] purple: add support for latest appstreamcli
+
+Newest version no longer accepts the --nonet option. Add another variant
+that uses --no-net instead.
+--- a/src/purple/Makefile.am
++++ b/src/purple/Makefile.am
+@@ -160,7 +160,8 @@ check: validate-metainfo
+ 
+ .PHONY: validate-metainfo
+ validate-metainfo: $(pidginmetainfofile_DATA)
+-	appstreamcli validate --pedantic --nonet $< || \
+-	appstreamcli validate --pedantic         $< || \
+-	appstream-validate                       $<
++	appstreamcli validate --pedantic --no-net $< || \
++	appstreamcli validate --pedantic --nonet  $< || \
++	appstreamcli validate --pedantic          $< || \
++	appstream-validate                        $<
+ endif
+-- 
+2.11.4.GIT
+

--- a/x11-plugins/pidgin-sipe/files/pidgin-sipe-1.25.0-libxml2.patch
+++ b/x11-plugins/pidgin-sipe/files/pidgin-sipe-1.25.0-libxml2.patch
@@ -1,0 +1,63 @@
+
+https://repo.or.cz/siplcs.git/commit/8c37bad762decd3aad86cfe758187a610804b196
+Bug: https://bugs.gentoo.org/932640
+
+From: Stefan Becker <chemobejk@gmail.com>
+Date: Mon, 22 Jan 2024 22:47:20 +0200
+Subject: [PATCH] xml: update for libxml2 >= 2.12 API changes
+
+- error callback is now passed a const error
+- provide alternative implementation for the deprecated
+  xmlSAXUserParseMemory() API
+--- a/src/core/sipe-xml.c
++++ b/src/core/sipe-xml.c
+@@ -154,7 +154,13 @@ static void callback_error(void *user_data, const char *msg, ...)
+ 	g_free(errmsg);
+ }
+ 
+-static void callback_serror(void *user_data, xmlErrorPtr error)
++static void callback_serror(void *user_data,
++#if LIBXML_VERSION > 21200
++			    const xmlError *error
++#else
++			    xmlErrorPtr error
++#endif
++)
+ {
+ 	struct _parser_data *pd = user_data;
+ 
+@@ -217,8 +223,31 @@ sipe_xml *sipe_xml_parse(const gchar *string, gsize length)
+ 	if (string && length) {
+ 		struct _parser_data *pd = g_new0(struct _parser_data, 1);
+ 
++#if LIBXML_VERSION > 21200
++		xmlParserCtxtPtr ctxt = xmlNewSAXParserCtxt(&parser, pd);
++
++		if (ctxt) {
++			xmlCtxtReadMemory(ctxt,
++					  string,
++					  length,
++					  NULL,
++					  NULL,
++					  0);
++
++			pd->error = !ctxt->wellFormed;
++
++			if (ctxt->myDoc) {
++				xmlFreeDoc(ctxt->myDoc);
++				ctxt->myDoc = NULL;
++			}
++
++			xmlFreeParserCtxt(ctxt);
++		} else
++			pd->error = TRUE;
++#else
+ 		if (xmlSAXUserParseMemory(&parser, pd, string, length))
+ 			pd->error = TRUE;
++#endif
+ 
+ 		if (pd->error) {
+ 			sipe_xml_free(pd->root);
+-- 
+2.11.4.GIT
+

--- a/x11-plugins/pidgin-sipe/pidgin-sipe-1.25.0-r3.ebuild
+++ b/x11-plugins/pidgin-sipe/pidgin-sipe-1.25.0-r3.ebuild
@@ -1,26 +1,35 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Pidgin Plug-in SIPE (Sip Exchange Protocol)"
-HOMEPAGE="http://sipe.sourceforge.net/"
+HOMEPAGE="https://sipe.sourceforge.io/"
 SRC_URI="https://downloads.sourceforge.net/sipe/${P}.tar.gz"
 
 inherit autotools
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
-IUSE="dbus debug kerberos ocs2005-message-hack openssl telepathy voice"
+IUSE="dbus debug kerberos ocs2005-message-hack openssl telepathy test voice"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	dev-libs/gmime:2.6
 	dev-libs/libxml2:=
+	net-im/pidgin[dbus?]
+	kerberos? ( virtual/krb5 )
 	openssl? ( dev-libs/openssl:= )
 	!openssl? ( dev-libs/nss )
-	kerberos? ( virtual/krb5 )
+	test? ( dev-libs/appstream )
+	telepathy? (
+		>=sys-apps/dbus-1.1.0
+		>=dev-libs/dbus-glib-0.61
+		>=dev-libs/glib-2.28:2
+		>=net-libs/telepathy-glib-0.18.0
+	)
 	voice? (
 		>=dev-libs/glib-2.28.0
 		>=net-libs/libnice-0.1.0
@@ -30,13 +39,6 @@ RDEPEND="
 	!voice? (
 		>=dev-libs/glib-2.12.0:2
 	)
-	net-im/pidgin[dbus?]
-	telepathy? (
-		>=sys-apps/dbus-1.1.0
-		>=dev-libs/dbus-glib-0.61
-		>=dev-libs/glib-2.28:2
-		>=net-libs/telepathy-glib-0.18.0
-	)
 "
 
 DEPEND="${RDEPEND}"
@@ -45,11 +47,15 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-src_prepare() {
-	eapply "${FILESDIR}"/${PN}-1.25.0-bashisms.patch
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.25.0-bashisms.patch
+	"${FILESDIR}"/${PN}-1.25.0-libxml2.patch
+	"${FILESDIR}"/${PN}-1.25.0-appstreamcli.patch
+)
 
-	eautoreconf
+src_prepare() {
 	default
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
I bumped with this when I was trying to rebuild it after the libxml2 subslot op

Closes: https://bugs.gentoo.org/730118
Closes: https://bugs.gentoo.org/932640
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
