### PR TITLE
autotools.eclass: add gettext/m4 path

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -384,10 +384,12 @@ eaclocal() {
 				${ESYSROOT}/usr/share/slibtool
 			EOF
 		fi
-
+		# See bug #957583 for adding gettext/m4
 		cat <<- EOF >> "${T}"/aclocal/dirlist || die
 			${BROOT}/usr/share/aclocal
 			${ESYSROOT}/usr/share/aclocal
+			${BROOT}/usr/share/gettext/m4
+			${ESYSROOT}/usr/share/gettext/m4
 		EOF
 	fi
 


### PR DESCRIPTION
since 0.24.1 (commit [02c475e2f3a64a9cc4e1caa9e712e5e643178579](https://gitweb.git.savannah.gnu.org/gitweb/?p=gettext.git;a=commitdiff;h=02c475e2f3a64a9cc4e1caa9e712e5e643178579)), gettext installs m4 files in /usr/share/gettext/m4 instead of aclocal. Add new path to dirlist.

All bugs from tracker \#957583 benefit from this modification.

Bug: https://bugs.gentoo.org/957583

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
