### PR TITLE
www-client/chromium: fix build with USE=bindist for all ebuilds in tree

### DIFF
--- a/www-client/chromium/chromium-137.0.7151.103.ebuild
+++ b/www-client/chromium/chromium-137.0.7151.103.ebuild
@@ -1110,8 +1110,8 @@ chromium_configure() {
 		myconf_gn+=(
 			# If this is set to false Chromium won't be able to load any proprietary codecs
 			# even if provided with an ffmpeg capable of h264/aac decoding
-			'proprietary_codecs=true"
-			"ffmpeg_branding="Chrome"'
+			"proprietary_codecs=true"
+			'ffmpeg_branding="Chrome"'
 			# build ffmpeg as an external component (libffmpeg.so) that we can remove / substitute
 			"is_component_ffmpeg=true"
 		)

--- a/www-client/chromium/chromium-138.0.7204.15.ebuild
+++ b/www-client/chromium/chromium-138.0.7204.15.ebuild
@@ -1106,8 +1106,8 @@ chromium_configure() {
 		myconf_gn+=(
 			# If this is set to false Chromium won't be able to load any proprietary codecs
 			# even if provided with an ffmpeg capable of h264/aac decoding
-			'proprietary_codecs=true"
-			"ffmpeg_branding="Chrome"'
+			"proprietary_codecs=true"
+			'ffmpeg_branding="Chrome"'
 			# build ffmpeg as an external component (libffmpeg.so) that we can remove / substitute
 			"is_component_ffmpeg=true"
 		)


### PR DESCRIPTION
Previous commit[1] did not address all the ebuilds in the tree.

[1] https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=f9acbd07df34ab92d58006c3d0410ac14fb9efe0

Closes: https://bugs.gentoo.org/957508
Closes: https://bugs.gentoo.org/957898

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
