### PR TITLE
net-misc/r8125: fixed build with kernel >=6.15

### DIFF
--- a/net-misc/r8125/r8125-9.013.02-r1.ebuild
+++ b/net-misc/r8125/r8125-9.013.02-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,6 +18,17 @@ IUSE="+multi-tx-q ptp +rss use-firmware"
 
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
+
+src_prepare() {
+	default
+
+	# Replace wrong EXTRA_CFLAGS (stopped working with kernels >= 6.15)
+	# with proper CFLAGS_MODULE (available since 2.6.36).
+	# Bug 957883
+	sed -E -i'' \
+	  -e 's/(^|[^A-Za-z0-9_])EXTRA_CFLAGS([^A-Za-z0-9_]|$)/\1CFLAGS_MODULE\2/g' \
+	  src/Makefile || die
+}
 
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )

--- a/net-misc/r8125/r8125-9.014.01.ebuild
+++ b/net-misc/r8125/r8125-9.014.01.ebuild
@@ -23,6 +23,17 @@ PATCHES=(
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+src_prepare() {
+	default
+
+	# Replace wrong EXTRA_CFLAGS (stopped working with kernels >= 6.15)
+	# with proper CFLAGS_MODULE (available since 2.6.36).
+	# Bug 957883
+	sed -E -i'' \
+	  -e 's/(^|[^A-Za-z0-9_])EXTRA_CFLAGS([^A-Za-z0-9_]|$)/\1CFLAGS_MODULE\2/g' \
+	  src/Makefile || die
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/957883

No revbump is rebuild is not needed if driver was compiled successfully.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
