### PR TITLE
dev-debug/apitrace: fix qt-6.9

### DIFF
--- a/dev-debug/apitrace/apitrace-12.0.ebuild
+++ b/dev-debug/apitrace/apitrace-12.0.ebuild
@@ -39,8 +39,6 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.0-disable-multiarch.patch
-	"${FILESDIR}"/${PN}-12.0-find_snappy.patch
-	"${FILESDIR}"/${PN}-12.0-tests.patch
 	"${FILESDIR}"/${PN}-12.0-unbundle.patch
 
 	# merged, to be removed for the next version
@@ -48,6 +46,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-12.0-include-stdint.patch
 	"${FILESDIR}"/${PN}-12.0-no_qtnetwork.patch
 	"${FILESDIR}"/${PN}-12.0-bump_cmake_min.patch
+	"${FILESDIR}"/${PN}-12.0-find_snappy.patch
+	"${FILESDIR}"/${PN}-12.0-tests.patch
+	"${FILESDIR}"/${PN}-12.0-fix_qt6.9.patch
 )
 
 src_prepare() {

--- a/dev-debug/apitrace/files/apitrace-12.0-fix_qt6.9.patch
+++ b/dev-debug/apitrace/files/apitrace-12.0-fix_qt6.9.patch
@@ -1,0 +1,31 @@
+https://github.com/apitrace/apitrace/pull/950.patch
+From 3f7f0ad7781b3200377eea7257c786317b22fb26 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Thu, 12 Jun 2025 04:48:21 +0200
+Subject: [PATCH] fix qt-6.9
+
+> gui/qubjson.cpp: In function QString readChar(QDataStream&):
+> gui/qubjson.cpp:151:19:
+> error: no matching function for call to QChar::QChar(qint8&)
+>  151 |     return QChar(c);
+
+implicit conversions are disabled for QChar::QChar with qt-6.9
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+---
+ gui/qubjson.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gui/qubjson.cpp b/gui/qubjson.cpp
+index 63a2424ac..096ed7eac 100644
+--- a/gui/qubjson.cpp
++++ b/gui/qubjson.cpp
+@@ -148,7 +148,7 @@ readChar(QDataStream &stream)
+     qint8 c;
+     stream >> c;
+     Q_ASSERT(c >= 0);
+-    return QChar(c);
++    return QChar(static_cast<char>(c));
+ }
+ 
+ 


### PR DESCRIPTION
patch for qt-6.9 merged

status updated for other merged patches as well

Closes: https://bugs.gentoo.org/957581

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
