### PR TITLE
x11-misc/clipmenu: add 9999 ebuild

### DIFF
--- a/x11-misc/clipmenu/clipmenu-9999.ebuild
+++ b/x11-misc/clipmenu/clipmenu-9999.ebuild
@@ -1,0 +1,72 @@
+# Copyright 2020-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit git-r3 systemd
+
+DESCRIPTION="Clipboard management"
+HOMEPAGE="https://github.com/cdown/clipmenu"
+EGIT_REPO_URI="https://github.com/cdown/clipmenu"
+EGIT_BRANCH="develop"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="+dmenu fzf rofi test"
+REQUIRED_USE="?? ( dmenu fzf rofi )"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	x11-libs/libX11
+	x11-libs/libXfixes
+"
+
+RDEPEND="
+	${DEPEND}
+	dmenu? ( x11-misc/dmenu )
+	fzf? ( app-shells/fzf )
+	rofi? ( x11-misc/rofi )
+"
+
+src_prepare() {
+	default
+
+	if use rofi ; then
+		sed -i 's|"dmenu"|"rofi"|g' src/config.c || die "sed failed"
+	elif use fzf ; then
+		sed -i 's|"dmenu"|"fzf"|g'  src/config.c || die "sed failed"
+	fi
+}
+
+src_compile() {
+	emake CFLAGS="${CFLAGS}"
+	use test && emake CFLAGS="${CFLAGS}" tests/test_store
+}
+
+src_install() {
+	emake install DESTDIR="${D}" PREFIX="${EPREFIX}"/usr \
+		systemd_user_dir="${D}/$(systemd_get_userunitdir)"
+
+	einstalldocs
+}
+
+src_test() {
+	# NOTE(NRK): the "x_integration_tests" are not enabled as they would
+	# require additional setup and dependencies
+	emake tests
+}
+
+pkg_postinst() {
+	if systemd_is_booted || has_version sys-apps/systemd; then
+		einfo ""
+		einfo "Make sure to import \$DISPLAY when using the systemd unit for clipmenud."
+		einfo "Please see the README for more details."
+	fi
+
+	if ! use dmenu && ! use fzf && ! use rofi ; then
+		ewarn ""
+		ewarn "Clipmenu has been installed without a launcher."
+		ewarn "You will need to set \$CM_LAUNCHER to a dmenu-compatible app for clipmenu to work."
+		ewarn "Please refer to the documents for more info."
+	fi
+}


### PR DESCRIPTION
this is in preparation for the next major release where the project has been rewritten in C. some notable changes in the ebuild:

- license changed to MIT per upstream
- enabled tests
- remove outdated dependencies and optfeature

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
