### PR TITLE
dev-libs/cowsql: remove libuv 1.50* restriction

### DIFF
--- a/dev-libs/cowsql/cowsql-1.15.7-r2.ebuild
+++ b/dev-libs/cowsql/cowsql-1.15.7-r2.ebuild
@@ -1,0 +1,56 @@
+# Copyright 2020-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Embeddable, replicated and fault tolerant SQL engine (fork of dqlite)"
+HOMEPAGE="https://cowsql.dev/ https://github.com/cowsql/cowsql"
+SRC_URI="https://github.com/cowsql/cowsql/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3-with-linking-exception"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="dev-db/sqlite:3
+	dev-libs/libuv:=
+	>=dev-libs/raft-0.18.1:="
+DEPEND="${RDEPEND}
+	test? ( dev-libs/raft[lz4,test] )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/dqlite-1.12.0-disable-werror.patch
+	"${FILESDIR}"/0001-src-lib-serialize.h-don-t-define-double-as-float_t.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-backtrace
+		--disable-debug
+		--disable-sanitize
+		--disable-static
+
+		# Will build a bundled libsqlite3.so.
+		--enable-build-sqlite=no
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	default
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/dev-libs/cowsql/files/0001-src-lib-serialize.h-don-t-define-double-as-float_t.patch
+++ b/dev-libs/cowsql/files/0001-src-lib-serialize.h-don-t-define-double-as-float_t.patch
@@ -1,0 +1,54 @@
+https://github.com/cowsql/cowsql/pull/37
+From: Brahmajit Das <listout@listout.xyz>
+Date: Sat, 14 Jun 2025 00:18:38 +0530
+Subject: [PATCH] src/lib/serialize.h: don't define double as float_t
+
+libuv with commit 85b526f makes uv.h include math.h for the definitions
+of NAN/INFINITY. That header also defines the ISO C standard float_t
+type. Now that that definition is in scope, the cowsql definition in
+src/lib/serialize.h conflicts with it.
+
+Fixes: 451cff63b29366237a9502823299b05bbff8662b
+Closes: https://github.com/cowsql/cowsql/issues/35
+Signed-off-by: Brahmajit Das <listout@listout.xyz>
+--- a/src/lib/serialize.h
++++ b/src/lib/serialize.h
+@@ -37,7 +37,7 @@ static_assert(sizeof(double) == sizeof(uint64_t),
+  * Basic type aliases to used by macro-based processing.
+  */
+ typedef const char *text_t;
+-typedef double float_t;
++typedef double cowsql_float;
+ typedef uv_buf_t blob_t;
+ 
+ /**
+@@ -143,7 +143,7 @@ COWSQL_INLINE size_t int64__sizeof(const int64_t *value)
+ 	return sizeof(int64_t);
+ }
+ 
+-COWSQL_INLINE size_t float__sizeof(const float_t *value)
++COWSQL_INLINE size_t float__sizeof(const cowsql_float *value)
+ {
+ 	(void)value;
+ 	return sizeof(double);
+@@ -190,7 +190,7 @@ COWSQL_INLINE void int64__encode(const int64_t *value, void **cursor)
+ 	*cursor += sizeof(int64_t);
+ }
+ 
+-COWSQL_INLINE void float__encode(const float_t *value, void **cursor)
++COWSQL_INLINE void float__encode(const cowsql_float *value, void **cursor)
+ {
+ 	*(uint64_t *)(*cursor) = ByteFlipLe64(*(uint64_t *)value);
+ 	*cursor += sizeof(uint64_t);
+@@ -273,7 +273,7 @@ COWSQL_INLINE int int64__decode(struct cursor *cursor, int64_t *value)
+ 	return 0;
+ }
+ 
+-COWSQL_INLINE int float__decode(struct cursor *cursor, float_t *value)
++COWSQL_INLINE int float__decode(struct cursor *cursor, cowsql_float *value)
+ {
+ 	size_t n = sizeof(double);
+ 	if (n > cursor->cap) {
+-- 
+2.49.0
+


### PR DESCRIPTION
cowsql defines float_t to double in src/lib/serialize.h which conflicts with newer libuv, since uv.h includes math.h for the definitions of NAN/INFINITY.

This is a hack that changes the definitions of float_t to float_cow to avoid conflict.

Please refer: https://github.com/cowsql/cowsql/issues/35.

This mainly due to https://bugs.gentoo.org/957996, where net-libs/nodejs-24.2.0 is failing due to missing new libuv.

Bug: https://bugs.gentoo.org/955693

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
