### PR TITLE
net-libs/nodejs: Fix libuv dep to 1.51.0 for 24.2.0

### DIFF
--- a/net-libs/nodejs/nodejs-24.2.0.ebuild
+++ b/net-libs/nodejs/nodejs-24.2.0.ebuild
@@ -35,7 +35,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND=">=app-arch/brotli-1.1.0:=
 	dev-db/sqlite:3
-	>=dev-libs/libuv-1.49.2:=
+	>=dev-libs/libuv-1.51.0:=
 	>=dev-libs/simdjson-3.10.1:=
 	>=net-dns/c-ares-1.34.4:=
 	>=net-libs/nghttp2-1.64.0:=


### PR DESCRIPTION
With upstream commit 843b64f[0] nodejs >=24.2.0 now depends on libuv 1.51.0 or later.

[0]: https://github.com/libuv/libuv/commit/843b64faf5fbbd19c04475bafa38c0c91514efb8

Closes: https://bugs.gentoo.org/957996

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
