### PR TITLE
net-libs/miniupnpc: Backport upstream patch to add missing cstddef

### DIFF
--- a/net-libs/miniupnpc/files/miniupnpc-2.3.3-cstddef.patch
+++ b/net-libs/miniupnpc/files/miniupnpc-2.3.3-cstddef.patch
@@ -1,0 +1,15 @@
+From e263ab6f56c382e10fed31347ec68095d691a0e8 Mon Sep 17 00:00:00 2001
+From: Thomas Bernard <miniupnp@free.fr>
+Date: Thu, 29 May 2025 00:35:21 +0200
+Subject: [PATCH] upnpcommands.h: #include <stddef.h> for size_t
+
+--- a/include/upnpcommands.h
++++ b/include/upnpcommands.h
+@@ -21,6 +21,7 @@
+  *
+  */
+ 
++#include <stddef.h>
+ #include "miniupnpc_declspec.h"
+ #include "miniupnpctypes.h"
+ 

--- a/net-libs/miniupnpc/miniupnpc-2.3.3-r1.ebuild
+++ b/net-libs/miniupnpc/miniupnpc-2.3.3-r1.ebuild
@@ -32,6 +32,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/miniupnp.asc
 src_prepare() {
 	local PATCHES=(
 		"${FILESDIR}"/miniupnpc-2.2.3-drop-which.patch
+		"${FILESDIR}"/miniupnpc-2.3.3-cstddef.patch
 	)
 	default
 


### PR DESCRIPTION
Building against this with GCC 15 can fail. This applies to 2.3.3 only. 2.3.2 doesn't use `size_t`.

Closes: https://bugs.gentoo.org/956800

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.