### PR TITLE
dev-libs/zxcvbn-c: libcxx-19 fix

### DIFF
--- a/dev-libs/zxcvbn-c/files/zxcvbn-c-2.5-gcc15.patch
+++ b/dev-libs/zxcvbn-c/files/zxcvbn-c-2.5-gcc15.patch
@@ -1,13 +1,20 @@
 https://bugs.gentoo.org/957161
 https://github.com/tsyrogit/zxcvbn-c/commit/b9f30993c88d9057d7d95a1b059989f7853fd1b0
 https://src.fedoraproject.org/rpms/zxcvbn-c/blob/rawhide/f/gcc15-c++23_fix.patch
+https://github.com/tsyrogit/zxcvbn-c/pull/34
 
+From b9f30993c88d9057d7d95a1b059989f7853fd1b0 Mon Sep 17 00:00:00 2001
+From: Mattia Verga <mattia.verga@tiscali.it>
+Date: Mon, 20 Jan 2025 09:04:12 +0100
+Subject: [PATCH] Fix for GCC15/c++23
+
+GCC 15 default standard is C++23. This include is needed to build zxcvbn with that language level.
 --- a/dict-generate.cpp
 +++ b/dict-generate.cpp
-@@ -22,6 +22,7 @@
-  *
+@@ -23,6 +23,7 @@
   **********************************************************************************/
  
+ #include <algorithm>
 +#include <cstdint>
  #include <iostream>
  #include <string>

--- a/dev-libs/zxcvbn-c/files/zxcvbn-c-2.5-libcxx-19.patch
+++ b/dev-libs/zxcvbn-c/files/zxcvbn-c-2.5-libcxx-19.patch
@@ -1,0 +1,67 @@
+https://bugs.gentoo.org/958181
+https://github.com/tsyrogit/zxcvbn-c/issues/35
+https://github.com/tsyrogit/zxcvbn-c/pull/31
+
+From 92c6ea875231876ca264187326ce2d615d5ad543 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <stephan.bergmann@allotropia.de>
+Date: Tue, 6 Feb 2024 13:14:08 +0100
+Subject: [PATCH] There is no std::basic_string<int>
+
+...and at least LLVM 19 trunk libc++ complains about it now since
+<c3668779c13596e223c26fbd49670d18cd638c40> "[libc++] Remove deprecated
+char_traits base template (#72694)" with
+
+> In file included from dict-generate.cpp:25:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/iostream:43:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/ios:223:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/__locale:24:
+> ~/llvm/inst/bin/../include/c++/v1/string:746:43: error: implicit instantiation of undefined template 'std::char_traits<int>'
+>   746 |   static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+>       |                                           ^
+> dict-generate.cpp:861:18: note: in instantiation of template class 'std::basic_string<int>' requested here
+>   861 |     StringOfInts Chld;
+>       |                  ^
+> ~/llvm/inst/bin/../include/c++/v1/__fwd/string.h:23:29: note: template is declared here
+>    23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
+>       |                             ^
+
+etc., so use a std::vector<int> instead
+--- a/dict-generate.cpp
++++ b/dict-generate.cpp
+@@ -22,6 +22,7 @@
+  *
+  **********************************************************************************/
+ 
++#include <algorithm>
+ #include <iostream>
+ #include <string>
+ #include <fstream>
+@@ -387,7 +388,7 @@ typedef map<string, Entry> EntryMap_t;
+ typedef list<string> StringList_t;
+ typedef list<NodeSPtr> NodeList_t;
+ typedef set<StringInt> StringIntSet_t;
+-typedef basic_string<int> StringOfInts;
++typedef vector<int> StringOfInts;
+ typedef vector<unsigned int> UintVect;
+ typedef vector<uint64_t> Uint64Vect;
+ typedef vector<StringInt *> StrIntPtrVect_t;
+@@ -864,15 +865,14 @@ void CreateArrays(NodeSPtr Root, StringIntSet_t & StrSet, StringOfInts & ChildAd
+     for(Itc = Root->ChildBegin(); Itc != Root->ChildEnd(); ++Itc)
+     {
+         int i = Itc->second->GetAddr();
+-        Chld += i;
++        Chld.push_back(i);
+     }
+     // Find where in pointer array the child pointer string is
+-    StringOfInts::size_type x = ChildAddrs.find(Chld);
+-    if (x == StringOfInts::npos)
++    StringOfInts::size_type x = search(ChildAddrs.begin(), ChildAddrs.end(), Chld.begin(), Chld.end()) - ChildAddrs.begin();
++    if (x == ChildAddrs.size())
+     {
+         // Not found, add it
+-        x = ChildAddrs.length();
+-        ChildAddrs += Chld;
++        ChildAddrs.insert(ChildAddrs.end(), Chld.begin(), Chld.end());
+     }
+     // Val will contain the final node data
+     uint64_t Val = Its->i;

--- a/dev-libs/zxcvbn-c/zxcvbn-c-2.5.ebuild
+++ b/dev-libs/zxcvbn-c/zxcvbn-c-2.5.ebuild
@@ -12,6 +12,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=(
+	"${FILESDIR}"/${P}-libcxx-19.patch
 	"${FILESDIR}"/${P}-gcc15.patch
 	"${FILESDIR}"/${PN}-2.5-makefile-install.patch
 )


### PR DESCRIPTION
Use upstream patch for gcc-15 so that both apply cleanly.

Closes: https://bugs.gentoo.org/958181

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
