### PR TITLE
mate-extra/caja-dropbox: enable py3.13

### DIFF
--- a/mate-extra/caja-dropbox/caja-dropbox-1.28.0.ebuild
+++ b/mate-extra/caja-dropbox/caja-dropbox-1.28.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10,11,12} )
+PYTHON_COMPAT=( python3_{10..13} )
 MATE_LA_PUNT="yes"
 
 inherit mate python-single-r1 linux-info eapi9-ver


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952510

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
