### PR TITLE
ROCm 6.x fixes

### DIFF
--- a/dev-libs/rocm-comgr/rocm-comgr-6.4.1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-6.4.1.ebuild
@@ -80,6 +80,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_STRIP=""  # disable stripping defined at lib/comgr/CMakeLists.txt:58
 		-DBUILD_TESTING=$(usex test ON OFF)
+		-DCOMGR_DISABLE_SPIRV=ON  # requires ROCm/SPIRV-LLVM-Translator (fork of dev-util/spirv-llvm-translator)
 	)
 	# Prevent CMake from finding systemwide hip, which breaks tests
 	use test && mycmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_hip=ON )

--- a/dev-libs/rocm-device-libs/rocm-device-libs-6.3.3.ebuild
+++ b/dev-libs/rocm-device-libs/rocm-device-libs-6.3.3.ebuild
@@ -41,6 +41,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-6.1.0-fix-llvm-link.patch"
 	"${FILESDIR}/${PN}-6.1.2-fix-build.patch"
 	"${FILESDIR}/${PN}-6.2.0-test-bitcode-dir.patch"
+	"${FILESDIR}/${PN}-6.4.2-cmake-4-compat.patch"
 )
 
 src_unpack() {

--- a/dev-libs/rocr-runtime/rocr-runtime-6.4.1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-6.4.1.ebuild
@@ -62,5 +62,12 @@ src_configure() {
 
 	use debug || append-cxxflags "-DNDEBUG"
 
+	# skip false positive detection in samples, bug #958188
+	local CMAKE_QA_COMPAT_SKIP=1
+
+	local mycmakeargs=(
+		-DCMAKE_DISABLE_FIND_PACKAGE_rocprofiler-register=ON
+	)
+
 	cmake_src_configure
 }

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-6.3.3.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-6.3.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 LLVM_COMPAT=( 19 )
 ROCM_SKIP_GLOBALS=1
-inherit cmake linux-info llvm-r1 rocm
+inherit cmake flag-o-matic linux-info llvm-r1 rocm
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/ROCm/ROCR-Runtime/"
@@ -69,6 +69,9 @@ src_configure() {
 	cmake_src_configure
 
 	if use test; then
+		# ODR violations (bug #956958)
+		filter-lto
+
 		export LIBHSAKMT_PATH="${BUILD_DIR}"
 		local mycmakeargs=(
 			-DLLVM_DIR="$(get_llvm_prefix)"

--- a/dev-util/rocm-smi/rocm-smi-6.3.3-r1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.3.3-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} python3_13t )
 
-inherit cmake python-r1
+inherit cmake linux-info python-r1
 
 DESCRIPTION="ROCm System Management Interface Library"
 HOMEPAGE="https://github.com/ROCm/rocm_smi_lib"
@@ -31,7 +31,10 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-remove-example.patch
 	"${FILESDIR}"/${PN}-6.3.0-set-soversion.patch
 	"${FILESDIR}"/${PN}-6.3.0-fix-flags.patch
+	"${FILESDIR}"/${PN}-6.4.1-log-exceptions.patch
 )
+
+CONFIG_CHECK="~HSA_AMD ~DRM_AMDGPU"
 
 src_prepare() {
 	cmake_src_prepare
@@ -57,4 +60,11 @@ src_install() {
 	python_foreach_impl python_domodule python_smi_tools/rsmiBindingsInit.py
 
 	mv "${ED}"/usr/share/doc/rocm_smi "${ED}/usr/share/doc/${PF}" || die
+}
+
+pkg_postinst() {
+	if ! has_version sys-apps/hwdata; then
+		elog "Install sys-apps/hwdata to see vendor and device names"
+		elog "instead of hex device IDs in rocm-smi output"
+	fi
 }

--- a/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} python3_13t )
 
-inherit cmake python-r1
+inherit cmake linux-info python-r1
 
 DESCRIPTION="ROCm System Management Interface Library"
 HOMEPAGE="https://github.com/ROCm/rocm_smi_lib"
@@ -34,6 +34,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.4.1-log-exceptions.patch
 )
 
+CONFIG_CHECK="~HSA_AMD ~DRM_AMDGPU"
+
 src_prepare() {
 	cmake_src_prepare
 
@@ -58,4 +60,11 @@ src_install() {
 	python_foreach_impl python_domodule python_smi_tools/rsmiBindingsInit.py
 
 	mv "${ED}"/usr/share/doc/rocm_smi "${ED}/usr/share/doc/${PF}" || die
+}
+
+pkg_postinst() {
+	if ! has_version sys-apps/hwdata; then
+		elog "Install sys-apps/hwdata to see vendor and device names"
+		elog "instead of hex device IDs in rocm-smi output"
+	fi
 }


### PR DESCRIPTION
* dev-libs/rocm-comgr: fix misdetection of incorrect spirv-llvm-translator 
Closes: https://bugs.gentoo.org/958178
* dev-libs/rocr-runtime: skip CMake 4 and rocprofiler-register warnings 
Closes: https://bugs.gentoo.org/958188
* dev-libs/roct-thunk-interface: disable lto for tests 
Closes: https://bugs.gentoo.org/892760
* dev-util/rocm-smi: add logging patch to 6.3.3, check for HSA_AMD, suggest sys-apps/hwdata
Bug: https://bugs.gentoo.org/957064
* dev-libs/rocm-device-libs: fix CMake 4 compatibility 
Closes: https://bugs.gentoo.org/952090

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
