### PR TITLE
www-apps/jellyfin-bin: unkeyword 10.11.0_rc1

### DIFF
--- a/www-apps/jellyfin-bin/jellyfin-bin-10.10.7.ebuild
+++ b/www-apps/jellyfin-bin/jellyfin-bin-10.10.7.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit pax-utils systemd tmpfiles
 
 DESCRIPTION="Jellyfin puts you in control of managing and streaming your media"
-HOMEPAGE="https://jellyfin.readthedocs.io/en/latest/
+HOMEPAGE="https://jellyfin.org/
 	https://github.com/jellyfin/jellyfin/"
 
 SRC_URI="

--- a/www-apps/jellyfin-bin/jellyfin-bin-10.11.0_rc1-r1.ebuild
+++ b/www-apps/jellyfin-bin/jellyfin-bin-10.11.0_rc1-r1.ebuild
@@ -6,13 +6,14 @@ EAPI=8
 inherit pax-utils systemd tmpfiles
 
 DESCRIPTION="Jellyfin puts you in control of managing and streaming your media"
-HOMEPAGE="https://jellyfin.readthedocs.io/en/latest/
+HOMEPAGE="https://jellyfin.org/
 	https://github.com/jellyfin/jellyfin/"
 MY_PV="${PV//_rc/-rc}"
 if [[ "${PV}" == *"rc"* ]]; then
 	MY_TYPE="preview"
 else
 	MY_TYPE="stable"
+	KEYWORDS="-* ~amd64 ~arm64"
 fi
 SRC_URI="
 	arm64? (
@@ -34,7 +35,6 @@ SRC_URI="
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="-* ~amd64 ~arm64"
 RESTRICT="mirror test"
 
 DEPEND="acct-user/jellyfin
@@ -79,4 +79,12 @@ src_install() {
 
 pkg_postinst() {
 	tmpfiles_process jellyfin.conf
+
+	ewarn "If you are upgrading from a previous version jellyfin will automatically"
+	ewarn "migrate to the new database backend during first startup. This may take"
+	ewarn "a long time but must not be aborted or the database could be left in an"
+	ewarn "inconsistent state."
+	ewarn "Note that upgrading from versions earlier than 10.10.7 is not supported."
+	ewarn "For more information see:"
+	ewarn "  https://notes.jellyfin.org/v10.11.0_features#Release-Notes"
 }


### PR DESCRIPTION
Unkeyword RC-release and add warning about required database migration. 
While here: update jellyfin project URL

Closes: https://bugs.gentoo.org/958196

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
