### PR TITLE
app-shells/nushell: Revbump: Using native TLS, using system-sqlite

### DIFF
--- a/app-shells/nushell/nushell-0.105.1-r1.ebuild
+++ b/app-shells/nushell/nushell-0.105.1-r1.ebuild
@@ -25,6 +25,8 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv"
 IUSE="plugins system-clipboard X"
 
 DEPEND="
+	dev-libs/openssl:0=
+	dev-db/sqlite:3=
 	system-clipboard? (
 		X? (
 			x11-libs/libX11
@@ -33,9 +35,7 @@ DEPEND="
 	)
 "
 RDEPEND="${DEPEND}"
-BDEPEND="
-	virtual/pkgconfig
-"
+BDEPEND="virtual/pkgconfig"
 
 RESTRICT+=" test"
 
@@ -48,13 +48,19 @@ src_prepare() {
 
 src_configure() {
 	# high magic to allow system-libs
+	export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+	export OPENSSL_NO_VENDOR=true
 	export PKG_CONFIG_ALLOW_CROSS=1
 
 	local myfeatures=(
+		plugin
+		native-tls
+		sqlite
 		$(usev system-clipboard)
+		trash-support
 	)
 
-	cargo_src_configure
+	cargo_src_configure --no-default-features
 }
 
 src_compile() {


### PR DESCRIPTION
As discussed in #42592, this revbump changes the following things:
- Unconditionally uses native-tls and links to libssl.so
- Introduced new USE flag '+sqlite'. If enabled, links to libsqlite3.so. Otherwise, all features using sqlite will not be built.

@arthurzam, @eli-schwartz: Please feel free to share if you see any remaining issues.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
