### PR TITLE
app-editors/vscode: add --wayland-text-input-version=3 for IME support

### DIFF
--- a/app-editors/vscode/vscode-1.100.3-r1.ebuild
+++ b/app-editors/vscode/vscode-1.100.3-r1.ebuild
@@ -122,7 +122,7 @@ src_install() {
 
 	local EXEC_EXTRA_FLAGS=()
 	if use wayland; then
-		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" "--wayland-text-input-version=3" )
 	fi
 	if use egl; then
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )

--- a/app-editors/vscode/vscode-1.101.0-r1.ebuild
+++ b/app-editors/vscode/vscode-1.101.0-r1.ebuild
@@ -122,7 +122,7 @@ src_install() {
 
 	local EXEC_EXTRA_FLAGS=()
 	if use wayland; then
-		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" "--wayland-text-input-version=3" )
 	fi
 	if use egl; then
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )


### PR DESCRIPTION
Without specifying `--wayland-text-input-version=3`, `fcitx5` and other input methods fail to work under Wayland (e.g. GNOME only supports v3). This commit appends the necessary flag when the `wayland` USE flag is enabled. 

See also: https://wiki.archlinux.org/title/Fcitx5#Wayland

Closes: https://bugs.gentoo.org/958245

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
