### PR TITLE
x11-misc/alock: improve current ebuild

### DIFF
--- a/x11-misc/alock/alock-1.0.0-r2.ebuild
+++ b/x11-misc/alock/alock-1.0.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/mgumz/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"
-IUSE="doc imlib pam"
+IUSE="imlib pam"
 
 DEPEND="virtual/libcrypt:=
 	x11-libs/libX11
@@ -25,7 +25,7 @@ DEPEND="virtual/libcrypt:=
 	imlib? ( media-libs/imlib2[X] )
 	pam? ( sys-libs/pam )"
 RDEPEND="${DEPEND}"
-BDEPEND="doc? ( app-text/asciidoc )"
+BDEPEND="app-text/asciidoc"
 
 PATCHES=(
 	"${FILESDIR}"/implicit_pointer_conversion_fix_amd64.patch
@@ -54,13 +54,10 @@ src_compile() {
 
 src_install() {
 	dobin src/alock
+	dodoc {CHANGELOG,README,TODO}.txt
 
-	if use doc; then
-		# We need to generate the manpage...
-		a2x -d manpage -f manpage ./"${PN}".txt || die "a2x conversion failed."
-		doman alock.1
-		dodoc {CHANGELOG,README,TODO}.txt
-	fi
+	a2x -d manpage -f manpage ./"${PN}".txt || die "a2x conversion failed."
+	doman alock.1
 
 	insinto /usr/share/alock/xcursors
 	doins contrib/xcursor-*

--- a/x11-misc/alock/alock-1.0.0-r3.ebuild
+++ b/x11-misc/alock/alock-1.0.0-r3.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+# We need this since there are no tagged releases yet
+DESCRIPTION="locks the local X display until a password is entered"
+HOMEPAGE="https://darkshed.net/projects/alock
+	https://github.com/mgumz/alock"
+SRC_URI="https://github.com/mgumz/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="imlib pam"
+
+DEPEND="virtual/libcrypt:=
+	x11-libs/libX11
+	x11-libs/libXcursor
+	x11-libs/libXext
+	x11-libs/libXpm
+	x11-libs/libXrender
+	imlib? ( media-libs/imlib2[X] )
+	pam? ( sys-libs/pam )"
+RDEPEND="${DEPEND}"
+BDEPEND="app-text/asciidoc" # needed for the manpage
+
+PATCHES=(
+	"${FILESDIR}"/implicit_pointer_conversion_fix_amd64.patch
+	"${FILESDIR}"/check-setuid.patch
+	"${FILESDIR}"/tidy-printf.patch
+	"${FILESDIR}"/fix-aliasing.patch
+	"${FILESDIR}"/no-xf86misc.patch
+	"${FILESDIR}"/no-which.patch
+)
+
+src_configure() {
+	tc-export CC
+
+	econf \
+		--with-all \
+		$(use_with pam) \
+		$(use_with imlib imlib2)
+}
+
+src_compile() {
+	# xmlto isn't required, so set to 'true' as dummy program
+	emake XMLTO=true
+}
+
+src_install() {
+	dobin src/alock
+	dodoc {CHANGELOG,README}.txt
+
+	a2x -d manpage -f manpage ./"${PN}".txt || die "a2x conversion failed."
+	doman alock.1
+
+	insinto /usr/share/alock/xcursors
+	doins contrib/xcursor-*
+
+	insinto /usr/share/alock/bitmaps
+	doins bitmaps/*
+
+	# Set suid so alock can correctly work with shadow
+	use pam || fperms 4755 /usr/bin/alock
+}

--- a/x11-misc/alock/metadata.xml
+++ b/x11-misc/alock/metadata.xml
@@ -13,7 +13,4 @@
 		</maintainer>
 		<remote-id type="github">mgumz/alock</remote-id>
 	</upstream>
-	<use>
-		<flag name="doc">Build and install manpage with <pkg>app-text/asciidoc</pkg>.</flag>
-	</use>
 </pkgmetadata>


### PR DESCRIPTION
- bump EAPI
- rename USE=doc to man
- sort DEPENDs
- remove wrong --prefix econfarg
- install CHANGELOG & README unconditionally
- do not install TODO
- make USE=pam section shorter in src_install

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
