### PR TITLE
app-shells/bash: Fix issues with COMMAND_PROMPT

### DIFF
--- a/app-shells/bash/bash-5.3_rc2_p20250606.ebuild
+++ b/app-shells/bash/bash-5.3_rc2_p20250606.ebuild
@@ -315,9 +315,12 @@ src_install() {
 	mv -- "${ED}"/usr/bin/bash "${ED}"/bin/ || die
 	dosym bash /bin/rbash
 
+	insinto /etc/profile.d
+	doins "${FILESDIR}"/00-gentoo-command-prompt-as-array.sh
+
 	insinto /etc/bash
 	doins "${FILESDIR}"/bash_logout
-	my_prefixify bashrc.d "${FILESDIR}"/bashrc-r1 | newins - bashrc
+	my_prefixify bashrc.d "${FILESDIR}"/bashrc-r2 | newins - bashrc
 
 	insinto /etc/bash/bashrc.d
 	my_prefixify DIR_COLORS "${FILESDIR}"/bashrc.d/10-gentoo-color-r2.bash | newins - 10-gentoo-color.bash

--- a/app-shells/bash/files/00-gentoo-command-prompt-as-array.sh
+++ b/app-shells/bash/files/00-gentoo-command-prompt-as-array.sh
@@ -1,0 +1,16 @@
+# Not bash? Return
+[ -n "${BASH_VERSION:-}" ] || return 0
+
+# Make sure that PROMPT_COMMAND is an array, which is permitted as of bash 5.1.
+case $(declare -p PROMPT_COMMAND 2>/dev/null) in
+        'declare -a '*)
+                # Nothing to do, already an array.
+                :
+                ;;
+        '')
+                PROMPT_COMMAND=()
+                ;;
+        *)
+                PROMPT_COMMAND=( "${PROMPT_COMMAND}" )
+                ;;
+esac

--- a/app-shells/bash/files/bashrc-r2
+++ b/app-shells/bash/files/bashrc-r2
@@ -1,0 +1,40 @@
+# /etc/bash/bashrc
+
+# Proceed no further in the case of a non-interactive shell.
+if [[ $- != *i* ]]; then
+	return
+fi
+
+# Disable errexit in case the user enabled it then chose to re-source this file.
+shopt -u -o errexit
+
+# Disable completion when the input buffer is empty. Mute STDERR because this
+# option is only present in the case that bash was built with readline support.
+shopt -s no_empty_cmd_completion 2>/dev/null &&
+
+# Append to HISTFILE rather than overwrite upon exiting, per bug #139609. This
+# option also requires for bash to have been built with readline support.
+shopt -s histappend
+
+# Make sure that PROMPT_COMMAND is an array, which is permitted as of bash 5.1.
+case $(declare -p PROMPT_COMMAND 2>/dev/null) in
+	'declare -a '*)
+		# Nothing to do, already an array.
+		:
+		;;
+	'')
+		PROMPT_COMMAND=()
+		;;
+	*)
+		PROMPT_COMMAND=( "${PROMPT_COMMAND}" )
+		;;
+esac
+
+# Don't let the user influence the order of sourcing for bash 5.3 or greater.
+unset -v GLOBSORT
+
+for _ in /etc/bash/bashrc.d/*; do
+	if [[ $_ == *.@(bash|sh) && -r $_ ]]; then
+		source "$_"
+	fi
+done


### PR DESCRIPTION
1. Initialize COMMAND_PROMPT as an array as early as possible.

2. Try to avoid clobbering the contents of COMMAND_PROMPT when making it an array in bashrc - this could happen if something in /etc/profile.d added something to COMMAND_PROMPT (like vte-2.91.sh does).

Overall, this helps with arranging gnome-terminal to launch new bash instances in tabs in the same working directory as the old tab. In order to get it to work, I needed to set gnome-terminal to run each shell as a login shell and to make the above fixes.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
