### PR TITLE
x11-libs/fltk: Patch out building of static libs in 1.4.3

### DIFF
--- a/x11-libs/fltk/files/fltk-1.4.3-no-static.patch
+++ b/x11-libs/fltk/files/fltk-1.4.3-no-static.patch
@@ -1,0 +1,79 @@
+There is currently no option to disable building static libs. We cannot simply
+delete them because that breaks the CMake export.
+
+--- a/CMake/export.cmake
++++ b/CMake/export.cmake
+@@ -30,6 +30,7 @@
+   else()
+     set(FLTK_FLUID_EXECUTABLE fltk::fluid)
+     set(FLUID_EXPORT fluid)                # export fluid
++    set(FLUID_EXPORT fluid-shared)
+   endif()
+ else()
+   # We don't build fluid /or/ we are cross-compiling (or both):
+--- a/CMake/fl_add_library.cmake
++++ b/CMake/fl_add_library.cmake
+@@ -229,16 +229,17 @@
+     endif(FLTK_OPTION_LARGE_FILE)
+   endif(MSVC)
+ 
++  if(LIBTYPE STREQUAL "SHARED")
+   install(TARGETS ${TARGET_NAME} EXPORT FLTK-Targets
+     RUNTIME DESTINATION ${FLTK_BINDIR}
+     LIBRARY DESTINATION ${FLTK_LIBDIR}
+     ARCHIVE DESTINATION ${FLTK_LIBDIR}
+   )
+ 
+-  if(LIBTYPE STREQUAL "SHARED")
+     list(APPEND FLTK_LIBRARIES_SHARED "${TARGET_NAME}")
+     set(FLTK_LIBRARIES_SHARED "${FLTK_LIBRARIES_SHARED}" PARENT_SCOPE)
+   else()
++    set_property(TARGET ${TARGET_NAME} PROPERTY EXCLUDE_FROM_ALL TRUE)
+     list(APPEND FLTK_LIBRARIES "${TARGET_NAME}")
+     set(FLTK_LIBRARIES "${FLTK_LIBRARIES}" PARENT_SCOPE)
+   endif()
+--- a/CMake/FLTKConfig.cmake.in
++++ b/CMake/FLTKConfig.cmake.in
+@@ -104,11 +104,8 @@
+       endif()
+     endfunction(_fltk_make_alias target)
+ 
+-    if(NOT TARGET fltk::fltk)
+-      message(FATAL "FLTKConfig.cmake: target fltk::fltk does not exist!")
+-    endif()
+ 
+-    _fltk_make_alias(fltk fltk::fltk)
++    _fltk_make_alias(fltk fltk::fltk-shared)
+     _fltk_make_alias(fltk-shared fltk::fltk-shared)
+ 
+     _fltk_make_alias(fluid fltk::fluid)
+@@ -118,7 +115,7 @@
+     _fltk_make_alias(fltk-options-cmd fltk::options-cmd)
+ 
+     foreach(target cairo forms gl images jpeg png z)
+-      _fltk_make_alias(fltk_${target} fltk::${target})
++      _fltk_make_alias(fltk_${target} fltk::${target}-shared)
+       _fltk_make_alias(fltk_${target}-shared fltk::${target}-shared)
+     endforeach()
+ 
+@@ -130,8 +127,8 @@
+ 
+   if(TARGET fltk::fluid-cmd)  # Windows only
+     set(FLTK_FLUID_EXECUTABLE fltk::fluid-cmd)
+-  elseif(TARGET fltk::fluid)
+-    set(FLTK_FLUID_EXECUTABLE fltk::fluid)
++  elseif(TARGET fltk::fluid-shared)
++    set(FLTK_FLUID_EXECUTABLE fltk::fluid-shared)
+   elseif(WIN32)
+     set(FLTK_FLUID_EXECUTABLE fluid-cmd)
+   else()
+--- a/fluid/CMakeLists.txt
++++ b/fluid/CMakeLists.txt
+@@ -179,7 +179,6 @@
+ 
+ # Build targets
+ 
+-make_target(fluid TRUE "${MAIN_FILES}" fluid-lib fluid)
+ 
+ # Build the console app on Windows
+ # This is done for all Windows targets, even if cross-compiling.

--- a/x11-libs/fltk/fltk-1.4.3-r1.ebuild
+++ b/x11-libs/fltk/fltk-1.4.3-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 2024-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake edo xdg
+
+DESCRIPTION="Fast Light GUI Toolkit"
+HOMEPAGE="https://www.fltk.org/"
+SRC_URI="https://github.com/fltk/fltk/releases/download/release-${PV}/${P}-source.tar.bz2"
+
+LICENSE="FLTK LGPL-2 MIT ZLIB"
+SLOT="1/$(ver_cut 1-2)" # README.abi-version.txt
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="+X +cairo doc examples opengl static-libs test wayland"
+REQUIRED_USE="
+	|| ( X wayland )
+	wayland? ( cairo )
+"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	media-libs/libjpeg-turbo:=
+	media-libs/libpng:=
+	sys-libs/zlib:=
+	X? (
+		x11-libs/libX11
+		x11-libs/libXcursor
+		x11-libs/libXfixes
+		x11-libs/libXinerama
+		!cairo? (
+			media-libs/fontconfig
+			x11-libs/libXft
+			x11-libs/libXrender
+		)
+	)
+	cairo? (
+		dev-libs/glib:2
+		x11-libs/cairo
+		x11-libs/pango[X?]
+	)
+	opengl? (
+		media-libs/glu
+		media-libs/libglvnd[X]
+	)
+	wayland? (
+		dev-libs/wayland
+		gui-libs/libdecor
+		sys-apps/dbus
+		x11-libs/libxkbcommon
+	)
+"
+DEPEND="
+	${RDEPEND}
+	X? ( x11-base/xorg-proto )
+	wayland? ( dev-libs/wayland-protocols )
+"
+BDEPEND="
+	doc? ( app-text/doxygen )
+	wayland? ( dev-util/wayland-scanner )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.1-fltk-config.patch
+	"${FILESDIR}"/${PN}-1.4.1-tests-odr.patch
+	"${FILESDIR}"/${PN}-1.4.3-no-games.patch
+	"${FILESDIR}"/${PN}-1.4.3-no-static.patch
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# fluid can optionally use html docs at runtime, adjust path
+	sed -i "s|\${FLTK_DOCDIR}/fltk|&-${PVR}/html|" CMake/export.cmake || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DFLTK_BACKEND_WAYLAND=$(usex wayland)
+		-DFLTK_BACKEND_X11=$(usex X)
+		-DFLTK_BUILD_FLUID=yes
+		-DFLTK_BUILD_FLUID_DOCS=no
+		-DFLTK_BUILD_GL=$(usex opengl)
+		-DFLTK_BUILD_HTML_DOCS=$(usex doc)
+		-DFLTK_BUILD_PDF_DOCS=no
+		-DFLTK_BUILD_SHARED_LIBS=yes
+		-DFLTK_BUILD_TEST=$(usex test)
+		-DFLTK_GRAPHICS_CAIRO=$(usex cairo)
+		-DFLTK_OPTION_STD=yes # will be removed & forced ON in fltk-1.5
+	)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile all $(usev doc docs)
+}
+
+src_test() {
+	# same that upstream's CI does except with the shared version
+	edo "${BUILD_DIR}"/bin/test/unittests-shared --core
+}
+
+src_install() {
+	local DOCS=(
+		ANNOUNCEMENT CHANGES* CREDITS.txt README*
+		$(usev examples)
+		# simpler than using -DFLTK_INSTALL_HTML_DOCS for the location
+		$(usev doc "${BUILD_DIR}"/documentation/html)
+	)
+	cmake_src_install
+}


### PR DESCRIPTION
Simply deleting the static libs is not enough as it breaks the CMake export.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.