### PR TITLE
net-misc/kea: keyword 2.6.3 for ~arm

### DIFF
--- a/net-misc/kea/kea-2.6.3.ebuild
+++ b/net-misc/kea/kea-2.6.3.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://gitlab.isc.org/isc-projects/kea.git"
 else
 	SRC_URI="https://downloads.isc.org/isc/kea/${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 LICENSE="MPL-2.0"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/958171

Add ~arm keyword. The code has been tested on a raspberry pi 3 with compiler flag -march=armv7-a 

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
