### PR TITLE
dev-util/dialog: make USE=minimal actually be minimal

### DIFF
--- a/dev-util/dialog/dialog-1.3.20250116-r1.ebuild
+++ b/dev-util/dialog/dialog-1.3.20250116-r1.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P=${PN}-$(ver_rs 2 -)
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/thomasdickey.asc
+inherit verify-sig
+
+DESCRIPTION="Tool to display dialog boxes from a shell"
+HOMEPAGE="https://invisible-island.net/dialog/"
+SRC_URI="https://invisible-island.net/archives/dialog/${MY_P}.tgz"
+SRC_URI+=" verify-sig? ( https://invisible-island.net/archives/dialog/${MY_P}.tgz.asc )"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="LGPL-2.1"
+SLOT="0/15"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="examples nls unicode"
+
+RDEPEND=">=sys-libs/ncurses-5.2-r5:=[unicode(+)?]"
+DEPEND="
+	${RDEPEND}
+	nls? ( sys-devel/gettext )
+"
+BDEPEND="
+	dev-build/libtool
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-thomasdickey )
+"
+
+src_prepare() {
+	default
+
+	sed -i -e '/LIB_CREATE=/s:${CC}:& ${LDFLAGS}:g' configure || die
+	sed -i '/$(LIBTOOL_COMPILE)/s:$: $(LIBTOOL_OPTS):' makefile.in || die
+}
+
+src_configure() {
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		export ac_cv_prog_LIBTOOL=glibtool
+	fi
+
+	econf \
+		--disable-rpath-hack \
+		--with-pkg-config \
+		--enable-pc-files \
+		$(use_enable nls) \
+		--with-libtool \
+		--with-libtool-opts='-shared' \
+		--with-ncurses$(usev unicode w)
+}
+
+src_install() {
+	emake DESTDIR="${D}" install-full
+
+	use examples && dodoc -r samples
+
+	dodoc CHANGES README
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
`foo && bar || baz` is a mindworm. If bar fails, both bar and baz get run. The correct grammatical construct is an if/then/else statement, no (or rare) exceptions.

More on that at https://mywiki.wooledge.org/BashPitfalls#pf22

In this case, we run `default_src_install`, which internally invokes make install, and then also always run emake install-full, even for minimal builds.

The reason is because portage is absolutely full of this too. It constantly runs things like `[[ -n ${VAR} ]] && do_thing_with "${VAR}"` or else `use foo && bar`. The return value is therefore 1, but no "die" was called so it "rarely ever matters". Here the issue is that `default_src_install` finishes by running `einstalldocs`, which error-returns if there are no docs.

The general rule of thumb is: assume ALL functions defined by PMS or an eclass *can* and *will* return nonzero at total whimsy unless explicitly documented to have explicit return values explicitly intended for explicit testing (such as `use`).

If you write your own ebuild-local functions, then good job, you! You may assume they are sanely written (because you wrote them), rather than assuming they are written in `die`-centric ebuildism code golf.

...
    
Note, even without install-full, a static library is installed by bad autoconf-dickey macros. Fixing the install rule only solves 7 out of 8 files; manually rm the last one.

Closes: https://bugs.gentoo.org/958297

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
