### PR TITLE
games-action/prismlauncher: add note that mangohud is in GURU

### DIFF
--- a/games-action/prismlauncher/prismlauncher-9.1-r1.ebuild
+++ b/games-action/prismlauncher/prismlauncher-9.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -112,6 +112,6 @@ pkg_postinst() {
 	# Original issue: https://github.com/PolyMC/PolyMC/issues/227
 	optfeature "old Minecraft (<= 1.12.2) support" x11-apps/xrandr
 
-	optfeature "built-in MangoHud support" games-util/mangohud
+	optfeature "built-in MangoHud support (available in GURU overlay)" games-util/mangohud
 	optfeature "built-in Feral Gamemode support" games-util/gamemode
 }

--- a/games-action/prismlauncher/prismlauncher-9.4.ebuild
+++ b/games-action/prismlauncher/prismlauncher-9.4.ebuild
@@ -112,6 +112,6 @@ pkg_postinst() {
 	# Original issue: https://github.com/PolyMC/PolyMC/issues/227
 	optfeature "old Minecraft (<= 1.12.2) support" x11-apps/xrandr
 
-	optfeature "built-in MangoHud support" games-util/mangohud
+	optfeature "built-in MangoHud support (available in GURU overlay)" games-util/mangohud
 	optfeature "built-in Feral Gamemode support" games-util/gamemode
 }

--- a/games-action/prismlauncher/prismlauncher-9999.ebuild
+++ b/games-action/prismlauncher/prismlauncher-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -112,6 +112,6 @@ pkg_postinst() {
 	# Original issue: https://github.com/PolyMC/PolyMC/issues/227
 	optfeature "old Minecraft (<= 1.12.2) support" x11-apps/xrandr
 
-	optfeature "built-in MangoHud support" games-util/mangohud
+	optfeature "built-in MangoHud support (available in GURU overlay)" games-util/mangohud
 	optfeature "built-in Feral Gamemode support" games-util/gamemode
 }


### PR DESCRIPTION
Add a note that games-util/mangohud is available in GURU, so users don't get confused when they try to search for it in the Gentoo tree, and find out it isn't there.

Closes: https://bugs.gentoo.org/954769

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
