### PR TITLE
www-apps/rutorrent: clean up useless files

### DIFF
--- a/www-apps/rutorrent/rutorrent-9999.ebuild
+++ b/www-apps/rutorrent/rutorrent-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,14 +29,24 @@ pkg_setup() {
 	webapp_pkg_setup
 }
 
-src_install() {
-	webapp_src_preinst
-
+src_prepare() {
 	rm -r .github || die
+	rm -r .vscode || die
+	rm -r tests || die
 	find . \( -name .gitignore -o -name .gitmodules \) -type f -delete || die
 	if [[ ${PV} == 9999 ]]; then
 		rm -r .git .gitattributes || die
 	fi
+
+	default
+}
+
+src_install() {
+	webapp_src_preinst
+
+	local docs="LICENSE.md README.md htaccess-example"
+	dodoc ${docs}
+	rm ${docs} || die
 
 	insinto "${MY_HTDOCSDIR}"
 	doins -r .


### PR DESCRIPTION
The archives contain metadata from version control and an editor. We always deleted that but now adding ".vscode" and moving things to src_prepare. Same goes for the "tests" directory which is not for end-users.
We now move documentation out of the webapp with dodoc.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
