### PR TITLE
media-libs/woff2: set cmake minimum ver to 3.10

### DIFF
--- a/media-libs/woff2/files/woff2-cmake-minimum-ver-3.10.patch
+++ b/media-libs/woff2/files/woff2-cmake-minimum-ver-3.10.patch
@@ -1,0 +1,25 @@
+From 2a6a699259f7960ce85dae9e9df10bbae0a318db Mon Sep 17 00:00:00 2001
+From: 1vybridge <openrc@posteo.de>
+Date: Thu, 19 Jun 2025 16:10:00 +0300
+Subject: [PATCH] Set CMake minimum required version to 3.10
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ecfbb83..612c25d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ # several CI services, such as Travis and Drone, use it.  Solaris 11
+ # has 2.8.6, and it's not difficult to support if you already have to
+ # support 2.8.7.
+-cmake_minimum_required(VERSION 2.8.6)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(woff2)
+ 
+-- 
+2.49.0
+

--- a/media-libs/woff2/woff2-1.0.2-r7.ebuild
+++ b/media-libs/woff2/woff2-1.0.2-r7.ebuild
@@ -21,6 +21,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${P}-aliasing.patch
 	"${FILESDIR}"/${PN}-1.0.2-gcc15.patch
+	"${FILESDIR}"/${PN}-cmake-minimum-ver-3.10.patch #951837
 )
 
 src_configure() {


### PR DESCRIPTION
Add patch to set the minimum CMake version to 3.10

Closes: https://bugs.gentoo.org/951837

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
