### PR TITLE
dev-libs/libffi: backport PowerPC closures patch to 3.4.8

### DIFF
--- a/dev-libs/libffi/files/libffi-3.4.8-powerpc-closures.patch
+++ b/dev-libs/libffi/files/libffi-3.4.8-powerpc-closures.patch
@@ -1,0 +1,38 @@
+https://github.com/libffi/libffi/issues/900
+
+https://github.com/php/php-src/issues/18881
+
+From aea22de28ec92a69cab9198de479263fe8b1a637 Mon Sep 17 00:00:00 2001
+From: Peter Bergner <bergner@linux.ibm.com>
+Date: Fri, 18 Apr 2025 10:09:45 -0500
+Subject: [PATCH] powerpc: Fix closures on powerpc64-linux when statically
+ linking (#900) (#902)
+
+Closures on powerpc64-linux using static trampolines do not work when
+statically linking libffi.  The problem is the usage of tramp_globals.text
+in libffi assumes it contains the entry point address of the first trampoline.
+Powerpc's ffi_tramp_arch code returns &trampoline_code_table which for ABIs
+that use function descriptors, ends up returning trampoline_code_table's
+function descriptor address instead of its entry point address.  Update
+the code to always return the entry point address for all ABIs.
+---
+ src/powerpc/ffi.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/powerpc/ffi.c b/src/powerpc/ffi.c
+index 0a9774165..3601cc4ab 100644
+--- a/src/powerpc/ffi.c
++++ b/src/powerpc/ffi.c
+@@ -183,6 +183,12 @@ ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+   extern void *trampoline_code_table;
+   *tramp_size = PPC_TRAMP_SIZE;
+   *map_size = PPC_TRAMP_MAP_SIZE;
++#if defined (_CALL_AIX) || _CALL_ELF == 1
++  /* The caller wants the entry point address of the trampoline code,
++     not the address of the function descriptor.  */
++  return *(void **)trampoline_code_table;
++#else
+   return &trampoline_code_table;
++#endif
+ }
+ #endif

--- a/dev-libs/libffi/libffi-3.4.8-r3.ebuild
+++ b/dev-libs/libffi/libffi-3.4.8-r3.ebuild
@@ -1,0 +1,100 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit dot-a multilib-minimal preserve-libs
+
+MY_PV=${PV/_rc/-rc}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="Portable, high level programming interface to various calling conventions"
+HOMEPAGE="https://sourceware.org/libffi/"
+
+if [[ ${PV} == 9999 ]] ; then
+	EGIT_REPO_URI="https://github.com/libffi/libffi"
+	inherit autotools git-r3
+else
+	inherit libtool
+	SRC_URI="https://github.com/libffi/libffi/releases/download/v${MY_PV}/${MY_P}.tar.gz"
+
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+fi
+
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="MIT"
+# This is a core package which is depended on by e.g. Python.
+# Please use preserve-libs.eclass in pkg_{pre,post}inst to cover users
+# with FEATURES="-preserved-libs" or another package manager if SONAME changes.
+SLOT="0/8" # SONAME=libffi.so.8
+IUSE="debug +exec-static-trampoline pax-kernel static-libs test"
+
+RESTRICT="!test? ( test )"
+BDEPEND="test? ( dev-util/dejagnu )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.4.8-pa-add-.note.GNU-stack-marker-to-linux.S.patch
+	"${FILESDIR}"/${PN}-3.4.8-powerpc-closures.patch
+)
+
+src_prepare() {
+	default
+
+	if [[ ${PV} == 9999 ]] ; then
+		eautoreconf
+	else
+		elibtoolize
+	fi
+
+	if [[ ${CHOST} == arm64-*-darwin* ]] ; then
+		# ensure we use aarch64 asm, not x86 on arm64
+		sed -i -e 's/aarch64\*-\*-\*/arm64*-*-*|&/' \
+			configure configure.host || die
+	fi
+}
+
+src_configure() {
+	use static-libs && lto-guarantee-fat
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	# --includedir= path maintains a few properties:
+	# 1. have stable name across libffi versions: some packages like
+	#    dev-lang/ghc or kde-frameworks/networkmanager-qt embed
+	#    ${includedir} at build-time. Don't require those to be
+	#    rebuilt unless SONAME changes. bug #695788
+	#
+	#    We use /usr/.../${PN} (instead of former /usr/.../${P}).
+	#
+	# 2. have ${ABI}-specific location as ffi.h is target-dependent.
+	#
+	#    We use /usr/$(get_libdir)/... to have ABI identifier.
+	ECONF_SOURCE="${S}" econf \
+		--includedir="${EPREFIX}"/usr/$(get_libdir)/${PN}/include \
+		--disable-multi-os-directory \
+		--with-pic \
+		$(use_enable static-libs static) \
+		$(use_enable exec-static-trampoline exec-static-tramp) \
+		$(use_enable pax-kernel pax_emutramp) \
+		$(use_enable debug)
+}
+
+multilib_src_test() {
+	emake -Onone check
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -name "*.la" -delete || die
+	strip-lto-bytecode
+}
+
+pkg_preinst() {
+	preserve_old_lib /usr/$(get_libdir)/libffi.so.7
+}
+
+pkg_postinst() {
+	preserve_old_lib_notify /usr/$(get_libdir)/libffi.so.7
+}


### PR DESCRIPTION
Fixes ELFv1 64-bit PowerPC issues; see libffi/libffi#900.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
