### PR TITLE
net-libs/libcorkipset: Set min cmake ver to 3.10

### DIFF
--- a/net-libs/libcorkipset/files/cmake-min-ver-3.10.patch
+++ b/net-libs/libcorkipset/files/cmake-min-ver-3.10.patch
@@ -1,0 +1,25 @@
+From 596b26708ccc099a3a9e5f9d5408d603d2b60e1c Mon Sep 17 00:00:00 2001
+From: 1vybridge <openrc@posteo.de>
+Date: Sat, 21 Jun 2025 16:38:23 +0300
+Subject: [PATCH] Set cmake minimum version to 3.10
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4711de2..329d98d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ # Please see the COPYING file in this distribution for license details.
+ # ----------------------------------------------------------------------
+ 
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.10)
+ set(PROJECT_NAME ipset)
+ set(RELEASE_DATE 2013-12-11)
+ project(${PROJECT_NAME})
+-- 
+2.49.0
+

--- a/net-libs/libcorkipset/libcorkipset-1.1.1.20150311_p8-r1.ebuild
+++ b/net-libs/libcorkipset/libcorkipset-1.1.1.20150311_p8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,7 +22,10 @@ RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-debian-${MY_PX}"
 
-PATCHES=( "${S}"/debian/patches/ )
+PATCHES=(
+	"${S}"/debian/patches/
+	"${FILESDIR}"/cmake-min-ver-3.10.patch
+)
 
 src_prepare() {
 	cmake_src_prepare


### PR DESCRIPTION
Add patch to set the minimum cmake version to 3.10

Closes: https://bugs.gentoo.org/957567

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
