### PR TITLE
Removed old abseil dependency, added new one

### DIFF
--- a/app-i18n/mozc/files/mozc-2.28.5029.102-abseil-20250512.patch
+++ b/app-i18n/mozc/files/mozc-2.28.5029.102-abseil-20250512.patch
@@ -1,0 +1,13 @@
+diff --git a/src/base/absl.gyp b/src/base/absl.gyp
+index a022b31..45749d8 100644
+--- a/src/base/absl.gyp
++++ b/src/base/absl.gyp
+@@ -275,7 +275,7 @@
+           'all_dependent_settings': {
+             'link_settings': {
+               'libraries': [
+-                '-labsl_random_distributions -labsl_random_internal_pool_urbg -labsl_random_internal_randen -labsl_random_internal_randen_hwaes -labsl_random_internal_randen_hwaes_impl -labsl_random_internal_randen_slow -labsl_random_internal_seed_material -labsl_random_seed_gen_exception -labsl_random_seed_sequences',
++                '-labsl_random_distributions -labsl_random_internal_entropy_pool -labsl_random_internal_randen -labsl_random_internal_randen_hwaes -labsl_random_internal_randen_hwaes_impl -labsl_random_internal_randen_slow -labsl_random_internal_seed_material -labsl_random_seed_gen_exception -labsl_random_seed_sequences',
+               ],
+             },
+           },


### PR DESCRIPTION
Removed linking dependency to absl_random_internal_pool_urbg, added dependency to absl_random_internal_entropy_pool since it's where the functionality was migrated.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
