### PR TITLE
ROCm 6.x fixes

### DIFF
--- a/dev-libs/rccl/rccl-6.3.0.ebuild
+++ b/dev-libs/rccl/rccl-6.3.0.ebuild
@@ -62,6 +62,7 @@ src_configure() {
 		-DROCM_SYMLINK_LIBS=OFF
 		-DROCM_PATH="${EPREFIX}/usr"
 		-DRCCL_ROCPROFILER_REGISTER=OFF
+		-DENABLE_MSCCLPP=OFF
 		-Wno-dev
 	)
 

--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -636,6 +636,11 @@ _test-flag-PROG() {
 
 			cmdline_extra+=(-xc)
 			;;
+		hip)
+			in_ext='hip'
+			in_src='int main(void) { return 0; }'
+			cmdline_extra+=(-xhip -c)
+			;;
 	esac
 	local test_in=${T}/test-flag.${in_ext}
 	local test_out=${T}/test-flag.exe
@@ -706,6 +711,12 @@ test-flag-FC() { _test-flag-PROG FC f95 "$@"; }
 # @DESCRIPTION:
 # Returns shell true if <flag> is supported by the C compiler and linker, else returns shell false.
 test-flag-CCLD() { _test-flag-PROG CC c+ld "$@"; }
+
+# @FUNCTION: test-flag-HIPCXX
+# @USAGE: <flag>
+# @DESCRIPTION:
+# Returns shell true if <flag> is supported by the HIP compiler, else returns shell false.
+test-flag-HIPCXX() { _test-flag-PROG HIPCXX hip "$@"; }
 
 # @FUNCTION: test-flags-PROG
 # @USAGE: <compiler> <flag> [more flags...]
@@ -788,6 +799,12 @@ test-flags-FC() { _test-flags-PROG FC "$@"; }
 # Returns shell true if <flags> are supported by the C compiler and default linker, else returns shell false.
 test-flags-CCLD() { _test-flags-PROG CCLD "$@"; }
 
+# @FUNCTION: test-flags-HIPCXX
+# @USAGE: <flags>
+# @DESCRIPTION:
+# Returns shell true if <flags> are supported by the HIP compiler and default linker, else returns shell false.
+test-flags-HIPCXX() { _test-flags-PROG HIPCXX "$@"; }
+
 # @FUNCTION: test-flags
 # @USAGE: <flags>
 # @DESCRIPTION:
@@ -810,7 +827,7 @@ test_version_info() {
 
 # @FUNCTION: strip-unsupported-flags
 # @DESCRIPTION:
-# Strip {C,CXX,F,FC}FLAGS of any flags not supported by the active toolchain.
+# Strip {C,CXX,F,FC,HIP}FLAGS of any flags not supported by the active toolchain.
 strip-unsupported-flags() {
 	[[ $# -ne 0 ]] && die "strip-unsupported-flags takes no arguments"
 	export CFLAGS=$(test-flags-CC ${CFLAGS})
@@ -818,6 +835,7 @@ strip-unsupported-flags() {
 	export FFLAGS=$(test-flags-F77 ${FFLAGS})
 	export FCFLAGS=$(test-flags-FC ${FCFLAGS})
 	export LDFLAGS=$(test-flags-CCLD ${LDFLAGS})
+	export HIPFLAGS=$(test-flags-HIPCXX ${HIPFLAGS})
 }
 
 # @FUNCTION: get-flag
@@ -1007,6 +1025,12 @@ test-compile() {
 			filename_out="${T}/test.exe"
 			args+=(${FCFLAGS[@]} ${LDFLAGS[@]} -xf95)
 			libs+=(${LIBS[@]})
+			;;
+		hip)
+			compiler="$(tc-getHIPCXX)"
+			filename_in="${T}/test.hip"
+			filename_out="${T}/test.o"
+			args+=(${CFLAGS[@]} -xhip -c)
 			;;
 		*)
 			die "Unknown compiled language ${lang}"

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -73,6 +73,10 @@ tc-getCPP() { tc-getPROG CPP "${CC:-gcc} -E" "$@"; }
 # @USAGE: [toolchain prefix]
 # @RETURN: name of the C++ compiler
 tc-getCXX() { tc-getPROG CXX g++ "$@"; }
+# @FUNCTION: tc-getHIPCXX
+# @USAGE: [toolchain prefix]
+# @RETURN: name of the HIP compiler
+tc-getHIPCXX() { tc-getPROG HIPCXX "$(hipconfig --hipclangpath)/clang++" "$@"; }
 # @FUNCTION: tc-getLD
 # @USAGE: [toolchain prefix]
 # @RETURN: name of the linker

--- a/sci-libs/hipBLASLt/hipBLASLt-6.4.1.ebuild
+++ b/sci-libs/hipBLASLt/hipBLASLt-6.4.1.ebuild
@@ -33,6 +33,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	${PYTHON_DEPS}
 	dev-build/rocm-cmake
+	dev-util/hipcc
 	sci-libs/hipBLAS-common:${SLOT}
 	$(python_gen_any_dep '
 		dev-python/msgpack[${PYTHON_USEDEP}]
@@ -99,8 +100,7 @@ src_prepare() {
 }
 
 src_configure() {
-	export CC="$(get_llvm_prefix)/bin/clang" CXX="$(get_llvm_prefix)/bin/clang++"
-	strip-unsupported-flags
+	rocm_use_clang
 
 	# too many warnings
 	append-cxxflags -Wno-explicit-specialization-storage-class

--- a/sci-libs/rocBLAS/rocBLAS-6.4.1.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-6.4.1.ebuild
@@ -64,10 +64,11 @@ src_prepare() {
 }
 
 src_configure() {
-	rocm_use_hipcc
+	llvm_prepend_path "${LLVM_SLOT}"
+	rocm_use_clang
 
 	# too many warnings
-	append-cxxflags -Wno-explicit-specialization-storage-class
+	append-cxxflags -Wno-explicit-specialization-storage-class -Wno-unused-value
 
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
@@ -87,10 +88,7 @@ src_configure() {
 
 	if usex video_cards_amdgpu; then
 		mycmakeargs+=(
-			-DTensile_LOGIC="asm_full"
 			-DTensile_COMPILER="hipcc"
-			-DTensile_LIBRARY_FORMAT="msgpack"
-			-DTensile_CODE_OBJECT_VERSION="default"
 			-DTensile_ROOT="${EPREFIX}/usr/share/Tensile"
 			-DTensile_CPU_THREADS="$(makeopts_jobs)"
 		)

--- a/sci-libs/rocThrust/files/rocThrust-6.4.1-no-tests-install.patch
+++ b/sci-libs/rocThrust/files/rocThrust-6.4.1-no-tests-install.patch
@@ -1,0 +1,22 @@
+Disable installation of test files.
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -106,7 +106,6 @@ function(add_rocthrust_test TEST)
+                 LABELS "hip"
+         )
+     endif()
+-    rocm_install(TARGETS ${TEST_TARGET} COMPONENT tests)
+     if (WIN32 AND NOT DEFINED DLLS_COPIED)
+       set(DLLS_COPIED "YES")
+       set(DLLS_COPIED ${DLLS_COPIED} PARENT_SCOPE)
+@@ -266,10 +265,3 @@ if(BUILD_HIPSTDPAR_TEST)
+         endif()
+     endif()
+ endif()
+-
+-rocm_install(
+-    FILES "${INSTALL_TEST_FILE}"
+-    DESTINATION "${CMAKE_INSTALL_BINDIR}/${PROJECT_NAME}"
+-    COMPONENT tests
+-    RENAME "CTestTestfile.cmake"
+-)

--- a/sci-libs/rocThrust/rocThrust-6.4.1-r1.ebuild
+++ b/sci-libs/rocThrust/rocThrust-6.4.1-r1.ebuild
@@ -43,7 +43,15 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-4.0-operator_new.patch"
 	"${FILESDIR}/${PN}-6.4.1-fix-libcxx.patch"
+	"${FILESDIR}/${PN}-6.4.1-no-tests-install.patch"
 )
+
+src_prepare() {
+	sed -e "s:set(ROCM_INSTALL_LIBDIR lib):set(ROCM_INSTALL_LIBDIR $(get_libdir)):" \
+		-i cmake/ROCMExportTargetsHeaderOnly.cmake || die
+
+	cmake_src_prepare
+}
 
 src_configure() {
 	rocm_use_hipcc


### PR DESCRIPTION
* `toolchain-funcs.eclass`: add `tc-getHIPCXX` function
    This allows to find compiler for HIP language files. Environment variable `HIPCXX` [is used by CMake ](https://cmake.org/cmake/help/latest/envvar/HIPCXX.html).
    In recent releases of CMake, it strictly requires clang++, not hipcc. When not defined, CMake uses multiple methods to find HIP compiler, hipconfig [is one of them](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/CMakeDetermineHIPCompiler.cmake).
*  `flag-o-matic.eclass`: Add functions for testing/stripping `HIPFLAGS`
    `HIPFLAFS` allows to specify default compilation flags to be used when compiling HIP files.
    As environment variable, it is supported in CMake for all projects that specify HIP as language (sources: [1](https://cmake.org/cmake/help/latest/envvar/HIPFLAGS.html), [2](https://rocm.docs.amd.com/en/latest/conceptual/cmake-packages.html#using-the-hip-single-source-programming-model)).
    Some flags like `-mtls-dialect=*` are not supported by HIP compiler; test-flags-HIPCXX can be used to test flags.
* `rocm.eclass`: add `rocm_use_clang` and strip flags in a better way
    In recent releases some ROCm packages switched from hipcc to clang++ (as hipcc is now mostly a simple wrapper that calls clang++).
    New `rocm_use_clang` function allows to switch compiler to HIP-compatible clang.
    Both hipcc and clang reject some flags when compiling *.hip files; to clean incompatible `CXXFLAGS` new `test-flags-HIPCXX` function is used.
* `sci-libs/rocBLAS`: fix compilation failure with incorrect clang selection (closes [949817](https://bugs.gentoo.org/949817))
    This switches compiles from hipcc to clang (no difference, just to remove warning), and more importantly prepends llvm path (build scripts calls clang++ in many places).
* `sci-libs/hipBLASLt`: improve flag filtration (bug [957893](https://bugs.gentoo.org/957893))
* `sci-libs/rocThrust`: don't install tests; install cmake files in a better place
* `dev-libs/rccl`: fix AMDGPU_TARGETS=gfx942 rccl-6.3.0 compilation (closes [949565](https://bugs.gentoo.org/949565))
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
