### PR TITLE
dev-python/poetry-plugin-export: Limit dependency to current major version

### DIFF
--- a/dev-python/poetry-plugin-export/poetry-plugin-export-1.9.0-r2.ebuild
+++ b/dev-python/poetry-plugin-export/poetry-plugin-export-1.9.0-r2.ebuild
@@ -19,12 +19,12 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="
-	>=dev-python/poetry-core-1.7.0[${PYTHON_USEDEP}]
+	=dev-python/poetry-core-2*[${PYTHON_USEDEP}]
 "
 
 DEPEND="
 	test? (
-		>=dev-python/poetry-1.7.0[${PYTHON_USEDEP}]
+		=dev-python/poetry-2*[${PYTHON_USEDEP}]
 		>=dev-python/pytest-mock-3.9[${PYTHON_USEDEP}]
 		>=dev-python/pytest-xdist-3.1[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
As updated in upstream pyproject.toml
https://github.com/python-poetry/poetry-plugin-export/pull/280

Limit dependency to poetry 2.x and not 3.x. There is no 3.x yet for now.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
