### PR TITLE
sci-electronics/librepcb: fix cmake min version

### DIFF
--- a/sci-electronics/librepcb/files/librepcb-1.3.0-cmake-minimum-required.patch
+++ b/sci-electronics/librepcb/files/librepcb-1.3.0-cmake-minimum-required.patch
@@ -1,0 +1,36 @@
+From 2638b76886b0eb0a371121aa965c895b1994a8b8 Mon Sep 17 00:00:00 2001
+From: "U. Bruhin" <urbibruhin@bluewin.ch>
+Date: Thu, 3 Apr 2025 19:04:47 +0200
+Subject: [PATCH] CMake: Bump minimum required version to 3.22
+
+---
+ CMakeLists.txt                       | 2 +-
+ external/debug_assert/CMakeLists.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 421ce0f..5617244 100644
+--- a/libs/type_safe/CMakeLists.txt
++++ b/libs/type_safe/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # This file is subject to the license terms in the LICENSE file
+ # found in the top-level directory of this distribution.
+ 
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.22)
+ 
+ project(TYPE_SAFE)
+ 
+diff --git a/external/debug_assert/CMakeLists.txt b/external/debug_assert/CMakeLists.txt
+index 7005afc..541ae4c 100644
+--- a/libs/type_safe/external/debug_assert/CMakeLists.txt
++++ b/libs/type_safe/external/debug_assert/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # This file is subject to the license terms in the LICENSE file
+ # found in the top-level directory of this distribution.
+ 
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.22)
+ project(DEBUG_ASSERT)
+ 
+ # Determine if debug_assert is built as a subproject (using add_subdirectory)

--- a/sci-electronics/librepcb/librepcb-1.3.0-r1.ebuild
+++ b/sci-electronics/librepcb/librepcb-1.3.0-r1.ebuild
@@ -111,6 +111,15 @@ BDEPEND="
 	app-arch/unzip
 	dev-qt/qttools:6[linguist]"
 
+PATCHES=( "${FILESDIR}"/librepcb-1.3.0-cmake-minimum-required.patch )
+
+src_prepare() {
+	# remove unbundled
+	rm -r libs/muparser || die
+	rm -r libs/googletest || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DQT_MAJOR_VERSION=6


### PR DESCRIPTION
 Fix cmake_minimum_required to 3.5

Bug: https://bugs.gentoo.org/957528
Signed-off-by: Victor Kustov <ktrace@yandex.ru>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
