### PR TITLE
net-p2p/bitcoin-core-29.0: fix CMake 4 compatibility

### DIFF
--- a/net-p2p/bitcoin-core/bitcoin-core-29.0.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-29.0.ebuild
@@ -138,6 +138,10 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/958361
+	# https://github.com/google/crc32c/commit/2bbb3be42e20a0e6c0f7b39dc07dc863d9ffbc07
+	sed -e '/^cmake_minimum_required(VERSION 3\.1)$/s/)$/6)/' -i src/crc32c/CMakeLists.txt || die
+
 	eapply_user
 	! use system-libsecp256k1 || rm -r src/secp256k1 || die
 	cmake_src_prepare


### PR DESCRIPTION
Bitcoin Core has not yet pulled in the CMake 4 fix for crc32c, but we can pull it from upstream and apply it ourselves. (It's only a bump in the `cmake_minimum_required` call.)

Closes: https://bugs.gentoo.org/958361
See: https://github.com/google/crc32c/commit/2bbb3be42e20a0e6c0f7b39dc07dc863d9ffbc07

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
