### PR TITLE
kde-frameworks/kidletime: add missing BDEPEND on dev-qt/qttools

### DIFF
--- a/kde-frameworks/kidletime/kidletime-6.15.0.ebuild
+++ b/kde-frameworks/kidletime/kidletime-6.15.0.ebuild
@@ -38,7 +38,10 @@ DEPEND="${RDEPEND}
 		>=dev-libs/wayland-protocols-1.27:0
 	)
 "
-BDEPEND="wayland? ( >=dev-qt/qtwayland-${QTMIN}:6 )"
+BDEPEND="
+	>=dev-qt/qttools-${QTMIN}:6[linguist]
+	wayland? ( >=dev-qt/qtwayland-${QTMIN}:6 )
+"
 
 src_prepare() {
 	ecm_src_prepare


### PR DESCRIPTION
ECMGenerateQDoc[1] requires qttools to function.

[1] https://invent.kde.org/frameworks/kidletime/-/blob/master/CMakeLists.txt#L26

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.