### PR TITLE
sci-libs/avogadrolibs: adapt lto/dot-a, cmake4, add DEPFix odr avogadrolibs

### DIFF
--- a/sci-chemistry/avogadro2/avogadro2-1.100.0-r1.ebuild
+++ b/sci-chemistry/avogadro2/avogadro2-1.100.0-r1.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	dev-cpp/eigen:3
+	vtk? ( dev-libs/pegtl )
 "
 BDEPEND="doc? ( app-text/doxygen )"
 

--- a/sci-libs/avogadrolibs/files/avogadrolibs-1.100-cmake4.patch
+++ b/sci-libs/avogadrolibs/files/avogadrolibs-1.100-cmake4.patch
@@ -1,0 +1,38 @@
+PR merged
+https://github.com/OpenChemistry/avogadrolibs/pull/2022.patch
+From 7edee1178f5cd95c3b81964ce39d529b413dbe22 Mon Sep 17 00:00:00 2001
+From: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
+Date: Thu, 5 Jun 2025 09:58:13 +0900
+Subject: [PATCH] build: bump cmake_minimum_required
+
+CMake 4 drops support of 3.4 or earlier
+
+note: FindPython is introduced in 3.12
+https://cmake.org/cmake/help/v3.12/release/3.12.html#modules
+
+Signed-off-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
+---
+ python/CMakeLists.txt                  | 2 +-
+ thirdparty/tinycolormap/CMakeLists.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 2cb3d0e17b..ab6b073746 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+ 
+ if (NOT TARGET Avogadro::Core)
+   find_package(AvogadroLibs REQUIRED)
+diff --git a/thirdparty/tinycolormap/CMakeLists.txt b/thirdparty/tinycolormap/CMakeLists.txt
+index ee88bf4878..d4c9096175 100644
+--- a/thirdparty/tinycolormap/CMakeLists.txt
++++ b/thirdparty/tinycolormap/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(tinycolormap CXX)
+ set(CMAKE_CXX_STANDARD 11)

--- a/sci-libs/avogadrolibs/files/avogadrolibs-1.100-fix_odr.patch
+++ b/sci-libs/avogadrolibs/files/avogadrolibs-1.100-fix_odr.patch
@@ -1,0 +1,98 @@
+https://github.com/OpenChemistry/avogadrolibs/pull/2059.patch
+From ef234b94bcff5e4416e7ae0546c3e8977d3ad3a2 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Tue, 24 Jun 2025 02:23:13 +0200
+Subject: [PATCH] Fix ODR violations, move enums into class scope
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+avogadrolibs-1.100.0/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp:61:6:
+error: type ‘Avogadro::QtPlugins::BasisOption’ violates the C++ One Definition Rule [-Werror=odr]
+   61 | enum BasisOption
+      |      ^
+avogadrolibs-1.100.0/work/avogadrolibs-1.100.0/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp:40:6:
+error: type ‘Avogadro::QtPlugins::CalculateOption’ violates the C++ One Definition Rule [-Werror=odr]
+   40 | enum CalculateOption
+      |      ^
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+---
+ .../qtplugins/cp2kinput/cp2kinputdialog.cpp   | 21 -------------------
+ .../qtplugins/cp2kinput/cp2kinputdialog.h     | 21 +++++++++++++++++++
+ 2 files changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
+index 5eec8b6d..97f583a3 100644
+--- a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
++++ b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.cpp
+@@ -37,16 +37,6 @@ using Avogadro::MoleQueue::JobObject;
+ 
+ namespace Avogadro::QtPlugins {
+ 
+-enum CalculateOption
+-{
+-  CalculateEnergy = 0,
+-  CalculateEnergyAndForces,
+-  CalculateMolecularDynamics,
+-  CalculateGeometryOptimization,
+-
+-  CalculateCount
+-};
+-
+ enum FunctionalOption
+ {
+   FunctionalBLYP = 0,
+@@ -58,17 +48,6 @@ enum FunctionalOption
+   FunctionalCount
+ };
+ 
+-enum BasisOption
+-{
+-  BasisSZVGTH = 0,
+-  BasisDZVGTH,
+-  BasisDZVPGTH,
+-  BasisTZVPGTH,
+-  BasisTZV2PGTH,
+-
+-  BasisCount
+-};
+-
+ enum MethodOption
+ {
+   DFT = 0,
+diff --git a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h
+index dc24594f..52be8dcd 100644
+--- a/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h
++++ b/avogadro/qtplugins/cp2kinput/cp2kinputdialog.h
+@@ -31,6 +31,27 @@ class Cp2kInputDialog : public QDialog
+ {
+   Q_OBJECT
+ 
++  enum CalculateOption
++  {
++    CalculateEnergy = 0,
++    CalculateEnergyAndForces,
++    CalculateMolecularDynamics,
++    CalculateGeometryOptimization,
++
++    CalculateCount
++  };
++
++  enum BasisOption
++  {
++    BasisSZVGTH = 0,
++    BasisDZVGTH,
++    BasisDZVPGTH,
++    BasisTZVPGTH,
++    BasisTZV2PGTH,
++
++    BasisCount
++  };
++
+ public:
+   explicit Cp2kInputDialog(QWidget* parent_ = nullptr,
+                            Qt::WindowFlags f = Qt::WindowFlags());
+-- 
+2.49.0
+


### PR DESCRIPTION
fix lto/ODR violations with pending upstream PR, except with vtk enabled (filter then).

add static-libs useflag for qtplugins libraries (previously enabled by default).
use dot-a with qt6 even w/o static-libs, because libgwavi.a is required to build avogadro2.

bump cmake_min for cmake4 compat.

add dev-libs/pegtl in DEPEND, required by vtk's cmake file (for sci-chemistry/avogadro2 too)

Bug: https://bugs.gentoo.org/942463

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
