### PR TITLE
dev-libs/rapidjson: fix build if USE="doc"

### DIFF
--- a/dev-libs/rapidjson/files/rapidjson-1.1.0-doc-build.patch
+++ b/dev-libs/rapidjson/files/rapidjson-1.1.0-doc-build.patch
@@ -1,0 +1,41 @@
+https://github.com/Tencent/rapidjson/commit/bbdf5d1d4b40891c82e5c1946d32dfc841926066
+
+From bbdf5d1d4b40891c82e5c1946d32dfc841926066 Mon Sep 17 00:00:00 2001
+From: Christopher Warrington <chwarr@microsoft.com>
+Date: Tue, 5 Sep 2017 16:58:09 -0700
+Subject: [PATCH] Fix Windows doc build MSBuild error MSB6001
+
+When using a MSBuild-based CMake generator like 'Visual Studio 15 2017
+Win64', the doc build was failing with the error 'MSB6001: Invalid
+command line switch for "cmd.exe". Illegal characters in path.'
+
+This was due to the dependency on Doxyfile*, which wasn't expanded by
+CMake.
+
+The fix is to expand this glob in CMake before specifying the custom
+command's dependencies.
+
+Partial fix for https://github.com/miloyip/rapidjson/issues/622
+
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index c1f165a3..c5345ba6 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -10,11 +10,13 @@ ELSE()
+     CONFIGURE_FILE(Doxyfile.in Doxyfile @ONLY)
+     CONFIGURE_FILE(Doxyfile.zh-cn.in Doxyfile.zh-cn @ONLY)
+ 
++    file(GLOB DOXYFILES ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile*)
++    
+     add_custom_command(OUTPUT html
+         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.zh-cn
+         COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/html
+-        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile*
++        DEPENDS ${MARKDOWN_DOC} ${SOURCES} ${DOXYFILES}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../
+         )
+ 
+-- 
+2.45.2
+

--- a/dev-libs/rapidjson/rapidjson-1.1.0-r5.ebuild
+++ b/dev-libs/rapidjson/rapidjson-1.1.0-r5.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-valgrind_optional.patch"
 	"${FILESDIR}/${P}-gcc14-const.patch"
 	"${FILESDIR}/${P}-cmake4.patch"
+	"${FILESDIR}/${P}-doc-build.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
by applying the upstream patch to expand the glob. Affter the minimum required CMake version was raised from 2.8 to 3.5 in the last commit, Ninja reports:

> ninja: error: 'doc/Doxyfile*', needed by 'doc/html', missing and no known rule to make it

Closes: https://bugs.gentoo.org/956433

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
