### PR TITLE
gnome-extra/evolution-data-server: Restrict to <gui-libs/gtk-4.18:4

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.52.4-r4.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.52.4-r4.ebuild
@@ -42,6 +42,7 @@ RDEPEND="
 	gtk? (
 		>=x11-libs/gtk+-3.20:3
 		>=gui-libs/gtk-4.4:4
+		<gui-libs/gtk-4.18:4
 		sound? (
 			|| (
 				media-libs/libcanberra-gtk3

--- a/gnome-extra/evolution-data-server/evolution-data-server-3.54.3-r2.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.54.3-r2.ebuild
@@ -42,6 +42,7 @@ RDEPEND="
 	gtk? (
 		>=x11-libs/gtk+-3.20:3
 		>=gui-libs/gtk-4.4:4
+		<gui-libs/gtk-4.18:4
 		sound? (
 			|| (
 				media-libs/libcanberra-gtk3


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/958438
Closes: https://github.com/gentoo/gentoo/pull/42743
Part-of: https://github.com/gentoo/gentoo/pull/42743

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
