### PR TITLE
dev-util/rocm_bandwidth_test, dev-util/rocm-smi: update LICENSE

### DIFF
--- a/dev-util/rocm-smi/rocm-smi-6.3.2.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.3.2.ebuild
@@ -20,7 +20,7 @@ else
 	S="${WORKDIR}/rocm_smi_lib-rocm-${PV}"
 fi
 
-LICENSE="MIT NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/dev-util/rocm-smi/rocm-smi-6.3.3-r1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.3.3-r1.ebuild
@@ -20,7 +20,7 @@ else
 	S="${WORKDIR}/rocm_smi_lib-rocm-${PV}"
 fi
 
-LICENSE="MIT NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
@@ -20,7 +20,7 @@ else
 	S="${WORKDIR}/rocm_smi_lib-rocm-${PV}"
 fi
 
-LICENSE="MIT NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-5.7.1.ebuild
+++ b/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-5.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,6 +8,7 @@ inherit cmake
 DESCRIPTION="Bandwidth test for ROCm"
 HOMEPAGE="https://github.com/RadeonOpenCompute/rocm_bandwidth_test"
 SRC_URI="https://github.com/RadeonOpenCompute/${PN}/archive/rocm-${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-rocm-${PV}"
 
 LICENSE="NCSA-AMD"
 SLOT="0/$(ver_cut 1-2)"
@@ -15,9 +16,6 @@ KEYWORDS="~amd64"
 
 DEPEND="dev-libs/rocr-runtime:="
 RDEPEND="${DEPEND}"
-BDEPEND=""
-
-S="${WORKDIR}/${PN}-rocm-${PV}"
 
 src_prepare() {
 	# the autodetection logic here is very very confused. This makes it not fail.

--- a/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.3.2.ebuild
+++ b/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.3.2.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/ROCm/rocm_bandwidth_test"
 SRC_URI="https://github.com/ROCm/${PN}/archive/rocm-${PV}.tar.gz -> ${P}.tar.gz"
 
 S="${WORKDIR}/${PN}-rocm-${PV}"
-LICENSE="NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~amd64"
 

--- a/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.3.3.ebuild
+++ b/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.3.3.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/ROCm/rocm_bandwidth_test"
 SRC_URI="https://github.com/ROCm/${PN}/archive/rocm-${PV}.tar.gz -> ${P}.tar.gz"
 
 S="${WORKDIR}/${PN}-rocm-${PV}"
-LICENSE="NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~amd64"
 

--- a/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.4.1.ebuild
+++ b/dev-util/rocm_bandwidth_test/rocm_bandwidth_test-6.4.1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/ROCm/rocm_bandwidth_test"
 SRC_URI="https://github.com/ROCm/${PN}/archive/rocm-${PV}.tar.gz -> ${P}.tar.gz"
 
 S="${WORKDIR}/${PN}-rocm-${PV}"
-LICENSE="NCSA-AMD"
+LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~amd64"
 


### PR DESCRIPTION
- `dev-util/rocm_bandwidth_test`: License was changed from NCSA to MIT in rocm-6.2.0 release in ROCm/rocm_bandwidth_test@c81c47c
- `dev-util/rocm-smi`: License was changed from NCSA to MIT in rocm-6.1.2 release in ROCm/rocm_smi_lib@e7d5494

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
