### PR TITLE
media-gfx/opentoonz: update opencv dependency

### DIFF
--- a/media-gfx/opentoonz/opentoonz-1.6.0.ebuild
+++ b/media-gfx/opentoonz/opentoonz-1.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -39,7 +39,7 @@ RDEPEND="
 	media-libs/libjpeg-turbo
 	>=media-libs/libmypaint-1.3.0:=
 	media-libs/libpng:=
-	media-libs/opencv:=
+	media-libs/opencv:=[features2d]
 	>=sci-libs/superlu-4.1:=
 	sys-libs/zlib
 	virtual/cblas


### PR DESCRIPTION
"features2d" is required, otherwise, the build fails due to a missing header file, causing the following error:

> no member named 'CALIB_CB_FILTER_QUADS' in namespace 'cv'

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
