### PR TITLE
app-editors/neovim: Fix hardcoded usage of ccache

### DIFF
--- a/app-editors/neovim/neovim-0.11.1.ebuild
+++ b/app-editors/neovim/neovim-0.11.1.ebuild
@@ -94,6 +94,8 @@ src_configure() {
 		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${LUA}"
+		# bug 906019: fix hardcoded usage of ccache
+		-DCACHE_PRG=OFF
 	)
 	cmake_src_configure
 }

--- a/app-editors/neovim/neovim-0.11.2.ebuild
+++ b/app-editors/neovim/neovim-0.11.2.ebuild
@@ -94,6 +94,8 @@ src_configure() {
 		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${LUA}"
+		# bug 906019: fix hardcoded usage of ccache
+		-DCACHE_PRG=OFF
 	)
 	cmake_src_configure
 }

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -94,6 +94,8 @@ src_configure() {
 		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${LUA}"
+		# bug 906019: fix hardcoded usage of ccache
+		-DCACHE_PRG=OFF
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Use the cmake variable CACHE_PRG to turn off usage of ccache and sccache by default if they are found on the system.

Refer: https://github.com/neovim/neovim/blob/f0757ee590cc2ebc60cf0fe6488a0421d5bfeaf9/CONTRIBUTING.md?plain=1#L48
Closes: https://bugs.gentoo.org/906019

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
