### PR TITLE
net-misc/onedrive: Fix prefix build

### DIFF
--- a/net-misc/onedrive/onedrive-2.5.6.ebuild
+++ b/net-misc/onedrive/onedrive-2.5.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit shell-completion optfeature systemd toolchain-funcs
+inherit shell-completion optfeature prefix systemd toolchain-funcs
 
 DESCRIPTION="Free Client for OneDrive on Linux"
 HOMEPAGE="https://abraunegg.github.io/"
@@ -38,6 +38,13 @@ pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && _setup_gdc
 }
 
+src_prepare() {
+	hprefixify contrib/init.d/onedrive.init
+	# Add EPREFIX to the system config path (/etc)
+	hprefixify -w '/string systemConfigDirBase/' src/config.d
+	default
+}
+
 src_configure() {
 	# GDCFLAGS are meant to be specified in make.conf. Avoid the DFLAGS
 	# name to support ::dlang which needs separate variables for each
@@ -70,7 +77,7 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" docdir=/usr/share/doc/${PF} install
+	emake DESTDIR="${D}" docdir="${EPREFIX}"/usr/share/doc/${PF} install
 	# log directory
 	keepdir /var/log/onedrive
 	fperms 775 /var/log/onedrive


### PR DESCRIPTION
The systemd user unit file still hardcodes the configuration path to `/home/<user>/.config` but it's unlikely that users are invoking onedrive through that.

Closes: https://bugs.gentoo.org/959096

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
