### PR TITLE
gui-libs/hyprutils: Fix error: uintptr_t does not name a type

### DIFF
--- a/gui-libs/hyprutils/files/hyprutils-fix-building-with-GCC16.patch
+++ b/gui-libs/hyprutils/files/hyprutils-fix-building-with-GCC16.patch
@@ -1,0 +1,32 @@
+https://github.com/hyprwm/hyprutils/commit/1eb6759ae7a53cff9a9f80e1e6db88235e0c7648
+From: Brahmajit Das <listout@listout.xyz>
+Date: Fri, 27 Jun 2025 00:46:44 +0530
+Subject: [PATCH] implbase: include cstdint and fix building with GCC 16
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without cstdint, building with GCC 16 fails with error
+
+In file included from /tmp/hyprutils/tests/memory.cpp:1:
+/tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp: In member function ‘bool Hyprutils::Memory::CUniquePointer<T>::operator()(const Hyprutils:
+:Memory::CUniquePointer<T>&, const Hyprutils::Memory::CUniquePointer<T>&) const’:
+
+..snip...
+
+ng ‘#include <cstdint>’
+
+Downstream-bug: https://bugs.gentoo.org/957409
+Signed-off-by: Brahmajit Das <listout@listout.xyz>
+--- a/include/hyprutils/memory/ImplBase.hpp
++++ b/include/hyprutils/memory/ImplBase.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ namespace Hyprutils {
+-- 
+2.50.0
+

--- a/gui-libs/hyprutils/hyprutils-0.7.1-r1.ebuild
+++ b/gui-libs/hyprutils/hyprutils-0.7.1-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2023-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Hyprland utilities library used across the ecosystem"
+HOMEPAGE="https://github.com/hyprwm/hyprutils"
+
+if [[ "${PV}" = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/hyprwm/${PN^}.git"
+else
+	SRC_URI="https://github.com/hyprwm/${PN^}/archive/refs/tags/v${PV}/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+	S="${WORKDIR}/${PN}-${PV}"
+
+	KEYWORDS="~amd64"
+fi
+
+LICENSE="BSD"
+SLOT="0/$(ver_cut 1-2)"
+
+DEPEND="
+	x11-libs/pixman
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	# Merged upstream, not need in live
+	"${FILESDIR}/${PN}-fix-building-with-GCC16.patch"
+)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/957409

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
