### PR TITLE
net-dialup/cutecom: improve current ebuild

### DIFF
--- a/net-dialup/cutecom/cutecom-0.60.0_rc1-r1.ebuild
+++ b/net-dialup/cutecom/cutecom-0.60.0_rc1-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake desktop xdg
+
+MY_PV=${PV/_rc/-RC}
+
+DESCRIPTION="Serial terminal, like minicom, written in Qt"
+HOMEPAGE="https://gitlab.com/cutecom/cutecom"
+SRC_URI="https://gitlab.com/cutecom/cutecom/-/archive/v${MY_PV}/cutecom-v${MY_PV}.tar.bz2"
+S="${WORKDIR}/cutecom-v${MY_PV}"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+DEPEND="
+	dev-qt/qtbase:6[gui,network,widgets]
+	dev-qt/qtserialport:6"
+RDEPEND="${DEPEND}
+	net-dialup/lrzsz"
+
+src_install() {
+	cmake_src_install
+	doicon "distribution/${PN}.png"
+}


### PR DESCRIPTION
Improved from https://github.com/gentoo/gentoo/pull/37872.

Thanks @a17r for pointing out the missing USE deps!

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
