### PR TITLE
sci-chemistry/gromacs: fixing opencl build for intel internal graphics

### DIFF
--- a/sci-chemistry/gromacs/gromacs-2025.2.ebuild
+++ b/sci-chemistry/gromacs/gromacs-2025.2.ebuild
@@ -40,7 +40,7 @@ HOMEPAGE="https://www.gromacs.org/"
 #        base,    vmd plugins, fftpack from numpy,  blas/lapck from netlib,        memtestG80 library,  mpi_thread lib
 LICENSE="LGPL-2.1 UoI-NCSA !mkl? ( !fftw? ( BSD ) !blas? ( BSD ) !lapack? ( BSD ) ) cuda? ( LGPL-3 ) threads? ( BSD )"
 SLOT="0/${PV}"
-IUSE="blas clang clang-cuda cuda  +custom-cflags +doc build-manual double-precision +fftw +gmxapi +gmxapi-legacy +hwloc lapack mkl mpi nnpot +offensive opencl openmp +python +single-precision test +threads +tng video_cards_intel ${ACCE_IUSE}"
+IUSE="blas clang clang-cuda cuda +custom-cflags +doc build-manual double-precision +fftw +gmxapi +gmxapi-legacy +hwloc lapack mkl mpi nnpot +offensive opencl openmp +python +single-precision test +threads +tng video_cards_intel ${ACCE_IUSE}"
 
 CDEPEND="
 	blas? ( virtual/blas )

--- a/sci-chemistry/gromacs/gromacs-2025.2.ebuild
+++ b/sci-chemistry/gromacs/gromacs-2025.2.ebuild
@@ -40,7 +40,7 @@ HOMEPAGE="https://www.gromacs.org/"
 #        base,    vmd plugins, fftpack from numpy,  blas/lapck from netlib,        memtestG80 library,  mpi_thread lib
 LICENSE="LGPL-2.1 UoI-NCSA !mkl? ( !fftw? ( BSD ) !blas? ( BSD ) !lapack? ( BSD ) ) cuda? ( LGPL-3 ) threads? ( BSD )"
 SLOT="0/${PV}"
-IUSE="blas clang clang-cuda cuda  +custom-cflags +doc build-manual double-precision +fftw +gmxapi +gmxapi-legacy +hwloc lapack mkl mpi nnpot +offensive opencl openmp +python +single-precision test +threads +tng ${ACCE_IUSE}"
+IUSE="blas clang clang-cuda cuda  +custom-cflags +doc build-manual double-precision +fftw +gmxapi +gmxapi-legacy +hwloc lapack mkl mpi nnpot +offensive opencl openmp +python +single-precision test +threads +tng video_cards_intel ${ACCE_IUSE}"
 
 CDEPEND="
 	blas? ( virtual/blas )
@@ -265,9 +265,11 @@ src_configure() {
 		local p
 		[[ ${x} = "double" ]] && p="-DGMX_DOUBLE=ON" || p="-DGMX_DOUBLE=OFF"
 		local gpu=( "-DGMX_GPU=OFF" )
+		local gpu_clusters=( "-DGMX_GPU_NB_CLUSTER_SIZE=8" )
 		[[ ${x} = "float" ]] && use cuda && gpu=( "-DGMX_GPU=CUDA" )
 		[[ ${x} = "float" ]] && use clang-cuda && gpu=( "-DGMX_GPU=CUDA" "-DGMX_CLANG_CUDA=ON" )
 		use opencl && gpu=( "-DGMX_GPU=OPENCL" )
+		use video_cards_intel && gpu_clusters=( "-DGMX_GPU_NB_CLUSTER_SIZE=4" )
 		local mycmakeargs=(
 			${mycmakeargs_pre[@]} ${p}
 			-DGMX_MPI=$(usex mpi)
@@ -275,6 +277,7 @@ src_configure() {
 			-DGMXAPI=$(usex gmxapi)
 			-DGMX_INSTALL_LEGACY_API=$(usex gmxapi-legacy)
 			"${gpu[@]}"
+			"${gpu_clusters[@]}"
 			"$(use test && echo -DREGRESSIONTEST_PATH="${WORKDIR}/${P}_${x}/tests")"
 			-DGMX_BINARY_SUFFIX="${suffix}"
 			-DGMX_LIBS_SUFFIX="${suffix}"

--- a/sci-chemistry/gromacs/metadata.xml
+++ b/sci-chemistry/gromacs/metadata.xml
@@ -24,5 +24,6 @@
 		<flag name="tng">Enable new trajectory format - tng</flag>
 		<flag name="mkl">Use <pkg>sci-libs/mkl</pkg> for fft, blas, lapack routines</flag>
 		<flag name="offensive">Enable gromacs partly offensive quotes</flag>
+		<flag name="video_cards_intel">Modifies the non-bonded GPU cluster size to 4 in order to enable opencl on Intel integrated graphics</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Intel integrated GPUs require: 
-DGMX_GPU_NB_CLUSTER_SIZE=4 
to be set, otherwise running a GPU job will result in GPU not found.  I added the video_cards_intel use flag, in order to check if we build gromacs for intel integrated graphics. If this is the case GMX_GPU_NB_CLUSTER_SIZE=4 will be set instead of the default 8. With this patch I get about 3x performance on an Intel Core Ultra 7 256 machine, utilizing integrated graphics that would be otherwise not found. Please integrate this patch in portage.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
