### PR TITLE
install-qa-check.d/60cargo-eclass: more minimum version checks

### DIFF
--- a/metadata/install-qa-check.d/60cargo-eclass
+++ b/metadata/install-qa-check.d/60cargo-eclass
@@ -15,7 +15,7 @@ cargo_ver_check() {
 
 	# Maximum value for "edition" across Cargo.toml files
 	local cargo_toml_edition=$(
-		find "${S}" -name Cargo.toml -exec sed -n -e 's/^\s*edition\s*=\s*"\([0-9]*\)"\s*$/\1/p' {} \+ |
+		find "${WORKDIR}" -name Cargo.toml -exec sed -n -e 's/^\s*edition\s*=\s*"\([0-9]*\)"\s*$/\1/p' {} \+ |
 		sort -n |
 		tail -n 1
 	)

--- a/metadata/install-qa-check.d/60cargo-eclass
+++ b/metadata/install-qa-check.d/60cargo-eclass
@@ -28,6 +28,19 @@ cargo_ver_check() {
 			eqawarn
 		fi
 	fi
+
+	# Maximum value for "rust-version" across Cargo.toml files
+	local cargo_toml_rust_version=$(
+		find "${WORKDIR}" -name Cargo.toml -exec sed -n -e 's/^\s*rust-version\s*=\s*"\([0-9.]*\)"\s*$/\1/p' {} \+ |
+		sort -V |
+		tail -n 1
+	)
+	if [[ -n ${cargo_toml_rust_version} ]] && ver_test "${RUST_MIN_VER:-0}" -lt "${cargo_toml_rust_version}"; then
+		eqawarn
+		eqawarn "QA Notice: found Cargo.toml file which specifies rust-version=\"${cargo_toml_rust_version}\""
+		eqawarn "which requires RUST_MIN_VER=\"${cargo_toml_rust_version}\""
+		eqawarn
+	fi
 }
 
 cargo_ver_check


### PR DESCRIPTION
@gentoo/rust 

I've changed it to scan over `${WORKDIR}` instead of `${S}`. 

> 
> There is a possibility that the current packages uses dependencies which require a newer version of Rust than the one listed in ${S}. For those cases, scan over the full ${WORKDIR} directory tree instead of just ${S}.
> 
> Maybe it will introduce false positives, for crates which are included but not used during real compilation, but it is better than missing a dependency which requires a newer version of Rust.

check min verison for 'rust-version='

> Another way Cargo.toml can specify the minimum Rust version is using the 'rust-version=' field. This commit adds a check for that field, and updates the required minimum Rust version accordingly.