### PR TITLE
sys-apps/xinetd: pass -std=gnu17 for gcc15

### DIFF
--- a/sys-apps/xinetd/xinetd-2.3.15.4-r1.ebuild
+++ b/sys-apps/xinetd/xinetd-2.3.15.4-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools systemd
+inherit autotools flag-o-matic systemd
 
 DESCRIPTION="Powerful replacement for inetd"
 HOMEPAGE="https://github.com/xinetd-org/xinetd https://github.com/openSUSE/xinetd"
@@ -41,6 +41,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# bug #943856
+	append-cflags -std=gnu17
+
 	econf \
 		$(use_with tcpd libwrap) \
 		$(use_with selinux labeled-networking) \


### PR DESCRIPTION
While waiting for an unlikely upstream fix.

Closes: https://bugs.gentoo.org/943856

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
