### PR TITLE
[Fix] Kernel version and .config file not detected when present. linu…

### DIFF
--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -546,6 +546,12 @@ get_version() {
 	KV_MINOR=$(getfilevar PATCHLEVEL "${KERNEL_MAKEFILE}")
 	KV_PATCH=$(getfilevar SUBLEVEL "${KERNEL_MAKEFILE}")
 	KV_EXTRA=$(getfilevar EXTRAVERSION "${KERNEL_MAKEFILE}")
+	if [[ -z "${KV_MAJOR}" || -z "${KV_MINOR}" || -z "${KV_PATCH}" ]]; then
+		KV_MAJOR=$(getfilevar_noexec VERSION "${KERNEL_MAKEFILE}")
+		KV_MINOR=$(getfilevar_noexec PATCHLEVEL "${KERNEL_MAKEFILE}")
+		KV_PATCH=$(getfilevar_noexec SUBLEVEL "${KERNEL_MAKEFILE}")
+		KV_EXTRA=$(getfilevar_noexec EXTRAVERSION "${KERNEL_MAKEFILE}")
+	fi
 
 	if [[ -z "${KV_MAJOR}" || -z "${KV_MINOR}" || -z "${KV_PATCH}" ]]; then
 		if [[ -z "${get_version_warning_done}" ]]; then


### PR DESCRIPTION
Bug 959228  
file linux-info.eclass 



Steps to Reproduce:
1. install newer version of gentoo-sources Linux kernel
2. emerge apprmor that have inherit linux-info.eclass in Ebuild
3. at setup or prepare phase it can't detect version when Makefile exist and folder /usr/src/linux
Actual Results:  
 * Determining the location of the kernel source code
 * Found kernel source directory:
 *     /usr/src/linux
/usr/src/linux/Makefile major  minor  patch  done
 * Could not detect kernel version.
 * Please ensure that /usr/src/linux points to a complete set of Linux sources.
 * Unable to calculate Linux Kernel version for build, attempting to use running version
 * Could not find a neither a usable .config in the kernel source directory
 * nor a /proc/config.gz file,
 * Please ensure that /usr/src/linux points to a configured set of Linux sources.
 * If you are using KBUILD_OUTPUT, please set the environment var so that
 * it points to the necessary object directory so that it might find .config


Expected Results:  
success in kernel version and .config file detection

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
