### PR TITLE
cmake.eclass: Keep myctestargs local

### DIFF
--- a/eclass/cmake.eclass
+++ b/eclass/cmake.eclass
@@ -761,12 +761,13 @@ cmake_src_test() {
 	pushd "${BUILD_DIR}" > /dev/null || die
 	[[ -e CTestTestfile.cmake ]] || { echo "No tests found. Skipping."; return 0 ; }
 
-	[[ -n ${TEST_VERBOSE} ]] && myctestargs+=( --extra-verbose --output-on-failure )
-	[[ -n ${CMAKE_SKIP_TESTS} ]] && myctestargs+=( -E '('$( IFS='|'; echo "${CMAKE_SKIP_TESTS[*]}")')'  )
+	local myctestargs_local=( "${myctestargs[@]}" )
+	[[ -n ${TEST_VERBOSE} ]] && myctestargs_local+=( --extra-verbose --output-on-failure )
+	[[ -n ${CMAKE_SKIP_TESTS} ]] && myctestargs_local+=( -E '('$( IFS='|'; echo "${CMAKE_SKIP_TESTS[*]}")')'  )
 
 	set -- ctest -j "${CTEST_JOBS:-$(get_makeopts_jobs 999)}" \
 		--test-load "${CTEST_LOADAVG:-$(get_makeopts_loadavg)}" \
-		"${myctestargs[@]}" "$@"
+		"${myctestargs_local[@]}" "$@"
 	echo "$@" >&2
 	if "$@" ; then
 		einfo "Tests succeeded."


### PR DESCRIPTION
When an ebuild calls cmake_src_test multiple times the function could internally modify myctestargs which will then be picked up by consequent invocations, leading to ctest being passed arguments from all previous cmake_src_test calls.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
