### PR TITLE
Patch 5.12.3 for qt6.9 filename changes

### DIFF
--- a/net-im/telegram-desktop/files/tdesktop-5.12.3-qt-namechange.patch
+++ b/net-im/telegram-desktop/files/tdesktop-5.12.3-qt-namechange.patch
@@ -1,0 +1,30 @@
+Qt 6.9.0 has renamed a couple of files, meaning telegram-desktop fails to build
+
+https://bugs.gentoo.org/959247
+
+--- tdesktop-5.12.3-full/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp	2025-06-29 10:42:13.725912379 +0100
++++ tdesktop-5.12.3-full-new/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp	2025-06-29 10:52:41.097335188 +0100
+@@ -16,7 +16,11 @@
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+ #include <qpa/qplatformintegration.h>
+ #include <private/qguiapplication_p.h>
++#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
++#include <private/qdesktopunixservices_p.h>
++#else
+ #include <private/qgenericunixservices_p.h>
++#endif // Qt >= 6.9.0
+ #endif // Qt >= 6.5.0
+ 
+ #include <sstream>
+@@ -39,7 +43,11 @@
+ 	}
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
++#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
++  if (const auto services = dynamic_cast<QDesktopUnixServices*>(
++#else
+ 	if (const auto services = dynamic_cast<QGenericUnixServices*>(
++#endif // Qt >= 6.9.0
+ 			QGuiApplicationPrivate::platformIntegration()->services())) {
+ 		return services->portalWindowIdentifier(window).toStdString();
+ 	}

--- a/net-im/telegram-desktop/telegram-desktop-5.12.3-r6.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-5.12.3-r6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=(python3_{11..13})
 
 inherit xdg cmake python-any-r1 optfeature flag-o-matic
 
@@ -81,6 +81,7 @@ PATCHES=(
 	"${FILESDIR}"/tdesktop-5.7.2-cstring.patch
 	"${FILESDIR}"/tdesktop-5.8.3-cstdint.patch
 	"${FILESDIR}"/tdesktop-5.12.3-fix-webview.patch
+	"${FILESDIR}"/tdesktop-5.12.3-qt-namechange.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Qt-6.9.0 changes some filenames, and as a result, building with Qt6.9 fails. This pull request fixes that problem.

Bug: https://bugs.gentoo.org/959247

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
