### PR TITLE
sys-libs/binutils-libs: add explicit texinfo dep

### DIFF
--- a/sys-libs/binutils-libs/binutils-libs-2.44-r2.ebuild
+++ b/sys-libs/binutils-libs/binutils-libs-2.44-r2.ebuild
@@ -44,6 +44,7 @@ fi
 BDEPEND="
 	nls? ( sys-devel/gettext )
 	test? ( dev-util/dejagnu )
+	sys-apps/texinfo
 "
 DEPEND="sys-libs/zlib[${MULTILIB_USEDEP}]"
 # Need a newer binutils-config that'll reset include/lib symlinks for us.

--- a/sys-libs/binutils-libs/binutils-libs-9999.ebuild
+++ b/sys-libs/binutils-libs/binutils-libs-9999.ebuild
@@ -44,6 +44,7 @@ fi
 BDEPEND="
 	nls? ( sys-devel/gettext )
 	test? ( dev-util/dejagnu )
+	sys-apps/texinfo
 "
 DEPEND="sys-libs/zlib[${MULTILIB_USEDEP}]"
 # Need a newer binutils-config that'll reset include/lib symlinks for us.


### PR DESCRIPTION
This makes the binutils-libs match the binutils ebuild since they both require the makeinfo command.

Fixes build failures like the following in certain situations where the implicit dep is not present:
"QA Notice: command not found:
     missing: line 81: makeinfo: command not found"

Closes: https://bugs.gentoo.org/955546

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
