### PR TITLE
net-p2p/deluge: use `EPYTEST_PLUGINS`

### DIFF
--- a/net-p2p/deluge/deluge-2.1.1-r5.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,13 +29,7 @@ REQUIRED_USE="
 
 BDEPEND="
 	dev-util/intltool
-	test? (
-		$(python_gen_cond_dep '
-			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
-		')
-	)
 "
-
 RDEPEND="
 	acct-group/deluge
 	acct-user/deluge
@@ -68,6 +62,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-consoleui-deferred.patch"
 )
 
+EPYTEST_PLUGINS=( pytest-twisted )
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -109,8 +104,7 @@ python_test() {
 		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
 	)
 
-	# dev-python/pytest-twisted has disabled autoloading
-	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+	epytest -m "not (todo or gtkui)" -v
 }
 
 python_install_all() {
@@ -118,7 +112,7 @@ python_install_all() {
 	if ! use console ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
 		rm "${ED}/usr/bin/deluge-console" || die
-		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" || die
 	fi
 	if ! use gui ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die

--- a/net-p2p/deluge/deluge-2.1.1-r6.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r6.ebuild
@@ -29,13 +29,7 @@ REQUIRED_USE="
 
 BDEPEND="
 	dev-util/intltool
-	test? (
-		$(python_gen_cond_dep '
-			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
-		')
-	)
 "
-
 RDEPEND="
 	acct-group/deluge
 	acct-user/deluge
@@ -69,6 +63,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-email-module-replace.patch"
 )
 
+EPYTEST_PLUGINS=( pytest-twisted )
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -110,8 +105,7 @@ python_test() {
 		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
 	)
 
-	# dev-python/pytest-twisted has disabled autoloading
-	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+	epytest -m "not (todo or gtkui)" -v
 }
 
 python_install_all() {
@@ -119,7 +113,7 @@ python_install_all() {
 	if ! use console ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
 		rm "${ED}/usr/bin/deluge-console" || die
-		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" || die
 	fi
 	if ! use gui ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die

--- a/net-p2p/deluge/deluge-2.1.1-r7.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r7.ebuild
@@ -30,13 +30,7 @@ REQUIRED_USE="
 
 BDEPEND="
 	dev-util/intltool
-	test? (
-		$(python_gen_cond_dep '
-			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
-		')
-	)
 "
-
 RDEPEND="
 	acct-group/deluge
 	acct-user/deluge
@@ -73,6 +67,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-email-module-replace.patch"
 )
 
+EPYTEST_PLUGINS=( pytest-twisted )
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -114,8 +109,7 @@ python_test() {
 		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
 	)
 
-	# dev-python/pytest-twisted has disabled autoloading
-	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+	epytest -m "not (todo or gtkui)" -v
 }
 
 python_install_all() {
@@ -123,7 +117,7 @@ python_install_all() {
 	if ! use console ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
 		rm "${ED}/usr/bin/deluge-console" || die
-		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" || die
 	fi
 	if ! use gui ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die

--- a/net-p2p/deluge/deluge-2.2.0.ebuild
+++ b/net-p2p/deluge/deluge-2.2.0.ebuild
@@ -30,13 +30,7 @@ REQUIRED_USE="
 
 BDEPEND="
 	dev-util/intltool
-	test? (
-		$(python_gen_cond_dep '
-			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
-		')
-	)
 "
-
 RDEPEND="
 	acct-group/deluge
 	acct-user/deluge
@@ -64,6 +58,7 @@ RDEPEND="
 	)
 "
 
+EPYTEST_PLUGINS=( pytest-twisted )
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -105,8 +100,7 @@ python_test() {
 		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
 	)
 
-	# dev-python/pytest-twisted has disabled autoloading
-	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+	epytest -m "not (todo or gtkui)" -v
 }
 
 python_install_all() {
@@ -114,7 +108,7 @@ python_install_all() {
 	if ! use console ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
 		rm "${ED}/usr/bin/deluge-console" || die
-		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" || die
 	fi
 	if ! use gui ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -30,13 +30,7 @@ REQUIRED_USE="
 
 BDEPEND="
 	dev-util/intltool
-	test? (
-		$(python_gen_cond_dep '
-			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
-		')
-	)
 "
-
 RDEPEND="
 	acct-group/deluge
 	acct-user/deluge
@@ -64,6 +58,7 @@ RDEPEND="
 	)
 "
 
+EPYTEST_PLUGINS=( pytest-twisted )
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -105,8 +100,7 @@ python_test() {
 		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
 	)
 
-	# dev-python/pytest-twisted has disabled autoloading
-	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+	epytest -m "not (todo or gtkui)" -v
 }
 
 python_install_all() {
@@ -114,7 +108,7 @@ python_install_all() {
 	if ! use console ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
 		rm "${ED}/usr/bin/deluge-console" || die
-		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" || die
 	fi
 	if ! use gui ; then
 		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die


### PR DESCRIPTION
See

- https://projects.gentoo.org/python/guide/pytest.html#controlling-pytest-plugins-used,
- https://devmanual.gentoo.org/eclass-reference/python-utils-r1.eclass/index.html (`EPYTEST_PLUGINS`).

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
