### PR TITLE
app-editors/gnome-text-editor: drop USE enchant

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,13 @@
 
 # New entries go on top.
 
+# Ivy <openrc@posteo.de> (2025-07-11)
+# app-editors/gnome-text-editor[spell] has been dropped upstream and
+# replaced with app-text/libspelling, but will likely be added back
+# in future releases.
+~app-editors/gnome-text-editor-47.2 spell
+~app-editors/gnome-text-editor-47.4 spell
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2025-06-27)
 # Prepare cleanup of kde-apps/cervisia
 kde-apps/kdesdk-meta cvs


### PR DESCRIPTION
This feature has been dropped since upstream commits [1] and [2] and was not needed in versions 47.2 and 47.4.

[1] https://gitlab.gnome.org/GNOME/gnome-text-editor/-/commit/7538b9a3dd27869c665e02a25f61ad623ab642b9
[2] https://gitlab.gnome.org/GNOME/gnome-text-editor/-/commit/908db71e4f6a7a2fbc2832bd3b54432e6cf95776

Closes: https://bugs.gentoo.org/959286

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
