### PR TITLE
media-libs/virglrenderer: wire up venus,vaapi,drm-renderers

### DIFF
--- a/media-libs/virglrenderer/metadata.xml
+++ b/media-libs/virglrenderer/metadata.xml
@@ -5,6 +5,9 @@
 		<email>virtualization@gentoo.org</email>
 		<name>Gentoo Virtualization Project</name>
 	</maintainer>
+	<use>
+		<flag name="venus">Enable Venus Virtio-GPU protocol</flag>
+	</use>
 	<upstream>
 		<remote-id type="freedesktop-gitlab">virgl/virglrenderer</remote-id>
 	</upstream>

--- a/media-libs/virglrenderer/virglrenderer-1.1.1-r1.ebuild
+++ b/media-libs/virglrenderer/virglrenderer-1.1.1-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://anongit.freedesktop.org/git/virglrenderer.git"
+	inherit git-r3
+else
+	MY_P="${PN}-${P}"
+	SRC_URI="https://gitlab.freedesktop.org/virgl/${PN}/-/archive/${P}/${MY_P}.tar.bz2"
+	S="${WORKDIR}/${MY_P}"
+
+	KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+fi
+
+DESCRIPTION="Library used implement a virtual 3D GPU used by qemu"
+HOMEPAGE="https://virgil3d.github.io/"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="static-libs test venus vaapi video_cards_amdgpu video_cards_freedreno"
+# Most of the testsuite cannot run in our sandboxed environment, just don't
+# deal with it for now.
+RESTRICT="!test? ( test ) test"
+
+RDEPEND="
+	>=x11-libs/libdrm-2.4.121
+	media-libs/libepoxy
+	venus? ( media-libs/vulkan-loader )
+	vaapi? ( media-libs/libva:= )
+"
+DEPEND="
+	${RDEPEND}
+	sys-kernel/linux-headers
+"
+
+src_configure() {
+	local -a gpus=()
+	use video_cards_amdgpu && gpus+=( amdgpu-experimental )
+	use video_cards_freedreno && gpus+=( msm )
+
+	local emesonargs=(
+		-Ddefault_library=$(usex static-libs both shared)
+		-Ddrm-renderers=$(IFS=,; echo "${gpus[*]}")
+		$(meson_use test tests)
+		$(meson_use venus)
+		$(meson_use vaapi video)
+	)
+
+	meson_src_configure
+}

--- a/media-libs/virglrenderer/virglrenderer-9999.ebuild
+++ b/media-libs/virglrenderer/virglrenderer-9999.ebuild
@@ -21,7 +21,7 @@ HOMEPAGE="https://virgil3d.github.io/"
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="static-libs test"
+IUSE="static-libs test venus vaapi video_cards_amdgpu video_cards_asahi video_cards_freedreno"
 # Most of the testsuite cannot run in our sandboxed environment, just don't
 # deal with it for now.
 RESTRICT="!test? ( test ) test"
@@ -29,6 +29,8 @@ RESTRICT="!test? ( test ) test"
 RDEPEND="
 	>=x11-libs/libdrm-2.4.121
 	media-libs/libepoxy
+	venus? ( media-libs/vulkan-loader )
+	vaapi? ( media-libs/libva:= )
 "
 DEPEND="
 	${RDEPEND}
@@ -36,10 +38,17 @@ DEPEND="
 "
 
 src_configure() {
+	local -a gpus=()
+	use video_cards_amdgpu && gpus+=( amdgpu-experimental )
+	use video_cards_asahi && gpus+=( asahi )
+	use video_cards_freedreno && gpus+=( msm )
+
 	local emesonargs=(
-		# TODO: Wire up drm-renderers= (msm, amdgpu-experimental as of 1.1.1)
 		-Ddefault_library=$(usex static-libs both shared)
+		-Ddrm-renderers=$(IFS=,; echo "${gpus[*]}")
 		$(meson_use test tests)
+		$(meson_use venus)
+		$(meson_use vaapi video)
 	)
 
 	meson_src_configure


### PR DESCRIPTION
![20250630_20h33m47s_grim](https://github.com/user-attachments/assets/b4e8e137-fa46-43c6-bc4d-e4f45302c909)

Honestly, that's pretty wild. I didn't expect this would work basically out of the box.
Playing a game inside a virtual machine without any gpu passthrough with basically host performance :)


This PR updates `media-libs/virglrenderer` to enable `venus`, `vaapi` and `drm-renderers`.

So far i only tested the `venus` and ` vaapi` part. `venus` works amazingly well (as seen in the screenshot).
`vaapi` does _something_. `vainfo` for example shows following:
```
Trying display: wayland
libva info: VA-API version 1.22.0
libva info: Trying to open /usr/lib64/va/drivers/virtio_gpu_drv_video.so
libva info: Found init function __vaDriverInit_1_22
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Mesa Gallium driver 25.1.4 for virgl (AMD Radeon RX 7900 XTX (radeonsi, navi31, LLVM 20.1....)
vainfo: Supported profile and entrypoints
      VAProfileNone                   : VAEntrypointVideoProc
```
and `mpv` doesn't seem to use vaapi when requested.

For the `drm-renderers` i have no idea how to test them. I'm not even sure if i got it correctly. `amdgpu-experimental` certainly referenced to the amdgpu driver. `msm` should be `freedreno` but i'm not really sure here.

