### PR TITLE
dev-lang/ruby: fix build issue with gcc15

### DIFF
--- a/dev-lang/ruby/files/3.2/017-socket-add-full-prototype.patch
+++ b/dev-lang/ruby/files/3.2/017-socket-add-full-prototype.patch
@@ -1,0 +1,48 @@
+https://github.com/ruby/ruby/commit/d77e02bd85ab7f841df8d473bac214b9a92a3506
+
+From d77e02bd85ab7f841df8d473bac214b9a92a3506 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Wed, 2 Jul 2025 09:09:52 +0800
+Subject: [PATCH] [Bug #21497] [ruby/socket]: add full prototype
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+otherwise, gcc 15 will complain:
+
+> init.c:573:19: error: too many arguments to function ‘Rconnect’; expected 0, have 3
+>   573 |     return (VALUE)Rconnect(arg->fd, arg->sockaddr, arg->len);
+>       |                   ^~~~~~~~ ~~~~~~~
+> In file included from init.c:11:
+> rubysocket.h:294:5: note: declared here
+>   294 | int Rconnect();
+>       |     ^~~~~~~~
+
+> sockssocket.c:33:9: error: too many arguments to function ‘SOCKSinit’; expected 0, have 1
+>    33 |         SOCKSinit("ruby");
+>       |         ^~~~~~~~~ ~~~~~~
+> In file included from sockssocket.c:11:
+> rubysocket.h:293:6: note: declared here
+>   293 | void SOCKSinit();
+>       |      ^~~~~~~~~
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/ext/socket/rubysocket.h b/ext/socket/rubysocket.h
+index 54a5381da4..dcafbe24e3 100644
+--- a/ext/socket/rubysocket.h
++++ b/ext/socket/rubysocket.h
+@@ -292,8 +292,8 @@ extern VALUE rb_eResolution;
+ #ifdef SOCKS
+ extern VALUE rb_cSOCKSSocket;
+ #  ifndef SOCKS5
+-void SOCKSinit();
+-int Rconnect();
++void SOCKSinit(char *);
++int Rconnect(int, const struct sockaddr *, socklen_t);
+ #  endif
+ #endif
+ 
+-- 
+2.49.1
+

--- a/dev-lang/ruby/files/3.3/015-strscan-update-extconf.rb.patch
+++ b/dev-lang/ruby/files/3.3/015-strscan-update-extconf.rb.patch
@@ -1,0 +1,29 @@
+From 4585ccd90f4251f4d42bfc338a5e14100236fa15 Mon Sep 17 00:00:00 2001
+From: Nobuyoshi Nakada <nobu@ruby-lang.org>
+Date: Thu, 12 Jun 2025 10:32:49 +0900
+Subject: [PATCH] [ruby/strscan] Update extconf.rb
+ (https://github.com/ruby/strscan/pull/158)
+
+- `have_func` includes "ruby.h" by default.
+- include "ruby/re.h" where `rb_reg_onig_match` is declared.
+
+https://github.com/ruby/strscan/commit/1ac96f47e9
+
+diff --git a/ext/strscan/extconf.rb b/ext/strscan/extconf.rb
+index bd65606a4e..abcbdb3ad2 100644
+--- a/ext/strscan/extconf.rb
++++ b/ext/strscan/extconf.rb
+@@ -2,8 +2,8 @@
+ require 'mkmf'
+ if RUBY_ENGINE == 'ruby'
+   $INCFLAGS << " -I$(top_srcdir)" if $extmk
+-  have_func("onig_region_memsize", "ruby.h")
+-  have_func("rb_reg_onig_match", "ruby.h")
++  have_func("onig_region_memsize")
++  have_func("rb_reg_onig_match", "ruby/re.h")
+   create_makefile 'strscan'
+ else
+   File.write('Makefile', dummy_makefile("").join)
+-- 
+2.45.2
+

--- a/dev-lang/ruby/files/3.3/016-io-console-add-header-ruby-io.h.patch
+++ b/dev-lang/ruby/files/3.3/016-io-console-add-header-ruby-io.h.patch
@@ -1,0 +1,58 @@
+had been fixed by upstream in commit
+
+https://github.com/ruby/io-console/commit/dd013030dd276a7372df34cf43ada1c14d0cbc21
+
+This patch is a cherry picked version.
+
+From 3226f1e3cc4787d4a00e639ff763a8b4cfcd5cdd Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Sun, 29 Jun 2025 21:41:42 +0800
+Subject: [PATCH 1/2] [ruby/io-console]: add header "ruby/io.h" for rb_io_*
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+otherwise, when compiling using gcc 15 with "-flto
+-Werror=lto-type-mismatch", ext/io/console/extconf.h will have:
+
+> #define HAVE_RB_IO_PATH 1
+> #define HAVE_RB_IO_DESCRIPTOR 1
+> #define HAVE_RB_IO_GET_WRITE_IO 1
+> #define HAVE_RB_IO_CLOSED_P 1
+> #define HAVE_RB_IO_OPEN_DESCRIPTOR 1
+
+the build is failed with:
+
+> console.c:1417:1: error: static declaration of ‘rb_io_closed_p’ follows non-static declaration
+>  1417 | rb_io_closed_p(VALUE io)
+>       | ^~~~~~~~~~~~~~
+> ../../.././include/ruby/io.h:385:7: note: previous declaration of ‘rb_io_closed_p’ with type ‘VALUE(VALUE)’ {aka ‘long unsigned int(long unsigned int)’}
+>   385 | VALUE rb_io_closed_p(VALUE io);
+>       |       ^~~~~~~~~~~~~~
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/ext/io/console/extconf.rb b/ext/io/console/extconf.rb
+index 4ad7ed6996..dd3d221ae5 100644
+--- a/ext/io/console/extconf.rb
++++ b/ext/io/console/extconf.rb
+@@ -6,11 +6,11 @@
+ rescue
+ end
+ 
+-have_func("rb_io_path")
+-have_func("rb_io_descriptor")
+-have_func("rb_io_get_write_io")
+-have_func("rb_io_closed_p")
+-have_func("rb_io_open_descriptor")
++have_func("rb_io_path", "ruby/io.h")
++have_func("rb_io_descriptor", "ruby/io.h")
++have_func("rb_io_get_write_io", "ruby/io.h")
++have_func("rb_io_closed_p", "ruby/io.h")
++have_func("rb_io_open_descriptor", "ruby/io.h")
+ 
+ ok = true if RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
+ hdr = nil
+-- 
+2.45.2
+

--- a/dev-lang/ruby/files/3.3/017-socket-add-full-prototype.patch
+++ b/dev-lang/ruby/files/3.3/017-socket-add-full-prototype.patch
@@ -1,0 +1,48 @@
+https://github.com/ruby/ruby/commit/d77e02bd85ab7f841df8d473bac214b9a92a3506
+
+From d77e02bd85ab7f841df8d473bac214b9a92a3506 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Wed, 2 Jul 2025 09:09:52 +0800
+Subject: [PATCH] [Bug #21497] [ruby/socket]: add full prototype
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+otherwise, gcc 15 will complain:
+
+> init.c:573:19: error: too many arguments to function ‘Rconnect’; expected 0, have 3
+>   573 |     return (VALUE)Rconnect(arg->fd, arg->sockaddr, arg->len);
+>       |                   ^~~~~~~~ ~~~~~~~
+> In file included from init.c:11:
+> rubysocket.h:294:5: note: declared here
+>   294 | int Rconnect();
+>       |     ^~~~~~~~
+
+> sockssocket.c:33:9: error: too many arguments to function ‘SOCKSinit’; expected 0, have 1
+>    33 |         SOCKSinit("ruby");
+>       |         ^~~~~~~~~ ~~~~~~
+> In file included from sockssocket.c:11:
+> rubysocket.h:293:6: note: declared here
+>   293 | void SOCKSinit();
+>       |      ^~~~~~~~~
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/ext/socket/rubysocket.h b/ext/socket/rubysocket.h
+index 54a5381da4..dcafbe24e3 100644
+--- a/ext/socket/rubysocket.h
++++ b/ext/socket/rubysocket.h
+@@ -292,8 +292,8 @@ extern VALUE rb_eResolution;
+ #ifdef SOCKS
+ extern VALUE rb_cSOCKSSocket;
+ #  ifndef SOCKS5
+-void SOCKSinit();
+-int Rconnect();
++void SOCKSinit(char *);
++int Rconnect(int, const struct sockaddr *, socklen_t);
+ #  endif
+ #endif
+ 
+-- 
+2.49.1
+

--- a/dev-lang/ruby/files/3.4/015-strscan-update-extconf.rb.patch
+++ b/dev-lang/ruby/files/3.4/015-strscan-update-extconf.rb.patch
@@ -1,0 +1,29 @@
+From 4585ccd90f4251f4d42bfc338a5e14100236fa15 Mon Sep 17 00:00:00 2001
+From: Nobuyoshi Nakada <nobu@ruby-lang.org>
+Date: Thu, 12 Jun 2025 10:32:49 +0900
+Subject: [PATCH] [ruby/strscan] Update extconf.rb
+ (https://github.com/ruby/strscan/pull/158)
+
+- `have_func` includes "ruby.h" by default.
+- include "ruby/re.h" where `rb_reg_onig_match` is declared.
+
+https://github.com/ruby/strscan/commit/1ac96f47e9
+
+diff --git a/ext/strscan/extconf.rb b/ext/strscan/extconf.rb
+index bd65606a4e..abcbdb3ad2 100644
+--- a/ext/strscan/extconf.rb
++++ b/ext/strscan/extconf.rb
+@@ -2,8 +2,8 @@
+ require 'mkmf'
+ if RUBY_ENGINE == 'ruby'
+   $INCFLAGS << " -I$(top_srcdir)" if $extmk
+-  have_func("onig_region_memsize", "ruby.h")
+-  have_func("rb_reg_onig_match", "ruby.h")
++  have_func("onig_region_memsize")
++  have_func("rb_reg_onig_match", "ruby/re.h")
+   create_makefile 'strscan'
+ else
+   File.write('Makefile', dummy_makefile("").join)
+-- 
+2.45.2
+

--- a/dev-lang/ruby/files/3.4/016-io-console-add-header-ruby-io.h.patch
+++ b/dev-lang/ruby/files/3.4/016-io-console-add-header-ruby-io.h.patch
@@ -1,0 +1,58 @@
+had been fixed by upstream in commit
+
+https://github.com/ruby/io-console/commit/dd013030dd276a7372df34cf43ada1c14d0cbc21
+
+This patch is a cherry picked version.
+
+From 3226f1e3cc4787d4a00e639ff763a8b4cfcd5cdd Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Sun, 29 Jun 2025 21:41:42 +0800
+Subject: [PATCH 1/2] [ruby/io-console]: add header "ruby/io.h" for rb_io_*
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+otherwise, when compiling using gcc 15 with "-flto
+-Werror=lto-type-mismatch", ext/io/console/extconf.h will have:
+
+> #define HAVE_RB_IO_PATH 1
+> #define HAVE_RB_IO_DESCRIPTOR 1
+> #define HAVE_RB_IO_GET_WRITE_IO 1
+> #define HAVE_RB_IO_CLOSED_P 1
+> #define HAVE_RB_IO_OPEN_DESCRIPTOR 1
+
+the build is failed with:
+
+> console.c:1417:1: error: static declaration of ‘rb_io_closed_p’ follows non-static declaration
+>  1417 | rb_io_closed_p(VALUE io)
+>       | ^~~~~~~~~~~~~~
+> ../../.././include/ruby/io.h:385:7: note: previous declaration of ‘rb_io_closed_p’ with type ‘VALUE(VALUE)’ {aka ‘long unsigned int(long unsigned int)’}
+>   385 | VALUE rb_io_closed_p(VALUE io);
+>       |       ^~~~~~~~~~~~~~
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/ext/io/console/extconf.rb b/ext/io/console/extconf.rb
+index 4ad7ed6996..dd3d221ae5 100644
+--- a/ext/io/console/extconf.rb
++++ b/ext/io/console/extconf.rb
+@@ -10,11 +10,11 @@
+   abort
+
+ have_func("rb_interned_str_cstr")
+-have_func("rb_io_path")
+-have_func("rb_io_descriptor")
+-have_func("rb_io_get_write_io")
+-have_func("rb_io_closed_p")
+-have_func("rb_io_open_descriptor")
++have_func("rb_io_path", "ruby/io.h")
++have_func("rb_io_descriptor", "ruby/io.h")
++have_func("rb_io_get_write_io", "ruby/io.h")
++have_func("rb_io_closed_p", "ruby/io.h")
++have_func("rb_io_open_descriptor", "ruby/io.h")
+ have_func("rb_ractor_local_storage_value_newkey")
+ 
+ is_wasi = /wasi/ =~ MakeMakefile::RbConfig::CONFIG["platform"]
+-- 
+2.45.2
+

--- a/dev-lang/ruby/files/3.4/017-socket-add-full-prototype.patch
+++ b/dev-lang/ruby/files/3.4/017-socket-add-full-prototype.patch
@@ -1,0 +1,48 @@
+https://github.com/ruby/ruby/commit/d77e02bd85ab7f841df8d473bac214b9a92a3506
+
+From d77e02bd85ab7f841df8d473bac214b9a92a3506 Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Wed, 2 Jul 2025 09:09:52 +0800
+Subject: [PATCH] [Bug #21497] [ruby/socket]: add full prototype
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+otherwise, gcc 15 will complain:
+
+> init.c:573:19: error: too many arguments to function ‘Rconnect’; expected 0, have 3
+>   573 |     return (VALUE)Rconnect(arg->fd, arg->sockaddr, arg->len);
+>       |                   ^~~~~~~~ ~~~~~~~
+> In file included from init.c:11:
+> rubysocket.h:294:5: note: declared here
+>   294 | int Rconnect();
+>       |     ^~~~~~~~
+
+> sockssocket.c:33:9: error: too many arguments to function ‘SOCKSinit’; expected 0, have 1
+>    33 |         SOCKSinit("ruby");
+>       |         ^~~~~~~~~ ~~~~~~
+> In file included from sockssocket.c:11:
+> rubysocket.h:293:6: note: declared here
+>   293 | void SOCKSinit();
+>       |      ^~~~~~~~~
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+
+diff --git a/ext/socket/rubysocket.h b/ext/socket/rubysocket.h
+index 54a5381da4..dcafbe24e3 100644
+--- a/ext/socket/rubysocket.h
++++ b/ext/socket/rubysocket.h
+@@ -292,8 +292,8 @@ extern VALUE rb_eResolution;
+ #ifdef SOCKS
+ extern VALUE rb_cSOCKSSocket;
+ #  ifndef SOCKS5
+-void SOCKSinit();
+-int Rconnect();
++void SOCKSinit(char *);
++int Rconnect(int, const struct sockaddr *, socklen_t);
+ #  endif
+ #endif
+ 
+-- 
+2.49.1
+

--- a/dev-lang/ruby/ruby-3.2.7.ebuild
+++ b/dev-lang/ruby/ruby-3.2.7.ebuild
@@ -86,6 +86,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/011*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/013*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/017*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/902*.patch
 
 	if use elibc_musl ; then
@@ -157,9 +158,6 @@ src_configure() {
 	# In many places aliasing rules are broken; play it safe
 	# as it's risky with newer compilers to leave it as it is.
 	append-flags -fno-strict-aliasing
-	# Avoid a compile error with certain USE flag combinations when
-	# using std=gnu23, bug #945643 and bug #945502
-	append-cflags -std=gnu17
 
 	# Workaround for bug #938302
 	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then

--- a/dev-lang/ruby/ruby-3.2.8.ebuild
+++ b/dev-lang/ruby/ruby-3.2.8.ebuild
@@ -86,6 +86,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/011*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/013*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/017*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/902*.patch
 
 	if use elibc_musl ; then
@@ -164,9 +165,6 @@ src_configure() {
 	# In many places aliasing rules are broken; play it safe
 	# as it's risky with newer compilers to leave it as it is.
 	append-flags -fno-strict-aliasing
-	# Avoid a compile error with certain USE flag combinations when
-	# using std=gnu23, bug #945643 and bug #945502
-	append-cflags -std=gnu17
 
 	# Workaround for bug #938302
 	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then

--- a/dev-lang/ruby/ruby-3.2.9.ebuild
+++ b/dev-lang/ruby/ruby-3.2.9.ebuild
@@ -86,6 +86,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/011*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/013*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/017*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/902*.patch
 
 	if use elibc_musl ; then

--- a/dev-lang/ruby/ruby-3.3.8.ebuild
+++ b/dev-lang/ruby/ruby-3.3.8.ebuild
@@ -85,6 +85,9 @@ pkg_setup() {
 src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/013*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/015*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/016*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/017*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/902*.patch
 
 	if use elibc_musl ; then
@@ -161,9 +164,6 @@ src_configure() {
 	# In many places aliasing rules are broken; play it safe
 	# as it's risky with newer compilers to leave it as it is.
 	append-flags -fno-strict-aliasing
-	# Avoid a compile error with certain USE flag combinations when
-	# using std=gnu23, bug #945643 and bug #945502
-	append-cflags -std=gnu17
 
 	# Workaround for bug #938302
 	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then

--- a/dev-lang/ruby/ruby-3.4.4.ebuild
+++ b/dev-lang/ruby/ruby-3.4.4.ebuild
@@ -98,6 +98,9 @@ pkg_setup() {
 
 src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/015*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/016*.patch
+	eapply "${FILESDIR}"/"${SLOT}"/017*.patch
 	eapply "${FILESDIR}"/"${SLOT}"/902*.patch
 
 	if use elibc_musl ; then
@@ -175,9 +178,6 @@ src_configure() {
 	# In many places aliasing rules are broken; play it safe
 	# as it's risky with newer compilers to leave it as it is.
 	append-flags -fno-strict-aliasing
-	# Avoid a compile error with certain USE flag combinations when
-	# using std=gnu23, bug #945643 and bug #945502
-	append-cflags -std=gnu17
 
 	# Workaround for bug #938302
 	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then


### PR DESCRIPTION
1. if USE="socks5", full protoype is required by C23
2. if CFLAGS="-flto -Werror=lto-type-mismatch", and building with -std=c23 (default for gcc 15), build will fail with" "static declaration of ‘rb_io_closed_p’ follows non-static declaration"

Closes: https://bugs.gentoo.org/945502
Closes: https://bugs.gentoo.org/945643

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
