### PR TITLE
dev-python/twisted: restore IDEPEND typing-extensions

### DIFF
--- a/dev-python/twisted/twisted-24.11.0-r1.ebuild
+++ b/dev-python/twisted/twisted-24.11.0-r1.ebuild
@@ -56,6 +56,7 @@ RDEPEND="
 IDEPEND="
 	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
 	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
+	>=dev-python/typing-extensions-4.2.0[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/twisted/twisted-25.5.0.ebuild
+++ b/dev-python/twisted/twisted-25.5.0.ebuild
@@ -59,6 +59,7 @@ RDEPEND="
 IDEPEND="
 	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
 	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
+	>=dev-python/typing-extensions-4.2.0[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/twisted/twisted-25.5.0_rc1.ebuild
+++ b/dev-python/twisted/twisted-25.5.0_rc1.ebuild
@@ -58,6 +58,7 @@ RDEPEND="
 IDEPEND="
 	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
 	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
+	>=dev-python/typing-extensions-4.2.0[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="


### PR DESCRIPTION
restore IDEPEND on typing-extensions because twisted-regen-cache still runs at install time and imports from typing-extensions

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
