### PR TITLE
net-nds/openldap: USE=iodbc requires USE=odbc

### DIFF
--- a/net-nds/openldap/openldap-2.6.8-r1.ebuild
+++ b/net-nds/openldap/openldap-2.6.8-r1.ebuild
@@ -36,6 +36,7 @@ IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
 REQUIRED_USE="
 	cxx? ( sasl )
+	iodbc? ( odbc )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl debug )
 	autoca? ( !gnutls )

--- a/net-nds/openldap/openldap-2.6.9.ebuild
+++ b/net-nds/openldap/openldap-2.6.9.ebuild
@@ -38,6 +38,7 @@ IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
 REQUIRED_USE="
 	cxx? ( sasl )
+	iodbc? ( odbc )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl debug )
 	autoca? ( !gnutls )


### PR DESCRIPTION
When USE=iodbc is selected without USE=odbc, current logic silently ignore ODBC USE flag and does not build any ODBC connector. This change introduce a requirement to set USE=odbc if USE=iodbc is selected.

Bug: https://bugs.gentoo.org/959391

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
