### PR TITLE
sys-libs/ncurses: Add tmux terminfo

### DIFF
--- a/sys-libs/ncurses/ncurses-6.5_p20241109-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20241109-r1.ebuild
@@ -22,7 +22,7 @@ SRC_URI="
 "
 
 GENTOO_PATCH_DEV=sam
-GENTOO_PATCH_PV=6.5_p20250301
+GENTOO_PATCH_PV=6.5_p20241109
 GENTOO_PATCH_NAME=${PN}-${GENTOO_PATCH_PV}-patches
 
 # Populated below in a loop. Do not add patches manually here.
@@ -68,23 +68,6 @@ if [[ ${PV} == *_p* ]] ; then
 		20241019
 		20241026
 		20241102
-		20241109
-		20241123
-		20241130
-		20241207
-		20241214
-		20241221
-		20241228
-		20250104
-		20250111
-		20250118
-		20250125
-		20250201
-		20250208
-		20250215
-		20250216
-		20250222
-		20250301
 
 		# Latest patch is just _pN = $(ver_cut 4)
 		$(ver_cut 4)
@@ -126,12 +109,9 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="MIT"
 # The subslot reflects the SONAME.
 SLOT="0/6"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="ada +cxx debug doc gpm minimal profile split-usr +stack-realign static-libs test tinfo trace"
-# In 6.5_p20250118, the C++ examples fail to link, but there's no automated
-# testsuite anyway. Controlling building examples isn't really what USE=test
-# is for. Just restrict them.
-RESTRICT="!test? ( test ) test"
+RESTRICT="!test? ( test )"
 
 # TODO: ncurses allows (and we take advantage of this, even) passing
 # the SONAME for dlopen() use, so only the header is needed at build time.
@@ -145,7 +125,6 @@ RDEPEND="
 	!<sys-libs/slang-2.3.2_pre23
 	!<x11-terms/rxvt-unicode-9.06-r3
 	!<x11-terms/st-0.6-r1
-	!minimal? ( !<x11-terms/ghostty-1.1.0 )
 "
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-thomasdickey )"
 
@@ -429,9 +408,10 @@ multilib_src_install_all() {
 		rxvt{,-unicode}{,-256color}
 		# xterm users are common, as is terminals re-using/spoofing it.
 		xterm xterm-{,256}color
-		# screen is common (and reused by tmux).
+		# screen and tmux are common.
 		screen{,-256color}
 		screen.xterm-256color
+		tmux{,-256color,-direct}
 	)
 	if use split-usr ; then
 		local x

--- a/sys-libs/ncurses/ncurses-6.5_p20250125-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250125-r1.ebuild
@@ -22,7 +22,7 @@ SRC_URI="
 "
 
 GENTOO_PATCH_DEV=sam
-GENTOO_PATCH_PV=6.5_p20250301
+GENTOO_PATCH_PV=6.5_p20250118
 GENTOO_PATCH_NAME=${PN}-${GENTOO_PATCH_PV}-patches
 
 # Populated below in a loop. Do not add patches manually here.
@@ -78,16 +78,6 @@ if [[ ${PV} == *_p* ]] ; then
 		20250104
 		20250111
 		20250118
-		20250125
-		20250201
-		20250208
-		20250215
-		20250216
-		20250222
-		20250301
-		20250308
-		20250315
-		20250322
 
 		# Latest patch is just _pN = $(ver_cut 4)
 		$(ver_cut 4)
@@ -129,7 +119,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="MIT"
 # The subslot reflects the SONAME.
 SLOT="0/6"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="ada +cxx debug doc gpm minimal profile split-usr +stack-realign static-libs test tinfo trace"
 # In 6.5_p20250118, the C++ examples fail to link, but there's no automated
 # testsuite anyway. Controlling building examples isn't really what USE=test
@@ -432,9 +422,10 @@ multilib_src_install_all() {
 		rxvt{,-unicode}{,-256color}
 		# xterm users are common, as is terminals re-using/spoofing it.
 		xterm xterm-{,256}color
-		# screen is common (and reused by tmux).
+		# screen and tmux are common.
 		screen{,-256color}
 		screen.xterm-256color
+		tmux{,-256color,-direct}
 	)
 	if use split-usr ; then
 		local x

--- a/sys-libs/ncurses/ncurses-6.5_p20250308-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250308-r1.ebuild
@@ -22,7 +22,7 @@ SRC_URI="
 "
 
 GENTOO_PATCH_DEV=sam
-GENTOO_PATCH_PV=6.5_p20250531
+GENTOO_PATCH_PV=6.5_p20250301
 GENTOO_PATCH_NAME=${PN}-${GENTOO_PATCH_PV}-patches
 
 # Populated below in a loop. Do not add patches manually here.
@@ -85,18 +85,6 @@ if [[ ${PV} == *_p* ]] ; then
 		20250216
 		20250222
 		20250301
-		20250308
-		20250315
-		20250322
-		20250329
-		20250405
-		20250412
-		20250419
-		20250426
-		20250503
-		20250510
-		20250517
-		20250524
 
 		# Latest patch is just _pN = $(ver_cut 4)
 		$(ver_cut 4)
@@ -200,6 +188,9 @@ src_configure() {
 
 	# bug #214642
 	BUILD_CPPFLAGS+=" -D_GNU_SOURCE"
+
+	# NCURSES_BOOL confusion, see https://lists.gnu.org/archive/html/bug-ncurses/2024-11/msg00010.html
+	append-cflags $(test-flags-CC -std=gnu17)
 
 	# Build the various variants of ncurses -- narrow, wide, and threaded. #510440
 	# Order matters here -- we want unicode/thread versions to come last so that the
@@ -438,9 +429,10 @@ multilib_src_install_all() {
 		rxvt{,-unicode}{,-256color}
 		# xterm users are common, as is terminals re-using/spoofing it.
 		xterm xterm-{,256}color
-		# screen is common (and reused by tmux).
+		# screen and tmux are common.
 		screen{,-256color}
 		screen.xterm-256color
+		tmux{,-256color,-direct}
 	)
 	if use split-usr ; then
 		local x

--- a/sys-libs/ncurses/ncurses-6.5_p20250329-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250329-r1.ebuild
@@ -22,7 +22,7 @@ SRC_URI="
 "
 
 GENTOO_PATCH_DEV=sam
-GENTOO_PATCH_PV=6.5_p20241109
+GENTOO_PATCH_PV=6.5_p20250301
 GENTOO_PATCH_NAME=${PN}-${GENTOO_PATCH_PV}-patches
 
 # Populated below in a loop. Do not add patches manually here.
@@ -68,6 +68,26 @@ if [[ ${PV} == *_p* ]] ; then
 		20241019
 		20241026
 		20241102
+		20241109
+		20241123
+		20241130
+		20241207
+		20241214
+		20241221
+		20241228
+		20250104
+		20250111
+		20250118
+		20250125
+		20250201
+		20250208
+		20250215
+		20250216
+		20250222
+		20250301
+		20250308
+		20250315
+		20250322
 
 		# Latest patch is just _pN = $(ver_cut 4)
 		$(ver_cut 4)
@@ -109,9 +129,12 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="MIT"
 # The subslot reflects the SONAME.
 SLOT="0/6"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="ada +cxx debug doc gpm minimal profile split-usr +stack-realign static-libs test tinfo trace"
-RESTRICT="!test? ( test )"
+# In 6.5_p20250118, the C++ examples fail to link, but there's no automated
+# testsuite anyway. Controlling building examples isn't really what USE=test
+# is for. Just restrict them.
+RESTRICT="!test? ( test ) test"
 
 # TODO: ncurses allows (and we take advantage of this, even) passing
 # the SONAME for dlopen() use, so only the header is needed at build time.
@@ -125,6 +148,7 @@ RDEPEND="
 	!<sys-libs/slang-2.3.2_pre23
 	!<x11-terms/rxvt-unicode-9.06-r3
 	!<x11-terms/st-0.6-r1
+	!minimal? ( !<x11-terms/ghostty-1.1.0 )
 "
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-thomasdickey )"
 
@@ -408,9 +432,10 @@ multilib_src_install_all() {
 		rxvt{,-unicode}{,-256color}
 		# xterm users are common, as is terminals re-using/spoofing it.
 		xterm xterm-{,256}color
-		# screen is common (and reused by tmux).
+		# screen and tmux are common.
 		screen{,-256color}
 		screen.xterm-256color
+		tmux{,-256color,-direct}
 	)
 	if use split-usr ; then
 		local x

--- a/sys-libs/ncurses/ncurses-6.5_p20250531-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250531-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,7 +22,7 @@ SRC_URI="
 "
 
 GENTOO_PATCH_DEV=sam
-GENTOO_PATCH_PV=6.4_p20240413
+GENTOO_PATCH_PV=6.5_p20250531
 GENTOO_PATCH_NAME=${PN}-${GENTOO_PATCH_PV}-patches
 
 # Populated below in a loop. Do not add patches manually here.
@@ -43,74 +43,60 @@ if [[ ${PV} == *_p* ]] ; then
 	# This array should contain a list of all the snapshots since the last
 	# release if there's no megapatch available yet.
 	PATCH_DATES=(
-		20230107
-		20230114
-		20230121
-		20230128
-		20230211
-		20230218
-		20230225
-		20230311
-		20230401
-		20230408
-		20230415
-		20230418
-		20230423
-		20230424
-		20230429
-		20230506
-		20230514
-		20230520
-		20230527
-		20230603
-		20230610
-		20230615
-		20230617
-		20230624
-		20230625
-		20230701
-		20230708
-		20230715
-		20230722
-		20230729
-		20230805
-		20230812
-		20230819
-		20230826
-		20230902
-		20230909
-		20230917
-		20230918
-		20230923
-		20231001
-		20231007
-		20231014
-		20231016
-		20231021
-		20231028
-		20231104
-		20231111
-		20231118
-		20231121
-		20231125
-		20231202
-		20231209
-		20231217
-		20231223
-		20231230
-		20240106
-		20240113
-		20240120
-		20240127
-		20240203
-		20240210
-		20240217
-		20240224
-		20240302
-		20240309
-		20240323
-		20240330
-		20240413
+		20240504
+		20240511
+		20240518
+		20240519
+		20240525
+		20240601
+		20240608
+		20240615
+		20240622
+		20240629
+		20240706
+		20240713
+		20240720
+		20240727
+		20240810
+		20240817
+		20240824
+		20240831
+		20240914
+		20240922
+		20240928
+		20241006
+		20241019
+		20241026
+		20241102
+		20241109
+		20241123
+		20241130
+		20241207
+		20241214
+		20241221
+		20241228
+		20250104
+		20250111
+		20250118
+		20250125
+		20250201
+		20250208
+		20250215
+		20250216
+		20250222
+		20250301
+		20250308
+		20250315
+		20250322
+		20250329
+		20250405
+		20250412
+		20250419
+		20250426
+		20250503
+		20250510
+		20250517
+		20250524
 
 		# Latest patch is just _pN = $(ver_cut 4)
 		$(ver_cut 4)
@@ -152,10 +138,17 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="MIT"
 # The subslot reflects the SONAME.
 SLOT="0/6"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="ada +cxx debug doc gpm minimal profile split-usr +stack-realign static-libs test tinfo trace"
-RESTRICT="!test? ( test )"
+# In 6.5_p20250118, the C++ examples fail to link, but there's no automated
+# testsuite anyway. Controlling building examples isn't really what USE=test
+# is for. Just restrict them.
+RESTRICT="!test? ( test ) test"
 
+# TODO: ncurses allows (and we take advantage of this, even) passing
+# the SONAME for dlopen() use, so only the header is needed at build time.
+# Maybe we should bundle a copy of gpm.h so we can move gpm to PDEPEND
+# which would be far nicer UX-wise.
 DEPEND="gpm? ( sys-libs/gpm[${MULTILIB_USEDEP}] )"
 # Block the older ncurses that installed all files w/SLOT=5, bug #557472
 RDEPEND="
@@ -164,6 +157,7 @@ RDEPEND="
 	!<sys-libs/slang-2.3.2_pre23
 	!<x11-terms/rxvt-unicode-9.06-r3
 	!<x11-terms/st-0.6-r1
+	!minimal? ( !<x11-terms/ghostty-1.1.0 )
 "
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-thomasdickey )"
 
@@ -178,10 +172,6 @@ PATCHES=(
 	# For the same reasons, please include the original configure.in changes,
 	# NOT just the generated results!
 	"${WORKDIR}"/${GENTOO_PATCH_NAME}
-
-	# Avoid breakage with CHOST ending in t64
-	"${FILESDIR}"/ncurses-6.4-t64-1.patch
-	"${FILESDIR}"/ncurses-6.4-t64-2.patch
 )
 
 src_unpack() {
@@ -288,6 +278,7 @@ do_configure() {
 
 		# Now the rest of the various standard flags.
 		--with-shared
+		--enable-fvisibility
 		# (Originally disabled until bug #245417 is sorted out, but now
 		# just keeping it off for good, given nobody needed it until now
 		# (2022) and we're trying to phase out bdb.)
@@ -301,7 +292,13 @@ do_configure() {
 		# The configure script uses ldd to parse the linked output which
 		# is flaky for cross-compiling/multilib/ldd versions/etc...
 		$(use_with gpm gpm libgpm.so.1)
-		--disable-term-driver
+
+		# bug #930806
+		--disable-setuid-environ
+		# TODO: Maybe do these for USE=hardened
+		#--disable-root-access
+		#--disable-root-environ
+
 		--disable-termcap
 		--enable-symlinks
 		--with-manpage-format=normal
@@ -322,6 +319,15 @@ do_configure() {
 		--disable-pkg-ldflags
 	)
 
+	case ${CHOST} in
+		*-mingw32*)
+			conf+=( --enable-term-driver )
+			;;
+		*)
+			conf+=( --disable-term-driver )
+			;;
+	esac
+
 	if [[ ${target} == ncurses*w ]] ; then
 		conf+=( --enable-widec )
 	else
@@ -330,15 +336,7 @@ do_configure() {
 	if [[ ${target} == ncursest* ]] ; then
 		conf+=( --with-{pthread,reentrant} )
 	else
-		conf+=(
-			--without-{pthread,reentrant}
-
-			# XXX: Revisit on next ABI break (>6) (bug #928873)
-			--disable-opaque-curses
-			--disable-opaque-form
-			--disable-opaque-menu
-			--disable-opaque-panel
-		)
+		conf+=( --without-{pthread,reentrant} )
 	fi
 
 	# Make sure each variant goes in a unique location.
@@ -440,9 +438,10 @@ multilib_src_install_all() {
 		rxvt{,-unicode}{,-256color}
 		# xterm users are common, as is terminals re-using/spoofing it.
 		xterm xterm-{,256}color
-		# screen is common (and reused by tmux).
+		# screen and tmux are common.
 		screen{,-256color}
 		screen.xterm-256color
+		tmux{,-256color,-direct}
 	)
 	if use split-usr ; then
 		local x


### PR DESCRIPTION
This fixes 'unknown terminal "tmux-256color"' errors.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
