### PR TITLE
profiles/base: update default PHP_TARGETS to 8.3

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -164,7 +164,7 @@ POSTGRES_TARGETS="postgres17"
 # Moreover, it should only contain targets that have a stable version
 # of PHP, to avoid pulling in an unstable PHP on stable systems.
 #
-PHP_TARGETS="php8-2"
+PHP_TARGETS="php8-3"
 
 # Sam James <sam@gentoo.org> (2025-02-19)
 #


### PR DESCRIPTION
profiles/base: update default PHP_TARGETS to 8.3

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
