### PR TITLE
games-emulation/rmg: fix compatibility with cmake4

### DIFF
--- a/games-emulation/rmg/files/rmg-0.7.9-discord-rapidjson-cmake4.patch
+++ b/games-emulation/rmg/files/rmg-0.7.9-discord-rapidjson-cmake4.patch
@@ -1,0 +1,24 @@
+https://github.com/Rosalie241/RMG/pull/382
+https://github.com/Rosalie241/RMG/commit/1c6210f9646229c81f6cfbf99e59516a20e4b623
+
+From 9c7e7c36d65f190ebeca1536559fe17d61bb8246 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Fri, 4 Jul 2025 11:37:06 -0700
+Subject: [PATCH] 3rdParty: change minimum cmake version in discord-rpc's
+ rapidjson
+
+Gentoo-Issue: https://bugs.gentoo.org/959468
+---
+ Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt b/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt
+index ceda71b1b..844eafe76 100644
+--- a/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt
++++ b/Source/3rdParty/discord-rpc/thirdparty/rapidjson/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10)
+ if(POLICY CMP0025)
+   # detect Apple's Clang
+   cmake_policy(SET CMP0025 NEW)

--- a/games-emulation/rmg/rmg-0.7.9.ebuild
+++ b/games-emulation/rmg/rmg-0.7.9.ebuild
@@ -78,6 +78,11 @@ BDEPEND="
 	rust-plugin? ( ${RUST_DEPEND} )
 "
 
+PATCHES=(
+	# https://bugs.gentoo.org/959468
+	"${FILESDIR}"/${P}-discord-rapidjson-cmake4.patch
+)
+
 pkg_setup() {
 	QA_FLAGS_IGNORED="/usr/$(get_libdir)/RMG/Plugin/Input/libmupen64plus_input_gca.so"
 	use rust-plugin && rust_pkg_setup
@@ -100,10 +105,11 @@ src_unpack() {
 }
 
 src_prepare() {
-	cmake_src_prepare
-
-	# Don't install unused 3rdParty code
+	# Remove unused 3rdParty code - https://bugs.gentoo.org/959468
+	rm -r "${S}"/Source/3rdParty/discord-rpc/thirdparty/rapidjson/example || die
 	rm -r "${S}"/Source/3rdParty/fmt || die
+	rm -r "${S}"/Source/3rdParty/imgui/examples || die
+	rm -r "${S}"/Source/3rdParty/mupen64plus-rsp-parallel/win32 || die
 
 	# Don't install XMAME licensed code
 	if ! use angrylion-plugin; then
@@ -115,6 +121,8 @@ src_prepare() {
 
 	# Enable verbose make(1) output
 	sed -e 's/CC=/V=1 CC=/' -i "${S}"/Source/3rdParty/CMakeLists.txt || die
+
+	cmake_src_prepare
 }
 
 src_configure() {

--- a/games-emulation/rmg/rmg-9999.ebuild
+++ b/games-emulation/rmg/rmg-9999.ebuild
@@ -100,10 +100,11 @@ src_unpack() {
 }
 
 src_prepare() {
-	cmake_src_prepare
-
-	# Don't install unused 3rdParty code
+	# Remove unused 3rdParty code - https://bugs.gentoo.org/959468
+	rm -r "${S}"/Source/3rdParty/discord-rpc/thirdparty/rapidjson/example || die
 	rm -r "${S}"/Source/3rdParty/fmt || die
+	rm -r "${S}"/Source/3rdParty/imgui/examples || die
+	rm -r "${S}"/Source/3rdParty/mupen64plus-rsp-parallel/win32 || die
 
 	# Don't install XMAME licensed code
 	if ! use angrylion-plugin; then
@@ -115,6 +116,8 @@ src_prepare() {
 
 	# Enable verbose make(1) output
 	sed -e 's/CC=/V=1 CC=/' -i "${S}"/Source/3rdParty/CMakeLists.txt || die
+
+	cmake_src_prepare
 }
 
 src_configure() {


### PR DESCRIPTION
This fixes the cmake version in the vendored copy of rapidjson in the vendored discord-rpc. Additionally unused directories with CMakeLists.txt are removed to prevent false positives.

Closes: https://bugs.gentoo.org/959468
Upstream-PR: https://github.com/Rosalie241/RMG/pull/382
Upstream-Commit: https://github.com/Rosalie241/RMG/commit/1c6210f9646229c81f6cfbf99e59516a20e4b62 3

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
