### PR TITLE
dev-libs/yaz: fix htmldir

### DIFF
--- a/dev-libs/yaz/yaz-5.35.1.ebuild
+++ b/dev-libs/yaz/yaz-5.35.1.ebuild
@@ -68,7 +68,7 @@ src_install() {
 		DESTDIR="${D}"
 		docdir="${EPREFIX}/usr/share/doc/${PF}/html"
 		# move common dir in html
-		PACKAGE_SUFFIX="-${PV}/html"
+		PACKAGE_SUFFIX="-${PVR}/html"
 	)
 	emake "${myemakeargs[@]}" install
 


### PR DESCRIPTION
We want common to be installed in doc/${PF}, so {PVR}, not {PV}.
 
sry @thesamesam 

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
