### PR TITLE
sys-process/audit: fix musl build with POSIX basename(3) include

### DIFF
--- a/sys-process/audit/audit-4.0.2-r1.ebuild
+++ b/sys-process/audit/audit-4.0.2-r1.ebuild
@@ -51,6 +51,10 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	strndupa
 )
 
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.1-musl-basename.patch"
+)
+
 src_prepare() {
 	# audisp-remote moved in multilib_src_install_all
 	sed -i \

--- a/sys-process/audit/files/audit-4.0.1-musl-basename.patch
+++ b/sys-process/audit/files/audit-4.0.1-musl-basename.patch
@@ -1,0 +1,14 @@
+Since musl 1.2.5, basename(3) is strict-POSIX compliant, and
+needs #include <libgen.h>, instead of the GNU version included
+with <string.h>
+
+--- a/audisp/plugins/zos-remote/zos-remote-config.c
++++ b/audisp/plugins/zos-remote/zos-remote-config.c
+@@ -32,6 +32,7 @@
+ #include <ctype.h>
+ #include <unistd.h>
+ #include <stdlib.h>
++#include <libgen.h>
+ #include "zos-remote-log.h"
+ 
+ /* Local prototypes */


### PR DESCRIPTION
Since musl 1.2.5, ```basename(3)``` is strict-POSIX compliant, and
needs ```#include <libgen.h>```, instead of the GNU version included
with ```<string.h>```

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
