### PR TITLE
dev-util/Tensile: fix compilation of sci-libs/rocBLAS on gfx906

### DIFF
--- a/dev-util/Tensile/Tensile-6.4.1-r1.ebuild
+++ b/dev-util/Tensile/Tensile-6.4.1-r1.ebuild
@@ -81,10 +81,13 @@ src_prepare() {
 
 	sed -e "s|os\.path\.dirname.*$|\"${EPREFIX}/usr/share/Tensile/Source\", end='')|" -i __init__.py || die
 
+	# bug 949817: fix v_dot4_i32_i8 syntax for clang-20
+	sed  's/ op_sel:\[0,0\] op_sel_hi:\[1,1\]//' -i Components/MAC_I8X4.py || die
+
 	popd || die
 
 	sed -e "/package_data/d" -e "/data_files/d" -i setup.py || die
-	use client && PATCHES= cmake_src_prepare  # do not apply patches again in cmake_src_prepare
+	use client && PATCHES='' cmake_src_prepare  # do not apply patches again in cmake_src_prepare
 }
 
 src_configure() {


### PR DESCRIPTION
Clang-20 disallowed op_sel in some VOP3P dot instructions. See: https://github.com/llvm/llvm-project/pull/100485

As ROCm maintains a fork of Clang, these changes did not reach official ROCm releases. However Gentoo uses original Clang-20, which has these incompatible changes. Luckilly, in Tensile these op_sel do nothing. Generally, they allow to shuffle vector elements before multiplication, but with values 0,0/1,1 shuffling is disabled and op_sel can be removed.

Closes: https://bugs.gentoo.org/949817

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
