### PR TITLE
nginx{,-module}.eclass: do not fail if econf_ngx --help is called

### DIFF
--- a/eclass/nginx-module.eclass
+++ b/eclass/nginx-module.eclass
@@ -109,12 +109,15 @@ econf_ngx() {
 	debug-print-function "${FUNCNAME[0]}" "$@"
 	[[ ! -x ./configure ]] &&
 		die "./configure is not present in the current working directory or is not executable"
-	nonfatal edo ./configure "$@"
-	# For some reason, NGINX's ./configure returns 1 if it is used with the
-	# '--help' argument.
-	if [[ $? -ne 0 && "$1" != --help ]]; then
-		die -n "./configure ${*@Q} failed"
+	if [[ $1 == --help ]]; then
+		# For some reason, NGINX ./configure returns 1 if it is used with the
+		# '--help' argument.
+		#
+		# Executing this without edo gets rid of the "Failed to run" message.
+		./configure "$@"
+		return
 	fi
+	edo ./configure "$@"
 }
 
 # @FUNCTION: ngx_mod_pkg_to_sonames

--- a/eclass/nginx.eclass
+++ b/eclass/nginx.eclass
@@ -267,12 +267,15 @@ econf_ngx() {
 	debug-print-function "${FUNCNAME[0]}" "$@"
 	[[ -x ./configure ]] ||
 		die "./configure is not present in the current working directory or is not executable"
-	nonfatal edo ./configure "$@"
-	# For some reason, NGINX ./configure returns 1 if it is used with the
-	# '--help' argument.
-	if [[ $? -ne 0 && $1 != --help ]]; then
-		die -n "./configure ${*@Q} failed"
+	if [[ $1 == --help ]]; then
+		# For some reason, NGINX ./configure returns 1 if it is used with the
+		# '--help' argument.
+		#
+		# Executing this without edo gets rid of the "Failed to run" message.
+		./configure "$@"
+		return
 	fi
+	edo ./configure "$@"
 }
 
 #-----> USE logic <-----


### PR DESCRIPTION
NGINX's ./configure return 1 if "--help" is passed. edo does not like it and thinks the command failed. The previous code was incorrect in how it handled the "--help" case.

edo actually never failed (since it was always called with nonfatal, even when no "--help" was passed), only showed the edo's "Failed to run command" message.

This commit fixes the --help and all other cases altogether, making econf_ngx fail when necessary and shut when not.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
