### PR TITLE
app-editors/ted: update HOMEPAGE

### DIFF
--- a/app-editors/ted/ted-2.23-r3.ebuild
+++ b/app-editors/ted/ted-2.23-r3.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit toolchain-funcs xdg-utils
 
 DESCRIPTION="X-based rich text editor"
-HOMEPAGE="https://www.nllgg.nl/Ted/"
+HOMEPAGE="https://ftp.nluug.nl/pub/editors/ted/"
 SRC_URI="ftp://ftp.nluug.nl/pub/editors/ted/${P}.src.tar.gz"
 S="${WORKDIR}/Ted-${PV}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/959623

The homepage was outdated and according to a user the homepage in the commit is the correct one. It looks legit and is also the upstream source of the source code.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
