### PR TITLE
media-gfx/gnome-screenshot: Add binary dependency on gtk x11 backend

### DIFF
--- a/media-gfx/gnome-screenshot/gnome-screenshot-41.0-r1.ebuild
+++ b/media-gfx/gnome-screenshot/gnome-screenshot-41.0-r1.ebuild
@@ -18,7 +18,7 @@ DEPEND="
 		x11-libs/libXext
 	)
 	>=dev-libs/glib-2.35.1:2[dbus]
-	>=x11-libs/gtk+-3.12.0:3
+	>=x11-libs/gtk+-3.12.0:3[X]
 	>=gui-libs/libhandy-1:1=
 "
 RDEPEND="${DEPEND}


### PR DESCRIPTION
Fixes this warning:
```
 * QA Notice: binaries depend on Gtk's x11-specific ABI without USE dep:
 *
 *   /usr/bin/gnome-screenshot
```

Closes: https://bugs.gentoo.org/958464

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
