### PR TITLE
sys-apps/musl-locales: Create env file

### DIFF
--- a/sys-apps/musl-locales/musl-locales-0.1.0-r1.ebuild
+++ b/sys-apps/musl-locales/musl-locales-0.1.0-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2023-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Locale program for musl libc"
+HOMEPAGE="https://git.adelielinux.org/adelie/musl-locales"
+SRC_URI="https://git.adelielinux.org/adelie/musl-locales/uploads/7e855b894b18ca4bf4ecb11b5bcbc4c1/${P}.tar.xz"
+
+LICENSE="LGPL-3 MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~x86"
+
+RDEPEND="!sys-libs/glibc"
+
+src_configure() {
+	local mycmakeargs=(
+		-DLOCALE_PROFILE=OFF
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	echo "MUSL_LOCPATH=\"/usr/share/i18n/locales/musl\"" | newenvd - 00locale
+}
+
+pkg_postinst() {
+	elog "Run . /etc/profile and then eselect locale list"
+	elog "to see available locales to use with musl. "
+}


### PR DESCRIPTION
With vimproved's work to add musl-locale to @system, it also make sense to streamline the install process for users so the env file is created during the install.

I've choosen to -r1 to make it easier to track issues that might occur, even if it likely is overkill for env file.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
