### PR TITLE
profiles/base: Force llvm_targets_SPIRV in 20+

### DIFF
--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -210,6 +210,7 @@ dev-java/openjdk:21 system-bootstrap
 >=llvm-core/clang-13.0.1_rc llvm_targets_X86 llvm_targets_XCore
 >=llvm-core/clang-14 llvm_targets_VE
 >=llvm-core/clang-16 llvm_targets_LoongArch
+>=llvm-core/clang-20 llvm_targets_SPIRV
 >=llvm-core/llvm-13.0.1_rc llvm_targets_AArch64 llvm_targets_AMDGPU
 >=llvm-core/llvm-13.0.1_rc llvm_targets_ARM llvm_targets_AVR llvm_targets_BPF
 >=llvm-core/llvm-13.0.1_rc llvm_targets_Hexagon llvm_targets_Lanai
@@ -220,6 +221,7 @@ dev-java/openjdk:21 system-bootstrap
 >=llvm-core/llvm-13.0.1_rc llvm_targets_X86 llvm_targets_XCore
 >=llvm-core/llvm-14 llvm_targets_VE
 >=llvm-core/llvm-16 llvm_targets_LoongArch
+>=llvm-core/llvm-20 llvm_targets_SPIRV
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (2021-07-14)
 # Upstream plans to drop libcrypt.so.1/crypt.h from glibc


### PR DESCRIPTION
Has been promoted to production target in LLVM 20: https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html

Used by Zig in latest 0.15.0-dev versions.

Closes: https://bugs.gentoo.org/953517

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
