### PR TITLE
profiles: Mask USE=dist-server for dev-util/sccache everywhere but amd64

### DIFF
--- a/profiles/default/linux/amd64/package.use.mask
+++ b/profiles/default/linux/amd64/package.use.mask
@@ -1,5 +1,9 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# idealseal <realidealseal@protonmail.com> (2025-07-08)
+# This target support distributing tasks.
+dev-util/sccache -dist-server
 
 # Mike Frysinger <vapier@gentoo.org> (2016-05-08)
 # This target supports VTV #547040.

--- a/profiles/default/linux/package.use.mask
+++ b/profiles/default/linux/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# idealseal <realidealseal@protonmail.com> (2025-07-08)
+# Only supported on x86-64.
+dev-util/sccache dist-server
+
 # Matt Turner <mattst88@gentoo.org> (2025-04-23)
 # Requires osmesa, which was removed in mesa-25.1
 app-emulation/aranym osmesa


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/959441

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
