### PR TITLE
dev-util/spirv-llvm-translator: fix "Option 'spirv-ext' registered more than once" runtime error

### DIFF
--- a/dev-util/spirv-llvm-translator/files/spirv-llvm-translator-20.1.3-option-registered.patch
+++ b/dev-util/spirv-llvm-translator/files/spirv-llvm-translator-20.1.3-option-registered.patch
@@ -1,0 +1,34 @@
+Fix for "Option 'spirv-ext' registered more than once" error.
+
+Bug: https://bugs.gentoo.org/959744
+Upstream PR: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3218
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -102,13 +102,6 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
+ 
+   message(STATUS "Found LLVM: ${LLVM_VERSION}")
+ 
+-  is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
+-  if(spirv_present_result)
+-    message(STATUS "Found SPIR-V Backend")
+-    set(SPIRV_BACKEND_FOUND TRUE)
+-    add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+-  endif()
+-
+   option(CCACHE_ALLOWED "allow use of ccache" TRUE)
+   find_program(CCACHE_EXE_FOUND ccache)
+   if(CCACHE_EXE_FOUND AND CCACHE_ALLOWED)
+@@ -118,6 +111,13 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
+   endif()
+ endif()
+ 
++is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
++if(spirv_present_result)
++  message(STATUS "Found SPIR-V Backend")
++  set(SPIRV_BACKEND_FOUND TRUE)
++  add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
++endif()
++
+ set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+ 
+ # first try locating SPIRV-Tools via pkgconfig (the old way)

--- a/dev-util/spirv-llvm-translator/spirv-llvm-translator-20.1.3-r1.ebuild
+++ b/dev-util/spirv-llvm-translator/spirv-llvm-translator-20.1.3-r1.ebuild
@@ -35,6 +35,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${PN}-20.1.3-option-registered.patch )
+
 src_prepare() {
 	append-flags -fPIC
 	cmake_src_prepare


### PR DESCRIPTION
Upstream bug: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3217
Upstream PR: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3218
Closes: https://bugs.gentoo.org/959744

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
