### PR TITLE
net-dns/pdns-recursor: add USE flag for dns-over-tls

### DIFF
--- a/net-dns/pdns-recursor/metadata.xml
+++ b/net-dns/pdns-recursor/metadata.xml
@@ -15,6 +15,7 @@ It also has built-in hooks for making graphs with rrdtool, providing insight int
 nameserver performance.
 </longdescription>
 <use>
+	<flag name="dns-over-tls">Enable support for DNS over TLS support</flag>
 	<flag name="dnstap">Enable support for dnstap</flag>
 	<flag name="sodium">Use <pkg>dev-libs/libsodium</pkg> for cryptography</flag>
 </use>

--- a/net-dns/pdns-recursor/pdns-recursor-5.2.2.ebuild
+++ b/net-dns/pdns-recursor/pdns-recursor-5.2.2.ebuild
@@ -59,7 +59,7 @@ SRC_URI="https://downloads.powerdns.com/releases/${P/_/-}.tar.bz2 ${CARGO_CRATE_
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm x86"
-IUSE="debug dnstap snmp sodium systemd test valgrind"
+IUSE="debug dns-over-tls dnstap snmp sodium systemd test valgrind"
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 RESTRICT="!test? ( test )"
 
@@ -101,6 +101,7 @@ src_configure() {
 		--with-lua="${ELUA}" \
 		$(use_enable debug verbose-logging) \
 		$(use_enable systemd) \
+		$(use_enable dns-over-tls) \
 		$(use_enable dnstap dnstap) \
 		$(use_enable test unit-tests) \
 		$(use_enable valgrind) \


### PR DESCRIPTION
pdns-recursor supports forcing DNS over TLS to listed authoritative nameservers in dot-to-auth-names configuration setting which is only accessible when --enable-dns-over-tls is specified.

See: https://github.com/PowerDNS/pdns/commit/a227f47d3323ca9a532b076f7e1b209dd2962346
See: https://docs.powerdns.com/recursor/settings.html#dot-to-auth-names

Bug: https://bugs.gentoo.org/959753

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
