### PR TITLE
mail-filter/opendmarc: add missing dependency on dev-perl/JSON

### DIFF
--- a/mail-filter/opendmarc/opendmarc-1.4.1.1-r6.ebuild
+++ b/mail-filter/opendmarc/opendmarc-1.4.1.1-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,6 +22,7 @@ RDEPEND="${DEPEND}
 	reports? (
 		dev-perl/DBD-mysql
 		dev-perl/HTTP-Message
+		dev-perl/JSON
 		dev-perl/Switch
 	)
 	spf? ( mail-filter/libspf2 )"


### PR DESCRIPTION
opendmarc-import provided by USE=reports has a dependency on perl module JSON, missing in RDEPEND.

See: https://github.com/trusteddomainproject/OpenDMARC/blob/master/reports/README

Bug: https://bugs.gentoo.org/959755

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
