### PR TITLE
dev-libs/openssl: Run openssl fipsinstall via sysroot_run_prefixed

### DIFF
--- a/dev-libs/openssl/openssl-3.5.0.ebuild
+++ b/dev-libs/openssl/openssl-3.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/openssl.org.asc
-inherit edo flag-o-matic linux-info toolchain-funcs
+inherit edo flag-o-matic linux-info sysroot toolchain-funcs
 inherit multilib multilib-minimal multiprocessing preserve-libs
 
 DESCRIPTION="Robust, full-featured Open Source Toolkit for the Transport Layer Security (TLS)"
@@ -272,11 +272,11 @@ multilib_src_install_all() {
 pkg_preinst() {
 	if use fips; then
 		# Regen fipsmodule.cnf, bug 900625
-		ebegin "Running openssl fipsinstall"
-		"${ED}/usr/bin/openssl" fipsinstall -quiet \
+		einfo "Running openssl fipsinstall"
+		sysroot_run_prefixed "${ED}/usr/bin/openssl" fipsinstall \
 			-out "${ED}${SSL_CNF_DIR}/fipsmodule.cnf" \
-			-module "${ED}/usr/$(get_libdir)/ossl-modules/fips.so"
-		eend $?
+			-module "${ED}/usr/$(get_libdir)/ossl-modules/fips.so" \
+			|| die "fipsinstall failed"
 	fi
 
 	preserve_old_lib /usr/$(get_libdir)/lib{crypto,ssl}$(get_libname 1) \

--- a/dev-libs/openssl/openssl-3.5.9999.ebuild
+++ b/dev-libs/openssl/openssl-3.5.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/openssl.org.asc
-inherit edo flag-o-matic linux-info toolchain-funcs
+inherit edo flag-o-matic linux-info sysroot toolchain-funcs
 inherit multilib multilib-minimal multiprocessing preserve-libs
 
 DESCRIPTION="Robust, full-featured Open Source Toolkit for the Transport Layer Security (TLS)"
@@ -272,11 +272,11 @@ multilib_src_install_all() {
 pkg_preinst() {
 	if use fips; then
 		# Regen fipsmodule.cnf, bug 900625
-		ebegin "Running openssl fipsinstall"
-		"${ED}/usr/bin/openssl" fipsinstall -quiet \
+		einfo "Running openssl fipsinstall"
+		sysroot_run_prefixed "${ED}/usr/bin/openssl" fipsinstall \
 			-out "${ED}${SSL_CNF_DIR}/fipsmodule.cnf" \
-			-module "${ED}/usr/$(get_libdir)/ossl-modules/fips.so"
-		eend $?
+			-module "${ED}/usr/$(get_libdir)/ossl-modules/fips.so" \
+			|| die "fipsinstall failed"
 	fi
 
 	preserve_old_lib /usr/$(get_libdir)/lib{crypto,ssl}$(get_libname 1) \


### PR DESCRIPTION
This fixes cross-compiling. Also make failure here fatal.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.