### PR TITLE
dev-python/pdm-backend: Keep de-vendored packages importable

### DIFF
--- a/dev-python/pdm-backend/pdm-backend-2.4.5-r1.ebuild
+++ b/dev-python/pdm-backend/pdm-backend-2.4.5-r1.ebuild
@@ -1,0 +1,81 @@
+# Copyright 2022-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=standalone
+PYTHON_COMPAT=( python3_{11..14} python3_{13,14}t pypy3_11 )
+
+inherit distutils-r1
+
+DESCRIPTION="A PEP 517 backend for PDM that supports PEP 621 metadata"
+HOMEPAGE="
+	https://pypi.org/project/pdm-backend/
+	https://github.com/pdm-project/pdm-backend/
+"
+SRC_URI="
+	https://github.com/pdm-project/pdm-backend/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+# see src/pdm/backend/_vendor/vendor.txt
+RDEPEND="
+	>=dev-python/editables-0.5[${PYTHON_USEDEP}]
+	>=dev-python/packaging-24.0[${PYTHON_USEDEP}]
+	>=dev-python/pyproject-metadata-0.9.0_beta7[${PYTHON_USEDEP}]
+	>=dev-python/tomli-w-1.0.0[${PYTHON_USEDEP}]
+
+	$(python_gen_cond_dep '
+		>=dev-python/tomli-2.0.1[${PYTHON_USEDEP}]
+	' 3.10)
+"
+BDEPEND="
+	${RDEPEND}
+	test? (
+		dev-python/setuptools[${PYTHON_USEDEP}]
+		dev-vcs/git
+	)
+"
+# setuptools are used to build C extensions
+RDEPEND+="
+	dev-python/setuptools[${PYTHON_USEDEP}]
+"
+
+EPYTEST_PLUGINS=()
+distutils_enable_tests pytest
+
+src_prepare() {
+	VENDOR=src/pdm/backend/_vendor
+	rm -r ${VENDOR} || die
+	mkdir ${VENDOR}
+	touch ${VENDOR}/__init__.py
+	for pkg in packaging tomli tomli_w pyproject_metadata editables; do
+		mkdir ${VENDOR}/${pkg}
+		cat > ${VENDOR}/${pkg}/__init__.py <<-EOF
+			import sys
+			import ${pkg}
+			sys.modules[__name__] = ${pkg}
+		EOF
+	done
+	distutils-r1_src_prepare
+}
+
+src_compile() {
+	# this must not be set during src_test()
+	local -x PDM_BUILD_SCM_VERSION=${PV}
+	distutils-r1_src_compile
+}
+
+src_test() {
+	git config --global user.email "test@example.com" || die
+	git config --global user.name "Test User" || die
+	distutils-r1_src_test
+}
+
+python_test() {
+	epytest -k "not [hg"
+}


### PR DESCRIPTION
This is helpful for some third party packages that (unfortunately) import packages via pdm-backends internal vendored directory.

Not the right way to do things, but worst case this change doesn't do anything and best case aligns things with the pip-installed trees

This specifically came up with [amaranth](https://github.com/amaranth-lang/amaranth/blob/bc5d1a4b06f1e3ae085629264f5ebc264b603ab6/pdm_build.py#L4)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
