### PR TITLE
media-libs/libva-intel-driver: fix bgo #959783

### DIFF
--- a/media-libs/libva-intel-driver/libva-intel-driver-2.4.4.ebuild
+++ b/media-libs/libva-intel-driver/libva-intel-driver-2.4.4.ebuild
@@ -39,8 +39,8 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-util/wayland-scanner
 	virtual/pkgconfig
+	wayland? ( dev-util/wayland-scanner )
 "
 
 multilib_src_configure() {


### PR DESCRIPTION
Make the BDEPEND on dev-util/wayland-scanner optional.

Closes: https://bugs.gentoo.org/959783

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
