### PR TITLE
mate-extra/mate-sensors-applet: Fix an invalid pointer crash

### DIFF
--- a/mate-extra/mate-sensors-applet/files/mate-sensors-applet-1.28.0-invalid-pointer.patch
+++ b/mate-extra/mate-sensors-applet/files/mate-sensors-applet-1.28.0-invalid-pointer.patch
@@ -1,0 +1,45 @@
+From: https://github.com/mate-desktop/mate-sensors-applet/commit/9b74dc16d852a40d37f7ce6c236406959fd013e5
+From: lukefromdc <lukefromdc@hushmail.com>
+Date: Mon, 13 Jan 2025 22:39:13 -0500
+Subject: [PATCH] Fix an invalid pointer crash with glib 2.83.2
+
+The typecast to non-const gchar produced invalid pointer errors on free() with glib 2.83.2
+--- a/plugins/udisks2/udisks2-plugin.c
++++ b/plugins/udisks2/udisks2-plugin.c
+@@ -304,16 +304,15 @@ syslog(LOG_ERR, "propdict2 type: %s", g_variant_print(propdict2, TRUE));
+ #endif
+ 
+             /* get data */
+-            gchar *id = NULL;
+-            gchar *model = NULL;
++            const gchar *id = NULL;
++            const gchar *model = NULL;
+ 
+             gboolean smartenabled;
+             gdouble temp;
+ 
+-            /* NULL, bc we don't care about the length of the string
+-             * typecast bc g_variant_get_string() returns const char* */
+-            id = (gchar *) g_variant_get_string (g_variant_lookup_value (propdict, "Id", G_VARIANT_TYPE_STRING), NULL);
+-            model = (gchar *) g_variant_get_string (g_variant_lookup_value (propdict, "Model", G_VARIANT_TYPE_STRING), NULL);
++            /* NULL, bc we don't care about the length of the string*/
++            id = g_variant_get_string (g_variant_lookup_value (propdict, "Id", G_VARIANT_TYPE_STRING), NULL);
++            model = g_variant_get_string (g_variant_lookup_value (propdict, "Model", G_VARIANT_TYPE_STRING), NULL);
+ 
+             smartenabled = g_variant_get_boolean (g_variant_lookup_value (propdict2, "SmartEnabled", G_VARIANT_TYPE_BOOLEAN));
+             temp = g_variant_get_double (g_variant_lookup_value (propdict2, "SmartTemperature", G_VARIANT_TYPE_DOUBLE));
+@@ -366,14 +365,6 @@ syslog(LOG_ERR, "No temp data for device: %s\n", key);
+ 
+                 g_debug ("No temp data for device: %s\n", key);
+             }
+-
+-#ifdef UD2PD
+-syslog(LOG_ERR, "b4 free1");
+-#endif
+-
+-            g_free (id);
+-            g_free (model);
+-
+         }
+ 
+ #ifdef UD2PD

--- a/mate-extra/mate-sensors-applet/mate-sensors-applet-1.28.0-r1.ebuild
+++ b/mate-extra/mate-sensors-applet/mate-sensors-applet-1.28.0-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MATE_LA_PUNT="yes"
+
+inherit mate
+
+MINOR=$(($(ver_cut 2) % 2))
+if [[ ${MINOR} -eq 0 ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~riscv ~x86"
+fi
+
+DESCRIPTION="MATE panel applet to display readings from hardware sensors"
+LICENSE="FDL-1.1+ GPL-2+"
+SLOT="0"
+
+IUSE="+dbus hddtemp libnotify lm-sensors video_cards_nvidia"
+
+COMMON_DEPEND="
+	>=dev-libs/glib-2.50:2
+	>=mate-base/mate-panel-1.28.0
+	>=x11-libs/cairo-1.0.4
+	x11-libs/gdk-pixbuf:2
+	>=x11-libs/gtk+-3.22:3
+	hddtemp? ( >=app-admin/hddtemp-0.3_beta13 )
+	libnotify? ( >=x11-libs/libnotify-0.7 )
+	lm-sensors? ( sys-apps/lm-sensors )
+	video_cards_nvidia? ( >=x11-drivers/nvidia-drivers-100.14.09:0[static-libs,tools] )
+"
+
+RDEPEND="${COMMON_DEPEND}
+	virtual/libintl
+"
+
+BDEPEND="${COMMON_DEPEND}
+	app-text/rarian
+	app-text/yelp-tools
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+"
+
+PDEPEND="hddtemp? ( dbus? ( sys-fs/udisks:2 ) )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.28.0-invalid-pointer.patch #959761
+)
+
+src_configure() {
+	local udisks
+
+	if use hddtemp && use dbus; then
+		udisks="--enable-udisks2"
+	else
+		udisks="--disable-udisks2"
+	fi
+
+	mate_src_configure \
+		--disable-netbsd \
+		$(use_enable libnotify) \
+		$(use_with lm-sensors libsensors) \
+		$(use_with video_cards_nvidia nvidia) \
+		${udisks}
+}


### PR DESCRIPTION
Fix an invalid pointer crash with glib 2.83.2
The typecast to non-const gchar produced invalid pointer errors on free() with glib 2.83.2

Not entirely sure why this wasn't included with 1.28.0 release, however as a Gentoo user has reported it resolves the issue for them and Fedora are using the same patch in https://bugzilla.redhat.com/show_bug.cgi?id=2326719 then I see no issue to cherrypick this before the 1.28.1 release.

Closes: https://bugs.gentoo.org/959761

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
