### PR TITLE
games-puzzle/freesweep: fix build with gcc15

### DIFF
--- a/games-puzzle/freesweep/files/freesweep-1.0.2-gcc15.patch
+++ b/games-puzzle/freesweep/files/freesweep-1.0.2-gcc15.patch
@@ -1,0 +1,14 @@
+https://bugs.gentoo.org/944183
+Since 1.0.2 the upstream code looks very different now
+
+--- a/game.c
++++ b/game.c
+@@ -414,7 +414,7 @@ int ParseArgs(GameStats* Game, int Argc, char** Argv)
+ 	{
+ 		StartCurses();
+ 		InitCharSet(Game,Game->LineDraw);
+-		PrintGPL(NULL);
++		PrintGPL();
+ 		clear();
+ 		noutrefresh();
+ 		doupdate();

--- a/games-puzzle/freesweep/freesweep-1.0.2-r2.ebuild
+++ b/games-puzzle/freesweep/freesweep-1.0.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,6 +16,10 @@ KEYWORDS="~amd64 ~x86 ~ppc-macos"
 RDEPEND="sys-libs/ncurses:="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}"-gcc15.patch
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/944183

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
