### PR TITLE
www-nginx/ngx-vod: fix unprototyped func declaration causing build er…

### DIFF
--- a/www-nginx/ngx-vod/files/ngx-vod-1.33-use-prototyped-declaration.patch
+++ b/www-nginx/ngx-vod/files/ngx-vod-1.33-use-prototyped-declaration.patch
@@ -1,0 +1,39 @@
+From f6f1668c1671703c7a47b10c948ed92ab102d198 Mon Sep 17 00:00:00 2001
+From: Zurab Kvachadze <zurabid2016@gmail.com>
+Date: Thu, 10 Jul 2025 23:11:18 +0200
+Subject: [PATCH] Adapt exit_process() declaration to match the expected in
+ ngx_module_t
+
+Signed-off-by: Zurab Kvachadze <zurabid2016@gmail.com>
+---
+ ngx_http_vod_module.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ngx_http_vod_module.c b/ngx_http_vod_module.c
+index e40b7ea..cb688a5 100644
+--- a/ngx_http_vod_module.c
++++ b/ngx_http_vod_module.c
+@@ -216,7 +216,7 @@ typedef struct {
+ static ngx_int_t ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx);
+ static ngx_int_t ngx_http_vod_send_notification(ngx_http_vod_ctx_t *ctx);
+ static ngx_int_t ngx_http_vod_init_process(ngx_cycle_t *cycle);
+-static void ngx_http_vod_exit_process();
++static void ngx_http_vod_exit_process(ngx_cycle_t *cycle);
+ 
+ static ngx_int_t ngx_http_vod_init_file_reader_with_fallback(ngx_http_request_t *r, ngx_str_t* path, uint32_t flags, void** context);
+ static ngx_int_t ngx_http_vod_init_file_reader(ngx_http_request_t *r, ngx_str_t* path, uint32_t flags, void** context);
+@@ -3397,8 +3397,10 @@ ngx_http_vod_init_process(ngx_cycle_t *cycle)
+ }
+ 
+ static void 
+-ngx_http_vod_exit_process()
++ngx_http_vod_exit_process(ngx_cycle_t *cycle)
+ {
++    // Not used.
++    (void)cycle;
+ #if (VOD_HAVE_ICONV)
+ 	webvtt_exit_process();
+ #endif // VOD_HAVE_ICONV
+-- 
+2.49.0
+

--- a/www-nginx/ngx-vod/ngx-vod-1.33.ebuild
+++ b/www-nginx/ngx-vod/ngx-vod-1.33.ebuild
@@ -32,4 +32,5 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.33-fix-clock-gettime-config-check.patch"
+	"${FILESDIR}/${PN}-1.33-use-prototyped-declaration.patch"
 )


### PR DESCRIPTION
…rors on new gcc's

Before version 15, GCC had -std=gnu17 as the default. GCC 15 bumped the default to -std=gnu23. One of the changes in C23 is the interpretation of function declaration without parameters (unprototyped declaration).

In C17 and before, the unprototyped declaration specified no information on the number and types of arguments. With GCC 15, the declaration of the form
    int myfunc()
is treated the same as
    int myfunc(void)
i.e. the function takes no arguments.

This change broke compilation of the module which relied on older interpretation. The broken function, having the unprototyped declaration, actually takes one argument of type ngx_cycle_t *.

This commit corrects the function declaration and definition, explicitly specifying the arguments.

Closes: https://bugs.gentoo.org/959586
Closes: https://bugs.gentoo.org/959690

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
