### PR TITLE
media-video/dvdauthor: handle libxml2-2.14 breakage

### DIFF
--- a/media-video/dvdauthor/dvdauthor-0.7.2-r4.ebuild
+++ b/media-video/dvdauthor/dvdauthor-0.7.2-r4.ebuild
@@ -29,6 +29,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-freetype-pkgconfig.patch
+	"${FILESDIR}"/${P}-libxml2-pkgconfig.patch
 )
 
 src_prepare() {

--- a/media-video/dvdauthor/files/dvdauthor-0.7.2-libxml2-pkgconfig.patch
+++ b/media-video/dvdauthor/files/dvdauthor-0.7.2-libxml2-pkgconfig.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/955781
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -135,10 +133,9 @@ dnl AM_LANGINFO_CODESET
+ 
+ AM_ICONV
+ 
+-ifdef([AM_PATH_XML2],
+-    [AM_PATH_XML2(2.6.0, , AC_MSG_ERROR([You must have libxml2 >= 2.6.0 installed]))],
+-    [errprint([You must have libxml2 (>= 2.6.0) installed
+-])m4_exit(1)AC_MSG_ERROR([You must have libxml2 (>= 2.6.0) installed])])
++PKG_CHECK_MODULES(XML, [libxml-2.0])
++AC_SUBST(XML_CFLAGS)
++AC_SUBST(XML_LIBS)
+ 
+ AC_CHECK_DECLS(O_BINARY, , , [ #include <fcntl.h> ] )
+ 
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -8,7 +8,7 @@ endif
+ nodist_bin_SCRIPTS = dvddirdel
+ 
+ AM_CPPFLAGS = -DSYSCONFDIR="\"$(sysconfdir)\"" \
+-    @XML_CPPFLAGS@ @MAGICK_CPPFLAGS@ @FREETYPE_CPPFLAGS@ @FRIBIDI_CFLAGS@ @FONTCONFIG_CFLAGS@
++    @XML_CFLAGS@ @MAGICK_CPPFLAGS@ @FREETYPE_CPPFLAGS@ @FRIBIDI_CFLAGS@ @FONTCONFIG_CFLAGS@
+ AM_CFLAGS = -Wall
+ 
+ dvdauthor_SOURCES = dvdauthor.c common.h dvdauthor.h da-internal.h \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/955781
Thanks-To: ak <4nykey@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
