### PR TITLE
sci-misc/lttoolbox: handle libxml2-2.14 breakage

### DIFF
--- a/sci-misc/lttoolbox/files/lttoolbox-3.7.1-libxml2-2.14.patch
+++ b/sci-misc/lttoolbox/files/lttoolbox-3.7.1-libxml2-2.14.patch
@@ -1,0 +1,21 @@
+https://bugs.gentoo.org/955673
+https://github.com/apertium/lttoolbox/issues/199
+https://github.com/apertium/lttoolbox/commit/92c2d2948a5396034dca7465a51dbb2fb1528fe4
+
+From 92c2d2948a5396034dca7465a51dbb2fb1528fe4 Mon Sep 17 00:00:00 2001
+From: Tino Didriksen <mail@tinodidriksen.com>
+Date: Thu, 12 Jun 2025 12:59:10 +0200
+Subject: [PATCH] initGenericErrorDefaultFunc -> xmlSetGenericErrorFunc (fixes
+ #199)
+
+--- a/lttoolbox/lt_comp.cc
++++ b/lttoolbox/lt_comp.cc
+@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
+     std::cerr << "Error: Cannot not open file '" << infile << "'." << std::endl << std::endl;
+     exit(EXIT_FAILURE);
+   }
+-  initGenericErrorDefaultFunc(NULL);
++  xmlSetGenericErrorFunc(nullptr, nullptr);
+ 
+ 
+   if(opc == "lr")

--- a/sci-misc/lttoolbox/lttoolbox-3.7.1-r2.ebuild
+++ b/sci-misc/lttoolbox/lttoolbox-3.7.1-r2.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Toolbox for lexical processing, morphological analysis and generation of words"
+HOMEPAGE="https://www.apertium.org"
+SRC_URI="https://github.com/apertium/lttoolbox/releases/download/v${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+# PKG_VERSION_ABI in configure.ac
+SLOT="0/3"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-libs/icu:=
+	dev-libs/libxml2:2=
+	dev-libs/utfcpp
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.7.1-bashism.patch
+	"${FILESDIR}"/${PN}-3.7.1-cstdint-include.patch
+	"${FILESDIR}"/${PN}-3.7.1-libxml2-2.14.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf --disable-python-bindings
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/955673

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
