### PR TITLE
app-editors/xmlcopyeditor: handle libxml2-2.14 breakage

### DIFF
--- a/app-editors/xmlcopyeditor/files/xmlcopyeditor-1.3.1.0-libxml2-2.14.patch
+++ b/app-editors/xmlcopyeditor/files/xmlcopyeditor-1.3.1.0-libxml2-2.14.patch
@@ -1,0 +1,70 @@
+https://bugs.gentoo.org/955797
+https://sourceforge.net/p/xml-copy-editor/code/ci/ad7c0fb931ed54dc8d8a3c2d42924daddc4ad17d/
+https://sourceforge.net/p/xml-copy-editor/code/ci/3c79ba3e37b53067c993de0c7d327b70ded6238a/
+
+From ad7c0fb931ed54dc8d8a3c2d42924daddc4ad17d Mon Sep 17 00:00:00 2001
+From: "Zane U. Ji" <zaneuji@gmail.com>
+Date: Thu, 15 May 2025 00:31:07 +0800
+Subject: [PATCH 1/1] Fix building with libxml2 2.14
+
+--- a/src/wraplibxml.cpp
++++ b/src/wraplibxml.cpp
+@@ -473,6 +473,7 @@ std::string WrapLibxml::dumpXPathObject ( xmlXPathObjectPtr obj )
+ 		sstream << obj->stringval;
+ 		break;
+ 
++#if LIBXML_VERSION < 21400
+ 	case XPATH_POINT:
+ 		xmlBufferPtr bufferPtr;
+ 		bufferPtr = xmlBufferCreate();
+@@ -486,6 +487,7 @@ std::string WrapLibxml::dumpXPathObject ( xmlXPathObjectPtr obj )
+ 
+ 	case XPATH_RANGE:
+ 	case XPATH_LOCATIONSET:
++#endif
+ 	case XPATH_XSLT_TREE:
+ 	default:
+ 		FILE *fp = tmpfile();
+@@ -706,7 +708,7 @@ int WrapLibxml::saveEncoding (
+ 
+ wxString WrapLibxml::getLastError()
+ {
+-	xmlErrorPtr err = xmlGetLastError();
++	const xmlError *err = xmlGetLastError();
+ 
+ 	if ( !err )
+ 		return nonParserError;
+@@ -722,7 +724,7 @@ wxString WrapLibxml::getLastError()
+ 
+ std::pair<int, int> WrapLibxml::getErrorPosition()
+ {
+-	xmlErrorPtr err = xmlGetLastError();
++	const xmlError *err = xmlGetLastError();
+ 	if ( !err )
+ 		return std::make_pair ( 1, 1 );
+ 
+-- 
+2.50.1
+
+From 3c79ba3e37b53067c993de0c7d327b70ded6238a Mon Sep 17 00:00:00 2001
+From: "Zane U. Ji" <zaneuji@gmail.com>
+Date: Thu, 15 May 2025 21:29:58 +0800
+Subject: [PATCH 1/1] Replace deprecated libxml2 initGenericErrorDefaultFunc
+
+--- a/src/wraplibxml.cpp
++++ b/src/wraplibxml.cpp
+@@ -54,7 +54,11 @@ public:
+ 		xmlLoadCatalog ( CONV ( catalogPath ) );
+ 		::catalog = xmlLoadACatalog ( CONV ( catalogPath ) );
+ 
++#if LIBXML_VERSION < 21400
+ 		initGenericErrorDefaultFunc ( NULL );
++#else
++		xmlSetGenericErrorFunc ( NULL, NULL );
++#endif
+ 	}
+ 
+ 	~Initializer ()
+-- 
+2.50.1
+

--- a/app-editors/xmlcopyeditor/xmlcopyeditor-1.3.1.0-r4.ebuild
+++ b/app-editors/xmlcopyeditor/xmlcopyeditor-1.3.1.0-r4.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+WX_GTK_VER="3.2-gtk3"
+inherit autotools wxwidgets xdg
+
+DESCRIPTION="XML Copy Editor is a fast, free, validating XML editor"
+HOMEPAGE="https://xml-copy-editor.sourceforge.io"
+SRC_URI="https://downloads.sourceforge.net/xml-copy-editor/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 -ppc ~x86 ~amd64-linux ~x86-linux"  # -ppc due SSE2 requirement
+IUSE="aqua nls"
+
+RDEPEND="
+	app-text/enchant:2
+	dev-libs/expat
+	dev-libs/glib:2
+	>=dev-libs/libxml2-2.12.5:=
+	dev-libs/libxslt
+	dev-libs/xerces-c:=[cpu_flags_x86_sse2,icu]
+	dev-libs/libpcre2:=
+	x11-libs/gtk+:3[X]
+	x11-libs/wxGTK:${WX_GTK_VER}=[X]
+"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+"
+BDEPEND="
+	dev-util/intltool
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libxml2-2.14.patch
+)
+
+src_prepare() {
+	default
+
+	# bug #440744
+	sed -i  -e 's/ -Wall -g -fexceptions//g' configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	setup-wxwidgets unicode
+	econf \
+		--with-gtk=3.0 \
+		--with-wx-config="${WX_CONFIG}" \
+		$(use_enable nls)
+}


### PR DESCRIPTION
Also add missing dependencies.

Bug: https://bugs.gentoo.org/955797

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
