### PR TITLE
dev-libs/libgcrypt: filter -mfpmath=sse on x86

### DIFF
--- a/dev-libs/libgcrypt/libgcrypt-1.11.1.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.11.1.ebuild
@@ -96,6 +96,11 @@ src_configure() {
 	#
 	use riscv && filter-lto
 
+	# Temporary workaround for mfpmath=sse on x86 cauing issues when -msse is
+	# stripped as it's not clear cut on how to handle in flag-o-matic we can at
+	# least solve it the ebuild see https://bugs.gentoo.org/959349
+	use x86 && filter-flags -mfpmath=sse
+
 	# Hardcodes the path to FGREP in libgcrypt-config
 	export ac_cv_path_SED="sed"
 	export ac_cv_path_EGREP="grep -E"


### PR DESCRIPTION
Temporary workaround for mfpmath=sse on x86 cauing issues when -msse is stripped with strip-flags. As it's not clear cut on how to handle in flag-o-matic we can at least solve it the ebuild without risking breaking other packages.

Bug: https://bugs.gentoo.org/959349

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
