### PR TITLE
python: better support for `${PN}` in `EPYTEST_PLUGINS`, fix `PYTEST_PLUGINS` order

### DIFF
--- a/dev-python/inline-snapshot/inline-snapshot-0.24.0.ebuild
+++ b/dev-python/inline-snapshot/inline-snapshot-0.24.0.ebuild
@@ -41,6 +41,8 @@ BDEPEND="
 	)
 "
 
+EPYTEST_PLUGIN_LOAD_VIA_ENV=1
+EPYTEST_PLUGINS=( "${PN}" pytest-{freezer,mock,subtests,xdist} )
 EPYTEST_XDIST=1
 distutils_enable_tests pytest
 
@@ -54,8 +56,6 @@ python_test() {
 	)
 
 	local -x COLUMNS=80
-	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
-	local -x PYTEST_PLUGINS=inline_snapshot.pytest_plugin,pytest_freezer,pytest_subtests.plugin,xdist.plugin
 	local -x PYTHONPATH=${S}/src
 	epytest -p pytest_mock
 }

--- a/dev-python/pytest-asyncio/pytest-asyncio-1.0.0.ebuild
+++ b/dev-python/pytest-asyncio/pytest-asyncio-1.0.0.ebuild
@@ -25,24 +25,19 @@ BDEPEND="
 	dev-python/setuptools-scm[${PYTHON_USEDEP}]
 "
 
-EPYTEST_PLUGINS=( hypothesis )
+EPYTEST_PLUGINS=( hypothesis "${PN}" )
 EPYTEST_PLUGIN_LOAD_VIA_ENV=1
 EPYTEST_XDIST=1
 distutils_enable_tests pytest
 
-python_test() {
-	local EPYTEST_DESELECT=(
-		# fail due to mismatched warning count
-		tests/test_event_loop_fixture.py::test_event_loop_already_closed
-		tests/test_event_loop_fixture.py::test_event_loop_fixture_asyncgen_error
-		tests/test_event_loop_fixture.py::test_event_loop_fixture_handles_unclosed_async_gen
-		tests/modes/test_strict_mode.py::test_strict_mode_marked_test_unmarked_fixture_warning
-		tests/modes/test_strict_mode.py::test_strict_mode_marked_test_unmarked_autouse_fixture_warning
-		# TODO
-		tests/modes/test_strict_mode.py::test_strict_mode_ignores_unmarked_coroutine
-		tests/modes/test_strict_mode.py::test_strict_mode_ignores_unmarked_fixture
-	)
-
-	local EPYTEST_PLUGINS=( "${EPYTEST_PLUGINS[@]}" pytest-asyncio )
-	epytest
-}
+EPYTEST_DESELECT=(
+	# fail due to mismatched warning count
+	tests/test_event_loop_fixture.py::test_event_loop_already_closed
+	tests/test_event_loop_fixture.py::test_event_loop_fixture_asyncgen_error
+	tests/test_event_loop_fixture.py::test_event_loop_fixture_handles_unclosed_async_gen
+	tests/modes/test_strict_mode.py::test_strict_mode_marked_test_unmarked_fixture_warning
+	tests/modes/test_strict_mode.py::test_strict_mode_marked_test_unmarked_autouse_fixture_warning
+	# TODO
+	tests/modes/test_strict_mode.py::test_strict_mode_ignores_unmarked_coroutine
+	tests/modes/test_strict_mode.py::test_strict_mode_ignores_unmarked_fixture
+)

--- a/dev-python/pytest-lazy-fixtures/pytest-lazy-fixtures-1.2.0.ebuild
+++ b/dev-python/pytest-lazy-fixtures/pytest-lazy-fixtures-1.2.0.ebuild
@@ -23,10 +23,5 @@ RDEPEND="
 "
 
 EPYTEST_PLUGIN_LOAD_VIA_ENV=1
-EPYTEST_PLUGINS=()
+EPYTEST_PLUGINS=( "${PN}" )
 distutils_enable_tests pytest
-
-python_test() {
-	local EPYTEST_PLUGINS=( pytest-lazy-fixtures )
-	epytest
-}

--- a/dev-python/tavern/tavern-2.16.0.ebuild
+++ b/dev-python/tavern/tavern-2.16.0.ebuild
@@ -42,28 +42,23 @@ BDEPEND="
 	)
 "
 
-EPYTEST_PLUGINS=()
+EPYTEST_PLUGINS=( "${PN}" )
 distutils_enable_tests pytest
+
+EPYTEST_DESELECT=(
+	# requires grpc
+	tests/unit/test_extensions.py::TestGrpcCodes
+	# broken with paho-mqtt-2
+	tests/unit/test_mqtt.py::TestClient::test_context_connection_success
+)
+EPYTEST_IGNORE=(
+	# require grpc*
+	tavern/_plugins/grpc
+	tests/unit/tavern_grpc
+)
 
 src_prepare() {
 	# strip unnecessary pins, upstream doesn't update them a lot
 	sed -i -E -e 's:,?<=?[0-9.]+::' pyproject.toml || die
 	distutils-r1_src_prepare
-}
-
-python_test() {
-	local EPYTEST_DESELECT=(
-		# requires grpc
-		tests/unit/test_extensions.py::TestGrpcCodes
-		# broken with paho-mqtt-2
-		tests/unit/test_mqtt.py::TestClient::test_context_connection_success
-	)
-	local EPYTEST_IGNORE=(
-		# require grpc*
-		tavern/_plugins/grpc
-		tests/unit/tavern_grpc
-	)
-
-	local EPYTEST_PLUGINS=( tavern )
-	epytest
 }

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -565,6 +565,10 @@ distutils_enable_tests() {
 			_set_epytest_plugins
 			for plugin in "${EPYTEST_PLUGINS[@]}"; do
 				case ${plugin} in
+					${PN})
+						# don't add a dependency on self
+						continue
+						;;
 					pkgcore)
 						plugin=sys-apps/${plugin}
 						;;

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1458,11 +1458,13 @@ epytest() {
 						from importlib.metadata import distribution, entry_points
 
 						packages = {distribution(x).name for x in sys.argv[1:]}
-						plugins = {
+						# In packages defining multiple entry points, we must
+						# list them in the same order!
+						plugins = (
 							x.value for x in entry_points(group="pytest11")
 							if x.dist.name in packages
-						}
-						sys.stdout.write(",".join(sorted(plugins)))
+						)
+						sys.stdout.write(",".join(plugins))
 					EOF
 				)
 			else


### PR DESCRIPTION
CC @gentoo/python 

1. Ignore `${PN}` when adding deps from `EPYTEST_PLUGINS`, so you could use it in `dev-python/pytest*` without having to override it locally.
2. Fix ordering of entry points in `PYTEST_PLUGINS`, so that `dev-python/inline-snapshot`'s test suite works as expected.