### PR TITLE
sys-kernel/scx: fix building 1.0.14 with GCC

### DIFF
--- a/sys-kernel/scx/files/scx-1.0.14-builtin-preserve-enum-value.patch
+++ b/sys-kernel/scx/files/scx-1.0.14-builtin-preserve-enum-value.patch
@@ -1,12 +1,16 @@
-Taken from https://github.com/sched-ext/scx/commit/7d9b2cc26473526883297df78e8eee3f2e7b6194.
+This patch is made obsolete by https://github.com/sched-ext/scx/commit/7d9b2cc26473526883297df78e8eee3f2e7b6194.
 
 --- a/lib/scxtest/overrides.h
 +++ b/lib/scxtest/overrides.h
-@@ -13,7 +13,7 @@
+@@ -13,7 +13,11 @@
   * that we want to get rid of that belongs here.
   */
  #define __builtin_preserve_field_info(x,y) 1
--#define __builtin_preserve_enum_value(x,y,z) 1
++#ifdef __clang__
 +#define __builtin_preserve_enum_value(x,y) 1
++#else
+ #define __builtin_preserve_enum_value(x,y,z) 1
++#endif
  
  #define bpf_addr_space_cast(var, dst_as, src_as)
+ 


### PR DESCRIPTION
This patch was accidentally clang-specific, as
__builtin_preserve_enum_value takes 2 arguments in clang versus 3 in GCC.

Closes: https://bugs.gentoo.org/960099

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
