### PR TITLE
net-misc/stunnel: handle mimalloc's .so filename

### DIFF
--- a/net-misc/stunnel/files/stunnel-5.74-hardened-mimalloc.patch
+++ b/net-misc/stunnel/files/stunnel-5.74-hardened-mimalloc.patch
@@ -1,0 +1,15 @@
+.so of mimalloc will be libmimalloc-secure.so if build with
+"-DMI_SECURE=ON" (USE="hardended" in Gentoo).
+diff --git a/configure.ac b/configure.ac
+index c647b5c..e2b1f55 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -225,7 +225,7 @@ AC_SEARCH_LIBS([openpty], [util])
+ AC_SEARCH_LIBS([dlopen], [dl])
+ AC_SEARCH_LIBS([shl_load], [dld])
+ # Checks for optional libraries
+-AC_SEARCH_LIBS([mi_malloc], [mimalloc])
++AC_SEARCH_LIBS([mi_malloc], [mimalloc mimalloc-secure])
+ 
+ # Add BeOS libraries
+ if test "x${host_os}" = "xbeos"; then

--- a/net-misc/stunnel/stunnel-5.74.ebuild
+++ b/net-misc/stunnel/stunnel-5.74.ebuild
@@ -43,6 +43,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.71-dont-clobber-fortify-source.patch
 	"${FILESDIR}"/${PN}-5.71-respect-EPYTHON-for-tests.patch
+	"${FILESDIR}"/${PN}-5.74-hardened-mimalloc.patch
 )
 
 python_check_deps() {

--- a/net-misc/stunnel/stunnel-5.75.ebuild
+++ b/net-misc/stunnel/stunnel-5.75.ebuild
@@ -43,6 +43,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.71-dont-clobber-fortify-source.patch
 	"${FILESDIR}"/${PN}-5.71-respect-EPYTHON-for-tests.patch
+	"${FILESDIR}"/${PN}-5.74-hardened-mimalloc.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
libmimalloc.so will be libmimalloc-secure.so if dev-libs/mimalloc is built with USE="hardened"

Thanks-to: Jiri Netolicky <netolicky@epos.cd.cz>
Closes: https://bugs.gentoo.org/956606
Closes: https://bugs.gentoo.org/956616

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
