### PR TITLE
dev-util/rocm-smi: update DEPENDS

### DIFF
--- a/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.4.1.ebuild
@@ -25,6 +25,10 @@ SLOT="0/$(ver_cut 1-2)"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="${PYTHON_DEPS}"
+DEPEND="${RDEPEND}
+	sys-kernel/linux-headers
+	x11-libs/libdrm
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-no-strip.patch


### PR DESCRIPTION
rocm-smi uses `libdrm/drm.h` and `linux/ioctl.h` headers.

Closes: https://bugs.gentoo.org/960283

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
