### PR TITLE
dev-build/autoconf{,-vanilla}: Drop PDEPEND on app-emacs/autoconf-mode

### DIFF
--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.69-r1.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.69-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -36,7 +36,6 @@ HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
 SLOT="${PV}"
-IUSE="emacs"
 
 BDEPEND+="
 	>=sys-devel/m4-1.4.16
@@ -49,8 +48,6 @@ RDEPEND="
 "
 
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
 	"${FILESDIR}"/${MY_PN}-2.69-perl-5.26.patch

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-2.71-r1.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-2.71-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,27 +11,17 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	MY_PN=${PN/-vanilla}
-	# For _beta handling replace with real version number
-	MY_PV="${PV}"
-	MY_P="${MY_PN}-${MY_PV}"
-	#PATCH_TARBALL_NAME="${MY_PN}-2.70-patches-01"
-
-	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/zackweinberg.asc
-	inherit verify-sig
+	MY_P=${MY_PN}-${PV}
 
 	SRC_URI="
 		mirror://gnu/${MY_PN}/${MY_P}.tar.xz
 		https://alpha.gnu.org/pub/gnu/${MY_PN}/${MY_P}.tar.xz
-		https://meyering.net/ac/${MY_P}.tar.xz
-		verify-sig? ( mirror://gnu/${PN}/${MY_P}.tar.xz.sig )
 	"
-	 S="${WORKDIR}"/${MY_P}
 
-	if [[ ${PV} != *_beta* ]] && ! [[ $(ver_cut 3) =~ [a-z] ]] ; then
+	if ! [[ ${PV} == *_beta* ]] ; then
 		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 	fi
-
-	BDEPEND="verify-sig? ( sec-keys/openpgp-keys-zackweinberg )"
+	S="${WORKDIR}"/${MY_P}
 fi
 
 inherit toolchain-autoconf
@@ -40,38 +30,28 @@ DESCRIPTION="Used to create autoconfiguration files"
 HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
-SLOT="$(ver_cut 1-2)"
-IUSE="emacs"
+SLOT="${PV/_*}"
 
-BDEPEND+="
-	>=dev-lang/perl-5.10
-	>=sys-devel/m4-1.4.16
-"
-RDEPEND="
-	${BDEPEND}
+# for 2.71, our Perl time resolution patch changes our min Perl from 5.6
+# (vanilla upstream for 2.71) to 5.8.
+BDEPEND=">=sys-devel/m4-1.4.16
+	>=dev-lang/perl-5.8"
+RDEPEND="${BDEPEND}
 	>=dev-build/autoconf-wrapper-15
-	!~dev-build/${P}:2.5
 	sys-devel/gnuconfig
-"
+	!~dev-build/${P}:2.5"
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
+	"${FILESDIR}"/${MY_P}-AC_LANG_CALL_C_cxx.patch
+	"${FILESDIR}"/${MY_P}-time.patch
+	"${FILESDIR}"/${MY_P}-make-4.4.patch
 	"${FILESDIR}"/"${MY_P}"-conflicts.patch
 )
 
 TC_AUTOCONF_ENVPREFIX=07
 
 src_prepare() {
-	if [[ ${PV} == *9999 ]] ; then
-		# Avoid the "dirty" suffix in the git version by generating it
-		# before we run later stages which might modify source files.
-		local ver=$(./build-aux/git-version-gen .tarball-version)
-		echo "${ver}" > .tarball-version || die
-
-		autoreconf -f -i || die
-	fi
-
 	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		PATCHES+=( "${FILESDIR}"/${MY_PN}-2.71-darwin.patch )
@@ -79,6 +59,13 @@ src_prepare() {
 
 	# Save timestamp to avoid later makeinfo call
 	touch -r doc/{,old_}autoconf.texi || die
+
+	local pdir
+	for pdir in "${WORKDIR}"/{upstream_,}patches ; do
+		if [[ -d "${pdir}" ]] ; then
+			eapply ${pdir}
+		fi
+	done
 
 	toolchain-autoconf_src_prepare
 

--- a/dev-build/autoconf-vanilla/autoconf-vanilla-9999.ebuild
+++ b/dev-build/autoconf-vanilla/autoconf-vanilla-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -41,7 +41,6 @@ HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
 SLOT="$(ver_cut 1-2)"
-IUSE="emacs"
 
 BDEPEND+="
 	>=dev-lang/perl-5.10
@@ -54,7 +53,6 @@ RDEPEND="
 	!~dev-build/${P}:2.5
 "
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
 	"${FILESDIR}"/"${MY_P}"-conflicts.patch

--- a/dev-build/autoconf/autoconf-2.69-r10.ebuild
+++ b/dev-build/autoconf/autoconf-2.69-r10.ebuild
@@ -29,7 +29,6 @@ HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
 SLOT="${PV}"
-IUSE="emacs"
 
 BDEPEND+="
 	>=sys-devel/m4-1.4.16
@@ -42,8 +41,6 @@ RDEPEND="
 "
 
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.69-perl-5.26.patch

--- a/dev-build/autoconf/autoconf-2.71-r8.ebuild
+++ b/dev-build/autoconf/autoconf-2.71-r8.ebuild
@@ -1,12 +1,7 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
-
-# Bumping notes:
-# * Remember to modify LAST_KNOWN_VER 'upstream' in dev-build/autoconf-wrapper
-# on new autoconf releases, as well as the dependency in RDEPEND below too.
-# * Update _WANT_AUTOCONF and _autoconf_atom case statement in autotools.eclass.
+EAPI=7
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/git/autoconf.git"
@@ -23,13 +18,13 @@ else
 	SRC_URI="
 		mirror://gnu/${PN}/${MY_P}.tar.xz
 		https://alpha.gnu.org/pub/gnu/${PN}/${MY_P}.tar.xz
-		https://meyering.net/ac/${P}.tar.xz
 		verify-sig? ( mirror://gnu/${PN}/${MY_P}.tar.xz.sig )
 	"
+	#SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${PATCH_TARBALL_NAME}.tar.xz"
 	S="${WORKDIR}"/${MY_P}
 
-	if [[ ${PV} != *_beta* ]] && ! [[ $(ver_cut 3) =~ [a-z] ]] ; then
-		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+	if ! [[ ${PV} == *_beta* ]] ; then
+		KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 	fi
 
 	BDEPEND="verify-sig? ( sec-keys/openpgp-keys-zackweinberg )"
@@ -41,37 +36,34 @@ DESCRIPTION="Used to create autoconfiguration files"
 HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
-SLOT="$(ver_cut 1-2)"
-IUSE="emacs"
+SLOT="${PV/_*}"
 
+# for 2.71, our Perl time resolution patch changes our min Perl from 5.6
+# (vanilla upstream for 2.71) to 5.8.
 BDEPEND+="
-	>=dev-lang/perl-5.10
 	>=sys-devel/m4-1.4.16
+	>=dev-lang/perl-5.8
 "
 RDEPEND="
 	${BDEPEND}
-	>=dev-build/autoconf-wrapper-20231224
+	>=dev-build/autoconf-wrapper-15
 	sys-devel/gnuconfig
 	!~${CATEGORY}/${P}:2.5
 "
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-2.72-gettext-0.25-autoreconf-Invoke-autopoint-in-more-situations.patch
-	"${FILESDIR}"/${PN}-2.72-gettext-0.25-autoreconf-Adapt-to-the-on-disk-situation-after-auto.patch
+	"${FILESDIR}"/${P}-AC_LANG_CALL_C_cxx.patch
+	"${FILESDIR}"/${P}-time.patch
+	"${FILESDIR}"/${P}-AC_C_BIGENDIAN-lto.patch
+	"${FILESDIR}"/${P}-K-R-decls-clang.patch
+	"${FILESDIR}"/${P}-make-4.4.patch
+	"${FILESDIR}"/${P}-K-R-decls-clang-deux.patch
+	"${FILESDIR}"/${P}-cxx11typo.patch
+	"${FILESDIR}"/${P}-bash52.patch
 )
 
 src_prepare() {
-	if [[ ${PV} == *9999 ]] ; then
-		# Avoid the "dirty" suffix in the git version by generating it
-		# before we run later stages which might modify source files.
-		local ver=$(./build-aux/git-version-gen .tarball-version)
-		echo "${ver}" > .tarball-version || die
-
-		autoreconf -f -i || die
-	fi
-
 	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		PATCHES+=( "${FILESDIR}"/${PN}-2.71-darwin.patch )
@@ -79,6 +71,13 @@ src_prepare() {
 
 	# Save timestamp to avoid later makeinfo call
 	touch -r doc/{,old_}autoconf.texi || die
+
+	local pdir
+	for pdir in "${WORKDIR}"/{upstream_,}patches ; do
+		if [[ -d "${pdir}" ]] ; then
+			eapply ${pdir}
+		fi
+	done
 
 	toolchain-autoconf_src_prepare
 

--- a/dev-build/autoconf/autoconf-2.72-r3.ebuild
+++ b/dev-build/autoconf/autoconf-2.72-r3.ebuild
@@ -1,7 +1,12 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+# Bumping notes:
+# * Remember to modify LAST_KNOWN_VER 'upstream' in dev-build/autoconf-wrapper
+# on new autoconf releases, as well as the dependency in RDEPEND below too.
+# * Update _WANT_AUTOCONF and _autoconf_atom case statement in autotools.eclass.
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://git.savannah.gnu.org/git/autoconf.git"
@@ -18,13 +23,13 @@ else
 	SRC_URI="
 		mirror://gnu/${PN}/${MY_P}.tar.xz
 		https://alpha.gnu.org/pub/gnu/${PN}/${MY_P}.tar.xz
+		https://meyering.net/ac/${P}.tar.xz
 		verify-sig? ( mirror://gnu/${PN}/${MY_P}.tar.xz.sig )
 	"
-	#SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${PATCH_TARBALL_NAME}.tar.xz"
 	S="${WORKDIR}"/${MY_P}
 
-	if ! [[ ${PV} == *_beta* ]] ; then
-		KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+	if [[ ${PV} != *_beta* ]] && ! [[ $(ver_cut 3) =~ [a-z] ]] ; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 	fi
 
 	BDEPEND="verify-sig? ( sec-keys/openpgp-keys-zackweinberg )"
@@ -36,36 +41,35 @@ DESCRIPTION="Used to create autoconfiguration files"
 HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
-SLOT="${PV/_*}"
-IUSE="emacs"
+SLOT="$(ver_cut 1-2)"
 
-# for 2.71, our Perl time resolution patch changes our min Perl from 5.6
-# (vanilla upstream for 2.71) to 5.8.
 BDEPEND+="
+	>=dev-lang/perl-5.10
 	>=sys-devel/m4-1.4.16
-	>=dev-lang/perl-5.8
 "
 RDEPEND="
 	${BDEPEND}
-	>=dev-build/autoconf-wrapper-15
+	>=dev-build/autoconf-wrapper-20231224
 	sys-devel/gnuconfig
 	!~${CATEGORY}/${P}:2.5
 "
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 PATCHES=(
-	"${FILESDIR}"/${P}-AC_LANG_CALL_C_cxx.patch
-	"${FILESDIR}"/${P}-time.patch
-	"${FILESDIR}"/${P}-AC_C_BIGENDIAN-lto.patch
-	"${FILESDIR}"/${P}-K-R-decls-clang.patch
-	"${FILESDIR}"/${P}-make-4.4.patch
-	"${FILESDIR}"/${P}-K-R-decls-clang-deux.patch
-	"${FILESDIR}"/${P}-cxx11typo.patch
-	"${FILESDIR}"/${P}-bash52.patch
+	"${FILESDIR}"/${PN}-2.72-gettext-0.25-autoreconf-Invoke-autopoint-in-more-situations.patch
+	"${FILESDIR}"/${PN}-2.72-gettext-0.25-autoreconf-Adapt-to-the-on-disk-situation-after-auto.patch
 )
 
 src_prepare() {
+	if [[ ${PV} == *9999 ]] ; then
+		# Avoid the "dirty" suffix in the git version by generating it
+		# before we run later stages which might modify source files.
+		local ver=$(./build-aux/git-version-gen .tarball-version)
+		echo "${ver}" > .tarball-version || die
+
+		autoreconf -f -i || die
+	fi
+
 	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
 	if [[ ${CHOST} == *-darwin* ]] ; then
 		PATCHES+=( "${FILESDIR}"/${PN}-2.71-darwin.patch )
@@ -73,13 +77,6 @@ src_prepare() {
 
 	# Save timestamp to avoid later makeinfo call
 	touch -r doc/{,old_}autoconf.texi || die
-
-	local pdir
-	for pdir in "${WORKDIR}"/{upstream_,}patches ; do
-		if [[ -d "${pdir}" ]] ; then
-			eapply ${pdir}
-		fi
-	done
 
 	toolchain-autoconf_src_prepare
 

--- a/dev-build/autoconf/autoconf-9999.ebuild
+++ b/dev-build/autoconf/autoconf-9999.ebuild
@@ -42,7 +42,6 @@ HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
 
 LICENSE="GPL-3+"
 SLOT="$(ver_cut 1-2)"
-IUSE="emacs"
 
 BDEPEND+="
 	>=dev-lang/perl-5.10
@@ -55,7 +54,6 @@ RDEPEND="
 	!~${CATEGORY}/${P}:2.5
 "
 [[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
-PDEPEND="emacs? ( app-emacs/autoconf-mode )"
 
 src_prepare() {
 	if [[ ${PV} == *9999 ]] ; then


### PR DESCRIPTION
The app-emacs package overrides the autoconf mode that is included with Emacs proper, which may not be wanted by all users.

Bug: https://bugs.gentoo.org/959856

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
