### PR TITLE
net-misc/rsync-bpc: fix build issue on rsync-bpc-3.1.3.0-r1

### DIFF
--- a/net-misc/rsync-bpc/files/rsync-bpc-3.1.3.0-r1-fix-gettimeofday-error.patch
+++ b/net-misc/rsync-bpc/files/rsync-bpc-3.1.3.0-r1-fix-gettimeofday-error.patch
@@ -1,0 +1,13 @@
+--- rsync-bpc-3.1.3.0/configure.ac.old	2025-02-21 20:05:47.000000000 -0600
++++ rsync-bpc-3.1.3.0/configure.ac	2025-02-21 20:02:27.000000000 -0600
+@@ -852,7 +852,9 @@
+ 
+ AC_CACHE_CHECK([if gettimeofday takes tz argument],rsync_cv_HAVE_GETTIMEOFDAY_TZ,[
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/time.h>
+-#include <unistd.h>]], [[struct timeval tv; exit(gettimeofday(&tv, NULL));]])],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=yes],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=no])])
++#ifdef HAVE_UNISTD_H
++#include <unistd.h>
++#endif]], [[struct timeval tv; return gettimeofday(&tv, NULL);]])],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=yes],[rsync_cv_HAVE_GETTIMEOFDAY_TZ=no])])
+ if test x"$rsync_cv_HAVE_GETTIMEOFDAY_TZ" != x"no"; then
+     AC_DEFINE(HAVE_GETTIMEOFDAY_TZ, 1, [Define to 1 if gettimeofday() takes a time-zone arg])
+ fi

--- a/net-misc/rsync-bpc/rsync-bpc-3.1.3.0-r1.ebuild
+++ b/net-misc/rsync-bpc/rsync-bpc-3.1.3.0-r1.ebuild
@@ -17,7 +17,7 @@ RDEPEND="virtual/ssh"
 DEPEND="${RDEPEND}"
 
 PATCHES=(
-	"${FILESDIR}/${P}-fix-gettimeofday-error.patch" #874666
+	"${FILESDIR}/${PN}-3.1.3.0-r1-fix-gettimeofday-error.patch" #874666
 )
 
 src_prepare() {


### PR DESCRIPTION
By adding the former patch again that differs from that of rsync-bpc-3.1.3.0_p20250706 the patch can successfully be applied again.

Closes: https://bugs.gentoo.org/960290

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
