### PR TITLE
dev-perl/Authen-SASL: fix CVE-2025-40918

### DIFF
--- a/dev-perl/Authen-SASL/Authen-SASL-2.180.0-r1.ebuild
+++ b/dev-perl/Authen-SASL/Authen-SASL-2.180.0-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DIST_AUTHOR=EHUELS
+DIST_VERSION=2.1800
+inherit perl-module
+
+DESCRIPTION="Perl SASL interface"
+
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~sparc ~x86"
+IUSE="kerberos"
+
+RDEPEND="
+	dev-perl/Crypt-URandom
+	dev-perl/Digest-HMAC
+	kerberos? ( dev-perl/GSSAPI )
+"
+BDEPEND="
+	${RDEPEND}
+	>=virtual/perl-ExtUtils-MakeMaker-6.42
+"
+
+PATCHES=( "${FILESDIR}"/${PN}-2.180.0_CVE-2025-40918-r1.patch )

--- a/dev-perl/Authen-SASL/files/Authen-SASL-2.180.0_CVE-2025-40918-r1.patch
+++ b/dev-perl/Authen-SASL/files/Authen-SASL-2.180.0_CVE-2025-40918-r1.patch
@@ -1,0 +1,43 @@
+From https://github.com/robrwo/perl-Authen-SASL/tree/rrwo/CVE-2025-40918
+diff --git a/README b/README
+index d7f071b..d564346 100644
+--- a/README
++++ b/README
+@@ -19,6 +19,7 @@ build Authen::SASL:
+     * Digest::MD5
+     * JSON::PP
+     * Test::More (for running tests only)
++  * Crypt::URandom
+   * Digest::HMAC_MD5
+   * GSSAPI (optional; for Kerberos v5 support)
+ 
+diff --git a/lib/Authen/SASL/Perl/DIGEST_MD5.pm b/lib/Authen/SASL/Perl/DIGEST_MD5.pm
+index f089849..8c4a67a 100644
+--- a/lib/Authen/SASL/Perl/DIGEST_MD5.pm
++++ b/lib/Authen/SASL/Perl/DIGEST_MD5.pm
+@@ -10,6 +10,7 @@ package Authen::SASL::Perl::DIGEST_MD5;
+ use strict;
+ use warnings;
+ use vars qw(@ISA $CNONCE $NONCE);
++use Crypt::URandom qw(urandom);
+ use Digest::MD5 qw(md5_hex md5);
+ use Digest::HMAC_MD5 qw(hmac_md5);
+ 
+@@ -201,7 +202,7 @@ sub server_start {
+ 
+   $self->{need_step} = 1;
+   $self->{error}     = undef;
+-  $self->{nonce}     = md5_hex($NONCE || join (":", $$, time, rand));
++  $self->{nonce}     = $NONCE ? md5_hex($NONCE) : unpack('H32',urandom(16));
+ 
+   $self->init_sec_layer;
+ 
+@@ -260,7 +261,7 @@ sub client_step {   # $self, $server_sasl_credentials
+ 
+   my %response = (
+     nonce        => $sparams{'nonce'},
+-    cnonce       => md5_hex($CNONCE || join (":", $$, time, rand)),
++    cnonce       => $CNONCE ? md5_hex($CNONCE) : unpack('H32',urandom(16)),
+     'digest-uri' => $self->service . '/' . $self->host,
+     # calc how often the server nonce has been seen; server expects "00000001"
+     nc           => sprintf("%08d",     ++$self->{nonce_counts}{$sparams{'nonce'}}),


### PR DESCRIPTION
Note that this (temporarily?) drops a lot of arches because upstream's fix adds a new dependency on dev-perl/Crypt-URandom which currently has very limited keywords.

Bug: https://bugs.gentoo.org/960293

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
