### PR TITLE
netperf: Inherit the autotools eclass

### DIFF
--- a/net-analyzer/netperf/netperf-2.7.0-r6.ebuild
+++ b/net-analyzer/netperf/netperf-2.7.0-r6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit flag-o-matic
+inherit autotools flag-o-matic
 
 DESCRIPTION="Network performance benchmark"
 HOMEPAGE="http://www.netperf.org/"


### PR DESCRIPTION
The ebuild for version 2.7.0 (netperf-2.7.0-r5.ebuild) doesn't include 'make' in its dependency graph, which may cause it to fail to emerge with 'make: command not found'.
There is also netperf-2.7.0_p20210121.ebuild, and quickly diff'ing the two reveals that the latter is inheriting autotools, pulling in make to the dependency graph.
Add this inherit in the 2.7.0 version.

Bug: 960348

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
