### PR TITLE
x11-misc/xscreensaver: drop obsolete dependencies, fix USE=offensive not applying to bsod hack

### DIFF
--- a/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=8
 
-inherit autotools flag-o-matic font greadme optfeature pam strip-linguas systemd xdg-utils
+inherit autotools flag-o-matic font optfeature pam strip-linguas systemd xdg-utils
 
 DESCRIPTION="Modular screen saver and locker for the X Window System"
 HOMEPAGE="https://www.jwz.org/xscreensaver/"
 SRC_URI="
-	https://www.jwz.org/xscreensaver/${PN}-${PV}.tar.gz
+	https://www.jwz.org/xscreensaver/${P}.tar.gz
 	logind-idle-hint? (
-		https://github.com/Flowdalic/xscreensaver/commit/e79e2f41be3367c196899ef2f38ab97436fa1a65.patch ->
-			${PN}-6.12-logind-idle-hint.patch
+		https://github.com/Flowdalic/xscreensaver/commit/59e7974c42dc08411c9af2a3a644a582c2116f46.patch ->
+			${PN}-6.06-logind-idle-hint.patch
 	)
 	systemd? (
 		https://github.com/Flowdalic/xscreensaver/commit/376b07ec76cfe1070f498773aaec8fd7030593af.patch ->
@@ -19,7 +19,6 @@ SRC_URI="
 	)
 "
 
-S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
 # Font license mapping for folder ./hacks/fonts/ as following:
 #   clacon.ttf       -- MIT
 #   gallant12x22.ttf -- unclear, hence dropped
@@ -29,7 +28,7 @@ S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
 LICENSE="BSD fonts? ( MIT Apache-2.0 ) systemd? ( ISC )"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="elogind ffmpeg fonts gdm gles glx jpeg +locking logind-idle-hint new-login offensive pam +perl selinux suid systemd xinerama wayland"
+IUSE="elogind ffmpeg fonts gdm gles glx jpeg +locking logind-idle-hint new-login offensive pam +perl selinux suid systemd xinerama"
 REQUIRED_USE="
 	gles? ( !glx )
 	?? ( elogind systemd )
@@ -48,10 +47,9 @@ COMMON_DEPEND="
 	x11-libs/libXt
 	x11-libs/libXxf86vm
 	elogind? ( sys-auth/elogind )
-	x11-libs/gdk-pixbuf-xlib
 	>=x11-libs/gdk-pixbuf-2.42.0:2
 	>=x11-libs/gtk+-3.0.0:3
-	ffmpeg? ( media-video/ffmpeg:= )
+	ffmpeg? ( <media-video/ffmpeg-7:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	locking? ( virtual/libcrypt:= )
 	new-login? (
@@ -65,7 +63,6 @@ COMMON_DEPEND="
 	systemd? ( >=sys-apps/systemd-221:= )
 	>=x11-libs/libXft-2.1.0
 	xinerama? ( x11-libs/libXinerama )
-	wayland? ( >=dev-libs/wayland-1.8 )
 "
 # For USE="perl" see output of `qlist xscreensaver | grep bin | xargs grep '::'`
 RDEPEND="
@@ -74,9 +71,9 @@ RDEPEND="
 	perl? (
 		dev-lang/perl
 		dev-perl/libwww-perl
+		virtual/perl-Digest-MD5
 	)
 	selinux? ( sec-policy/selinux-xscreensaver )
-	wayland? ( gui-apps/grim )
 "
 DEPEND="
 	${COMMON_DEPEND}
@@ -158,11 +155,7 @@ src_prepare() {
 	fi
 
 	if use logind-idle-hint; then
-		eapply "${DISTDIR}/${PN}-6.12-logind-idle-hint.patch"
-	fi
-
-	if use glx; then
-		sed -i -e 's;OpenGL/gl.h;GL/gl.h;' driver/subprocs.c || die
+		eapply "${DISTDIR}/${PN}-6.06-logind-idle-hint.patch"
 	fi
 
 	config_rpath_update "${S}"/config.rpath
@@ -198,7 +191,6 @@ src_configure() {
 		$(use_with suid setuid-hacks)
 		$(use_with systemd)
 		$(use_with xinerama xinerama-ext)
-		$(use_with wayland)
 		--with-jpeg=$(usex jpeg yes no)
 		--with-record-animation=$(usex ffmpeg yes no)
 		--with-png=yes
@@ -265,36 +257,15 @@ src_install() {
 
 	# bug #885989
 	fperms 4755 /usr/$(get_libdir)/misc/xscreensaver/xscreensaver-auth
-
-	greadme_stdin <<-EOF
-	You can configure xscreensaver via 'xscreensaver-settings'.
-	EOF
-
-	# bug #811885
-	if ! use glx; then
-		greadme_stdin --append <<-EOF
-		Enable USE='glx' if OpenGL screensavers are crashing.
-		EOF
-	fi
-
-	if use wayland; then
-		greadme_stdin --append <<-EOF
-		WARNING: Wayland support is preliminary. It does not lock and you need
-		a supported compositor, like:
-
-		 *  kde-plasma/kwin
-		 *  gui-wm/sway
-		 *  gui-wm/hyprland
-		 *  gui-wm/wayfire
-		 *  gui-wm/labwc
-		EOF
-	fi
 }
 
 pkg_postinst() {
 	use fonts && font_pkg_postinst
 
-	greadme_pkg_postinst
+	# bug #811885
+	if ! use glx; then
+		elog "Enable USE='glx' if OpenGL screensavers are crashing."
+	fi
 
 	optfeature 'Bitmap fonts 75dpi' media-fonts/font-adobe-75dpi
 	optfeature 'Bitmap fonts 100dpi' media-fonts/font-adobe-100dpi

--- a/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
@@ -71,7 +71,6 @@ RDEPEND="
 	perl? (
 		dev-lang/perl
 		dev-perl/libwww-perl
-		virtual/perl-Digest-MD5
 	)
 	selinux? ( sec-policy/selinux-xscreensaver )
 "

--- a/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.09-r3.ebuild
@@ -150,6 +150,12 @@ src_prepare() {
 			's| Stay.*fucking mask\.$||' \
 			hacks/glx/covid19.man \
 			hacks/config/covid19.xml || die
+		sed -i \
+			-e 's|Ass |Dumb |g' \
+			-e 's|Buttcorn|Blue Corn|g' \
+			-e 's| dick||gi' \
+			-e 's| shit||g' \
+			hacks/bsod.c || die
 		eapply "${FILESDIR}/xscreensaver-6.05-teach-handsy-some-manners.patch"
 	fi
 

--- a/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
@@ -72,7 +72,6 @@ RDEPEND="
 	perl? (
 		dev-lang/perl
 		dev-perl/libwww-perl
-		virtual/perl-Digest-MD5
 	)
 	selinux? ( sec-policy/selinux-xscreensaver )
 "

--- a/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
@@ -48,7 +48,6 @@ COMMON_DEPEND="
 	x11-libs/libXt
 	x11-libs/libXxf86vm
 	elogind? ( sys-auth/elogind )
-	x11-libs/gdk-pixbuf-xlib
 	>=x11-libs/gdk-pixbuf-2.42.0:2
 	>=x11-libs/gtk+-3.0.0:3
 	ffmpeg? ( media-video/ffmpeg:= )

--- a/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.10.1-r2.ebuild
@@ -151,6 +151,12 @@ src_prepare() {
 			's| Stay.*fucking mask\.$||' \
 			hacks/glx/covid19.man \
 			hacks/config/covid19.xml || die
+		sed -i \
+			-e 's|Ass |Dumb |g' \
+			-e 's|Buttcorn|Blue Corn|g' \
+			-e 's| dick||gi' \
+			-e 's| shit||g' \
+			hacks/bsod.c || die
 		eapply "${FILESDIR}/xscreensaver-6.05-teach-handsy-some-manners.patch"
 	fi
 

--- a/x11-misc/xscreensaver/xscreensaver-6.12-r1.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.12-r1.ebuild
@@ -153,6 +153,12 @@ src_prepare() {
 			's| Stay.*fucking mask\.$||' \
 			hacks/glx/covid19.man \
 			hacks/config/covid19.xml || die
+		sed -i \
+			-e 's|Ass |Dumb |g' \
+			-e 's|Buttcorn|Blue Corn|g' \
+			-e 's| dick||gi' \
+			-e 's| shit||g' \
+			hacks/bsod.c || die
 		eapply "${FILESDIR}/xscreensaver-6.05-teach-handsy-some-manners.patch"
 	fi
 

--- a/x11-misc/xscreensaver/xscreensaver-6.12-r1.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.12-r1.ebuild
@@ -3,15 +3,15 @@
 
 EAPI=8
 
-inherit autotools flag-o-matic font optfeature pam strip-linguas systemd xdg-utils
+inherit autotools flag-o-matic font greadme optfeature pam strip-linguas systemd xdg-utils
 
 DESCRIPTION="Modular screen saver and locker for the X Window System"
 HOMEPAGE="https://www.jwz.org/xscreensaver/"
 SRC_URI="
-	https://www.jwz.org/xscreensaver/${P}.tar.gz
+	https://www.jwz.org/xscreensaver/${PN}-${PV}.tar.gz
 	logind-idle-hint? (
-		https://github.com/Flowdalic/xscreensaver/commit/59e7974c42dc08411c9af2a3a644a582c2116f46.patch ->
-			${PN}-6.06-logind-idle-hint.patch
+		https://github.com/Flowdalic/xscreensaver/commit/e79e2f41be3367c196899ef2f38ab97436fa1a65.patch ->
+			${PN}-6.12-logind-idle-hint.patch
 	)
 	systemd? (
 		https://github.com/Flowdalic/xscreensaver/commit/376b07ec76cfe1070f498773aaec8fd7030593af.patch ->
@@ -19,6 +19,7 @@ SRC_URI="
 	)
 "
 
+S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
 # Font license mapping for folder ./hacks/fonts/ as following:
 #   clacon.ttf       -- MIT
 #   gallant12x22.ttf -- unclear, hence dropped
@@ -28,7 +29,7 @@ SRC_URI="
 LICENSE="BSD fonts? ( MIT Apache-2.0 ) systemd? ( ISC )"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="elogind ffmpeg fonts gdm gles glx jpeg +locking logind-idle-hint new-login offensive pam +perl selinux suid systemd xinerama"
+IUSE="elogind ffmpeg fonts gdm gles glx jpeg +locking logind-idle-hint new-login offensive pam +perl selinux suid systemd xinerama wayland"
 REQUIRED_USE="
 	gles? ( !glx )
 	?? ( elogind systemd )
@@ -47,10 +48,9 @@ COMMON_DEPEND="
 	x11-libs/libXt
 	x11-libs/libXxf86vm
 	elogind? ( sys-auth/elogind )
-	x11-libs/gdk-pixbuf-xlib
 	>=x11-libs/gdk-pixbuf-2.42.0:2
 	>=x11-libs/gtk+-3.0.0:3
-	ffmpeg? ( <media-video/ffmpeg-7:= )
+	ffmpeg? ( media-video/ffmpeg:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	locking? ( virtual/libcrypt:= )
 	new-login? (
@@ -64,6 +64,7 @@ COMMON_DEPEND="
 	systemd? ( >=sys-apps/systemd-221:= )
 	>=x11-libs/libXft-2.1.0
 	xinerama? ( x11-libs/libXinerama )
+	wayland? ( >=dev-libs/wayland-1.8 )
 "
 # For USE="perl" see output of `qlist xscreensaver | grep bin | xargs grep '::'`
 RDEPEND="
@@ -72,9 +73,9 @@ RDEPEND="
 	perl? (
 		dev-lang/perl
 		dev-perl/libwww-perl
-		virtual/perl-Digest-MD5
 	)
 	selinux? ( sec-policy/selinux-xscreensaver )
+	wayland? ( gui-apps/grim )
 "
 DEPEND="
 	${COMMON_DEPEND}
@@ -156,7 +157,11 @@ src_prepare() {
 	fi
 
 	if use logind-idle-hint; then
-		eapply "${DISTDIR}/${PN}-6.06-logind-idle-hint.patch"
+		eapply "${DISTDIR}/${PN}-6.12-logind-idle-hint.patch"
+	fi
+
+	if use glx; then
+		sed -i -e 's;OpenGL/gl.h;GL/gl.h;' driver/subprocs.c || die
 	fi
 
 	config_rpath_update "${S}"/config.rpath
@@ -192,6 +197,7 @@ src_configure() {
 		$(use_with suid setuid-hacks)
 		$(use_with systemd)
 		$(use_with xinerama xinerama-ext)
+		$(use_with wayland)
 		--with-jpeg=$(usex jpeg yes no)
 		--with-record-animation=$(usex ffmpeg yes no)
 		--with-png=yes
@@ -258,15 +264,36 @@ src_install() {
 
 	# bug #885989
 	fperms 4755 /usr/$(get_libdir)/misc/xscreensaver/xscreensaver-auth
+
+	greadme_stdin <<-EOF
+	You can configure xscreensaver via 'xscreensaver-settings'.
+	EOF
+
+	# bug #811885
+	if ! use glx; then
+		greadme_stdin --append <<-EOF
+		Enable USE='glx' if OpenGL screensavers are crashing.
+		EOF
+	fi
+
+	if use wayland; then
+		greadme_stdin --append <<-EOF
+		WARNING: Wayland support is preliminary. It does not lock and you need
+		a supported compositor, like:
+
+		 *  kde-plasma/kwin
+		 *  gui-wm/sway
+		 *  gui-wm/hyprland
+		 *  gui-wm/wayfire
+		 *  gui-wm/labwc
+		EOF
+	fi
 }
 
 pkg_postinst() {
 	use fonts && font_pkg_postinst
 
-	# bug #811885
-	if ! use glx; then
-		elog "Enable USE='glx' if OpenGL screensavers are crashing."
-	fi
+	greadme_pkg_postinst
 
 	optfeature 'Bitmap fonts 75dpi' media-fonts/font-adobe-75dpi
 	optfeature 'Bitmap fonts 100dpi' media-fonts/font-adobe-100dpi


### PR DESCRIPTION
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
