### PR TITLE
gui-libs/libwlembed: Add missing dev-build/xfce4-dev-tools dependency

### DIFF
--- a/gui-libs/libwlembed/libwlembed-0.0.0_pre20250715.ebuild
+++ b/gui-libs/libwlembed/libwlembed-0.0.0_pre20250715.ebuild
@@ -43,6 +43,7 @@ DEPEND+="
 "
 BDEPEND="
 	${PYTHON_DEPS}
+	dev-build/xfce4-dev-tools
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gtk-doc )
 "

--- a/gui-libs/libwlembed/libwlembed-9999.ebuild
+++ b/gui-libs/libwlembed/libwlembed-9999.ebuild
@@ -34,6 +34,7 @@ DEPEND+="
 "
 BDEPEND="
 	${PYTHON_DEPS}
+	dev-build/xfce4-dev-tools
 	virtual/pkgconfig
 	gtk-doc? ( dev-util/gtk-doc )
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/960363
