### PR TITLE
x11-drivers/xf86-video-amdgpu: Update live ebuild

### DIFF
--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 XORG_DRI="always"
-inherit xorg-3
+inherit xorg-meson
 
 if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
@@ -19,9 +19,9 @@ RDEPEND=">=x11-libs/libdrm-2.4.89[video_cards_amdgpu]
 DEPEND="${RDEPEND}"
 
 src_configure() {
-	local XORG_CONFIGURE_OPTIONS=(
-		--enable-glamor
-		$(use_enable udev)
+	local emesonargs=(
+		-Dglamor=enabled
+		$(meson_feature udev)
 	)
-	xorg-3_src_configure
+	meson_src_configure
 }


### PR DESCRIPTION
The amdgpu project switched to meson [1][2]. Update the live ebuild.

1: https://gitlab.freedesktop.org/xorg/driver/xf86-video-amdgpu/-/commit/c98eb1336c34399f271dbeb6e66cedec49193d45
2: https://gitlab.freedesktop.org/xorg/driver/xf86-video-amdgpu/-/commit/b696afac63a62afa43b54cb395f897d4a583fa18

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
