### PR TITLE
net-nds/389-ds-base: enable py3.13

### DIFF
--- a/net-nds/389-ds-base/389-ds-base-3.0.2-r1.ebuild
+++ b/net-nds/389-ds-base/389-ds-base-3.0.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -107,7 +107,7 @@ CRATES="
 	zeroize_derive@1.4.2
 "
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=setuptools


### PR DESCRIPTION
Enable python3_13 for 389-ds-base-3.0.2-r1. Builds successfully and has been running it for a few weeks. Tools appear to be working OK too.

Output from `pkgcheck scan --commits --net` is unchanged since before this change.
```
net-nds/389-ds-base
  UnstableOnly: for arches: [ amd64, arm64 ], all versions are unstable: [ 3.0.2-r1 ]
```

Closes: https://bugs.gentoo.org/952626

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
