### PR TITLE
`multilib.eclass`: respect `SYSROOT` when overriding `PKG_CONFIG_*` vars

### DIFF
--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: multilib.eclass
@@ -552,10 +552,10 @@ multilib_toolchain_setup() {
 		export STRIP="$(tc-getSTRIP)" # Avoid 'strip', use '${CHOST}-strip'
 
 		export CHOST=$(get_abi_CHOST $1)
-		export PKG_CONFIG_LIBDIR=${EPREFIX}/usr/$(get_libdir)/pkgconfig
-		export PKG_CONFIG_PATH=${EPREFIX}/usr/share/pkgconfig
-		export PKG_CONFIG_SYSTEM_INCLUDE_PATH=${EPREFIX}/usr/include
-		export PKG_CONFIG_SYSTEM_LIBRARY_PATH=${EPREFIX}/$(get_libdir):${EPREFIX}/usr/$(get_libdir)
+		export PKG_CONFIG_LIBDIR=${ESYSROOT}/usr/$(get_libdir)/pkgconfig
+		export PKG_CONFIG_PATH=${ESYSROOT}/usr/share/pkgconfig
+		export PKG_CONFIG_SYSTEM_INCLUDE_PATH=${ESYSROOT}/usr/include
+		export PKG_CONFIG_SYSTEM_LIBRARY_PATH=${ESYSROOT}/$(get_libdir):${ESYSROOT}/usr/$(get_libdir)
 	fi
 }
 


### PR DESCRIPTION
In `multilib.eclass`, `multilib_toolchain_setup()` overrides the environment variables `PKG_CONFIG_LIBDIR`, `PKG_CONFIG_PATH`, `PKG_CONFIG_SYSTEM_INCLUDE_PATH`, and `PKG_CONFIG_SYSTEM_LIBRARY_PATH` so that the `.pc` files for the correct ABI will be found and used.

As a reminder, pkgconfig is normally called upon to find packages that have been installed into the *host* system — i.e., packages listed in `DEPEND`. The [“Ebuild writing: Variables”](https://devmanual.gentoo.org/ebuild-writing/variables/) page describes the `SYSROOT` variable as “(EAPI=7) The absolute path to the root directory containing build dependencies satisfied by `DEPEND`” and `ESYSROOT` as “(EAPI=7) Shorthand for `${SYSROOT%/}${EPREFIX}/`.” (@chewi [says](https://github.com/gentoo/gentoo/pull/43088#issuecomment-3104918192) that definition is wrong, as the value of `ESYSROOT` actually is guaranteed *not* to end in a slash.)

In order to support the use case of setting `SYSROOT` to a path other than `/` while building packages for ABIs other than the default ABI, change `multilib.eclass` so that it prefixes the `PKG_CONFIG_*` vars with `${ESYSROOT}` rather than `${EPREFIX}`.

For Gentoo users who do not set `SYSROOT`, this change will have no bearing.

This change could conceivably affect crossdev users, but I think typically crossdev sysroots do not support multilib anyway, so this change wouldn't affect them either.

Closes: https://bugs.gentoo.org/945108

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` uselessly reports `pkgcheck scan: error: failed running git: fatal: not a git repository (or any parent up to mount point /var/db)` even though I definitely am running it in a Git worktree.

Please note that all boxes must be checked for the pull request to be merged.
