### PR TITLE
python-utils-r1.eclass: Add EPYTEST_RERUNS

### DIFF
--- a/dev-python/wheel/wheel-0.45.1.ebuild
+++ b/dev-python/wheel/wheel-0.45.1.ebuild
@@ -29,9 +29,21 @@ BDEPEND="
 "
 
 # xdist is slightly flaky here
-EPYTEST_PLUGINS=( pytest-rerunfailures )
+EPYTEST_PLUGINS=()
+EPYTEST_RERUNS=5
 EPYTEST_XDIST=1
 distutils_enable_tests pytest
+
+EPYTEST_DESELECT=(
+	# fails if any setuptools plugin imported the module first
+	tests/test_bdist_wheel.py::test_deprecated_import
+
+	# broken by setuptools license changes
+	# upstream removed the tests already
+	tests/test_bdist_wheel.py::test_licenses_default
+	tests/test_bdist_wheel.py::test_licenses_deprecated
+	tests/test_bdist_wheel.py::test_licenses_override
+)
 
 src_prepare() {
 	local PATCHES=(
@@ -46,19 +58,4 @@ src_prepare() {
 	find -name '*.py' -exec sed -i \
 		-e 's:wheel\.vendored\.::' \
 		-e 's:\.\+vendored\.::' {} + || die
-}
-
-python_test() {
-	local EPYTEST_DESELECT=(
-		# fails if any setuptools plugin imported the module first
-		tests/test_bdist_wheel.py::test_deprecated_import
-
-		# broken by setuptools license changes
-		# upstream removed the tests already
-		tests/test_bdist_wheel.py::test_licenses_default
-		tests/test_bdist_wheel.py::test_licenses_deprecated
-		tests/test_bdist_wheel.py::test_licenses_override
-	)
-
-	epytest --reruns=5
 }

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -554,6 +554,9 @@ distutils_enable_tests() {
 			;&
 		pytest)
 			test_pkgs+=' >=dev-python/pytest-7.4.4[${PYTHON_USEDEP}]'
+			if [[ -n ${EPYTEST_RERUNS} ]]; then
+				test_pkgs+=' dev-python/pytest-rerunfailures[${PYTHON_USEDEP}]'
+			fi
 			if [[ -n ${EPYTEST_TIMEOUT} ]]; then
 				test_pkgs+=' dev-python/pytest-timeout[${PYTHON_USEDEP}]'
 			fi

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1354,6 +1354,16 @@ _set_epytest_plugins() {
 	fi
 }
 
+# @ECLASS_VARIABLE: EPYTEST_RERUNS
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# If set to a non-empty value, enables pytest-rerunfailures plugin
+# and sets rerun count to the specified value.  This variable can be
+# either set in ebuilds with flaky tests, or by user to try if it helps.
+# If this variable is set prior to calling distutils_enable_tests
+# in distutils-r1, a test dependency on dev-python/pytest-rerunfailures
+# is added automatically.
+
 # @ECLASS_VARIABLE: EPYTEST_TIMEOUT
 # @DEFAULT_UNSET
 # @DESCRIPTION:
@@ -1514,6 +1524,18 @@ epytest() {
 			-p no:tavern
 			# does something to logging
 			-p no:salt-factories
+		)
+	fi
+
+	if [[ -n ${EPYTEST_RERUNS} ]]; then
+		if [[ ${PYTEST_PLUGINS} != *pytest_rerunfailures* ]]; then
+			args+=(
+				-p rerunfailures
+			)
+		fi
+
+		args+=(
+			"--reruns=${EPYTEST_RERUNS}"
 		)
 	fi
 


### PR DESCRIPTION
Add EPYTEST_RERUNS variable to enable pytest-rerunfailures with a specified rerun count.  This should provide a more streamlined approach to handling flaky test suites.

CC @gentoo/python 