### PR TITLE
dev-util/geany: themes from geany-themes are now included

### DIFF
--- a/dev-util/geany/geany-2.1.ebuild
+++ b/dev-util/geany/geany-2.1.ebuild
@@ -18,7 +18,7 @@ else
 	SRC_URI="https://download.geany.org/${P}.tar.bz2"
 	KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
-LICENSE="GPL-2+ HPND"
+LICENSE="GPL-2+ HPND LGPL-2+ LGPL-2.1+"
 SLOT="0"
 
 IUSE="+vte wayland X"
@@ -27,6 +27,7 @@ BDEPEND="virtual/pkgconfig"
 RDEPEND="
 	>=dev-libs/glib-2.32:2
 	>=x11-libs/gtk+-3.24:3[wayland?,X?]
+	!x11-themes/geany-themes
 	vte? ( x11-libs/vte:2.91 )
 "
 DEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/960535

No bump here, if `collision-protect` was on geany-2.1 and geany-themes could never have been installed together. If it was off and ignored, and geany-themes was installed after geany-2.1 then some themes could have been left overwritten. But that seems unlikely and not worth the energy that would be used by forcing a recompilation of all existing geany-2.1 installations.

Best overview of the licenses:
https://github.com/geany/geany/blob/f04c620b883061180626500a0ec70a00c7ba6e7a/scripts/update-themes.py

upstream "adds lgpl-2.0.txt, lgpl-2.1.txt to data/colorschemes to  cover themes not falling under Geany's GPL 2.0 or later"
https://github.com/geany/geany/commit/68918428bffd811320fe7939450e3cb0ce7a4502

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
