### PR TITLE
media-sound/musescore: update live, fix video, unbundle gtest, clean …

### DIFF
--- a/media-sound/musescore/files/musescore-4.6.0-unbundle-gtest.patch
+++ b/media-sound/musescore/files/musescore-4.6.0-unbundle-gtest.patch
@@ -1,0 +1,63 @@
+unbundle gtest
+diff --git a/buildscripts/cmake/DeclareModuleSetup.cmake b/buildscripts/cmake/DeclareModuleSetup.cmake
+index a40159ea51..2e697d6791 100644
+--- a/buildscripts/cmake/DeclareModuleSetup.cmake
++++ b/buildscripts/cmake/DeclareModuleSetup.cmake
+@@ -182,13 +182,11 @@ macro(setup_module)
+         ${MUSE_FRAMEWORK_PATH}
+         ${MUSE_FRAMEWORK_PATH}/framework
+         ${MUSE_FRAMEWORK_PATH}/framework/global
+-        ${MUSE_FRAMEWORK_PATH}/framework/testing/thirdparty/googletest/googletest/include
+ 
+         # compat
+         ${MUSE_FRAMEWORK_PATH}/src
+         ${MUSE_FRAMEWORK_PATH}/src/framework
+         ${MUSE_FRAMEWORK_PATH}/src/framework/global
+-        ${MUSE_FRAMEWORK_PATH}/src/framework/testing/thirdparty/googletest/googletest/include
+         # end compat
+ 
+         ${MODULE_INCLUDE_PRIVATE}
+diff --git a/src/framework/CMakeLists.txt b/src/framework/CMakeLists.txt
+index 7db7bbd36d..cf17f4aafb 100644
+--- a/src/framework/CMakeLists.txt
++++ b/src/framework/CMakeLists.txt
+@@ -123,8 +123,6 @@ if (MUSE_ENABLE_UNIT_TESTS)
+         FULL_DOCS "List XML files outputted by google test."
+     )
+ 
+-    set(INSTALL_GTEST OFF)
+-    add_subdirectory(testing/thirdparty/googletest)
+ endif()
+ 
+ # Stubs
+diff --git a/src/framework/testing/gtest.cmake b/src/framework/testing/gtest.cmake
+index eb6b059674..30fdff0049 100644
+--- a/src/framework/testing/gtest.cmake
++++ b/src/framework/testing/gtest.cmake
+@@ -50,13 +50,11 @@ target_include_directories(${MODULE_TEST} PRIVATE
+     ${MUSE_FRAMEWORK_PATH}
+     ${MUSE_FRAMEWORK_PATH}/framework
+     ${MUSE_FRAMEWORK_PATH}/framework/global
+-    ${MUSE_FRAMEWORK_PATH}/framework/testing/thirdparty/googletest/googletest/include
+ 
+     # compat
+     ${MUSE_FRAMEWORK_PATH}/src
+     ${MUSE_FRAMEWORK_PATH}/src/framework
+     ${MUSE_FRAMEWORK_PATH}/src/framework/global
+-    ${MUSE_FRAMEWORK_PATH}/src/framework/testing/thirdparty/googletest/googletest/include
+     # end compat
+ 
+     ${MODULE_TEST_INCLUDE}
+@@ -74,10 +72,12 @@ endif()
+ 
+ find_package(Qt6Core REQUIRED)
+ find_package(Qt6Gui REQUIRED)
++find_package(GTest REQUIRED)
+ 
+ target_link_libraries(${MODULE_TEST}
+     Qt6::Core
+     Qt6::Gui
++    gtest
+     gmock
+     muse_global
+     ${MODULE_TEST_LINK}


### PR DESCRIPTION
…patches

remove the call of qt5_get_bindir (thus qmake-utils eclass)

deps :
set slot for qtbase
remove qttools:6[assistant], because no doc is generated
remove really old min version for alsa-lib and freetype
add media-libs/harfbuzz because system-libs is forced
add dev-cpp/gtest, unbundled with a new patch

clean patches :
use DGZIP_EXECUTABLE=OFF instead of a patch to avoid compressed manpages
dynamic_cast-crash.patch fixed by upstream with [a42d4f1b](https://github.com/musescore/MuseScore/commit/a42d4f1b)
all includes patch, no longer required

definitions :
remove CMAKE_INSTALL_PATH, without prefix and already handled by eclass
var name for video useflag has changed
var name for ccache has changed
disable module update
add MUSE_ENABLE_UNIT_TESTS to handle framework unit tests

remove the custom compile phase :
cmake_build (was cmake_build lrelease manpages) duplicates cmake_src_compile

tests :
skip one more test (to investigate because it occurs only with gcc) use offscreen instead of virtx because it works

QA Notice for CMake < 3.5 are for thirdparty only

remove the custom install phase :
bundled libraries no longer installs files since upstream commit [21cd1ec](https://github.com/musescore/MuseScore/commit/21cd1ec)

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
