### PR TITLE
dev-util/cvise: bump to llvm-r2

### DIFF
--- a/dev-util/cvise/cvise-2.11.0-r2.ebuild
+++ b/dev-util/cvise/cvise-2.11.0-r2.ebuild
@@ -3,29 +3,22 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {16..21} )
+PYTHON_COMPAT=( python3_{11..13} )
+LLVM_COMPAT=( {16..20} )
 inherit cmake llvm-r2 python-single-r1
 
 DESCRIPTION="Super-parallel Python port of the C-Reduce"
-HOMEPAGE="https://github.com/marxin/cvise"
-
-if [[ ${PV} == 9999 ]] ; then
-	EGIT_REPO_URI="https://github.com/marxin/cvise"
-	inherit git-r3
-else
-	SRC_URI="
-		https://github.com/marxin/cvise/archive/v${PV}.tar.gz -> ${P}.tar.gz
-	"
-
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
-fi
+HOMEPAGE="https://github.com/marxin/cvise/"
+SRC_URI="
+	https://github.com/marxin/cvise/archive/v${PV}.tar.gz -> ${P}.tar.gz
+"
 
 LICENSE="UoI-NCSA"
 SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
-REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+REQUIRED_USE=${PYTHON_REQUIRED_USE}
 
 DEPEND="
 	$(llvm_gen_dep '
@@ -38,10 +31,8 @@ RDEPEND="
 	${PYTHON_DEPS}
 	$(python_gen_cond_dep '
 		dev-python/chardet[${PYTHON_USEDEP}]
-		dev-python/jsonschema[${PYTHON_USEDEP}]
 		dev-python/pebble[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
-		dev-python/zstandard[${PYTHON_USEDEP}]
 	')
 	dev-util/unifdef
 	app-alternatives/lex
@@ -56,6 +47,10 @@ BDEPEND="
 		')
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}"/${P}-llvm20.patch
+)
 
 pkg_setup() {
 	python-single-r1_pkg_setup


### PR DESCRIPTION
llvm-r2 handles cmake find_package better as otherwise the build system would pick up llvm-21 for me.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
