### PR TITLE
app-i18n/ibus-hangul: enable py3.13

### DIFF
--- a/app-i18n/ibus-hangul/ibus-hangul-1.5.5.ebuild
+++ b/app-i18n/ibus-hangul/ibus-hangul-1.5.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit autotools gnome2-utils python-single-r1 xdg virtualx
 


### PR DESCRIPTION
Passes test suite.

```
============================
Testsuite summary for ibus-hangul 1.5.5
============================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

Closes: https://bugs.gentoo.org/952206

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
