### PR TITLE
app-i18n/ibus-pinyin: enable py3.13

### DIFF
--- a/app-i18n/ibus-pinyin/ibus-pinyin-1.5.1.ebuild
+++ b/app-i18n/ibus-pinyin/ibus-pinyin-1.5.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2008-2024 Gentoo Authors
+# Copyright 2008-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 LUA_COMPAT=( lua5-1 )
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit autotools lua-single python-single-r1
 


### PR DESCRIPTION
Seems to pass test suite, but not 100% sure it did anything useful.

Did pass runtime testing as much I could possible test.

Closes: https://bugs.gentoo.org/952208

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
