### PR TITLE
net-misc/ipv6calc: missing dies, don't call ldconfig

### DIFF
--- a/net-misc/ipv6calc/files/ipv6calc-4.3.2-ldconfig_musl.patch
+++ b/net-misc/ipv6calc/files/ipv6calc-4.3.2-ldconfig_musl.patch
@@ -1,14 +1,15 @@
-https://github.com/pbiering/ipv6calc/pull/49
+ldconfig is not helpfull here
+the abspath may be wrong in some env
+ldconfig from musl doesn't support any arg
 diff --git a/databases/lib/Makefile.in b/databases/lib/Makefile.in
 index ed3c55d..a57a080 100644
 --- a/databases/lib/Makefile.in
 +++ b/databases/lib/Makefile.in
-@@ -91,7 +91,7 @@ ifeq ($(SHARED_LIBRARY), yes)
+@@ -91,7 +91,6 @@ ifeq ($(SHARED_LIBRARY), yes)
  		echo "Install shared library"
  		mkdir -p $(DESTDIR)$(libdir)
  		install -m 755 libipv6calc_db_wrapper.so.@PACKAGE_VERSION@ $(DESTDIR)$(libdir)
 -		/sbin/ldconfig -n $(DESTDIR)$(libdir)
-+		/sbin/ldconfig $(DESTDIR)$(libdir)
  else
  		echo "Nothing to do (shared library mode is not enabled)"
  endif
@@ -16,12 +17,11 @@ diff --git a/lib/Makefile.in b/lib/Makefile.in
 index 827e3ae..61527b7 100644
 --- a/lib/Makefile.in
 +++ b/lib/Makefile.in
-@@ -121,7 +121,7 @@ ifeq ($(SHARED_LIBRARY), yes)
+@@ -121,7 +121,6 @@ ifeq ($(SHARED_LIBRARY), yes)
  		echo "Install shared library"
  		mkdir -p $(DESTDIR)$(libdir)
  		install -m 755 libipv6calc.so.@PACKAGE_VERSION@ $(DESTDIR)$(libdir)
 -		/sbin/ldconfig -n $(DESTDIR)$(libdir)
-+		/sbin/ldconfig $(DESTDIR)$(libdir)
  else
  		echo "Nothing to do (shared library mode is not enabled)"
  endif

--- a/net-misc/ipv6calc/ipv6calc-4.3.2.ebuild
+++ b/net-misc/ipv6calc/ipv6calc-4.3.2.ebuild
@@ -84,12 +84,12 @@ src_configure() {
 src_test() {
 	if [[ ${EUID} -eq 0 ]]; then
 		# Disable tests that fail as root
-		echo true > ipv6logstats/test_ipv6logstats.sh
+		echo true > ipv6logstats/test_ipv6logstats.sh || die
 	fi
 	# it requires an apache instance
-	echo true > mod_ipv6calc/test_mod_ipv6calc.sh
+	echo true > mod_ipv6calc/test_mod_ipv6calc.sh || die
 	# it requires network
-	echo true > ipv6calcweb/test_ipv6calcweb.sh
-	echo true > ipv6calcweb/test_ipv6calcweb_form.sh
+	echo true > ipv6calcweb/test_ipv6calcweb.sh || die
+	echo true > ipv6calcweb/test_ipv6calcweb_form.sh || die
 	default
 }


### PR DESCRIPTION
ldconfig is not helpfull here (no reverse dep), the abspath may be wrong in some env, and ldconfig from musl doesn't support any arg

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
