### PR TITLE
app-admin/whowatch: fix gcc15, remove dead HOMEPAGE

### DIFF
--- a/app-admin/whowatch/files/whowatch-1.8.6-fix_gcc15.patch
+++ b/app-admin/whowatch/files/whowatch-1.8.6-fix_gcc15.patch
@@ -1,0 +1,53 @@
+PR merged
+https://github.com/mtsuszycki/whowatch/pull/13.patch
+From dae08e498ee8ced3083cc7061586c7bdd8cdc041 Mon Sep 17 00:00:00 2001
+From: Richard Fearn <richardfearn@gmail.com>
+Date: Sat, 25 Jan 2025 19:14:21 +0000
+Subject: [PATCH] Allow compilation with GCC 15
+
+* Remove/replace incorrect declarations of update_tree
+* Fix signature of winch_handler signal handler, which must take an int
+---
+ src/proctree.h | 1 -
+ src/whowatch.c | 2 +-
+ src/whowatch.h | 2 +-
+ 3 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/proctree.h b/src/proctree.h
+index 13e5328..ee175b7 100644
+--- a/src/proctree.h
++++ b/src/proctree.h
+@@ -41,7 +41,6 @@ struct proc_t {
+ };
+ 
+ int update_tree(void del(void*));
+-int update_tree();
+ struct proc_t* find_by_pid(int pid);
+ struct proc_t* tree_start(int root, int start);
+ struct proc_t* tree_next();
+diff --git a/src/whowatch.c b/src/whowatch.c
+index 77828a7..37a7e8a 100644
+--- a/src/whowatch.c
++++ b/src/whowatch.c
+@@ -243,7 +243,7 @@ werase(w->wd);
+ 	size_changed = 0;
+ }
+ 
+-static void winch_handler()
++static void winch_handler(int i)
+ {
+ 	size_changed++;
+ }
+diff --git a/src/whowatch.h b/src/whowatch.h
+index 42cebbe..52b67e6 100644
+--- a/src/whowatch.h
++++ b/src/whowatch.h
+@@ -185,7 +185,7 @@ void curses_init();
+ void curses_end();
+ 
+ /* proctree.c */
+-int update_tree();
++int update_tree(void del(void*));
+ 
+ /* plist.c */
+ void delete_tree_line(void *line);

--- a/app-admin/whowatch/whowatch-1.8.6-r2.ebuild
+++ b/app-admin/whowatch/whowatch-1.8.6-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit autotools
 
 DESCRIPTION="Displays information about users currently logged on in real time"
-HOMEPAGE="http://wizard.ae.krakow.pl/~mike/ https://github.com/mtsuszycki/whowatch/"
+HOMEPAGE="https://github.com/mtsuszycki/whowatch/"
 SRC_URI="https://github.com/mtsuszycki/${PN}/releases/download/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
@@ -20,6 +20,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.8.4-tinfo.patch
 	"${FILESDIR}"/${PN}-1.8.4-configure-clang16.patch
+	"${FILESDIR}"/${PN}-1.8.6-fix_gcc15.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
remove dead HOMEPAGE without A/AAAA
fix gcc-15

Closes: https://bugs.gentoo.org/881981

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
