### PR TITLE
qmake-utils.eclass: add "-spec ..." for qmake6

### DIFF
--- a/eclass/qmake-utils.eclass
+++ b/eclass/qmake-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: qmake-utils.eclass
@@ -159,6 +159,20 @@ qt6_get_plugindir() {
 # @DESCRIPTION:
 # Echoes a multi-line string containing arguments to pass to qmake.
 qt6_get_qmake_args() {
+	local QMAKE_SPEC=
+	local QMAKE_SPEC_DEF=$("$(qt6_get_bindir)"/qmake -query QMAKE_SPEC || die)
+	if use kernel_linux ; then
+		if tc-is-gcc ; then
+			QMAKE_SPEC="linux-g++"
+		elif tc-is-clang ; then
+			QMAKE_SPEC="linux-clang"
+		fi
+	fi
+
+	[[ "${QMAKE_SPEC}" == "${QMAKE_SPEC_DEF}" ]] && {
+		QMAKE_SPEC=
+	}
+
 	cat <<-EOF
 		QMAKE_AR="$(tc-getAR) cqs"
 		QMAKE_CC="$(tc-getCC)"
@@ -182,6 +196,8 @@ qt6_get_qmake_args() {
 		QMAKE_LFLAGS_RELEASE=
 		QMAKE_LFLAGS_DEBUG=
 		QMAKE_LFLAGS_RELEASE_WITH_DEBUGINFO=
+		${QMAKE_SPEC:+-spec}
+		${QMAKE_SPEC:+${QMAKE_SPEC}}
 	EOF
 }
 


### PR DESCRIPTION
If qt6 is built with clang, QMAKE_SPEC defaults to linux-clang. However, if we try to build, for example, "app-benchmarks/i7z" with gcc, if will fail with:

> g++: error: unrecognized command-line option '-fno-direct-access-external-data'

This suggests that setting QMAKE_CC / QMAKE_CXX / ... alone is not sufficient for qmake to select the correct compiler. See the test case below:

> \# cat a.pro
> message(QMAKE_CC is $$QMAKE_CC)
> clang {
>         message("clang is true")
> } else {
>         message("clang is false")
> }
> \# /usr/lib64/qt6/bin/qmake a.pro
> Project MESSAGE: QMAKE_CC is clang
> Project MESSAGE: clang is true
> \# /usr/lib64/qt6/bin/qmake a.pro QMAKE_CC=gcc
> Project MESSAGE: QMAKE_CC is gcc
> Project MESSAGE: clang is true

After adding "-spec linux-g++",

> \# /usr/lib64/qt6/bin/qmake a.pro QMAKE_CC=gcc -spec linux-g++
> Project MESSAGE: QMAKE_CC is gcc
> Project MESSAGE: clang is false

Please note: for now, we only handle Linux with GCC or Clang.

Closes: https://bugs.gentoo.org/960633

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
