### PR TITLE
meson.eclass: set python.bytecompile to 2

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -352,6 +352,7 @@ setup_meson_src_configure() {
 		--build.pkg-config-path "${BUILD_PKG_CONFIG_PATH}${BUILD_PKG_CONFIG_PATH:+:}${EPREFIX}/usr/share/pkgconfig"
 		--pkg-config-path "${PKG_CONFIG_PATH}${PKG_CONFIG_PATH:+:}${EPREFIX}/usr/share/pkgconfig"
 		--native-file "$(_meson_create_native_file)"
+		--python.bytecompile 2
 
 		# gcc[pch] is masked in profiles due to consistent bugginess
 		# without forcing this off, some packages may fail too (like gjs,


### PR DESCRIPTION
Since release 1.2.0 Meson has by default been byte-compiling Python modules at level 0. Changing to level 2 makes it possible for some ebuilds to stop using python_optimize.

---

Sent to gentoo-dev@lists.gentoo.org, base-system@gentoo.org

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
