### PR TITLE
dev-embedded/urjtag: enable py3.13, py3.14

### DIFF
--- a/dev-embedded/urjtag/urjtag-2021.03.ebuild
+++ b/dev-embedded/urjtag/urjtag-2021.03.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit python-r1
 

--- a/dev-embedded/urjtag/urjtag-9999.ebuild
+++ b/dev-embedded/urjtag/urjtag-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit python-r1
 


### PR DESCRIPTION
** NOTE: Please only merge if happy with my findings, only suggesting as I'm pretty confident it's safe and save someone redoing the same tests I did ** 

Difficult one to test as it's binding to use Python projects. I'm reasonably sure this is safe after checking https://github.com/shuckc/urjtag/blob/master/urjtag/doc/urjtag-python.txt and doing some very basic sanity tests, however there is still a risk we'll only find out with some real user testing.

Upstream also seems dead with the github archived, SF last fix being a grammer fix in 2023 and last bug closed in 2021.

Closes: https://bugs.gentoo.org/952291

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
