### PR TITLE
sys-process/btop: add dep on libmd

### DIFF
--- a/sys-process/btop/btop-1.4.4.ebuild
+++ b/sys-process/btop/btop-1.4.4.ebuild
@@ -16,6 +16,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~x86"
 
 BDEPEND="
+	app-crypt/libmd
 	app-text/lowdown
 "
 


### PR DESCRIPTION
On a brand-new gentoo VM, using the officially provided qcow2 image, installing btop fails due to missing a dependency on `libmd.so.0`.  Running `e-file libmd.so.0` points to `app-crypt/libmd`.  Installing `libmd` first allows btop to be built.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
