### PR TITLE
app-office/libreoffice: Make wayland and X optional for gtk

### DIFF
--- a/app-office/libreoffice/libreoffice-25.2.5.2-r1.ebuild
+++ b/app-office/libreoffice/libreoffice-25.2.5.2-r1.ebuild
@@ -92,6 +92,7 @@ LO_EXTS="nlpsolver scripting-beanshell scripting-javascript wiki-publisher"
 
 IUSE="accessibility base bluetooth +branding coinmp +cups custom-cflags +dbus debug eds
 googledrive gstreamer +gtk3 gtk4 kde ldap +mariadb odk pdfimport postgres qt6 test valgrind vulkan
+wayland X
 $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -198,7 +199,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-libs/glib:2
 		gnome-base/dconf
 		media-libs/mesa[egl(+)]
-		x11-libs/gtk+:3[wayland,X]
+		x11-libs/gtk+:3[wayland?,X?]
 		x11-libs/pango
 	)
 	gtk4? (
@@ -206,7 +207,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 		dev-libs/glib:2
 		gnome-base/dconf
 		media-libs/mesa[egl(+)]
-		gui-libs/gtk:4[wayland,X]
+		gui-libs/gtk:4[wayland?,X?]
 		x11-libs/pango
 	)
 	kde? (


### PR DESCRIPTION
This commit makes the wayland and X flags optional for gtk instead of enabling both by default. This is done by adding these flags to the libreoffice ebuild.

---

Please check all the boxes that apply:

- [*] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [*] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [*] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [*] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
