### PR TITLE
app-text/podofo: backport libc++ 20 build fix

### DIFF
--- a/app-text/podofo/files/podofo-0.10.3-libcxx-20-from_chars.patch
+++ b/app-text/podofo/files/podofo-0.10.3-libcxx-20-from_chars.patch
@@ -1,0 +1,23 @@
+From https://github.com/podofo/podofo/commit/aa9267229b40b49e5927f286841be4cbe81d05d5.patch Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sun, 22 Jun 2025 07:02:49 +0000
+Subject: [PATCH] private: charconv: Don't define from_chars for libc++ 20 or
+ later
+
+LLVM libc++ starts to provide a float-point-capable std::from_chars()
+since LLVM 20 release[1]. Unconditionally defining from_chars() when
+using Clang will cause ambiguous references and fails the build.
+
+Link: https://github.com/llvm/llvm-project/pull/91651 # [1]
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+--- a/src/podofo/private/charconv_compat.h
++++ b/src/podofo/private/charconv_compat.h
+@@ -7,7 +7,7 @@
+ #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 10
+ #define WANT_CHARS_FORMAT
+ #endif
+-#if (defined(__GNUC__) && __GNUC__ < 11) || defined(__clang__)
++#if (defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11) || (defined(__clang__) && defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION < 200000))
+ #define WANT_FROM_CHARS
+ #endif
+ #if (defined(__GNUC__) && !defined(__clang__) && !defined(__MINGW32__) &&  __GNUC__ < 11) || (defined(__MINGW32__) &&  __GNUC__ < 12) || (defined(__clang__) && ((defined(__apple_build_version__) && __apple_build_version__ < 15000000) || __clang_major__ < 14))

--- a/app-text/podofo/podofo-0.10.3-r1.ebuild
+++ b/app-text/podofo/podofo-0.10.3-r1.ebuild
@@ -37,6 +37,11 @@ BDEPEND="
 	test? ( fontconfig? ( media-fonts/liberation-fonts ) )
 "
 
+PATCHES=(
+	# backport of https://github.com/podofo/podofo/commit/aa9267229b40b49e5927f286841be4cbe81d05d5
+	"${FILESDIR}/${P}-libcxx-20-from_chars.patch"
+)
+
 src_prepare() {
 	cmake_src_prepare
 	if use test; then


### PR DESCRIPTION
PoDoFo also has a separate issue with the upcoming libc++ 21 that I have not managed to fix yet. In addition, the latest release upstream is at 1.0.1, however I'm leaving that bump to the package's actual maintainers since it has massive API changes.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
