### PR TITLE
dev-libs/libfmt: fix build with libc++ 21

### DIFF
--- a/dev-libs/libfmt/files/libfmt-11.2.0-libcxx-21-cstdlib.patch
+++ b/dev-libs/libfmt/files/libfmt-11.2.0-libcxx-21-cstdlib.patch
@@ -1,0 +1,37 @@
+From https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2 Mon Sep 17 00:00:00 2001
+From: Remy Jette <remy@remyjette.com>
+Date: Sat, 21 Jun 2025 07:28:14 -0700
+Subject: [PATCH] Fix compilation on clang-21 / libc++-21 (#4477)
+
+`<cstdlib>` was not being included, so malloc and free were only declared
+via transitive includes. Some includes changed in the latest libc++-21
+build which broke fmt.
+
+Also changed `malloc`/`free` to `std::malloc` and `std::free`, as
+putting those symbols in the global namespace is optional for the
+implementation when including `<cstdlib>`.
+--- a/include/fmt/format.h
++++ b/include/fmt/format.h
+@@ -44,6 +44,7 @@
+ #  include <cmath>    // std::signbit
+ #  include <cstddef>  // std::byte
+ #  include <cstdint>  // uint32_t
++#  include <cstdlib>  // std::malloc, std::free
+ #  include <cstring>  // std::memcpy
+ #  include <limits>   // std::numeric_limits
+ #  include <new>      // std::bad_alloc
+@@ -755,12 +756,12 @@ template <typename T> struct allocator : private std::decay<void> {
+ 
+   T* allocate(size_t n) {
+     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
+-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
++    T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+     if (!p) FMT_THROW(std::bad_alloc());
+     return p;
+   }
+ 
+-  void deallocate(T* p, size_t) { free(p); }
++  void deallocate(T* p, size_t) { std::free(p); }
+ };
+ 
+ }  // namespace detail

--- a/dev-libs/libfmt/libfmt-11.2.0-r1.ebuild
+++ b/dev-libs/libfmt/libfmt-11.2.0-r1.ebuild
@@ -22,6 +22,11 @@ SLOT="0/${PV}"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	# backport of https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2
+	"${FILESDIR}/${P}-libcxx-21-cstdlib.patch"
+)
+
 multilib_src_configure() {
 	append-lfs-flags
 	local mycmakeargs=(

--- a/dev-util/ccache/ccache-4.11.3.ebuild
+++ b/dev-util/ccache/ccache-4.11.3.ebuild
@@ -75,6 +75,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.5-nvcc-test.patch
 	"${FILESDIR}"/${PN}-4.0-objdump.patch
 	"${FILESDIR}"/${PN}-4.11-avoid-run-user.patch
+	"${FILESDIR}"/${PN}-4.11.3-libfmt-libcxx-21.patch
 )
 
 src_unpack() {

--- a/dev-util/ccache/files/ccache-4.11.3-libfmt-libcxx-21.patch
+++ b/dev-util/ccache/files/ccache-4.11.3-libfmt-libcxx-21.patch
@@ -1,0 +1,37 @@
+From https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2 Mon Sep 17 00:00:00 2001
+From: Remy Jette <remy@remyjette.com>
+Date: Sat, 21 Jun 2025 07:28:14 -0700
+Subject: [PATCH] Fix compilation on clang-21 / libc++-21 (#4477)
+
+`<cstdlib>` was not being included, so malloc and free were only declared
+via transitive includes. Some includes changed in the latest libc++-21
+build which broke fmt.
+
+Also changed `malloc`/`free` to `std::malloc` and `std::free`, as
+putting those symbols in the global namespace is optional for the
+implementation when including `<cstdlib>`.
+--- a/src/third_party/fmt/fmt/format.h
++++ b/src/third_party/fmt/fmt/format.h
+@@ -44,6 +44,7 @@
+ #  include <cmath>    // std::signbit
+ #  include <cstddef>  // std::byte
+ #  include <cstdint>  // uint32_t
++#  include <cstdlib>  // std::malloc, std::free
+ #  include <cstring>  // std::memcpy
+ #  include <limits>   // std::numeric_limits
+ #  include <new>      // std::bad_alloc
+@@ -755,12 +756,12 @@ template <typename T> struct allocator : private std::decay<void> {
+ 
+   T* allocate(size_t n) {
+     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
+-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
++    T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+     if (!p) FMT_THROW(std::bad_alloc());
+     return p;
+   }
+ 
+-  void deallocate(T* p, size_t) { free(p); }
++  void deallocate(T* p, size_t) { std::free(p); }
+ };
+ 
+ }  // namespace detail

--- a/media-libs/openal/files/openal-1.24.3-libfmt-libcxx-21.patch
+++ b/media-libs/openal/files/openal-1.24.3-libfmt-libcxx-21.patch
@@ -1,0 +1,37 @@
+From https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2 Mon Sep 17 00:00:00 2001
+From: Remy Jette <remy@remyjette.com>
+Date: Sat, 21 Jun 2025 07:28:14 -0700
+Subject: [PATCH] Fix compilation on clang-21 / libc++-21 (#4477)
+
+`<cstdlib>` was not being included, so malloc and free were only declared
+via transitive includes. Some includes changed in the latest libc++-21
+build which broke fmt.
+
+Also changed `malloc`/`free` to `std::malloc` and `std::free`, as
+putting those symbols in the global namespace is optional for the
+implementation when including `<cstdlib>`.
+--- a/fmt-11.1.1/include/fmt/format.h
++++ b/fmt-11.1.1/include/fmt/format.h
+@@ -44,6 +44,7 @@
+ #  include <cmath>    // std::signbit
+ #  include <cstddef>  // std::byte
+ #  include <cstdint>  // uint32_t
++#  include <cstdlib>  // std::malloc, std::free
+ #  include <cstring>  // std::memcpy
+ #  include <limits>   // std::numeric_limits
+ #  include <new>      // std::bad_alloc
+@@ -755,12 +756,12 @@ template <typename T> struct allocator : private std::decay<void> {
+ 
+   T* allocate(size_t n) {
+     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
+-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
++    T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+     if (!p) FMT_THROW(std::bad_alloc());
+     return p;
+   }
+ 
+-  void deallocate(T* p, size_t) { free(p); }
++  void deallocate(T* p, size_t) { std::free(p); }
+ };
+ 
+ }  // namespace detail

--- a/media-libs/openal/openal-1.24.3.ebuild
+++ b/media-libs/openal/openal-1.24.3.ebuild
@@ -46,7 +46,12 @@ DEPEND="${RDEPEND}
 
 DOCS=( alsoftrc.sample docs/env-vars.txt docs/hrtf.txt ChangeLog README.md )
 
-PATCHES=( "${FILESDIR}/${P}-qt6.patch" ) # bug 955274; git master
+PATCHES=(
+	# bug 955274; git master
+	"${FILESDIR}/${P}-qt6.patch"
+	# backport of https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2 for bundled libfmt
+	"${FILESDIR}/${PN}-1.24.3-libfmt-libcxx-21.patch"
+)
 
 multilib_src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Backports https://github.com/fmtlib/fmt/commit/f4345467fce7edbc6b36c3fa1cf197a67be617e2 for dev-libs/libfmt and bundled libfmt in dev-util/ccache.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
