### PR TITLE
[ffmpeg-chromium] Add -DCHROMIUM_NO_LOGGING for binary size

### DIFF
--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-139.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-139.ebuild
@@ -207,6 +207,7 @@ src_configure() {
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \
+		--extra-cflags="-DCHROMIUM_NO_LOGGING" \
 		--disable-all \
 		--disable-autodetect \
 		--disable-error-resilience \


### PR DESCRIPTION
Hello. I'm on Arch Linux and have 2 pkgs, [same src with Gentoo/ffmpeg-chromium](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=opera-ffmpeg-codecs) or [ffmpeg.org src](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=chromium-ffmpeg-codecs).

[chromium/third_pirty/ffmpeg](https://chromium.googlesource.com/chromium/third_party/ffmpeg/+/refs/heads/master/chromium/patches/README) has `-DCHROMIUM_NO_LOGGING` flag to drop binary size about 0.1~0.2 MB.
I don't know is it should be default for Gentoo. But it should be useful.

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
