### PR TITLE
sys-apps/musl-locales: fix installation

### DIFF
--- a/sys-apps/musl-locales/musl-locales-0.1.0-r2.ebuild
+++ b/sys-apps/musl-locales/musl-locales-0.1.0-r2.ebuild
@@ -23,6 +23,7 @@ src_configure() {
 }
 
 src_install() {
+	cmake_src_install
 	echo "MUSL_LOCPATH=\"/usr/share/i18n/locales/musl\"" | newenvd - 00locale
 }
 


### PR DESCRIPTION
When the env.d file was added, cmake_src_install was not included in the new src_install function, so musl-locales was not actually getting installed. This fixes that.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
