### PR TITLE
sys-fs/udiskie: Add XDG-compatible autostart

### DIFF
--- a/sys-fs/udiskie/files/udiskie.desktop
+++ b/sys-fs/udiskie/files/udiskie.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=udiskie
+Comment=An automatic disk mounting service using udisks
+Exec=/usr/bin/udiskie
+Terminal=false
+Type=Application
+X-GNOME-HiddenUnderSystemd=true
+X-KDE-HiddenUnderSystemd=true
+X-systemd-skip=true

--- a/sys-fs/udiskie/metadata.xml
+++ b/sys-fs/udiskie/metadata.xml
@@ -9,4 +9,7 @@
 		<remote-id type="pypi">udiskie</remote-id>
 		<remote-id type="github">coldfix/udiskie</remote-id>
 	</upstream>
+	<use>
+		<flag name="autostart">Enable XDG-compatible autostart of udiskie</flag>
+	</use>
 </pkgmetadata>

--- a/sys-fs/udiskie/udiskie-2.5.8-r1.ebuild
+++ b/sys-fs/udiskie/udiskie-2.5.8-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{9..13} )
+DISTUTILS_USE_PEP517=setuptools
+inherit distutils-r1 pypi xdg-utils
+
+DESCRIPTION="An automatic disk mounting service using udisks"
+HOMEPAGE="https://pypi.org/project/udiskie/ https://github.com/coldfix/udiskie"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="autostart libnotify"
+
+RDEPEND="dev-python/docopt[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	sys-fs/udisks:2[daemon]
+	libnotify? ( x11-libs/libnotify[introspection] )"
+DEPEND="app-text/asciidoc
+	test? ( dev-python/keyutils[${PYTHON_USEDEP}]
+		dev-python/pyyaml[${PYTHON_USEDEP}] )"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	sed -i -e 's:gtk-update-icon-cache:true:' setup.py || die
+	sed -i -e 's: HACKING.rst, TRANSLATIONS.rst,::'	setup.cfg || die
+	default
+
+	distutils-r1_src_prepare
+}
+
+src_compile() {
+	distutils-r1_src_compile
+	emake -C doc
+}
+
+src_install() {
+	distutils-r1_src_install
+	doman doc/${PN}.8
+
+	if use autostart; then
+		insinto /etc/xdg/autostart
+		newins "${FILESDIR}/udiskie.desktop" udiskie.desktop
+	fi
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Add a new use flag (`autostart`) which enables installation of XDG-compatible autostart configuration.

This is convenient for systems without systemd and with desktop environments, which support XDG autostart (e.g. COSMIC).

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
