### PR TITLE
make sci-chemistry/surf-1.0.ebuild compile with modern compiliers i.e…

### DIFF
--- a/sci-chemistry/surf/surf-1.0.ebuild
+++ b/sci-chemistry/surf/surf-1.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -23,6 +23,7 @@ PATCHES=(
 )
 
 src_configure() {
+	append-cflags -std=gnu89
 	tc-export CC
 }
 


### PR DESCRIPTION
…. gcc-14

Added -std=gnu89 as compilation otherwise fails as newer standards do not allow for implicit int and implicit functions as required by surf.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
