### PR TITLE
python-utils-r1.eclass: use 6 'X's for mktemp

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1416,7 +1416,7 @@ epytest() {
 	[[ ${NO_COLOR} ]] && color=no
 
 	mkdir -p "${T}/pytest-xml" || die
-	local junit_xml=$(mktemp "${T}/pytest-xml/${EPYTHON}-XXX.xml" || die)
+	local junit_xml=$(mktemp "${T}/pytest-xml/${EPYTHON}-XXXXXX.xml" || die)
 
 	local args=(
 		# verbose progress reporting and tracebacks


### PR DESCRIPTION
As required by POSIX.1-2024 for mkstemp(3) (and future-POSIX for mktemp(1))

Although you'd need de-facto standard mkstemps(3) due to the .xml suffix,
but same contrains of 6 'X's applies, at least with musl.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
