### PR TITLE
gnome-base/gnome-control-center: enforce binary dependency on gtk x11 and wayland backends

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-46.4-r3.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-46.4-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"

--- a/gnome-base/gnome-control-center/gnome-control-center-46.4-r3.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-46.4-r3.ebuild
@@ -2,19 +2,19 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{11..13} )
 
+PYTHON_COMPAT=( python3_{10..13} )
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"
 HOMEPAGE="https://apps.gnome.org/Settings"
-SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${PN}-47.3-patchset.tar.xz"
+SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${P}-patchset-r1.tar.xz"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo.svg"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo-dark.svg"
 # Logo is CC-BY-SA-2.5
 LICENSE="GPL-2+ CC-BY-SA-2.5"
 SLOT="2"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+KEYWORDS="amd64 ~arm arm64 ~loong ~ppc ~ppc64 ~riscv x86"
 
 IUSE="+bluetooth +cups debug elogind +gnome-online-accounts +ibus input_devices_wacom kerberos +geolocation networkmanager systemd test wayland"
 REQUIRED_USE="
@@ -32,19 +32,19 @@ RESTRICT="!test? ( test )"
 # Second block is dependency() from subdir meson.builds, sorted by directory name occurrence order
 DEPEND="
 	gnome-online-accounts? (
-		x11-libs/gtk+:3
-		>=net-libs/gnome-online-accounts-3.51.0:=
+		x11-libs/gtk+:3[X,wayland=]
+		>=net-libs/gnome-online-accounts-3.49.1:=
 	)
 	>=media-libs/libpulse-2.0[glib]
-	>=gui-libs/gtk-4.15.2:4[X,wayland=]
-	>=gui-libs/libadwaita-1.6_beta:1
-	>=sys-apps/accountsservice-23.11.69
+	>=gui-libs/gtk-4.11.2:4[X,wayland=]
+	>=gui-libs/libadwaita-1.4_alpha:1
+	>=sys-apps/accountsservice-0.6.39
 	>=x11-misc/colord-0.1.34:0=
 	>=x11-libs/gdk-pixbuf-2.23.0:2
 	>=dev-libs/glib-2.76.6:2
 	gnome-base/gnome-desktop:4=
 	>=gnome-base/gnome-settings-daemon-41.0[colord,input_devices_wacom?]
-	>=gnome-base/gsettings-desktop-schemas-47.0
+	>=gnome-base/gsettings-desktop-schemas-46_beta
 	dev-libs/libxml2:2=
 	>=sys-power/upower-0.99.8:=
 	>=dev-libs/libgudev-232
@@ -132,7 +132,6 @@ BDEPEND="${PYTHON_DEPS}
 		$(python_gen_any_dep '
 			dev-python/python-dbusmock[${PYTHON_USEDEP}]
 		')
-		x11-apps/setxkbmap
 	)
 "
 
@@ -194,8 +193,6 @@ src_configure() {
 }
 
 src_test() {
-	# tests are fragile to long socket paths, bug #921583
-	local -x TMPDIR=/tmp
 	virtx meson_src_test
 }
 

--- a/gnome-base/gnome-control-center/gnome-control-center-47.3-r2.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.3-r2.ebuild
@@ -2,19 +2,19 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-
 PYTHON_COMPAT=( python3_{10..13} )
+
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"
 HOMEPAGE="https://apps.gnome.org/Settings"
-SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${P}-patchset-r1.tar.xz"
+SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${P}-patchset.tar.xz"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo.svg"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo-dark.svg"
 # Logo is CC-BY-SA-2.5
 LICENSE="GPL-2+ CC-BY-SA-2.5"
 SLOT="2"
-KEYWORDS="amd64 ~arm arm64 ~loong ~ppc ~ppc64 ~riscv x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
 IUSE="+bluetooth +cups debug elogind +gnome-online-accounts +ibus input_devices_wacom kerberos +geolocation networkmanager systemd test wayland"
 REQUIRED_USE="
@@ -32,19 +32,19 @@ RESTRICT="!test? ( test )"
 # Second block is dependency() from subdir meson.builds, sorted by directory name occurrence order
 DEPEND="
 	gnome-online-accounts? (
-		x11-libs/gtk+:3
-		>=net-libs/gnome-online-accounts-3.49.1:=
+		x11-libs/gtk+:3[X,wayland=]
+		>=net-libs/gnome-online-accounts-3.51.0:=
 	)
 	>=media-libs/libpulse-2.0[glib]
-	>=gui-libs/gtk-4.11.2:4[X,wayland=]
-	>=gui-libs/libadwaita-1.4_alpha:1
+	>=gui-libs/gtk-4.15.2:4[X,wayland=]
+	>=gui-libs/libadwaita-1.6_beta:1
 	>=sys-apps/accountsservice-0.6.39
 	>=x11-misc/colord-0.1.34:0=
 	>=x11-libs/gdk-pixbuf-2.23.0:2
 	>=dev-libs/glib-2.76.6:2
 	gnome-base/gnome-desktop:4=
 	>=gnome-base/gnome-settings-daemon-41.0[colord,input_devices_wacom?]
-	>=gnome-base/gsettings-desktop-schemas-46_beta
+	>=gnome-base/gsettings-desktop-schemas-47.0
 	dev-libs/libxml2:2=
 	>=sys-power/upower-0.99.8:=
 	>=dev-libs/libgudev-232
@@ -132,6 +132,7 @@ BDEPEND="${PYTHON_DEPS}
 		$(python_gen_any_dep '
 			dev-python/python-dbusmock[${PYTHON_USEDEP}]
 		')
+		x11-apps/setxkbmap
 	)
 "
 

--- a/gnome-base/gnome-control-center/gnome-control-center-47.3-r2.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.3-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 

--- a/gnome-base/gnome-control-center/gnome-control-center-47.6-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.6-r1.ebuild
@@ -32,7 +32,7 @@ RESTRICT="!test? ( test )"
 # Second block is dependency() from subdir meson.builds, sorted by directory name occurrence order
 DEPEND="
 	gnome-online-accounts? (
-		x11-libs/gtk+:3
+		x11-libs/gtk+:3[X,wayland=]
 		>=net-libs/gnome-online-accounts-3.51.0:=
 	)
 	>=media-libs/libpulse-2.0[glib]

--- a/gnome-base/gnome-control-center/gnome-control-center-47.6-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.6-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 

--- a/gnome-base/gnome-control-center/gnome-control-center-47.7-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.7-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 

--- a/gnome-base/gnome-control-center/gnome-control-center-47.7-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-47.7-r1.ebuild
@@ -2,13 +2,13 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit flag-o-matic gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 
 DESCRIPTION="GNOME's main interface to configure various aspects of the desktop"
 HOMEPAGE="https://apps.gnome.org/Settings"
-SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${P}-patchset.tar.xz"
+SRC_URI+=" https://dev.gentoo.org/~pacho/${PN}/${PN}-47.3-patchset.tar.xz"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo.svg"
 SRC_URI+=" https://dev.gentoo.org/~mattst88/distfiles/${PN}-gentoo-logo-dark.svg"
 # Logo is CC-BY-SA-2.5
@@ -32,13 +32,13 @@ RESTRICT="!test? ( test )"
 # Second block is dependency() from subdir meson.builds, sorted by directory name occurrence order
 DEPEND="
 	gnome-online-accounts? (
-		x11-libs/gtk+:3
+		x11-libs/gtk+:3[X,wayland=]
 		>=net-libs/gnome-online-accounts-3.51.0:=
 	)
 	>=media-libs/libpulse-2.0[glib]
 	>=gui-libs/gtk-4.15.2:4[X,wayland=]
 	>=gui-libs/libadwaita-1.6_beta:1
-	>=sys-apps/accountsservice-0.6.39
+	>=sys-apps/accountsservice-23.11.69
 	>=x11-misc/colord-0.1.34:0=
 	>=x11-libs/gdk-pixbuf-2.23.0:2
 	>=dev-libs/glib-2.76.6:2
@@ -194,6 +194,8 @@ src_configure() {
 }
 
 src_test() {
+	# tests are fragile to long socket paths, bug #921583
+	local -x TMPDIR=/tmp
 	virtx meson_src_test
 }
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
