### PR TITLE
media-sound/mixxx: add missing include

### DIFF
--- a/media-sound/mixxx/files/mixxx-2.5.2-libcxx21_include.patch
+++ b/media-sound/mixxx/files/mixxx-2.5.2-libcxx21_include.patch
@@ -1,0 +1,35 @@
+https://github.com/mixxxdj/mixxx/pull/15132.patch
+From 9f9a7496f90fe7d1f153d2d62af4613b6d2f1d74 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Sun, 27 Jul 2025 16:06:26 +0200
+Subject: [PATCH] missing include cstdlib
+
+Error with libcxx-21
+
+>In file included from ./mixxx-2.5.2/lib/reverb/Reverb.cc:46:
+>In file included from ./mixxx-2.5.2/lib/reverb/Reverb.h:54:
+>./mixxx-2.5.2/lib/reverb/dsp/Delay.h:51:14: error: use of undeclared identifier 'free'
+>   51 |                 ~Delay() { free (data); }
+>      |                            ^~~~
+>./mixxx-2.5.2/work/mixxx-2.5.2/lib/reverb/dsp/Delay.h:57:25: error: use of undeclared identifier 'calloc'
+>   57 |                                 data = (sample_t *) calloc (sizeof (sample_t), size);
+>      |                                                     ^~~~~~
+>2 errors generated.
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+---
+ lib/reverb/dsp/Delay.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/reverb/dsp/Delay.h b/lib/reverb/dsp/Delay.h
+index d530fee58a1c..a560b7552446 100644
+--- a/lib/reverb/dsp/Delay.h
++++ b/lib/reverb/dsp/Delay.h
+@@ -32,6 +32,7 @@
+ #ifndef _DSP_DELAY_H_
+ #define _DSP_DELAY_H_
+ 
++#include <cstdlib> // for free and calloc
+ #include <cstring> // for memset
+ 
+ #include "util.h"

--- a/media-sound/mixxx/mixxx-2.5.2.ebuild
+++ b/media-sound/mixxx/mixxx-2.5.2.ebuild
@@ -101,6 +101,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.5.2-x11_opt.patch
 	# Fix colum header text asignment. From upstream.
 	"${FILESDIR}"/${P}-fix_col_headers.patch
+	# Fix build with libcxx-21
+	# https://github.com/mixxxdj/mixxx/pull/15132.patch
+	"${FILESDIR}"/${P}-libcxx21_include.patch
 )
 
 CMAKE_SKIP_TESTS=(


### PR DESCRIPTION
Add missing cstdlib with libcxx-21

Closes: https://bugs.gentoo.org/960756

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
