### PR TITLE
net-libs/udns, mail-filter/rblcheck: avoid collision for rblcheck binary

### DIFF
--- a/mail-filter/rblcheck/rblcheck-1.5-r3.ebuild
+++ b/mail-filter/rblcheck/rblcheck-1.5-r3.ebuild
@@ -13,6 +13,8 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~hppa ~mips ppc sparc x86"
 
+RDEPEND="!net-libs/udns[tools]"
+
 PATCHES=(
 	"${FILESDIR}"/${P}-autoconf.patch
 )

--- a/net-libs/udns/udns-0.6.ebuild
+++ b/net-libs/udns/udns-0.6.ebuild
@@ -14,6 +14,8 @@ SLOT="0"
 KEYWORDS="amd64 ~arm64 ~hppa ppc ppc64 sparc x86"
 IUSE="ipv6 +tools"
 
+RDEPEND="tools? ( !mail-filter/rblcheck )"
+
 src_configure() {
 	# Uses non-standard configure script, econf doesn't work
 	CC="$(tc-getCC)" RANLIB="$(tc-getRANLIB)" edo ./configure $(use_enable ipv6)


### PR DESCRIPTION
Add a blocker for both packages.

Closes: https://bugs.gentoo.org/525462

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
