### PR TITLE
app-accessibility/espeakup: fixups and keywording

### DIFF
--- a/app-accessibility/espeakup/espeakup-0.90-r3.ebuild
+++ b/app-accessibility/espeakup/espeakup-0.90-r3.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/linux-speakup/espeakup/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
 inherit linux-info meson

--- a/app-accessibility/espeakup/espeakup-0.90-r3.ebuild
+++ b/app-accessibility/espeakup/espeakup-0.90-r3.ebuild
@@ -44,7 +44,7 @@ src_install() {
 	einstalldocs
 	newconfd "${FILESDIR}"/espeakup.confd espeakup
 	newinitd "${FILESDIR}"/espeakup.initd espeakup
-	insinto /etc/modprobe.d
+	insinto /etc/modules-load.d/
 	newins "${FILESDIR}/modules.espeakup" espeakup.conf
 
 }

--- a/app-accessibility/espeakup/espeakup-9999.ebuild
+++ b/app-accessibility/espeakup/espeakup-9999.ebuild
@@ -42,7 +42,7 @@ src_install() {
 	einstalldocs
 	newconfd "${FILESDIR}"/espeakup.confd espeakup
 	newinitd "${FILESDIR}"/espeakup.initd espeakup
-	insinto /etc/modprobe.d
+	insinto /etc/modules-load.d/
 	newins "${FILESDIR}/modules.espeakup" espeakup.conf
 }
 

--- a/app-accessibility/espeakup/espeakup-9999.ebuild
+++ b/app-accessibility/espeakup/espeakup-9999.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/linux-speakup/espeakup/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
 inherit linux-info meson

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ian Jordan <immoloism@gmail.com> (2025-07-28)
+# Needs app-text/ronn-ng, which is not keyworded here
+app-accessibility/espeakup man
+
 # Cristian Othón Martínez Vera <cfuga@cfuga.mx> (2025-07-15)
 # Needs gui-apps/grim, which is not keyworded here
 x11-misc/xscreensaver wayland


### PR DESCRIPTION
app-accessibility/espeakup: module load fixup

I don't understand the difference between modprobe.d and modules-load.d and incorrectly made the fix in the wrong place in -r2.

Will remember these packages need extra care in future.

app-accessibility/espeakup: keyword 0.90-r3

Adding keywords for alpha, hppa, ppc, ppc64, riscv and sparc.

The have been reasonable tested with QEMU for me to be happy with, and would like hopefully to get more user testing before adding into all the live media. We can discuss other niche(er) arches at another date.

profiles/arch/alpha: espeakup pu.mask man

As much as I'd like to have manpage support on all arches, keywording the required package would put an unfair amount of work on the alpha team when it will likely be used
by very few people as they will already know the basics to the software anyway.


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
