### PR TITLE
wine.eclass: filter "-O3" usage

### DIFF
--- a/eclass/wine.eclass
+++ b/eclass/wine.eclass
@@ -192,6 +192,9 @@ wine_src_configure() {
 	# avoid gcc-15's c23 default with older wine (bug #943849)
 	ver_test -lt 10 && append-cflags -std=gnu17
 
+	# filter O3 usage, otherwise crashes in shell32 happens.
+	replace-flags -O3 -O2
+
 	# Wine uses many linker tricks that are unlikely to work
 	# with anything but bfd or lld (bug #867097)
 	if ! tc-ld-is-bfd && ! tc-ld-is-lld; then


### PR DESCRIPTION
with -O3, cause crashes in shell32.dll.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
