### PR TITLE
x11-base/xorg-server: drop patch from live ebuild

### DIFF
--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -95,8 +95,6 @@ REQUIRED_USE="!minimal? (
 PATCHES=(
 	"${UPSTREAMED_PATCHES[@]}"
 	"${FILESDIR}"/${PN}-1.12-unloadsubmodule.patch
-	# needed for new eselect-opengl, bug #541232
-	"${FILESDIR}"/${PN}-1.18-support-multiple-Files-sections.patch
 )
 
 src_configure() {


### PR DESCRIPTION
This patch no longer applies to the live ebuild and a fix was applied upstream.

Bug: https://bugs.gentoo.org/541232
Upstream-Issue: https://gitlab.freedesktop.org/xorg/xserver/-/issues/467
Upstream-PR: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2045
Upstream-Commit: https://gitlab.freedesktop.org/tsic404/xserver/-/commit/9b6f72395ae8b10f2c4a42d26f56e6dceaeb49f9

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
