### PR TITLE
games-util/lutris: Add 7zip, drop webkit-gtk:4

### DIFF
--- a/games-util/lutris/lutris-0.5.17-r1.ebuild
+++ b/games-util/lutris/lutris-0.5.17-r1.ebuild
@@ -49,10 +49,7 @@ RDEPEND="
 		dev-python/moddb[${PYTHON_USEDEP}]
 	')
 	media-sound/fluid-soundfont
-	|| (
-		net-libs/webkit-gtk:4[introspection]
-		net-libs/webkit-gtk:4.1[introspection]
-	)
+	net-libs/webkit-gtk:4.1[introspection]
 	sys-apps/pciutils
 	sys-apps/xdg-desktop-portal
 	x11-apps/mesa-progs

--- a/games-util/lutris/lutris-0.5.17-r1.ebuild
+++ b/games-util/lutris/lutris-0.5.17-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,7 +29,10 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-arch/cabextract
-	app-arch/p7zip
+	|| (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	)
 	app-arch/unzip
 	$(python_gen_cond_dep '
 		dev-python/certifi[${PYTHON_USEDEP}]

--- a/games-util/lutris/lutris-0.5.18.ebuild
+++ b/games-util/lutris/lutris-0.5.18.ebuild
@@ -49,10 +49,7 @@ RDEPEND="
 		dev-python/moddb[${PYTHON_USEDEP}]
 	')
 	media-sound/fluid-soundfont
-	|| (
-		net-libs/webkit-gtk:4[introspection]
-		net-libs/webkit-gtk:4.1[introspection]
-	)
+	net-libs/webkit-gtk:4.1[introspection]
 	sys-apps/pciutils
 	sys-apps/xdg-desktop-portal
 	x11-apps/mesa-progs

--- a/games-util/lutris/lutris-0.5.18.ebuild
+++ b/games-util/lutris/lutris-0.5.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,7 +29,10 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-arch/cabextract
-	app-arch/p7zip
+	|| (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	)
 	app-arch/unzip
 	$(python_gen_cond_dep '
 		dev-python/certifi[${PYTHON_USEDEP}]

--- a/games-util/lutris/lutris-0.5.19.ebuild
+++ b/games-util/lutris/lutris-0.5.19.ebuild
@@ -49,10 +49,7 @@ RDEPEND="
 		dev-python/moddb[${PYTHON_USEDEP}]
 	')
 	media-sound/fluid-soundfont
-	|| (
-		net-libs/webkit-gtk:4[introspection]
-		net-libs/webkit-gtk:4.1[introspection]
-	)
+	net-libs/webkit-gtk:4.1[introspection]
 	sys-apps/pciutils
 	sys-apps/xdg-desktop-portal
 	x11-apps/mesa-progs

--- a/games-util/lutris/lutris-0.5.19.ebuild
+++ b/games-util/lutris/lutris-0.5.19.ebuild
@@ -29,7 +29,10 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-arch/cabextract
-	app-arch/p7zip
+	|| (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	)
 	app-arch/unzip
 	$(python_gen_cond_dep '
 		dev-python/certifi[${PYTHON_USEDEP}]

--- a/games-util/lutris/lutris-9999.ebuild
+++ b/games-util/lutris/lutris-9999.ebuild
@@ -49,10 +49,7 @@ RDEPEND="
 		dev-python/moddb[${PYTHON_USEDEP}]
 	')
 	media-sound/fluid-soundfont
-	|| (
-		net-libs/webkit-gtk:4[introspection]
-		net-libs/webkit-gtk:4.1[introspection]
-	)
+	net-libs/webkit-gtk:4.1[introspection]
 	sys-apps/pciutils
 	sys-apps/xdg-desktop-portal
 	x11-apps/mesa-progs

--- a/games-util/lutris/lutris-9999.ebuild
+++ b/games-util/lutris/lutris-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,7 +29,10 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="
 	${PYTHON_DEPS}
 	app-arch/cabextract
-	app-arch/p7zip
+	|| (
+		>=app-arch/7zip-24.09[symlink(+)]
+		app-arch/p7zip
+	)
 	app-arch/unzip
 	$(python_gen_cond_dep '
 		dev-python/certifi[${PYTHON_USEDEP}]


### PR DESCRIPTION
games-util/lutris: Add 7zip

    Some users don't want to use p7zip due to the risk of a CVE on their system.
    Using NRK's suggestion this will let users carry as normal using p7zip,
    or by default use 7zip without running into blockers until a full plan is made.

 games-util/lutris: Drop webkit-gtk:4 dep

    net-libs/webkit-gtk:4 is no longer in tree so removing to clean up ebuild.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
