### PR TITLE
net-libs/libtorrent: fix GREP call

### DIFF
--- a/net-libs/libtorrent/files/libtorrent-0.15.5-find_grep.patch
+++ b/net-libs/libtorrent/files/libtorrent-0.15.5-find_grep.patch
@@ -1,0 +1,14 @@
+https://github.com/rakshasa/libtorrent/pull/539.patch
+configure fails with slibtool because it doesn't define GREP
+diff --git a/scripts/common.m4 b/scripts/common.m4
+index 480bdef..7129204 100644
+--- a/scripts/common.m4
++++ b/scripts/common.m4
+@@ -23,6 +23,7 @@ AC_DEFUN([TORRENT_WITH_SYSROOT], [
+ 
+ AC_DEFUN([TORRENT_REMOVE_UNWANTED],
+ [
++  AC_REQUIRE([AC_PROG_GREP])
+   values_to_check=`for i in $2; do echo $i; done`
+   unwanted_values=`for i in $3; do echo $i; done`
+   if test -z "${unwanted_values}"; then

--- a/net-libs/libtorrent/libtorrent-0.15.5.ebuild
+++ b/net-libs/libtorrent/libtorrent-0.15.5.ebuild
@@ -33,6 +33,8 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.14.0-tests-address.patch
 	"${FILESDIR}"/${PN}-0.15.3-unbundle_udns.patch
+	# https://github.com/rakshasa/libtorrent/pull/539.patch
+	"${FILESDIR}"/${PN}-0.15.5-find_grep.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
scripts/common.m4 calls $GREP at configure time.
this can cause problems with slibtool and maybe also split-usr env.
export the most common abspath as it is done in other ebuilds.

problem raised in the forum

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
