### PR TITLE
profiles/arch/mips: remove obsolete ~dev-lang/rust-1.71.1[system-llvm] USE mask

### DIFF
--- a/profiles/arch/mips/package.use.mask
+++ b/profiles/arch/mips/package.use.mask
@@ -87,10 +87,6 @@ dev-perl/Template-Toolkit gd latex vim-syntax
 # requires dev-libs/hidapi to be keyworded
 dev-libs/libfido2 hidapi
 
-# Matt Jolly <kangie@gentoo.org> (2024-11-03)
-# Requires llvm 16 which is not keyworded
-~dev-lang/rust-1.71.1 system-llvm
-
 # Felix Janda <felix.janda@posteo.de> (2024-10-20)
 # requires dev-libs/libcss and net-libs/libdom to be keyworded
 www-client/elinks libcss


### PR DESCRIPTION
Commit 415354385e9854085e1eb55712cb436f9789ec08 removed the masked package
(2024-12-19)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
