### PR TITLE
profiles/arch/arm: remove obsolete USE masks (net-analyzer/zmap[mongo], dev-libs/libcec[-raspberry-pi])

### DIFF
--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -391,10 +391,6 @@ dev-db/mariadb -jdbc
 # does not build on arm at all (upstream bug)
 dev-scheme/racket futures jit
 
-# Ian Whyman <thev00d00@gentoo.org> (2016-05-22)
-# RPI support on arm
-dev-libs/libcec -raspberry-pi
-
 # Thomas Deutschmann <whissi@gentoo.org> (2016-03-19)
 # Unkeyworded deps, bug #564274
 app-metrics/collectd collectd_plugins_ipmi


### PR DESCRIPTION

* Commit 06b60e91f324bbe618449fda820950e66f323936 removed the last ```net-analyzer/zmap``` ebuild with USE=mongo support (2024-12-24)
* Commit 9d333b9cf6363a5867de3e45b06b0d1e597c9a28 removed the last ```dev-libs/libcec``` ebuild with USE=raspberry-pi support (2025-04-30)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
