### PR TITLE
profiles/arch/alpha: remove obsolete media-sound/fluidsynth[lash] mask

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -347,10 +347,6 @@ dev-util/ragel doc
 # Dependency not keyworded on this arch.
 app-text/enchant voikko
 
-# Andreas Sturmlechner <asturm@gentoo.org> (2020-11-12)
-# media-sound/lash not keyworded, bug #736725
-media-sound/fluidsynth lash
-
 # Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com> (2020-10-14)
 # app-i18n/fcitx:4 not keyworded.
 media-libs/libsdl2 fcitx


### PR DESCRIPTION
Commit bacb80f0983217da21c008d6fe262ef6abec5c2c removed the last
```media-sound/fluidsynth``` ebuild with USE=lash support (2025-01-01)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
