### PR TITLE
eclass/postgres: require user to choose exactly one Postgres slot

### DIFF
--- a/eclass/postgres-multi.eclass
+++ b/eclass/postgres-multi.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: postgres-multi.eclass
@@ -38,6 +38,9 @@ inherit multibuild postgres
 if ! declare -p POSTGRES_COMPAT &>/dev/null; then
 	die 'Required variable POSTGRES_COMPAT not declared.'
 fi
+
+# Allow multiple slots.
+POSTGRES_REQ_USE="${POSTGRES_REQ_USE/^^/||}"
 
 # @ECLASS_VARIABLE: _POSTGRES_INTERSECT_SLOTS
 # @INTERNAL

--- a/eclass/postgres.eclass
+++ b/eclass/postgres.eclass
@@ -92,7 +92,7 @@ if declare -p POSTGRES_COMPAT &> /dev/null ; then
 	done
 
 	POSTGRES_DEP=""
-	POSTGRES_REQ_USE=" || ("
+	POSTGRES_REQ_USE=" ^^ ("
 	for slot in "${_POSTGRES_COMPAT[@]}" ; do
 		POSTGRES_DEP+=" postgres_targets_postgres${slot/\./_}? ( dev-db/postgresql:${slot}="
 		declare -p POSTGRES_USEDEP &>/dev/null && \


### PR DESCRIPTION
At present, `postgres.eclass` generates the `POSTGRES_REQ_USE` variable using the _any-of_ operator. This allows the user to specify multiple PostgreSQL implementations. However, only the newest of the specified implementations (that is also found in `POSTGRES_COMPAT`) is actually used when building.

Consider a package Xyz that links with `libpq.so.5`. Suppose the user installs Xyz with `POSTGRES_TARGETS="postgres16 postgres17"`. Both `dev-db/postgresql:16` and `:17` are pulled in on the build system to satisfy `DEPEND` and on the host system to satisfy `RDEPEND` even though `dev-db/postgresql:16` is actually required neither at build time nor at run time. This is a needless dependency. Moreover, then it becomes impossible to prune `dev-db/postgresql:16` from the host system without rebuilding Xyz with `USE="-postgres_targets_postgres16"` even though Xyz never actually used PostgreSQL 16 at all and there will be no difference in the build products after rebuilding.

For reference, look at how `llvm-r2.eclass` generates the `LLVM_REQUIRED_USE` variable. It uses the _exactly-one-of_ operator to enforce that the user selects exactly one LLVM slot to build/link against.

Therefore, modify `postgres.eclass` to generate the `POSTGRES_REQ_USE` variable using the _exactly-one-of_ operator to make clear to users that `postgres.eclass`-inheriting packages do not in fact need or use multiple slots of PostgreSQL.

Also, add a fixup in `postgres-multi.eclass` to change the _exactly-one-of_ operator back to an _any-of_ operator since `postgres-multi`.eclass- inheriting packages _can_ actually use multiple slots of PostgreSQL simultaneously.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` bizarrely claims, `pkgcheck scan: error: failed running git: fatal: not a git repository (or any parent up to mount point /var/db)`, even though I am in fact running it in a Git worktree.

Please note that all boxes must be checked for the pull request to be merged.
