### PR TITLE
dev-util/radare2: drop to maintainer-needed

### DIFF
--- a/dev-util/radare2/metadata.xml
+++ b/dev-util/radare2/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>davidroman96@gmail.com</email>
-		<name>David Roman</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">radareorg/radare2</remote-id>
 	</upstream>


### PR DESCRIPTION
It requires consistent amount of patching. There is calls to "git clone" everywhere without options to disable this behavior (except for capstone). I don't use radare2 that much anymore, and given there is already rizin in the tree (which is a fork of radare2) I don't have motivation to maintain radare2.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
