### PR TITLE
media-libs/mesa: enable anti-lag vulkan layer

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -379,7 +379,7 @@ multilib_src_configure() {
 			fi
 		fi
 
-		emesonargs+=(-Dvulkan-layers=device-select,overlay)
+		emesonargs+=(-Dvulkan-layers=anti-lag,device-select,overlay)
 	fi
 
 	driver_list() {


### PR DESCRIPTION
Enable the anti-lag vulkan layer from upstream MR 34242. It has no additional dependencies. Tested it with Counter-Strike 2, and the option to enable anti-lag appears in the game.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
