### PR TITLE
net-libs/paho-mqtt-c: Changed 'bool' typedef to 'bit'

### DIFF
--- a/net-libs/paho-mqtt-c/files/paho-mqtt-c-1.3.14-changed-bool-typedef-to-bit.patch
+++ b/net-libs/paho-mqtt-c/files/paho-mqtt-c-1.3.14-changed-bool-typedef-to-bit.patch
@@ -1,0 +1,86 @@
+# Changed 'bool' typedef to 'bit'
+# Bug: 955115
+# Upstream: https://github.com/eclipse-paho/paho.mqtt.c/commit/ff1d9229314079321272e521c165b18c92773c9f
+
+--- a/src/MQTTPacket.h
++++ b/src/MQTTPacket.h
+@@ -28,7 +28,7 @@
+ #include "LinkedList.h"
+ #include "Clients.h"
+ 
+-typedef unsigned int bool;
++typedef unsigned int bit;
+ typedef void* (*pf)(int, unsigned char, char*, size_t);
+ 
+ #include "MQTTProperties.h"
+@@ -67,16 +67,16 @@ typedef union
+ 	struct
+ 	{
+ 		unsigned int type : 4;	/**< message type nibble */
+-		bool dup : 1;			/**< DUP flag bit */
++		bit dup : 1;			/**< DUP flag bit */
+ 		unsigned int qos : 2;	/**< QoS value, 0, 1 or 2 */
+-		bool retain : 1;		/**< retained flag bit */
++		bit retain : 1;		/**< retained flag bit */
+ 	} bits;
+ #else
+ 	struct
+ 	{
+-		bool retain : 1;		/**< retained flag bit */
++		bit retain : 1;		/**< retained flag bit */
+ 		unsigned int qos : 2;	/**< QoS value, 0, 1 or 2 */
+-		bool dup : 1;			/**< DUP flag bit */
++		bit dup : 1;			/**< DUP flag bit */
+ 		unsigned int type : 4;	/**< message type nibble */
+ 	} bits;
+ #endif
+@@ -95,24 +95,24 @@ typedef struct
+ #if defined(REVERSED)
+ 		struct
+ 		{
+-			bool username : 1;			/**< 3.1 user name */
+-			bool password : 1; 			/**< 3.1 password */
+-			bool willRetain : 1;		/**< will retain setting */
++			bit username : 1;			/**< 3.1 user name */
++			bit password : 1; 			/**< 3.1 password */
++			bit willRetain : 1;		/**< will retain setting */
+ 			unsigned int willQoS : 2;	/**< will QoS value */
+-			bool will : 1;			/**< will flag */
+-			bool cleanstart : 1;	/**< cleansession flag */
++			bit will : 1;			/**< will flag */
++			bit cleanstart : 1;	/**< cleansession flag */
+ 			int : 1;	/**< unused */
+ 		} bits;
+ #else
+ 		struct
+ 		{
+ 			int : 1;	/**< unused */
+-			bool cleanstart : 1;	/**< cleansession flag */
+-			bool will : 1;			/**< will flag */
++			bit cleanstart : 1;	/**< cleansession flag */
++			bit will : 1;			/**< will flag */
+ 			unsigned int willQoS : 2;	/**< will QoS value */
+-			bool willRetain : 1;		/**< will retain setting */
+-			bool password : 1; 			/**< 3.1 password */
+-			bool username : 1;			/**< 3.1 user name */
++			bit willRetain : 1;		/**< will retain setting */
++			bit password : 1; 			/**< 3.1 password */
++			bit username : 1;			/**< 3.1 user name */
+ 		} bits;
+ #endif
+ 	} flags;	/**< connect flags byte */
+@@ -140,12 +140,12 @@ typedef struct
+ 		struct
+ 		{
+ 			unsigned int reserved : 7;	/**< message type nibble */
+-			bool sessionPresent : 1;    /**< was a session found on the server? */
++			bit sessionPresent : 1;    /**< was a session found on the server? */
+ 		} bits;
+ #else
+ 		struct
+ 		{
+-			bool sessionPresent : 1;    /**< was a session found on the server? */
++			bit sessionPresent : 1;    /**< was a session found on the server? */
+ 			unsigned int reserved : 7;	/**< message type nibble */
+ 		} bits;
+ #endif

--- a/net-libs/paho-mqtt-c/paho-mqtt-c-1.3.14-r1.ebuild
+++ b/net-libs/paho-mqtt-c/paho-mqtt-c-1.3.14-r1.ebuild
@@ -1,0 +1,106 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} pypy3_11 )
+
+inherit cmake python-any-r1 toolchain-funcs
+
+TEST_UTILS="paho.mqtt.testing"
+TEST_COMMIT="9d7bb80bb8b9d9cfc0b52f8cb4c1916401281103"
+
+DESCRIPTION="An Eclipse Paho C client library for MQTT for Windows, Linux and MacOS."
+HOMEPAGE="https://eclipse.org/paho"
+SRC_URI="
+	https://github.com/eclipse/paho.mqtt.c/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
+	https://github.com/eclipse/${TEST_UTILS}/archive/${TEST_COMMIT}.tar.gz -> ${TEST_UTILS}-${TEST_COMMIT}.tar.gz
+"
+S="${WORKDIR}/paho.mqtt.c-${PV}"
+
+LICENSE="EPL-2.0"
+SLOT="1.3"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc examples +high-performance +ssl test"
+
+# Building samples needs ssl: #912262
+REQUIRED_USE="examples? ( ssl )"
+
+# Tests require net-redirections to be enabled in bash. See bug #915718
+BDEPEND="
+	doc? ( app-text/doxygen
+		   media-gfx/graphviz )
+	ssl? ( dev-libs/openssl )
+	test? (
+		${PYTHON_DEPS}
+		app-shells/bash[net]
+	)
+"
+PATCHES=(
+	# Changed 'bool' typedef to 'bit'. See bug #955115
+	"${FILESDIR}/${P}-changed-bool-typedef-to-bit.patch"
+)
+
+# Tests can be run only if a MQTT broker is available
+RESTRICT="!test? ( test )"
+
+BUILD_DIR="${S}_build"
+
+src_prepare(){
+	cmake_src_prepare
+	if use test; then
+		mv "${WORKDIR}/${TEST_UTILS}-${TEST_COMMIT}" "${WORKDIR}/${TEST_UTILS}" || die
+	fi
+}
+
+src_configure(){
+	local mycmakeargs=(
+		-DPAHO_BUILD_SHARED=TRUE
+		-DPAHO_HIGH_PERFORMANCE="$(usex high-performance "TRUE" "FALSE")"
+		-DPAHO_WITH_SSL="$(usex ssl "TRUE" "FALSE")"
+		-DPAHO_BUILD_DOCUMENTATION="$(usex doc "TRUE" "FALSE")"
+		-DPAHO_BUILD_SAMPLES="$(usex examples "TRUE" "FALSE")"
+		-DPAHO_ENABLE_TESTING="$(usex test "TRUE" "FALSE")"
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	cd "${WORKDIR}/${TEST_UTILS}/interoperability" || die
+
+	${EPYTHON} startbroker.py -c localhost_testing.conf \
+			   > "${T}/testbroker.log" &
+	local -r startbroker_pid=$!
+
+	${EPYTHON} "${S}"/test/mqttsas.py \
+			   > "${T}/testmqttsas.log" &
+	local -r mqttsas_pid=$!
+
+	local port ports
+	ports=(1883 1888{3..8})
+
+	for port in ${ports[@]}; do
+		einfo "Waiting for TCP port ${port} to become available"
+		if timeout 30 bash -c \
+				'until printf "" >/dev/tcp/${0}/${1} 2>> "${T}/portlog"; do sleep 1; done' \
+				localhost "${port}"; then
+			continue
+		fi
+
+		kill ${startbroker_pid} ${mqttsas_pid}
+		die "Timeout waiting for port ${port} to become available"
+	done
+
+	local myctestargs=(
+		-j 1
+		--timeout 600
+	)
+	cmake_src_test
+
+	kill ${startbroker_pid} ${mqttsas_pid} || die
+}


### PR DESCRIPTION
Upstream: https://github.com/eclipse-paho/paho.mqtt.c/commit/ff1d9229314079321272e521c165b18c92773c9f
Closes: https://bugs.gentoo.org/955115

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
