### PR TITLE
distutils-r1.eclass: Update scikit-build-core options

### DIFF
--- a/dev-python/awkward-cpp/awkward-cpp-48.ebuild
+++ b/dev-python/awkward-cpp/awkward-cpp-48.ebuild
@@ -30,9 +30,3 @@ BDEPEND="
 
 EPYTEST_PLUGINS=()
 distutils_enable_tests pytest
-
-src_prepare() {
-	default
-	# https://github.com/scikit-build/scikit-build-core/issues/912
-	sed -i -e '/scikit-build-core/s:0\.11:0.8:' pyproject.toml || die
-}

--- a/dev-python/iminuit/iminuit-2.31.1.ebuild
+++ b/dev-python/iminuit/iminuit-2.31.1.ebuild
@@ -54,8 +54,6 @@ src_prepare() {
 
 	# do not force LTO
 	sed -i -e '/INTERPROCEDURAL_OPTIMIZATION/d' CMakeLists.txt || die
-	# https://github.com/scikit-build/scikit-build-core/issues/912
-	sed -i -e '/scikit-build-core/s:0\.10:0.8:' pyproject.toml || die
 }
 
 src_test() {

--- a/dev-python/nanobind/nanobind-2.8.0.ebuild
+++ b/dev-python/nanobind/nanobind-2.8.0.ebuild
@@ -34,8 +34,6 @@ EPYTEST_XDIST=1
 distutils_enable_tests pytest
 
 src_prepare() {
-	# https://github.com/scikit-build/scikit-build-core/issues/912
-	sed -i -e '/scikit-build-core/s:0\.10:0.8:' pyproject.toml || die
 	cmake_src_prepare
 	distutils-r1_src_prepare
 }

--- a/dev-python/pybind11/pybind11-3.0.0.ebuild
+++ b/dev-python/pybind11/pybind11-3.0.0.ebuild
@@ -45,9 +45,6 @@ distutils_enable_tests pytest
 src_prepare() {
 	cmake_src_prepare
 	distutils-r1_src_prepare
-
-	# https://github.com/scikit-build/scikit-build-core/issues/912
-	sed -i -e '/scikit-build-core/s:0\.11\.2:0.8:' pyproject.toml || die
 }
 
 python_configure() {

--- a/dev-python/rapidfuzz/rapidfuzz-3.13.0.ebuild
+++ b/dev-python/rapidfuzz/rapidfuzz-3.13.0.ebuild
@@ -43,8 +43,6 @@ src_prepare() {
 	find src -name '*.cxx' -delete || die
 	# do not require exact taskflow version
 	sed -i -e '/Taskflow/s:3\.9\.0::' CMakeLists.txt || die
-	# https://github.com/scikit-build/scikit-build-core/issues/912
-	sed -i -e '/scikit-build-core/s:0\.11:0.8:' pyproject.toml || die
 
 	distutils-r1_src_prepare
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -292,7 +292,7 @@ _distutils_set_globals() {
 			;;
 		scikit-build-core)
 			bdep+='
-				>=dev-python/scikit-build-core-0.10.7[${PYTHON_USEDEP}]
+				>=dev-python/scikit-build-core-0.11.5[${PYTHON_USEDEP}]
 			'
 			;;
 		setuptools)
@@ -1145,9 +1145,9 @@ distutils_pep517_install() {
 					ninjaopts = shlex.split(os.environ["NINJAOPTS"])
 					print(json.dumps({
 						"build.tool-args": ninjaopts,
+						"build.verbose": True,
 						"cmake.args": ";".join(sys.argv[1:]),
 						"cmake.build-type": "${CMAKE_BUILD_TYPE}",
-						"cmake.verbose": True,
 						"install.strip": False,
 					}))
 				EOF


### PR DESCRIPTION
Once again switch to the newer scikit-build-core `build.verbose` option to fix compatibility with packages requiring the newer version, and let us stop patching ebuilds.  Upstream fixed the behavior to allow using newer options in `config_settings`.

Bug: https://github.com/scikit-build/scikit-build-core/issues/912
Pull-Request: https://github.com/scikit-build/scikit-build-core/pull/1054
