### PR TITLE
dev-util/vulkan-tools: fix cube build on wayland

### DIFF
--- a/dev-util/vulkan-tools/files/vulkan-tools-1.4.321-fix-cube-wayland.patch
+++ b/dev-util/vulkan-tools/files/vulkan-tools-1.4.321-fix-cube-wayland.patch
@@ -1,0 +1,90 @@
+https://bugs.gentoo.org/959725
+https://github.com/KhronosGroup/Vulkan-Tools/issues/1130
+https://github.com/KhronosGroup/Vulkan-Tools/pull/1134
+https://github.com/KhronosGroup/Vulkan-Tools/commit/105d6c1fede00c3a9055e5a531ebf3d99bac406e
+
+From f546743016f5301c063f2c50af0ea43dd2485ef4 Mon Sep 17 00:00:00 2001
+From: Charles Giessen <charles@lunarg.com>
+Date: Thu, 17 Jul 2025 09:56:40 -0500
+Subject: [PATCH] build: Remove pkg-config provided library names
+
+The library names of Xcb, Xlib, and Wayland do not need to be queried from pkg-config,
+instead they can be hardcoded to use the fallback names.
+
+The intent of querying the library names was to prevent issues where the hardcoded name
+was not the platform-appropriate name. But because <library>_LINK_LIBRARIES can have
+more than one library name, the logic to assign <library>_LINK_LIBRARIES into a compile
+definition breaks horribly. While it is possible to handle this in CMake, the dlopen code would
+also have to handle it which is much more error prone.
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -307,16 +307,6 @@ if (ANDROID)
+     return()
+ endif()
+ 
+-if (XCB_LINK_LIBRARIES)
+-    target_compile_definitions(vkcube PRIVATE "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
+-endif()
+-if (X11_LINK_LIBRARIES)
+-    target_compile_definitions(vkcube PRIVATE "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
+-endif()
+-if (WAYLAND_CLIENT_LINK_LIBRARIES)
+-    target_compile_definitions(vkcube PRIVATE "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
+-endif()
+-
+ # ----------------------------------------------------------------------------
+ # vkcubepp
+ 
+@@ -360,16 +350,6 @@ target_include_directories(vkcubepp PRIVATE .)
+ target_compile_definitions(vkcubepp PRIVATE ${ENABLED_CUBE_PLATFORMS})
+ target_link_libraries(vkcubepp ${CMAKE_DL_LIBS} Vulkan::Headers)
+ 
+-if (XCB_LINK_LIBRARIES )
+-    target_compile_definitions(vkcubepp PUBLIC "XCB_LIBRARY=\"${XCB_LINK_LIBRARIES}\"")
+-endif()
+-if (X11_LINK_LIBRARIES)
+-    target_compile_definitions(vkcubepp PUBLIC "XLIB_LIBRARY=\"${X11_LINK_LIBRARIES}\"")
+-endif()
+-if (WAYLAND_CLIENT_LINK_LIBRARIES)
+-    target_compile_definitions(vkcubepp PUBLIC "WAYLAND_LIBRARY=\"${WAYLAND_CLIENT_LINK_LIBRARIES}\"")
+-endif()
+-
+ if(APPLE)
+     install(
+         TARGETS vkcubepp
+--- a/cube/wayland_loader.h
++++ b/cube/wayland_loader.h
+@@ -80,9 +80,6 @@ static PFN_wl_display_disconnect cube_wl_display_disconnect = NULL;
+ 
+ static inline void *initialize_wayland() {
+     void *wayland_library = NULL;
+-#if defined(WAYLAND_LIBRARY)
+-    wayland_library = dlopen(WAYLAND_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+-#endif
+     if (NULL == wayland_library) {
+         wayland_library = dlopen("libwayland-client.so.0", RTLD_NOW | RTLD_LOCAL);
+     }
+--- a/cube/xcb_loader.h
++++ b/cube/xcb_loader.h
+@@ -88,9 +88,6 @@ static PFN_xcb_screen_next cube_xcb_screen_next = NULL;
+ 
+ void *initialize_xcb() {
+     void *xcb_library = NULL;
+-#if defined(XCB_LIBRARY)
+-    xcb_library = dlopen(XCB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+-#endif
+     if (NULL == xcb_library) {
+         xcb_library = dlopen("libxcb.so.1", RTLD_NOW | RTLD_LOCAL);
+     }
+--- a/cube/xlib_loader.h
++++ b/cube/xlib_loader.h
+@@ -72,9 +72,6 @@ static PFN_XFlush cube_XFlush = NULL;
+ 
+ void* initialize_xlib() {
+     void* xlib_library = NULL;
+-#if defined(XLIB_LIBRARY)
+-    xlib_library = dlopen(XLIB_LIBRARY, RTLD_NOW | RTLD_LOCAL);
+-#endif
+     if (NULL == xlib_library) {
+         xlib_library = dlopen("libX11.so.6", RTLD_NOW | RTLD_LOCAL);
+     }

--- a/dev-util/vulkan-tools/vulkan-tools-1.4.321.0-r1.ebuild
+++ b/dev-util/vulkan-tools/vulkan-tools-1.4.321.0-r1.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN=Vulkan-Tools
+PYTHON_COMPAT=( python3_{11..14} )
+inherit cmake-multilib python-any-r1
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"
+	EGIT_SUBMODULES=()
+	inherit git-r3
+else
+	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/vulkan-sdk-${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv"
+	S="${WORKDIR}"/${MY_PN}-vulkan-sdk-${PV}
+fi
+
+DESCRIPTION="Official Vulkan Tools and Utilities for Windows, Linux, Android, and MacOS"
+HOMEPAGE="https://github.com/KhronosGroup/Vulkan-Tools"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="cube wayland test X"
+RESTRICT="!test? ( test )"
+
+BDEPEND="${PYTHON_DEPS}
+	cube? ( ~dev-util/glslang-${PV}:=[${MULTILIB_USEDEP}] )
+"
+RDEPEND="
+	wayland? ( dev-libs/wayland[${MULTILIB_USEDEP}] )
+	X? (
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		x11-libs/libxcb:=[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}
+	~dev-util/vulkan-headers-${PV}
+	X? ( x11-libs/libXrandr[${MULTILIB_USEDEP}] )
+	test? ( ~media-libs/vulkan-loader-${PV}[${MULTILIB_USEDEP},wayland?,X?] )
+"
+
+PATCHES=(
+	"${FILESDIR}"/vulkan-tools-1.4.321-fix-cube-wayland.patch
+)
+
+pkg_setup() {
+	MULTILIB_CHOST_TOOLS=(
+		/usr/bin/vulkaninfo
+	)
+
+	use cube && MULTILIB_CHOST_TOOLS+=(
+		/usr/bin/vkcube
+		/usr/bin/vkcubepp
+	)
+
+	python-any-r1_pkg_setup
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_C_FLAGS="${CFLAGS} -DNDEBUG"
+		-DCMAKE_CXX_FLAGS="${CXXFLAGS} -DNDEBUG -DGIT_BRANCH_NAME=\\\"gentoo\\\" -DGIT_TAG_INFO=\\\"${PV//./_}\\\""
+		-DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+		-DCMAKE_SKIP_RPATH=ON
+		-DBUILD_VULKANINFO=ON
+		-DBUILD_CUBE=$(usex cube)
+		-DBUILD_TESTS=$(usex test)
+		-DBUILD_WERROR=OFF
+		-DBUILD_WSI_WAYLAND_SUPPORT=$(usex wayland)
+		-DBUILD_WSI_XCB_SUPPORT=$(usex X)
+		-DBUILD_WSI_XLIB_SUPPORT=$(usex X)
+		-DVULKAN_HEADERS_INSTALL_DIR="${ESYSROOT}/usr"
+	)
+
+	cmake_src_configure
+}
+
+pkg_postinst() {
+	if use cube; then
+		einfo "As of version 1.4.304.0, the window system for 'vkcube' and 'vkcubepp'"
+		einfo "can be selected at runtime using the '--wsi' runtime argument."
+		einfo "For example, Wayland can be selected using '--wsi wayland'."
+		einfo "As such, 'vkcube-wayland' has been removed and the runtime argument"
+		einfo "must be used instead. See 'vkcube --help' for more information."
+	fi
+}


### PR DESCRIPTION
I feel a rebvump is warranted as the patch removes dlopens from the x11 path as well.

Bug: https://bugs.gentoo.org/959725

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
