### PR TITLE
llvm-runtimes/libgcc: 21+ requires third-party/siphash on arm64

### DIFF
--- a/llvm-runtimes/libgcc/libgcc-21.1.0.9999.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.1.0.9999.ebuild
@@ -33,7 +33,7 @@ BDEPEND="
 	)
 "
 
-LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake llvm-libgcc )
+LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake llvm-libgcc third-party/siphash )
 LLVM_TEST_COMPONENTS=( llvm/include/llvm/TargetParser )
 llvm.org_set_globals
 

--- a/llvm-runtimes/libgcc/libgcc-21.1.0_rc2.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.1.0_rc2.ebuild
@@ -33,7 +33,7 @@ BDEPEND="
 	)
 "
 
-LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake llvm-libgcc )
+LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake llvm-libgcc third-party/siphash )
 LLVM_TEST_COMPONENTS=( llvm/include/llvm/TargetParser )
 llvm.org_set_globals
 


### PR DESCRIPTION
Same deal as https://github.com/gentoo/gentoo/commit/cfaceb488b6884128cb95fedc6228695d4606c8d since libgcc also builds compiler-rt.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
