### PR TITLE
sys-libs/libcap: use dot-a.eclass for LTO

### DIFF
--- a/sys-libs/libcap/libcap-2.71.ebuild
+++ b/sys-libs/libcap/libcap-2.71.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit multilib-minimal toolchain-funcs pam
+inherit dot-a multilib-minimal toolchain-funcs pam
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -59,6 +59,7 @@ run_emake() {
 }
 
 src_configure() {
+	use static-libs && lto-guarantee-fat
 	tc-export_build_env BUILD_CC
 	multilib-minimal_src_configure
 }
@@ -75,7 +76,9 @@ multilib_src_install() {
 	# no configure, needs explicit install line #444724#c3
 	run_emake DESTDIR="${D}" install
 
-	if ! use static-libs ; then
+	if use static-libs ; then
+		strip-lto-bytecode
+	else
 		rm "${ED}"/usr/$(get_libdir)/lib{cap,psx}.a || die
 	fi
 

--- a/sys-libs/libcap/libcap-2.76.ebuild
+++ b/sys-libs/libcap/libcap-2.76.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit multilib-minimal toolchain-funcs pam
+inherit dot-a multilib-minimal toolchain-funcs pam
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -59,6 +59,7 @@ run_emake() {
 }
 
 src_configure() {
+	use static-libs && lto-guarantee-fat
 	tc-export_build_env BUILD_CC
 	multilib-minimal_src_configure
 }
@@ -75,7 +76,9 @@ multilib_src_install() {
 	# no configure, needs explicit install line #444724#c3
 	run_emake DESTDIR="${D}" install
 
-	if ! use static-libs ; then
+	if use static-libs ; then
+		strip-lto-bytecode
+	else
 		rm "${ED}"/usr/$(get_libdir)/lib{cap,psx}.a || die
 	fi
 

--- a/sys-libs/libcap/libcap-9999.ebuild
+++ b/sys-libs/libcap/libcap-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal toolchain-funcs pam
+inherit dot-a multilib-minimal toolchain-funcs pam
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -59,6 +59,7 @@ run_emake() {
 }
 
 src_configure() {
+	use static-libs && lto-guarantee-fat
 	tc-export_build_env BUILD_CC
 	multilib-minimal_src_configure
 }
@@ -75,7 +76,9 @@ multilib_src_install() {
 	# no configure, needs explicit install line #444724#c3
 	run_emake DESTDIR="${D}" install
 
-	if ! use static-libs ; then
+	if use static-libs ; then
+		strip-lto-bytecode
+	else
 		rm "${ED}"/usr/$(get_libdir)/lib{cap,psx}.a || die
 	fi
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
