### PR TITLE
app-text/dblatex: enable py3.13

### DIFF
--- a/app-text/dblatex/dblatex-0.3.12-r3.ebuild
+++ b/app-text/dblatex/dblatex-0.3.12-r3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit distutils-r1
 

--- a/app-text/dblatex/dblatex-0.3.12-r4.ebuild
+++ b/app-text/dblatex/dblatex-0.3.12-r4.ebuild
@@ -4,7 +4,7 @@
 EAPI="8"
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Test suites pass other than a error : unreachable network: getaddrinfo failed related issues as tested on a musl system, will be fine on glibc.

Closes: https://bugs.gentoo.org/952248

I've left for now, but I think we can safely drop -r2 at this point as it's not really doing anything useful, but left just for an over cautious sanity check.

Full test log:

```
>>> Test phase: app-text/dblatex-0.3.12-r4
 * python3_13: running distutils-r1_run_phase python_test
make -j2 -C tests/mathml
make: Entering directory '/var/tmp/portage/app-text/dblatex-0.3.12-r4/work/dblatex3-0.3.12/tests/mathml'
../../scripts/dblatex mmltest2.xml
Build the book set list...
INFO:dblatex:Build the book set list...
error : unreachable network: getaddrinfo failed
/var/tmp/portage/app-text/dblatex-0.3.12-r4/work/dblatex3-0.3.12/tests/mathml/mmltest2.xml:4: warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/mathml/1.0/dbmathml.dtd"
         >
          ^
Build the listings...
INFO:dblatex:Build the listings...
error : unreachable network: getaddrinfo failed
/var/tmp/portage/app-text/dblatex-0.3.12-r4/work/dblatex3-0.3.12/tests/mathml/mmltest2.xml:4: warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/mathml/1.0/dbmathml.dtd"
         >
          ^
error : unreachable network: getaddrinfo failed
/var/tmp/portage/app-text/dblatex-0.3.12-r4/work/dblatex3-0.3.12/tests/mathml/mmltest2.xml:4: warning: failed to load external entity "http://www.oasis-open.org/docbook/xml/mathml/1.0/dbmathml.dtd"
         >
          ^
XSLT stylesheets DocBook - LaTeX 2e (0.3.12)
===================================================
No template matches mtd in mml:math.
No template matches mtd in mml:math.
The value bold-italic for mathvariant is not supported
The value bold-fraktur for mathvariant is not supported
The value bold-script for mathvariant is not supported
The value bold-sans-serif for mathvariant is not supported
The value sans-serif-italic for mathvariant is not supported
The value sans-serif-bold-italic for mathvariant is not supported
The value bold-italic for mathvariant is not supported
The value bold-fraktur for mathvariant is not supported
The value bold-script for mathvariant is not supported
The value bold-sans-serif for mathvariant is not supported
The value sans-serif-italic for mathvariant is not supported
The value sans-serif-bold-italic for mathvariant is not supported
The value bold-fraktur for mathvariant is not supported
The value bold-fraktur for mathvariant is not supported
The value bold-script for mathvariant is not supported
The value bold-script for mathvariant is not supported
Build mmltest2.pdf
INFO:dblatex:Build mmltest2.pdf
Character U+62 (b) not in font 'msbm10'
WARNING:dblatex:Character U+62 (b) not in font 'msbm10'
Character U+63 (c) not in font 'msbm10'
WARNING:dblatex:Character U+63 (c) not in font 'msbm10'
Character U+64 (d) not in font 'msbm10'
WARNING:dblatex:Character U+64 (d) not in font 'msbm10'
Character U+65 (e) not in font 'msbm10'
WARNING:dblatex:Character U+65 (e) not in font 'msbm10'
Character U+C2 (Â) not in font 'zptmcm7t'
WARNING:dblatex:Character U+C2 (Â) not in font 'zptmcm7t'
'mmltest2.pdf' successfully built
INFO:dblatex:'mmltest2.pdf' successfully built
make: Leaving directory '/var/tmp/portage/app-text/dblatex-0.3.12-r4/work/dblatex3-0.3.12/tests/mathml'
>>> Completed testing app-text/dblatex-0.3.12-r4
```

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
