### PR TITLE
profiles/arch/x86: remove obsolete sys-cluster/ceph[zfs] package.use.mask

### DIFF
--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -481,10 +481,6 @@ sys-kernel/installkernel -systemd-boot -ukify -uki
 # media-libs/libbdplus is keyworded on x86, so unmask the useflag
 media-libs/libbluray -bdplus
 
-# Yixun Lan <dlan@gentoo.org> (2014-05-21)
-# sys-fs/zfs not keyworded on x86
-sys-cluster/ceph zfs
-
 # Lars Wendler <polynomial-c@gentoo.org> (2014-04-23)
 # Works on 32bit x86
 media-sound/lmms -vst


### PR DESCRIPTION
Commit c7898802b4b5626f9082e9befa793d3a0c5f28fa removed the last
```sys-cluster/ceph``` ebuild with USE=zfs support (2024-11-01)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
