### PR TITLE
profiles/arch/x86: remove obsolete dev-util/catalyst[-system-bootloader] package.use.mask

### DIFF
--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -388,10 +388,6 @@ net-analyzer/zmap mongo
 # Unmask arch-specific USE flag available on x86
 net-analyzer/testssl -bundled-openssl
 
-# Rick Farina <zerochaos@gentoo.org> (2018-06-27)
-# Catalyst has support for assembling bootloader on this arch
-dev-util/catalyst -system-bootloader
-
 # Jan Ziak <0xe2.0x9a.0x9b@gmail.com> (2018-03-14)
 # Expose SVGA backend for x86 users
 app-emulation/fuse -backend-svga


### PR DESCRIPTION
Commti 2b32b247c3b59636c7d02c5bc24e4a18360ec9bb removed the last
```dev-util/catalyst``` ebuild with USE=system-bootloader support (2024-11-09)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
