### PR TITLE
profiles/arch/x86: remove obsolete app-emulation/nemu[spice] package.use.mask

### DIFF
--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -372,10 +372,6 @@ x11-apps/igt-gpu-tools -overlay
 # freeipmi is supported on x86
 app-admin/conserver -freeipmi
 
-# Mikle Kolyada <zlogene@gentoo.org> (2019-03-03)
-# No Spice protocol for x86
-app-emulation/nemu spice
-
 # Tomáš Mózes <hydrapolic@gmail.com> (2019-11-02)
 # Requires dev-db/mongodb which has dropped x86 support
 dev-php/pecl-mongodb test


### PR DESCRIPTION
Commit 50670bd2fa9bc5afeff4136018fe93a7b10dc391 removed the last
```app-emulation/nemu``` ebuild with USE=spice support (2024-11-29)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
