### PR TITLE
profiles/arch/x86: remove obsolete net-analyzer/zmap[mongo] package.use.mask

### DIFF
--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -381,10 +381,6 @@ app-emulation/nemu spice
 # Requires dev-db/mongodb which has dropped x86 support
 dev-php/pecl-mongodb test
 
-# Alexys Jacob <ultrabug@gentoo.org> (2018-11-05)
-# Requires dev-db/mongodb which has dropped x86 support
-net-analyzer/zmap mongo
-
 # Michael Palimaka <kensington@gentoo.org> (2018-10-12)
 # Unmask arch-specific USE flag available on x86
 net-analyzer/testssl -bundled-openssl


### PR DESCRIPTION
Commit 06b60e91f324bbe618449fda820950e66f323936 removed the last
```net-analyzer/zmap``` ebuild with USE=mongo support (2024-12-24)

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
