### PR TITLE
llvm-runtimes/libcxxabi: Set CTARGET to CHOST if the package is not cross

### DIFF
--- a/llvm-runtimes/libcxx/libcxx-19.1.7.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-19.1.7.ebuild
@@ -84,6 +84,12 @@ src_configure() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxx/libcxx-20.1.8.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-20.1.8.ebuild
@@ -86,6 +86,12 @@ src_configure() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxx/libcxx-21.1.0.9999.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-21.1.0.9999.ebuild
@@ -85,6 +85,12 @@ src_configure() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxx/libcxx-22.0.0.9999.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-22.0.0.9999.ebuild
@@ -85,6 +85,12 @@ src_configure() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxxabi/libcxxabi-19.1.7.ebuild
+++ b/llvm-runtimes/libcxxabi/libcxxabi-19.1.7.ebuild
@@ -47,6 +47,12 @@ python_check_deps() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxxabi/libcxxabi-20.1.8.ebuild
+++ b/llvm-runtimes/libcxxabi/libcxxabi-20.1.8.ebuild
@@ -47,6 +47,12 @@ python_check_deps() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxxabi/libcxxabi-21.1.0.9999.ebuild
+++ b/llvm-runtimes/libcxxabi/libcxxabi-21.1.0.9999.ebuild
@@ -48,6 +48,12 @@ python_check_deps() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libcxxabi/libcxxabi-22.0.0.9999.ebuild
+++ b/llvm-runtimes/libcxxabi/libcxxabi-22.0.0.9999.ebuild
@@ -48,6 +48,12 @@ python_check_deps() {
 }
 
 multilib_src_configure() {
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		llvm_prepend_path -b "${LLVM_MAJOR}"
 		local -x CC=${CTARGET}-clang

--- a/llvm-runtimes/libunwind/libunwind-19.1.7.ebuild
+++ b/llvm-runtimes/libunwind/libunwind-19.1.7.ebuild
@@ -55,6 +55,12 @@ multilib_src_configure() {
 	# also separately bug #863917
 	filter-lto
 
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		local -x CC=${CTARGET}-clang
 		local -x CXX=${CTARGET}-clang++

--- a/llvm-runtimes/libunwind/libunwind-20.1.8.ebuild
+++ b/llvm-runtimes/libunwind/libunwind-20.1.8.ebuild
@@ -55,6 +55,12 @@ multilib_src_configure() {
 	# also separately bug #863917
 	filter-lto
 
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		local -x CC=${CTARGET}-clang
 		local -x CXX=${CTARGET}-clang++

--- a/llvm-runtimes/libunwind/libunwind-21.1.0.9999.ebuild
+++ b/llvm-runtimes/libunwind/libunwind-21.1.0.9999.ebuild
@@ -54,6 +54,12 @@ multilib_src_configure() {
 	# also separately bug #863917
 	filter-lto
 
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		local -x CC=${CTARGET}-clang
 		local -x CXX=${CTARGET}-clang++

--- a/llvm-runtimes/libunwind/libunwind-22.0.0.9999.ebuild
+++ b/llvm-runtimes/libunwind/libunwind-22.0.0.9999.ebuild
@@ -54,6 +54,12 @@ multilib_src_configure() {
 	# also separately bug #863917
 	filter-lto
 
+	# Workaround for bgo #961153.
+	# TODO: Fix the multilib.eclass, so it sets CTARGET properly.
+	if ! is_crosspkg ; then
+		export CTARGET=${CHOST}
+	fi
+
 	if use clang; then
 		local -x CC=${CTARGET}-clang
 		local -x CXX=${CTARGET}-clang++


### PR DESCRIPTION
<!-- Please put the pull request description above -->

The multilib eclass doesn't set the CTARGET. Therefore, using CTARGET was breaking the multilib builds. At the same time, using CTARGET is necessary for crossdev to work.

The long term solution should be fixing multilib eclass, but for now, make sure that CTARGET is correct inside the ebuilds.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
