### PR TITLE
media-video/ffmpeg-chromium: Drop unused features

### DIFF
--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-134.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-134.ebuild
@@ -218,9 +218,9 @@ src_configure() {
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-135.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-135.ebuild
@@ -212,15 +212,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-136.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-136.ebuild
@@ -212,15 +212,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-137.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-137.ebuild
@@ -212,15 +212,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-138.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-138.ebuild
@@ -212,15 +212,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-139.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-139.ebuild
@@ -213,15 +213,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \

--- a/media-video/ffmpeg-chromium/ffmpeg-chromium-140.ebuild
+++ b/media-video/ffmpeg-chromium/ffmpeg-chromium-140.ebuild
@@ -213,15 +213,16 @@ src_configure() {
 		--disable-error-resilience \
 		--disable-everything \
 		--disable-faan \
+		--disable-iamf \
 		--disable-iconv \
 		--disable-network \
 		--enable-avcodec \
 		--enable-avformat \
 		--enable-avutil \
 		--enable-libopus \
-		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,theora,vorbis,vp8 \
+		--enable-decoder=aac,flac,h264,libopus,mp3,pcm_alaw,pcm_f32le,pcm_mulaw,pcm_s16be,pcm_s16le,pcm_s24be,pcm_s24le,pcm_s32le,pcm_u8,vorbis \
 		--enable-demuxer=aac,flac,matroska,mov,mp3,ogg,wav \
-		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp3,vp8,vp9 \
+		--enable-parser=aac,flac,h264,mpegaudio,opus,vorbis,vp9 \
 		--enable-pic \
 		--enable-static \
 		"${myconf[@]}" \


### PR DESCRIPTION
Upstream use [--disable-iamf](https://chromium.googlesource.com/chromium/third_party/ffmpeg/+/refs/heads/master/chromium/config/Chrome/linux/x64/config.h) at least for M135+.

`--enable-theora,vp8 --enable-parser=vp3,vp8` is [not used at upstream](https://chromium.googlesource.com/chromium/third_party/ffmpeg/+/refs/heads/master/chromium/config/Chrome/linux/x64/libavcodec/parser_list.c). [codec_list.c](https://chromium.googlesource.com/chromium/third_party/ffmpeg/+/refs/heads/master/chromium/config/Chrome/linux/x64/libavcodec/codec_list.c). They are not using [ffmpeg's vp8](https://issues.chromium.org/issues/41187291) yet. theore is not in whilelist of M120 or later which means we need patched Chromium to use it. So they should not be default.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
