### PR TITLE
media-libs/rubberband: fix building w/ libc++ 21

### DIFF
--- a/media-libs/rubberband/files/rubberband-4.0.0-cstdlib-include.patch
+++ b/media-libs/rubberband/files/rubberband-4.0.0-cstdlib-include.patch
@@ -1,0 +1,23 @@
+From https://github.com/breakfastquay/rubberband/pull/126 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Sun, 27 Jul 2025 15:53:17 +0200
+Subject: [PATCH] missing include cstdlib
+
+Fix an error with libcxx-21
+
+>In file included from ../rubberband-4.0.0/src/common/mathmisc.cpp:24:
+>../rubberband-4.0.0/src/common/mathmisc.h:58:1:
+>error: unknown type name 'size_t'; did you mean 'std::size_t'?
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+--- a/src/common/mathmisc.h
++++ b/src/common/mathmisc.h
+@@ -26,6 +26,8 @@
+ 
+ #include "sysutils.h"
+ 
++#include <cstdlib>
++
+ #ifndef M_PI
+ #define M_PI 3.14159265358979323846
+ #endif // M_PI

--- a/media-libs/rubberband/rubberband-4.0.0-r1.ebuild
+++ b/media-libs/rubberband/rubberband-4.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -32,6 +32,10 @@ BDEPEND="
 	virtual/pkgconfig
 	test? ( dev-libs/boost[${MULTILIB_USEDEP}] )
 "
+
+PATCHES=(
+	"${FILESDIR}/rubberband-4.0.0-cstdlib-include.patch"
+)
 
 EMESON_BUILDTYPE=release
 


### PR DESCRIPTION
libc++ 21 shuffled some internal includes around, so cstdlib now needs to be explicitly included here.

Closes: https://bugs.gentoo.org/960754

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
