### PR TITLE
fcaps.eclass: do not set suid bit as a fallback

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -33,9 +33,9 @@ DEPEND="
 "
 
 FILECAPS=(
-	cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep usr/bin/cdrecord --
-	cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep usr/bin/cdda2wav --
-	cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep usr/bin/readcd
+	-m u+s cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep usr/bin/cdrecord --
+	-m u+s cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep usr/bin/cdda2wav --
+	-m u+s cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep usr/bin/readcd
 )
 
 cdrtools_os() {
@@ -277,6 +277,9 @@ src_install() {
 	# If not built with -j1, "sometimes" manpages are not installed.
 	emake -j1 CPPOPTX="${CPPFLAGS}" COPTX="${CFLAGS}" C++OPTX="${CXXFLAGS}" \
 		LDOPTX="${LDFLAGS}" GMAKE_NOWARN="true" install
+
+	# Let fcaps handle this
+	fperms 0755 /usr/bin/{cdda2wav,cdrecord,readcd}
 
 	# These symlinks are for compat with cdrkit.
 	dosym schily /usr/include/scsilib

--- a/app-emulation/qemu/qemu-10.0.0.ebuild
+++ b/app-emulation/qemu/qemu-10.0.0.ebuild
@@ -943,7 +943,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-10.0.2-r50.ebuild
+++ b/app-emulation/qemu/qemu-10.0.2-r50.ebuild
@@ -957,7 +957,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-10.0.2.ebuild
+++ b/app-emulation/qemu/qemu-10.0.2.ebuild
@@ -943,7 +943,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-10.0.3.ebuild
+++ b/app-emulation/qemu/qemu-10.0.3.ebuild
@@ -957,7 +957,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-9.1.3-r2.ebuild
+++ b/app-emulation/qemu/qemu-9.1.3-r2.ebuild
@@ -954,7 +954,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-9.2.3-r3.ebuild
+++ b/app-emulation/qemu/qemu-9.2.3-r3.ebuild
@@ -944,7 +944,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-9.2.4.ebuild
+++ b/app-emulation/qemu/qemu-9.2.4.ebuild
@@ -943,7 +943,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -943,7 +943,7 @@ pkg_postinst() {
 	xdg_icon_cache_update
 
 	[[ -z ${EPREFIX} ]] && [[ -f ${EROOT}/usr/libexec/qemu-bridge-helper ]] && \
-		fcaps cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
+		fcaps -m u+s cap_net_admin "${EROOT}"/usr/libexec/qemu-bridge-helper
 
 	DISABLE_AUTOFORMATTING=true
 	readme.gentoo_print_elog

--- a/app-i18n/fbterm/fbterm-1.7_p20190503.ebuild
+++ b/app-i18n/fbterm/fbterm-1.7_p20190503.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -27,7 +27,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=( "${FILESDIR}"/${PN}-autoconf-2.68.patch )
 
 FILECAPS=(
-	cap_sys_tty_config+ep usr/bin/${PN}
+	-m u+s cap_sys_tty_config+ep usr/bin/${PN}
 )
 
 src_prepare() {
@@ -46,12 +46,6 @@ src_configure() {
 
 src_compile() {
 	emake AR="$(tc-getAR)"
-}
-
-src_install() {
-	default
-
-	use filecaps || fperms u+s /usr/bin/${PN}
 }
 
 pkg_postinst() {

--- a/eclass/fcaps.eclass
+++ b/eclass/fcaps.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: fcaps.eclass
@@ -105,11 +105,6 @@ fcaps() {
 	local mode=u+s
 	local caps_mode=
 
-	if [[ -n ${FCAPS_DENY_WORLD_READ} ]]; then
-		mode=u+s,go-r
-		caps_mode=go-r
-	fi
-
 	while [[ $# -gt 0 ]] ; do
 		case $1 in
 		-o) owner=$2; shift;;
@@ -143,12 +138,16 @@ fcaps() {
 	for file ; do
 		[[ ${file} != /* ]] && file="${root}/${file}"
 
+		# Remove the read bits if requested.
+		if [[ -n ${FCAPS_DENY_WORLD_READ} ]]; then
+			chmod go-r "${file}" || die
+		fi
+
 		if use filecaps ; then
 			# Try to set capabilities.  Ignore errors when the
 			# fs doesn't support it, but abort on all others.
 			debug-print "${FUNCNAME}: setting caps '${caps}' on '${file}'"
 
-			# Remove the read bits if requested.
 			if [[ -n ${caps_mode} ]]; then
 				chmod ${caps_mode} "${file}" || die
 			fi

--- a/gui-apps/swaylock/swaylock-1.8.0.ebuild
+++ b/gui-apps/swaylock/swaylock-1.8.0.ebuild
@@ -50,5 +50,5 @@ src_configure() {
 }
 
 pkg_postinst() {
-	use !pam && fcaps cap_sys_admin usr/bin/swaylock
+	use !pam && fcaps -m u+s cap_sys_admin usr/bin/swaylock
 }

--- a/gui-apps/swaylock/swaylock-9999.ebuild
+++ b/gui-apps/swaylock/swaylock-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -50,5 +50,5 @@ src_configure() {
 }
 
 pkg_postinst() {
-	use !pam && fcaps cap_sys_admin usr/bin/swaylock
+	use !pam && fcaps -m u+s cap_sys_admin usr/bin/swaylock
 }

--- a/sys-libs/pam/pam-1.7.0_p20241230-r3.ebuild
+++ b/sys-libs/pam/pam-1.7.0_p20241230-r3.ebuild
@@ -188,5 +188,5 @@ pkg_postinst() {
 
 	# The pam_unix module needs to check the password of the user which requires
 	# read access to /etc/shadow only.
-	fcaps cap_dac_override sbin/unix_chkpwd
+	fcaps -m u+s cap_dac_override sbin/unix_chkpwd
 }

--- a/sys-libs/pam/pam-1.7.1.ebuild
+++ b/sys-libs/pam/pam-1.7.1.ebuild
@@ -187,5 +187,5 @@ pkg_postinst() {
 
 	# The pam_unix module needs to check the password of the user which requires
 	# read access to /etc/shadow only.
-	fcaps cap_dac_override sbin/unix_chkpwd
+	fcaps -m u+s cap_dac_override sbin/unix_chkpwd
 }

--- a/x11-misc/slock/slock-1.5.ebuild
+++ b/x11-misc/slock/slock-1.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,7 +58,7 @@ pkg_postinst() {
 	# cap_dac_read_search used to be enough for shadow access
 	# but now slock wants to write to /proc/self/oom_score_adj
 	# and for that it needs:
-	fcaps \
+	fcaps -m u+s \
 		cap_dac_override,cap_setgid,cap_setuid,cap_sys_resource \
 		/usr/bin/slock
 

--- a/x11-misc/slock/slock-1.6.ebuild
+++ b/x11-misc/slock/slock-1.6.ebuild
@@ -51,7 +51,7 @@ pkg_postinst() {
 	# cap_dac_read_search used to be enough for shadow access
 	# but now slock wants to write to /proc/self/oom_score_adj
 	# and for that it needs:
-	fcaps \
+	fcaps -m u+s \
 		cap_dac_override,cap_setgid,cap_setuid,cap_sys_resource \
 		/usr/bin/slock
 


### PR DESCRIPTION
Update fcaps.eclass to avoid setting the suid bit by default when file capabilities are disabled.

I also did a scan of packages inheriting fcaps and added `-m u+s` where I felt it was appropriate. It is possible I missed some, but I think the risk is fairly small and it should be easy for maintainers to correct at a later date if necessary.

Bug: https://bugs.gentoo.org/811105