### PR TITLE
`multilib.eclass`: append ABI flags to build-machine toolchain variables

### DIFF
--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: multilib.eclass
@@ -487,6 +487,17 @@ multilib_toolchain_setup() {
 	local save_restore_variables=(
 		CBUILD
 		CHOST
+		BUILD_AR
+		BUILD_CC
+		BUILD_CXX
+		BUILD_LD
+		BUILD_NM
+		BUILD_OBJCOPY
+		BUILD_PKG_CONFIG
+		BUILD_RANLIB
+		BUILD_READELF
+		BUILD_STRINGS
+		BUILD_STRIP
 		AR
 		CC
 		CXX
@@ -535,6 +546,20 @@ multilib_toolchain_setup() {
 		#
 		# Make sure ${save_restore_variables[@]} list matches below.
 		export CHOST=$(get_abi_CHOST ${DEFAULT_ABI})
+
+		# Derive the build-machine toolchain variables before we
+		# override the host-machine toolchain variables.
+		export BUILD_AR="$(tc-getBUILD_AR)" # Avoid 'ar', use "${CBUILD}-ar"
+		export BUILD_CC="$(tc-getBUILD_CC) $(get_abi_CFLAGS)"
+		export BUILD_CXX="$(tc-getBUILD_CXX) $(get_abi_CFLAGS)"
+		export BUILD_LD="$(tc-getBUILD_LD) $(get_abi_LDFLAGS)"
+		export BUILD_NM="$(tc-getBUILD_NM)" # Avoid 'nm', use "${CBUILD}-nm"
+		export BUILD_OBJCOPY="$(tc-getBUILD_OBJCOPY)" # Avoid 'objcopy', use "${CBUILD}-objcopy"
+		export BUILD_PKG_CONFIG="$(tc-getBUILD_PKG_CONFIG)"
+		export BUILD_RANLIB="$(tc-getBUILD_RANLIB)" # Avoid 'ranlib', use "${CBUILD}-ranlib"
+		export BUILD_READELF="$(tc-getBUILD_READELF)" # Avoid 'readelf', use "${CBUILD}-readelf"
+		export BUILD_STRINGS="$(tc-getBUILD_STRINGS)" # Avoid 'strings', use "${CBUILD}-strings"
+		export BUILD_STRIP="$(tc-getBUILD_STRIP)" # Avoid 'strip', use "${CBUILD}-strip"
 
 		export AR="$(tc-getAR)" # Avoid 'ar', use '${CHOST}-ar'
 		export CC="$(tc-getCC) $(get_abi_CFLAGS)"


### PR DESCRIPTION
Currently we have some inconsistent automagic:

 * If the user _has_ specified a build-machine toolchain (by setting `BUILD_CC`, `BUILD_CXX`, etc.), then in every phase of the multi-build, `multilib.eclass` will cause all build-time helper executables to be compiled invariably for whichever ABI the user specified (or implied) in their build-machine toolchain variables.

 * If the user _has not_ specified a build-machine toolchain, then in each phase of the multi-build, `multilib.eclass` will cause all build-time helper executables to be compiled for the ABI targeted _in that phase_.

Assuming that the intent was indeed for build-time helper executables to be built for each distinct targeted ABI, then `multilib.eclass` needs to append `"$(get_abi_*FLAGS)"` also to `BUILD_CC`, `BUILD_CXX`, and `BUILD_LD` so that the ABI flags will be passed even when the user has specified a build-machine toolchain.

Closes: https://bugs.gentoo.org/960506

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` mysteriously claims `pkgcheck scan: error: failed running git: fatal: not a git repository (or any parent up to mount point /var/db)` even though I am running it in a Git worktree.

Please note that all boxes must be checked for the pull request to be merged.
