### PR TITLE
games-simulation/openrct2: fix build with libc++ 21

### DIFF
--- a/games-simulation/openrct2/files/openrct2-0.4.21-libcxx-21-cstdlib.patch
+++ b/games-simulation/openrct2/files/openrct2-0.4.21-libcxx-21-cstdlib.patch
@@ -1,0 +1,18 @@
+From https://github.com/OpenRCT2/OpenRCT2/commit/1abd50ff1ff75360c9ad77ec07be15d97d7d643a Mon Sep 17 00:00:00 2001
+From: Violet Purcell <66446404+vimproved@users.noreply.github.com>
+Date: Thu, 7 Aug 2025 16:03:03 -0400
+Subject: [PATCH] Add explicit <cstdlib> include to Range.hpp (#24918)
+
+LLVM libc++ 21 shuffled around some includes internally, causing cstdlib
+to no longer be transitively included here. Explicitly include it for
+size_t.
+--- a/src/openrct2/core/Range.hpp
++++ b/src/openrct2/core/Range.hpp
+@@ -10,6 +10,7 @@
+ #pragma once
+ 
+ #include <cmath>
++#include <cstdlib>
+ #include <type_traits>
+ 
+ template<typename T>

--- a/games-simulation/openrct2/openrct2-0.4.21.ebuild
+++ b/games-simulation/openrct2/openrct2-0.4.21.ebuild
@@ -79,6 +79,8 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-0.4.1-gtest-1.10.patch"
 	"${FILESDIR}/${PN}-0.4.16-include-additional-paths.patch"
+	# backport of https://github.com/OpenRCT2/OpenRCT2/commit/1abd50ff1ff75360c9ad77ec07be15d97d7d643a
+	"${FILESDIR}/${P}-libcxx-21-cstdlib.patch"
 )
 
 src_unpack() {


### PR DESCRIPTION
Backport fix for building with libc++ 21.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
