### PR TITLE
sys-fs/snapraid: dash-compatibility fix

### DIFF
--- a/sys-fs/snapraid/files/snapraid-12.4-dash-compatibility.patch
+++ b/sys-fs/snapraid/files/snapraid-12.4-dash-compatibility.patch
@@ -1,0 +1,23 @@
+Replace conditional expression with `test`
+to ensure compatibility with different shell environments.
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -512,7 +512,7 @@
+ 	echo RUN > bench/disk1/RUN-CHMOD
+ if HAVE_POSIX
+ # Doesn't run this test as root because the root user override permissions
+-	if [[ $$EUID -ne 0 ]]; then \
++	if test "$$EUID" -ne 0; then \
+ 		$(FAILENV) ./snapraid$(EXEEXT) $(CHECKFLAGS) -c $(CONF) --test-run "chmod a-r bench/disk1/RUN-CHMOD" --test-expect-failure sync; \
+ 	fi
+ endif
+@@ -532,7 +532,7 @@
+ 	echo HASH > bench/disk1/HASH-CHMOD
+ if HAVE_POSIX
+ # Doesn't run this test as root because the root user override permissions
+-	if [[ $$EUID -ne 0 ]]; then \
++	if test "$$EUID" -ne 0; then \
+ 		$(FAILENV) ./snapraid$(EXEEXT) $(CHECKFLAGS) -c $(CONF) --test-run "chmod a-r bench/disk1/HASH-CHMOD" --test-expect-failure -h sync; \
+ 	fi
+ endif

--- a/sys-fs/snapraid/snapraid-12.4-r1.ebuild
+++ b/sys-fs/snapraid/snapraid-12.4-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Backup program with disk array for cold data on existing filesystems"
+HOMEPAGE="https://www.snapraid.it/"
+SRC_URI="https://github.com/amadvance/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+BDEPEND="test? ( sys-apps/smartmontools )"
+
+DOCS=( "AUTHORS" "HISTORY" "README" "TODO" "snapraid.conf.example" )
+
+PATCHES=(
+	"${FILESDIR}/snapraid-12.4-dash-compatibility.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+pkg_postinst() {
+	elog "To start using SnapRAID, change the example configuration"
+	elog "${EPREFIX}/usr/share/doc/${PF}/snapraid.conf.example.bz2"
+	elog "to fit your needs and copy it to ${EPREFIX}/etc/snapraid.conf"
+}


### PR DESCRIPTION
This is a patch for the testing processes that remove dependency on bash shell.

related to [Bug 927538](https://bugs.gentoo.org/927538):
sys-fs/snapraid-12.2 calls commands that do not exist: [[

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
