### PR TITLE
dev-util/sysprof: fix compilation with Clang

### DIFF
--- a/dev-util/sysprof/files/sysprof-48.0-shadowed-variable.patch
+++ b/dev-util/sysprof/files/sysprof-48.0-shadowed-variable.patch
@@ -1,0 +1,25 @@
+Compilation with Clang fails on -Werror=shadow: 'environ' shadows declaration from /usr/include/unistd.h
+
+Bug: https://gitlab.gnome.org/GNOME/sysprof/-/issues/150
+--- a/src/sysprof/sysprof-greeter.c
++++ b/src/sysprof/sysprof-greeter.c
+@@ -626,14 +626,14 @@ sysprof_greeter_init (SysprofGreeter *self)
+ 
+   if (self->recording_template)
+     {
+-      g_auto(GStrv) environ = NULL;
++      g_auto(GStrv) environ_ = NULL;
+       g_object_get (self->recording_template,
+-                    "environ", &environ,
++                    "environ", &environ_,
+                     NULL);
+-      if (environ)
++      if (environ_)
+         {
+-          for (guint i = 0; environ[i]; i++)
+-            gtk_string_list_append (self->envvars, environ[i]);            
++          for (guint i = 0; environ_[i]; i++)
++            gtk_string_list_append (self->envvars, environ_[i]);            
+         }
+     }
+ 

--- a/dev-util/sysprof/sysprof-48.0-r1.ebuild
+++ b/dev-util/sysprof/sysprof-48.0-r1.ebuild
@@ -46,6 +46,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-48.0-shadowed-variable.patch
+)
+
 src_prepare() {
 	default
 	xdg_environment_reset


### PR DESCRIPTION
Fixes the following build error:
```
/usr/lib/llvm/20/bin/clang -Isrc/sysprof/sysprof.p -Isrc/sysprof -I../sysprof-48.0/src/sysprof -Isrc/libsysprof -I../sysprof-48.0/src/libsysprof -Isrc/libsysprof-capture -I../sysprof-48.0/src/libsysprof-capture -Icontrib/eggbitset -I../sysprof-48.0/contrib/eggbitset -Icontrib/elfparser -I../sysprof-48.0/contrib/elfparser -Icontrib/linereader -I../sysprof-48.0/contrib/linereader -I/usr/include/gtk-4.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/webp -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/pixman-1 -I/usr/include/graphene-1.0 -I/usr/lib64/graphene-1.0/include -I/usr/lib64/libffi/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/sysprof-6 -I/usr/include/libadwaita-1 -I/usr/include/appstream -I/usr/include/libpanel-1 -I/usr/include/gio-unix-2.0 -I/usr/include/libdex-1 -I/usr/include/json-glib-1.0 -I/usr/include/polkit-1 -I/var/tmp/portage/dev-util/sysprof-48.0-r1/work/sysprof-48.0-build -flto=thin -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu17 -DSYSPROF_COMPILATION -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_76 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_76 -DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_16 -DGDK_VERSION_MAX_ALLOWED=GDK_VERSION_4_16 -Wcast-align -Wdeclaration-after-statement -Wformat-nonliteral -Wformat-security -Wmissing-include-dirs -Wnested-externs -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter -Wno-cast-function-type -Wpointer-arith -Wredundant-decls -Wswitch-default -Wswitch-enum -Wuninitialized -Werror=format-security -Werror=format=2 -Werror=empty-body -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=init-self -Werror=int-conversion -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=overflow -Werror=return-type -Werror=shadow -Werror=strict-prototypes -Werror=undef -march=native -O2 -pipe -fdiagnostics-color=always -frecord-gcc-switches -Werror=odr -Werror=strict-aliasing -pthread -mfpmath=sse -msse -msse2 -mfpmath=sse -msse -msse2 -mfpmath=sse -msse -msse2 -MD -MQ src/sysprof/sysprof.p/sysprof-greeter.c.o -MF src/sysprof/sysprof.p/sysprof-greeter.c.o.d -o src/sysprof/sysprof.p/sysprof-greeter.c.o -c ../sysprof-48.0/src/sysprof/sysprof-greeter.c
../sysprof-48.0/src/sysprof/sysprof-greeter.c:629:21: error: declaration shadows a variable in the global scope [-Werror,-Wshadow]
  629 |       g_auto(GStrv) environ = NULL;
      |                     ^
/usr/include/unistd.h:566:15: note: previous declaration is here
  566 | extern char **environ;
      |               ^
```

Bug: https://gitlab.gnome.org/GNOME/sysprof/-/issues/150

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
