### PR TITLE
media-libs/virglrenderer: amdgpu_renderer.c: Fix error: extension used

### DIFF
--- a/media-libs/virglrenderer/files/0001-mesa-util-use-c11-alignof-instead-of-our-own.patch
+++ b/media-libs/virglrenderer/files/0001-mesa-util-use-c11-alignof-instead-of-our-own.patch
@@ -1,0 +1,34 @@
+From 4ee18a4d5a14d63ff758bf94df04cd1d4e570074 Mon Sep 17 00:00:00 2001
+From: Erik Faye-Lund <erik.faye-lund@collabora.com>
+Date: Tue, 7 Jun 2022 16:33:02 +0200
+Subject: [PATCH] mesa/util: use c11 alignof instead of our own
+
+...with an exception for MSVC, which doesn't have stdalign.h, so let's
+add a definition for that.
+
+Taken from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/16908
+
+Part-of: <https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1542>
+--- a/src/mesa/util/macros.h
++++ b/src/mesa/util/macros.h
+@@ -442,13 +442,11 @@ enum pipe_debug_type
+    PIPE_DEBUG_TYPE_CONFORMANCE,
+ };
+ 
+-#if !defined(alignof) && !defined(__cplusplus)
+-#if __STDC_VERSION__ >= 201112L
+-#define alignof(t) _Alignof(t)
+-#elif defined(_MSC_VER)
+-#define alignof(t) __alignof(t)
++#ifndef __cplusplus
++#ifdef _MSC_VER
++#define alignof _Alignof
+ #else
+-#define alignof(t) __alignof__(t)
++#include <stdalign.h>
+ #endif
+ #endif
+ 
+-- 
+2.50.1
+

--- a/media-libs/virglrenderer/files/virglrenderer-fix-clang-warning-about-typeof.patch
+++ b/media-libs/virglrenderer/files/virglrenderer-fix-clang-warning-about-typeof.patch
@@ -1,0 +1,26 @@
+https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1547
+From: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Date: Mon, 11 Aug 2025 13:17:56 +0300
+Subject: [PATCH] drm: amdgpu: Fix clang warning about typeof() extension
+
+AMDGPU nctx code uses typeof(), which is a GCC extension. Clang supports
+typeof(), but emits a warning that breaks compilation because -Werror is
+enabled by default. Silence the clang warning about typeof() like we do it
+for drm_utils.
+
+Closes: https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/627
+Signed-off-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Part-of: <https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1547>
+--- a/src/drm/amdgpu/amdgpu_renderer.c
++++ b/src/drm/amdgpu/amdgpu_renderer.c
+@@ -51,6 +51,7 @@
+ 
+ #if defined(__clang__)
+ #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
++#pragma GCC diagnostic ignored "-Wlanguage-extension-token"
+ #endif
+ 
+ #if 0
+-- 
+GitLab
+

--- a/media-libs/virglrenderer/virglrenderer-1.1.1-r1.ebuild
+++ b/media-libs/virglrenderer/virglrenderer-1.1.1-r1.ebuild
@@ -37,6 +37,13 @@ DEPEND="
 	sys-kernel/linux-headers
 "
 
+PATCHES=(
+	# ALready in main, can be dropped in newer versions
+	"${FILESDIR}/0001-mesa-util-use-c11-alignof-instead-of-our-own.patch"
+	# bug 961270
+	"${FILESDIR}/${PN}-fix-clang-warning-about-typeof.patch"
+)
+
 src_configure() {
 	local -a gpus=()
 	use video_cards_amdgpu && gpus+=( amdgpu-experimental )


### PR DESCRIPTION
typeof has been part of C23 in clang. Hence we can switch to C23 by default.

Closes: https://bugs.gentoo.org/961270

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
