### PR TITLE
sys-fs/xfsprogs: add 9999

### DIFF
--- a/sys-fs/xfsprogs/xfsprogs-9999.ebuild
+++ b/sys-fs/xfsprogs/xfsprogs-9999.ebuild
@@ -1,0 +1,192 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic systemd udev
+
+DESCRIPTION="XFS filesystem utilities"
+HOMEPAGE="https://xfs.wiki.kernel.org/ https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	inherit autotools
+	REGEN_BDEPEND="
+		dev-build/autoconf
+		dev-build/automake
+		dev-build/libtool
+	"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git"
+	EGIT_BRANCH="for-next"
+	EGIT_CLONE_TYPE="shallow"
+else
+	REGEN_BDEPEND=""
+	SRC_URI="https://www.kernel.org/pub/linux/utils/fs/xfs/${PN}/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+IUSE="icu libedit nls selinux static-libs"
+
+RDEPEND="
+	dev-libs/inih
+	dev-libs/userspace-rcu:=
+	>=sys-apps/util-linux-2.17.2
+	icu? ( dev-libs/icu:= )
+	libedit? ( dev-libs/libedit )
+"
+DEPEND="
+	${RDEPEND}
+	>=sys-kernel/linux-headers-6.11
+"
+BDEPEND="
+	${REGEN_BDEPEND}
+	nls? ( sys-devel/gettext )
+"
+RDEPEND+=" selinux? ( sec-policy/selinux-xfs )"
+
+call_prepare_release() {
+	local version
+
+	#test sed -i
+	#	's/^AC_INIT\(\[xfsprogs\],\[([0-9]+).([0-9]+).([0-9]+)\],\[linux-xfs@vger\.kernel\.org\]\)$/\1.\2.9a999/'
+	#	configure.ac
+
+	version="$(grep -o -- \
+		'^AC_INIT(\[xfsprogs\],\[[0-9]\+\.[0-9]\+\.[0-9]\+\],\[linux-xfs@vger.kernel.org\])$' \
+		configure.ac)"
+	if [ $? != 0 ]; then die; fi
+
+	#test version+='a'
+	version=$(echo "${version}" | ( sed -r \
+		's/^AC_INIT\(\[xfsprogs\],\[([0-9]+).([0-9]+).([0-9]+)\],\[linux-xfs@vger\.kernel\.org\]\)$/\1.\2.9999/;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+
+	#test sed -i 's/^update_version\(\) \{/aupdate_version()  {/g' release.sh
+	# https://stackoverflow.com/questions/8818119/how-can-i-run-a-function-from-a-script-in-command-line
+	local update_version_function=$(sed -n \
+		'/^update_version() {/,/^}$/p' release.sh) || die
+	update_version_function=$( echo "${update_version_function}" | (sed -r \
+		's/^update_version\(\) \{$//;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+	update_version_function=$( echo "${update_version_function}" | (sed -r \
+		's/^\}$//;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+	echo "${update_version_function}" > ./release_update_version.sh
+
+	#test version+='a'
+	local version_file
+	# https://stackoverflow.com/questions/15965073/return-value-of-sed-for-no-match
+	local version_major=$( echo "${version}" | ( sed -r \
+		's/^([0-9]+).([0-9]+).([0-9]+)$/\1/;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+	version_file+="PKG_MAJOR="${version_major}""
+	version_file+=$'\n'
+	local version_minor=$( echo "${version}" | ( sed -r \
+		's/^([0-9]+).([0-9]+).([0-9]+)$/\2/;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+	version_file+="PKG_MINOR="${version_minor}""
+	version_file+=$'\n'
+	local version_revision=$( echo "${version}" | ( sed -r \
+		's/^([0-9]+).([0-9]+).([0-9]+)$/\3/;tm;${x;/1/{x;q};x;q1};b;:m;x;s/.*/1/;x' \
+		|| die ) )
+	version_file+="PKG_REVISION="${version_revision}""
+	version_file+=$'\n'
+	echo "${version_file}" > ./VERSION
+	chmod +x release_update_version.sh
+	# https://stackoverflow.com/questions/17583578/what-command-means-do-nothing-in-a-conditional-in-bash
+	EDITOR="true" version="${version}" ./release_update_version.sh || die
+}
+
+src_prepare() {
+	default
+
+	# Fix doc dir
+	sed -i \
+		-e "/^PKG_DOC_DIR/s:@pkg_name@:${PF}:" \
+		include/builddefs.in || die
+
+	# Don't install compressed docs
+	sed 's@\(CHANGES\)\.gz[[:space:]]@\1 @' -i doc/Makefile || die
+
+	if [[ ${PV} == *9999 ]]; then
+		call_prepare_release || die
+	fi
+
+	if [[ ${PV} == *9999 ]]; then
+		make configure || die
+	fi
+}
+
+src_configure() {
+	# include/builddefs.in will add FCFLAGS to CFLAGS which will
+	# unnecessarily clutter CFLAGS (and fortran isn't used)
+	unset FCFLAGS
+
+	# If set in user env, this breaks configure
+	unset PLATFORM
+
+	export DEBUG=-DNDEBUG
+
+	# Package is honoring CFLAGS; No need to use OPTIMIZER anymore.
+	# However, we have to provide an empty value to avoid default
+	# flags.
+	export OPTIMIZER=" "
+
+	# Avoid automagic on libdevmapper (bug #709694)
+	export ac_cv_search_dm_task_create=no
+
+	# bug 903611, 948468
+	use elibc_musl && \
+		append-flags -D_LARGEFILE64_SOURCE -DOVERRIDE_SYSTEM_STATX
+
+	# Upstream does NOT support --disable-static anymore,
+	# https://www.spinics.net/lists/linux-xfs/msg30185.html
+	# https://www.spinics.net/lists/linux-xfs/msg30272.html
+	local myconf=(
+		--enable-static
+		# Doesn't do anything beyond adding -flto (bug #930947).
+		--disable-lto
+		# The default value causes double 'lib'
+		--localstatedir="${EPREFIX}/var"
+		--with-crond-dir="${EPREFIX}/etc/cron.d"
+		--with-systemd-unit-dir="$(systemd_get_systemunitdir)"
+		--with-udev-rule-dir="$(get_udevdir)/rules.d"
+		$(use_enable icu libicu)
+		$(use_enable nls gettext)
+		$(use_enable libedit editline)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_compile() {
+	# -j1 for:
+	# gmake[2]: *** No rule to make target '../libhandle/libhandle.la', needed by 'xfs_spaceman'.  Stop.
+	emake V=1 -j1
+}
+
+src_install() {
+	# XXX: There's a missing dep in the install-dev target, so split it
+	emake DIST_ROOT="${ED}" HAVE_ZIPPED_MANPAGES=false install
+	emake DIST_ROOT="${ED}" HAVE_ZIPPED_MANPAGES=false install-dev
+
+	# Not actually used but --localstatedir causes this empty dir
+	# to be installed.
+	rmdir "${ED}"/var/lib/xfsprogs "${ED}"/var/lib || die
+
+	if ! use static-libs; then
+		rm "${ED}/usr/$(get_libdir)/libhandle.a" || die
+	fi
+
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postrm() {
+	udev_reload
+}
+
+pkg_postinst() {
+	udev_reload
+}


### PR DESCRIPTION
The ebuild code only adds extra steps to the already existing testing ebuild (6.15.0 at the moment).
It fetches the next release branch of the upstream git, then
  in prepare phase, it generates a new version number and call the upstream script to update the version where needed.
It avoids calling the interactive editor of the upstream script, which manually updates the version.

current diff of 6.15.0 and 9999 ebuilds: [https://editor.mergely.com/71qjrYsJ](url)

xfs-progs live build request: 
Bug: https://bugs.gentoo.org/547122

- As it is, it is good enough for dev/testing, it may be masked as well.
- I can personally maintain it, but I am not related to the upstream dev.

- It automatically parses the version number and update it in the VERSION file.
  - The build version number is changed, for example, from 6.15.1 to 6.15.9999,
  so it reflects on the final executables of the package.
    - May there be a better approach to this?
- Autoconf is called by the upstream script, so pkgcheck says Autotools is unused. 
  -   Autoconf and automake are added to BDEPEND.
- There may be a better way to ensure sed replacements were actually performed.
- The call to make configure (which uses autoconf) is in the prepare phase, is it right?
- Calling a script from the ebuild gives:
  -   ./release_update_version.sh: /usr/share/bashdb/bashdb-main.inc: No such file or directory
  -   ./release_update_version.sh: warning: cannot start debugger; debugging mode disabled
- Should it call make clean in case of recompilation attempt?
- There may be a better way for, from an ebuild, calling only one function of an extern script,
  -   "source ..." and ". something.sh" don't work in this case

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
