### PR TITLE
media-libs/libpng-compat: drop cpu_flags_arm_neon check, cleanup

### DIFF
--- a/media-libs/libpng-compat/libpng-compat-1.2.59-r1.ebuild
+++ b/media-libs/libpng-compat/libpng-compat-1.2.59-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,11 +7,11 @@ EAPI=8
 
 inherit libtool multilib-minimal
 
-MY_P=libpng-${PV}
+MY_P="libpng-${PV}"
 DESCRIPTION="Portable Network Graphics library"
-HOMEPAGE="http://www.libpng.org/"
+HOMEPAGE="https://www.libpng.org/"
 SRC_URI="https://downloads.sourceforge.net/libpng/${MY_P}.tar.xz"
-S="${WORKDIR}"/${MY_P}
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="libpng"
 SLOT="1.2"

--- a/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
+++ b/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,6 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="libpng"
 SLOT="1.5"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
-IUSE="cpu_flags_arm_neon"
 
 RDEPEND="
 	sys-libs/zlib:=[${MULTILIB_USEDEP}]
@@ -37,14 +36,6 @@ src_prepare() {
 	default
 
 	elibtoolize
-}
-
-multilib_src_configure() {
-	local myeconfargs=(
-		$(use_enable cpu_flags_arm_neon arm-neon check)
-	)
-
-	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 
 multilib_src_compile() {

--- a/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
+++ b/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
@@ -9,7 +9,7 @@ inherit libtool multilib-minimal
 
 MY_P="libpng-${PV}"
 DESCRIPTION="Portable Network Graphics library"
-HOMEPAGE="http://www.libpng.org/"
+HOMEPAGE="https://www.libpng.org/"
 SRC_URI="https://downloads.sourceforge.net/libpng/${MY_P}.tar.xz"
 S="${WORKDIR}/${MY_P}"
 

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -285,11 +285,6 @@ dev-util/diffoscope pascal
 # media-plugins/zam-plugins not keyworded here
 media-sound/easyeffects zamaudio
 
-# Sam James <sam@gentoo.org> (2021-04-14)
-# Supports 64-bit NEON
-# Note: libpng-compat 1.5.30 does NOT seem to.
-media-libs/libpng -cpu_flags_arm_neon
-
 # Sam James <sam@gentoo.org> (2021-03-20)
 # Supports both 'neon32' and 'neon64'
 sys-libs/zlib-ng -cpu_flags_arm_neon


### PR DESCRIPTION
media-libs/libpng-compat:
- Do not rely on the internal checking code as it is deprecated and poorly supported.
- Update Homepage, align ebuilds.

media-libs/libpng:
- Drop obsolete use mask

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
