### PR TITLE
media-libs/libpng-compat: set ECONF_SOURCE

### DIFF
--- a/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
+++ b/media-libs/libpng-compat/libpng-compat-1.5.30-r1.ebuild
@@ -38,6 +38,10 @@ src_prepare() {
 	elibtoolize
 }
 
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf
+}
+
 multilib_src_compile() {
 	emake libpng15.la
 }


### PR DESCRIPTION
Turns out you need to explicitly pass it.

Closes: https://bugs.gentoo.org/961325

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
