### PR TITLE
dev-scheme/chicken: add static-libs use flag

### DIFF
--- a/dev-scheme/chicken/chicken-5.3.0.ebuild
+++ b/dev-scheme/chicken/chicken-5.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -12,7 +12,7 @@ SRC_URI="https://code.call-cc.org/releases/${PV}/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~mips ppc ppc64 ~riscv x86"
-IUSE="doc"
+IUSE="static-libs doc"
 
 RDEPEND=""
 DEPEND=""
@@ -65,7 +65,8 @@ src_install() {
 		DESTDIR="${D}" \
 		install
 	einstalldocs
-	find "${ED}" -name '*.a' -delete || die
+
+	use static-libs || find "${ED}" -name '*.a' -delete || die
 
 	# let portage track this file (created later)
 	touch "${ED}"/usr/$(get_libdir)/${PN}/11/modules.db || die

--- a/dev-scheme/chicken/chicken-5.4.0.ebuild
+++ b/dev-scheme/chicken/chicken-5.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ SRC_URI="https://code.call-cc.org/releases/${PV}/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~mips ppc ppc64 ~riscv x86"
-IUSE="doc"
+IUSE="static-libs doc"
 
 src_prepare() {
 	default
@@ -64,7 +64,7 @@ src_install() {
 		DESTDIR="${D}" \
 		install
 	einstalldocs
-	find "${ED}" -name '*.a' -delete || die
+	use static-libs || find "${ED}" -name '*.a' -delete || die
 
 	# let portage track this file (created later)
 	touch "${ED}"/usr/$(get_libdir)/${PN}/11/modules.db || die


### PR DESCRIPTION
Installation of `libchicken.a` was removed in https://bugs.gentoo.org/724080. In this PR I'm bringing it back by adding `static-libs` USE flag.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
