### PR TITLE
media-libs/libspng: skip broken tests due to newer libpng

### DIFF
--- a/media-libs/libspng/libspng-0.7.4.ebuild
+++ b/media-libs/libspng/libspng-0.7.4.ebuild
@@ -35,3 +35,23 @@ src_configure() {
 
 	meson_src_configure
 }
+
+src_test() {
+	local -a tests
+	tests=( $(meson test --list -C "${BUILD_DIR}") )
+
+	local -a skip_tests=(
+		# Incompatabilities with >=libpng-1.6.47
+		# bug #956692
+		ch1n3p04
+		ch2n3p08
+	)
+
+	for test_index in ${!tests[@]}; do
+		if [[ ${skip_tests[@]} =~ ${tests[${test_index}]} ]]; then
+			unset tests[${test_index}]
+		fi
+	done
+
+	meson_src_test ${tests[@]}
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/956692

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
