### PR TITLE
app-admin/gamin-derived ebuilds: bug fixes; updates

### DIFF
--- a/app-admin/gam-server/files/gam-server-0.1.10-fix-build-with-gcc-14-and-clang.patch
+++ b/app-admin/gam-server/files/gam-server-0.1.10-fix-build-with-gcc-14-and-clang.patch
@@ -1,0 +1,59 @@
+Fix build with gcc-14 and clang
+
+Origin: Combiened from original patches posted to Gentoo bugzilla
+Author: David Betancur Vallejo <sunset666@sunset666.net>
+Bug: https://bugs.gentoo.org/509696
+Bug: https://bugs.gentoo.org/870574
+Bug: https://bugs.gentoo.org/920356
+--- a/server/gam_connection.c	2007-07-04 09:36:49.000000000 -0400
++++ b/server/gam_connection.c	2025-06-10 23:55:11.300403185 -0400
+@@ -19,6 +19,7 @@
+ #include "gam_inotify.h"
+ #endif
+ #include "fam.h"
++#include "gam_excludes.h"
+ 
+ /************************************************************************
+  *									*
+--- a/server/gam_eq.c	2007-07-04 09:36:49.000000000 -0400
++++ b/server/gam_eq.c	2025-06-10 23:57:02.457123587 -0400
+@@ -124,7 +124,7 @@
+ {
+ 	gboolean done_work = FALSE;
+ 	if (!eq)
+-		return;
++		return done_work;
+ 
+ #ifdef GAM_EQ_VERBOSE
+ 	GAM_DEBUG(DEBUG_INFO, "gam_eq: Flushing event queue for %s\n", gam_connection_get_pidname (conn));
+--- a/server/gam_inotify.c	2025-06-10 23:58:55.040118509 -0400
++++ b/server/gam_inotify.c	2025-06-10 23:58:47.249981960 -0400
+@@ -30,6 +30,7 @@
+ #include "gam_server.h"
+ #include "gam_subscription.h"
+ #include "gam_inotify.h"
++#include "gam_poll_basic.h"
+ 
+ /* Transforms a inotify event to a gamin event. */
+ static GaminEventType
+--- a/server/gam_listener.c	2007-07-04 09:36:49.000000000 -0400
++++ b/server/gam_listener.c	2025-06-10 23:39:04.914127952 -0400
+@@ -25,6 +25,7 @@
+ #include "gam_server.h"
+ #include "gam_error.h"
+ #include "gam_pidname.h"
++#include "gam_excludes.h"
+ #ifdef ENABLE_INOTIFY
+ #include "gam_inotify.h"
+ #endif
+--- a/server/gam_server.h	2025-06-10 23:52:52.003110180 -0400
++++ b/server/gam_server.h	2025-06-10 23:52:07.096202211 -0400
+@@ -79,6 +79,8 @@
+ gboolean	gam_poll_remove_all_for		(GamListener *listener);
+ GaminEventType	gam_poll_file			(GamNode *node);
+ 
++extern void gam_error_init(void);
++
+ #ifdef __cplusplus
+ }
+ #endif

--- a/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
+++ b/app-admin/gam-server/gam-server-0.1.10-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ GNOME_TARBALL_SUFFIX="bz2"
 inherit autotools flag-o-matic gnome.org
 
 DESCRIPTION="Library providing the FAM File Alteration Monitor API"
-HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
+HOMEPAGE="https://gitlab.gnome.org/Archive/gamin"
 SRC_URI="${SRC_URI}
 	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
 	https://pkgconfig.freedesktop.org/releases/pkg-config-0.26.tar.gz" # pkg.m4 for eautoreconf
@@ -21,8 +21,7 @@ IUSE="debug"
 
 RDEPEND=">=dev-libs/glib-2:2
 	>=dev-libs/libgamin-0.1.10
-	!app-admin/fam
-	!<app-admin/gamin-0.1.10"
+	!app-admin/fam"
 
 DEPEND="${RDEPEND}"
 
@@ -46,6 +45,9 @@ src_prepare() {
 
 	# Fix deadlocks with glib-2.32, bug #413331, upstream #667230
 	eapply "${FILESDIR}/${P}-ih_sub_cancel-deadlock.patch"
+
+	# Fix build with gcc-14 and clang bug #559464 #870574 #920356
+	eapply "${FILESDIR}/${P}-fix-build-with-gcc-14-and-clang.patch"
 
 	# Drop DEPRECATED flags
 	sed -i -e 's:-DG_DISABLE_DEPRECATED:$(NULL):g' server/Makefile.am || die

--- a/app-admin/gam-server/metadata.xml
+++ b/app-admin/gam-server/metadata.xml
@@ -4,4 +4,7 @@
   <maintainer type="project">
     <email>freedesktop-bugs@gentoo.org</email>
   </maintainer>
+  <upstream>
+    <remote-id type="gnome-gitlab">Archive/gamin</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/app-admin/gamin/gamin-0.1.10-r1.ebuild
+++ b/app-admin/gamin/gamin-0.1.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit multilib-build
 
 DESCRIPTION="Meta package providing the File Alteration Monitor API & Server"
-HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
+HOMEPAGE="https://gitlab.gnome.org/Archive/gamin"
 
 LICENSE="LGPL-2"
 SLOT="0"

--- a/app-admin/gamin/metadata.xml
+++ b/app-admin/gamin/metadata.xml
@@ -4,4 +4,7 @@
 <maintainer type="project">
 <email>freedesktop-bugs@gentoo.org</email>
 </maintainer>
+  <upstream>
+    <remote-id type="gnome-gitlab">Archive/gamin</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/dev-libs/libgamin/libgamin-0.1.10-r7.ebuild
+++ b/dev-libs/libgamin/libgamin-0.1.10-r7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,10 +9,10 @@ GNOME_TARBALL_SUFFIX="bz2"
 inherit autotools gnome.org multilib-minimal
 
 DESCRIPTION="Library providing the FAM File Alteration Monitor API"
-HOMEPAGE="https://www.gnome.org/~veillard/gamin/"
+HOMEPAGE="https://gitlab.gnome.org/Archive/gamin"
 SRC_URI="${SRC_URI}
 	mirror://gentoo/gamin-0.1.9-freebsd.patch.bz2
-	https://dev.gentoo.org/~grobian/patches/libgamin-0.1.10-opensolaris.patch.bz2
+	https://dev.gentoo.org/~grobian/patches/${P}-opensolaris.patch.bz2
 	https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" # pkg.m4 for eautoreconf
 
 LICENSE="LGPL-2"
@@ -23,8 +23,7 @@ IUSE="debug static-libs"
 RESTRICT="test" # needs gam-server
 
 RDEPEND="
-	!app-admin/fam
-	!<app-admin/gamin-0.1.10"
+	!app-admin/fam"
 DEPEND="${RDEPEND}"
 
 src_prepare() {

--- a/dev-libs/libgamin/metadata.xml
+++ b/dev-libs/libgamin/metadata.xml
@@ -4,4 +4,7 @@
 <maintainer type="project">
 <email>freedesktop-bugs@gentoo.org</email>
 </maintainer>
+  <upstream>
+    <remote-id type="gnome-gitlab">Archive/gamin</remote-id>
+  </upstream>
 </pkgmetadata>


### PR DESCRIPTION
* fix build with gcc-14/clang
* make SRC_URI non-static, i.e. use `${P}`
* drop outdated blocker to apiece pkgcheck (it is not in portage since the migration to git)
* update HOMEPAGE

Closes: https://bugs.gentoo.org/509696
Closes: https://bugs.gentoo.org/870574
Closes: https://bugs.gentoo.org/920356

---

No revbump due to the bugs concern build-time issues.

The [gamin-0.1.9-freebsd.patch.bz2.zip](https://github.com/user-attachments/files/21723065/gamin-0.1.9-freebsd.patch.bz2.zip) (zipped version due to github limitations) was removed from gentoo mirrors. Please re-upload it.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
