### PR TITLE
dev-python/gpgmepy: fix installation

### DIFF
--- a/dev-python/gpgmepy/gpgmepy-2.0.0-r1.ebuild
+++ b/dev-python/gpgmepy/gpgmepy-2.0.0-r1.ebuild
@@ -63,6 +63,12 @@ python_configure() {
 	emake -Onone prepare
 }
 
+python_compile() {
+	# otherwise distutils will try to build out of S
+	cd "${BUILD_DIR}" || die
+	distutils-r1_python_compile
+}
+
 python_test() {
 	emake -C "${BUILD_DIR}"/tests -Onone check \
 		PYTHON=${EPYTHON} \


### PR DESCRIPTION
Otherwise it will install from the unprepared directory which will be missing the gpg dir (which is symlinked in make prepare).

<!-- Please put the pull request description above -->

Before:
```
$ qlist gpgmepy
/usr/lib/python3.13/site-packages/__init__.py
/usr/lib/python3.13/site-packages/callbacks.py
/usr/lib/python3.13/site-packages/core.py
/usr/lib/python3.13/site-packages/errors.py
/usr/lib/python3.13/site-packages/results.py
/usr/lib/python3.13/site-packages/util.py
/usr/lib/python3.13/site-packages/constants/__init__.py
/usr/lib/python3.13/site-packages/constants/create.py
/usr/lib/python3.13/site-packages/constants/event.py
/usr/lib/python3.13/site-packages/constants/import_type.py
/usr/lib/python3.13/site-packages/constants/keysign.py
/usr/lib/python3.13/site-packages/constants/md.py
/usr/lib/python3.13/site-packages/constants/pk.py
/usr/lib/python3.13/site-packages/constants/protocol.py
/usr/lib/python3.13/site-packages/constants/sigsum.py
/usr/lib/python3.13/site-packages/constants/status.py
/usr/lib/python3.13/site-packages/constants/validity.py
/usr/lib/python3.13/site-packages/constants/data/__init__.py
/usr/lib/python3.13/site-packages/constants/data/encoding.py
/usr/lib/python3.13/site-packages/constants/data/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/data/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/data/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/data/__pycache__/encoding.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/data/__pycache__/encoding.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/data/__pycache__/encoding.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__init__.py
/usr/lib/python3.13/site-packages/constants/keylist/mode.py
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/mode.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/mode.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/keylist/__pycache__/mode.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/sig/__init__.py
/usr/lib/python3.13/site-packages/constants/sig/mode.py
/usr/lib/python3.13/site-packages/constants/sig/notation.py
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/mode.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/mode.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/mode.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/notation.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/notation.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/sig/__pycache__/notation.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__init__.py
/usr/lib/python3.13/site-packages/constants/tofu/policy.py
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/policy.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/policy.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/tofu/__pycache__/policy.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/create.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/create.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/create.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/event.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/event.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/event.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/import_type.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/import_type.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/import_type.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/keysign.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/keysign.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/keysign.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/md.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/md.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/md.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/pk.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/pk.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/pk.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/protocol.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/protocol.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/protocol.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/sigsum.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/sigsum.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/sigsum.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/status.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/status.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/status.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/validity.cpython-313.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/validity.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/constants/__pycache__/validity.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/METADATA
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/WHEEL
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/top_level.txt
/usr/lib/python3.13/site-packages/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/__pycache__/callbacks.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/callbacks.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/callbacks.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/__pycache__/core.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/core.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/core.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/__pycache__/errors.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/errors.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/errors.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/__pycache__/results.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/results.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/results.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/__pycache__/util.cpython-313.pyc
/usr/lib/python3.13/site-packages/__pycache__/util.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/__pycache__/util.cpython-313.opt-2.pyc
/usr/lib/python3.14/site-packages/__init__.py
/usr/lib/python3.14/site-packages/callbacks.py
/usr/lib/python3.14/site-packages/core.py
/usr/lib/python3.14/site-packages/errors.py
/usr/lib/python3.14/site-packages/results.py
/usr/lib/python3.14/site-packages/util.py
/usr/lib/python3.14/site-packages/constants/__init__.py
/usr/lib/python3.14/site-packages/constants/create.py
/usr/lib/python3.14/site-packages/constants/event.py
/usr/lib/python3.14/site-packages/constants/import_type.py
/usr/lib/python3.14/site-packages/constants/keysign.py
/usr/lib/python3.14/site-packages/constants/md.py
/usr/lib/python3.14/site-packages/constants/pk.py
/usr/lib/python3.14/site-packages/constants/protocol.py
/usr/lib/python3.14/site-packages/constants/sigsum.py
/usr/lib/python3.14/site-packages/constants/status.py
/usr/lib/python3.14/site-packages/constants/validity.py
/usr/lib/python3.14/site-packages/constants/data/__init__.py
/usr/lib/python3.14/site-packages/constants/data/encoding.py
/usr/lib/python3.14/site-packages/constants/data/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/data/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/data/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/data/__pycache__/encoding.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/data/__pycache__/encoding.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/data/__pycache__/encoding.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__init__.py
/usr/lib/python3.14/site-packages/constants/keylist/mode.py
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/mode.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/mode.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/keylist/__pycache__/mode.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/sig/__init__.py
/usr/lib/python3.14/site-packages/constants/sig/mode.py
/usr/lib/python3.14/site-packages/constants/sig/notation.py
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/mode.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/mode.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/mode.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/notation.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/notation.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/sig/__pycache__/notation.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__init__.py
/usr/lib/python3.14/site-packages/constants/tofu/policy.py
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/policy.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/policy.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/tofu/__pycache__/policy.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/create.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/create.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/create.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/event.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/event.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/event.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/import_type.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/import_type.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/import_type.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/keysign.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/keysign.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/keysign.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/md.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/md.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/md.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/pk.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/pk.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/pk.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/protocol.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/protocol.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/protocol.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/sigsum.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/sigsum.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/sigsum.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/status.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/status.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/status.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/validity.cpython-314.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/validity.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/constants/__pycache__/validity.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/METADATA
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/WHEEL
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/top_level.txt
/usr/lib/python3.14/site-packages/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/__pycache__/callbacks.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/callbacks.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/callbacks.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/__pycache__/core.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/core.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/core.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/__pycache__/errors.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/errors.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/errors.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/__pycache__/results.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/results.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/results.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/__pycache__/util.cpython-314.pyc
/usr/lib/python3.14/site-packages/__pycache__/util.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/__pycache__/util.cpython-314.opt-2.pyc
/usr/share/doc/gpgmepy-2.0.0/README.bz2
/usr/share/doc/gpgmepy-2.0.0/AUTHORS.bz2
/usr/share/doc/gpgmepy-2.0.0/NEWS.bz2
/usr/share/doc/gpgmepy-2.0.0/ChangeLog.bz2
```

After:
```
/usr/lib/python3.13/site-packages/gpg/__init__.py
/usr/lib/python3.13/site-packages/gpg/callbacks.py
/usr/lib/python3.13/site-packages/gpg/core.py
/usr/lib/python3.13/site-packages/gpg/errors.py
/usr/lib/python3.13/site-packages/gpg/gpgme.py
/usr/lib/python3.13/site-packages/gpg/results.py
/usr/lib/python3.13/site-packages/gpg/util.py
/usr/lib/python3.13/site-packages/gpg/version.py
/usr/lib/python3.13/site-packages/gpg/constants/__init__.py
/usr/lib/python3.13/site-packages/gpg/constants/create.py
/usr/lib/python3.13/site-packages/gpg/constants/event.py
/usr/lib/python3.13/site-packages/gpg/constants/import_type.py
/usr/lib/python3.13/site-packages/gpg/constants/keysign.py
/usr/lib/python3.13/site-packages/gpg/constants/md.py
/usr/lib/python3.13/site-packages/gpg/constants/pk.py
/usr/lib/python3.13/site-packages/gpg/constants/protocol.py
/usr/lib/python3.13/site-packages/gpg/constants/sigsum.py
/usr/lib/python3.13/site-packages/gpg/constants/status.py
/usr/lib/python3.13/site-packages/gpg/constants/validity.py
/usr/lib/python3.13/site-packages/gpg/constants/data/__init__.py
/usr/lib/python3.13/site-packages/gpg/constants/data/encoding.py
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/encoding.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/encoding.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/data/__pycache__/encoding.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__init__.py
/usr/lib/python3.13/site-packages/gpg/constants/keylist/mode.py
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__init__.py
/usr/lib/python3.13/site-packages/gpg/constants/sig/mode.py
/usr/lib/python3.13/site-packages/gpg/constants/sig/notation.py
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/mode.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/mode.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/mode.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/notation.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/notation.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/sig/__pycache__/notation.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__init__.py
/usr/lib/python3.13/site-packages/gpg/constants/tofu/policy.py
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/create.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/create.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/create.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/event.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/event.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/event.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/import_type.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/import_type.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/import_type.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/keysign.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/keysign.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/keysign.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/md.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/md.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/md.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/pk.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/pk.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/pk.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/protocol.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/protocol.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/protocol.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/sigsum.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/sigsum.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/sigsum.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/status.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/status.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/status.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/validity.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/validity.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/constants/__pycache__/validity.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/__init__.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/__init__.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/__init__.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/callbacks.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/callbacks.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/callbacks.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/core.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/core.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/core.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/errors.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/errors.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/errors.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/gpgme.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/gpgme.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/gpgme.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/results.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/results.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/results.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/util.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/util.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/util.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/version.cpython-313.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/version.cpython-313.opt-1.pyc
/usr/lib/python3.13/site-packages/gpg/__pycache__/version.cpython-313.opt-2.pyc
/usr/lib/python3.13/site-packages/gpg/_gpgme.cpython-313-x86_64-linux-gnu.so
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/METADATA
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/WHEEL
/usr/lib/python3.13/site-packages/gpg-2.0.0.dist-info/top_level.txt
/usr/lib/python3.14/site-packages/gpg/__init__.py
/usr/lib/python3.14/site-packages/gpg/callbacks.py
/usr/lib/python3.14/site-packages/gpg/core.py
/usr/lib/python3.14/site-packages/gpg/errors.py
/usr/lib/python3.14/site-packages/gpg/gpgme.py
/usr/lib/python3.14/site-packages/gpg/results.py
/usr/lib/python3.14/site-packages/gpg/util.py
/usr/lib/python3.14/site-packages/gpg/version.py
/usr/lib/python3.14/site-packages/gpg/constants/__init__.py
/usr/lib/python3.14/site-packages/gpg/constants/create.py
/usr/lib/python3.14/site-packages/gpg/constants/event.py
/usr/lib/python3.14/site-packages/gpg/constants/import_type.py
/usr/lib/python3.14/site-packages/gpg/constants/keysign.py
/usr/lib/python3.14/site-packages/gpg/constants/md.py
/usr/lib/python3.14/site-packages/gpg/constants/pk.py
/usr/lib/python3.14/site-packages/gpg/constants/protocol.py
/usr/lib/python3.14/site-packages/gpg/constants/sigsum.py
/usr/lib/python3.14/site-packages/gpg/constants/status.py
/usr/lib/python3.14/site-packages/gpg/constants/validity.py
/usr/lib/python3.14/site-packages/gpg/constants/data/__init__.py
/usr/lib/python3.14/site-packages/gpg/constants/data/encoding.py
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/encoding.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/encoding.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/data/__pycache__/encoding.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__init__.py
/usr/lib/python3.14/site-packages/gpg/constants/keylist/mode.py
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/keylist/__pycache__/mode.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__init__.py
/usr/lib/python3.14/site-packages/gpg/constants/sig/mode.py
/usr/lib/python3.14/site-packages/gpg/constants/sig/notation.py
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/mode.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/mode.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/mode.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/notation.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/notation.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/sig/__pycache__/notation.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__init__.py
/usr/lib/python3.14/site-packages/gpg/constants/tofu/policy.py
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/tofu/__pycache__/policy.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/create.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/create.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/create.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/event.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/event.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/event.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/import_type.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/import_type.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/import_type.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/keysign.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/keysign.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/keysign.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/md.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/md.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/md.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/pk.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/pk.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/pk.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/protocol.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/protocol.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/protocol.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/sigsum.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/sigsum.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/sigsum.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/status.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/status.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/status.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/validity.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/validity.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/constants/__pycache__/validity.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/__init__.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/__init__.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/__init__.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/callbacks.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/callbacks.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/callbacks.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/core.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/core.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/core.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/errors.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/errors.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/errors.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/gpgme.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/gpgme.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/gpgme.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/results.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/results.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/results.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/util.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/util.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/util.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/version.cpython-314.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/version.cpython-314.opt-1.pyc
/usr/lib/python3.14/site-packages/gpg/__pycache__/version.cpython-314.opt-2.pyc
/usr/lib/python3.14/site-packages/gpg/_gpgme.cpython-314-x86_64-linux-gnu.so
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/METADATA
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/WHEEL
/usr/lib/python3.14/site-packages/gpg-2.0.0.dist-info/top_level.txt
/usr/share/doc/gpgmepy-2.0.0-r1/AUTHORS.bz2
/usr/share/doc/gpgmepy-2.0.0-r1/README.bz2
/usr/share/doc/gpgmepy-2.0.0-r1/ChangeLog.bz2
/usr/share/doc/gpgmepy-2.0.0-r1/NEWS.bz2

```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
