### PR TITLE
app-misc/anki: fix build w/ dev-lang/rust:1.89.0, enable py3_14, make xdg IDEPEND conditional, add REQUIRED_USE="doc? ( gui )"

### DIFF
--- a/app-misc/anki/anki-25.07.3.ebuild
+++ b/app-misc/anki/anki-25.07.3.ebuild
@@ -54,7 +54,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 IUSE="+gui"
-REQUIRED_USE="gui? ( ${PYTHON_REQUIRED_USE} )"
+REQUIRED_USE="
+	doc? ( gui )
+	gui? ( ${PYTHON_REQUIRED_USE} )
+"
 RESTRICT="!gui? ( test ) !test? ( test )"
 
 # Dependencies:

--- a/app-misc/anki/anki-25.07.3.ebuild
+++ b/app-misc/anki/anki-25.07.3.ebuild
@@ -7,7 +7,7 @@ DISTUTILS_EXT=1
 DISTUTILS_OPTIONAL=1
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 declare -A GIT_CRATES=(
 	[linkcheck]='https://github.com/ankitects/linkcheck;184b2ca50ed39ca43da13f0b830a463861adb9ca;linkcheck-%commit%'

--- a/app-misc/anki/anki-25.07.3.ebuild
+++ b/app-misc/anki/anki-25.07.3.ebuild
@@ -135,6 +135,7 @@ EPYTEST_PLUGINS=()
 distutils_enable_tests pytest
 
 PATCHES=(
+	"${FILESDIR}"/${P}-rust-1.89.0.patch
 	"${FILESDIR}"/24.06.3/remove-yarn.patch
 	"${FILESDIR}"/24.04.1/remove-mypy-protobuf.patch
 	"${FILESDIR}"/24.04.1/revert-cert-store-hack.patch

--- a/app-misc/anki/anki-25.07.3.ebuild
+++ b/app-misc/anki/anki-25.07.3.ebuild
@@ -16,7 +16,7 @@ declare -A GIT_CRATES=(
 RUST_MIN_VER="1.85.0"
 
 inherit cargo desktop distutils-r1 edo greadme multiprocessing ninja-utils \
-	optfeature toolchain-funcs xdg
+	optfeature toolchain-funcs xdg-utils
 
 DESCRIPTION="Smart spaced repetition flashcard program"
 HOMEPAGE="https://apps.ankiweb.net/"
@@ -96,7 +96,12 @@ RDEPEND="
 	app-misc/ca-certificates
 	gui? ( ${GUI_RDEPEND} )
 "
-
+IDEPEND="
+	gui? (
+		dev-util/desktop-file-utils
+		x11-misc/shared-mime-info
+	)
+"
 BDEPEND="
 	>=app-arch/zstd-1.5.5:=
 	dev-libs/protobuf[protoc(+)]
@@ -290,15 +295,11 @@ src_install() {
 	fi
 }
 
-pkg_preinst() {
-	greadme_pkg_preinst
-	use gui && xdg_pkg_preinst
-}
-
 pkg_postinst() {
 	greadme_pkg_postinst
 	if use gui; then
-		xdg_pkg_postinst
+		xdg_desktop_database_update
+		xdg_mimeinfo_database_update
 		optfeature "LaTeX in cards" "app-text/texlive[extra] app-text/dvipng"
 		optfeature "sound support" media-video/mpv media-video/mplayer
 		optfeature "recording support" "media-sound/lame[frontend] dev-python/pyqt6[multimedia]"
@@ -308,5 +309,12 @@ pkg_postinst() {
 
 		einfo "You can customize the LaTeX header for your cards to fit your needs:"
 		einfo "Notes > Manage Note Types > [select a note type] > Options"
+	fi
+}
+
+pkg_postrm() {
+	if use gui; then
+		xdg_desktop_database_update
+		xdg_mimeinfo_database_update
 	fi
 }

--- a/app-misc/anki/files/anki-25.07.3-rust-1.89.0.patch
+++ b/app-misc/anki/files/anki-25.07.3-rust-1.89.0.patch
@@ -1,0 +1,24 @@
+Rust 1.89.0 removes support for lint level attributes for `text_direction_codepoint_in_literal` except at the crate level.
+https://github.com/rust-lang/rust/pull/141004
+https://aur.archlinux.org/packages/anki#comment-1035765
+From: Robert H <robert@jadedpasta.net>
+--- a/rslib/i18n/src/generated.rs
++++ b/rslib/i18n/src/generated.rs
+@@ -4,6 +4,5 @@
+ // Include auto-generated content
+ 
+ #![allow(clippy::all)]
+-#![allow(text_direction_codepoint_in_literal)]
+ 
+ include!(concat!(env!("OUT_DIR"), "/strings.rs"));
+--- a/rslib/i18n/src/lib.rs
++++ b/rslib/i18n/src/lib.rs
+@@ -1,6 +1,8 @@
+ // Copyright: Ankitects Pty Ltd and contributors
+ // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+ 
++#![allow(text_direction_codepoint_in_literal)]
++
+ mod generated;
+ 
+ use std::borrow::Cow;


### PR DESCRIPTION
The xdg eclass injects its dependencies unconditionally so switch to xdg-utils to add them conditional of USE flag `gui`.

The GUI build generates certains directories listed in `python/sphinx/conf.py`, which Sphinx AutoAPI documents or errors out if these are not present.  Simply amend `REQUIRED_USE`, since the Sphinx output documents the Python modules used in the GUI and providing a workaround for `USE="doc,-gui"` makes no sense.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
