### PR TITLE
kde-apps/kget: fix build against gpgmepp-2

### DIFF
--- a/kde-apps/kget/files/kget-25.04.03-fix-gpgmepp-2.patch
+++ b/kde-apps/kget/files/kget-25.04.03-fix-gpgmepp-2.patch
@@ -1,0 +1,61 @@
+https://bugs.gentoo.org/961434
+
+https://invent.kde.org/network/kget/-/commit/6254c0cefa17fe82f44842bc21f5e5c241f66aec
+https://invent.kde.org/network/kget/-/merge_requests/100
+
+From 6254c0cefa17fe82f44842bc21f5e5c241f66aec Mon Sep 17 00:00:00 2001
+From: Antonio Rojas <arojas@archlinux.org>
+Date: Tue, 3 Jun 2025 23:13:39 +0200
+Subject: [PATCH] Fix build with GPGME++ 2.0
+
+GpgME::Error is no longer implicitly converted to a string
+--- a/ui/signaturedlg.cpp
++++ b/ui/signaturedlg.cpp
+@@ -185,7 +185,7 @@ void SignatureDlg::updateData()
+             QByteArray fingerprint = fingerprintString.toLatin1();
+             const GpgME::Key key = context->key(fingerprint.constData(), err);
+             if (err || key.isNull() || !key.numUserIDs() || !key.numSubkeys()) {
+-                qCDebug(KGET_DEBUG) << "There was an error while loading the key:" << err;
++                qCDebug(KGET_DEBUG) << "There was an error while loading the key:" << err.asStdString();
+             } else {
+                 static const QStringList OWNERTRUST = QStringList()
+                     << i18nc("trust level", "Unknown") << i18nc("trust level", "Undefined") << i18nc("trust level", "Never") << i18nc("trust level", "Marginal")
+-- 
+GitLab
+
+https://invent.kde.org/network/kget/-/commit/a9aa30e58ca3281285a3ba64d1da6c22fe0ab31a
+https://invent.kde.org/network/kget/-/merge_requests/101
+
+From a9aa30e58ca3281285a3ba64d1da6c22fe0ab31a Mon Sep 17 00:00:00 2001
+From: Antonio Rojas <arojas@archlinux.org>
+Date: Wed, 4 Jun 2025 07:26:10 +0000
+Subject: [PATCH] Fix build with GPGME++<1.24
+
+`GpgME::Error::asStdString` was introduced in 1.24
+
+Amends 6254c0cefa17fe82f44842bc21f5e5c241f66aec
+--- a/ui/signaturedlg.cpp
++++ b/ui/signaturedlg.cpp
+@@ -30,6 +30,7 @@
+ #ifdef HAVE_QGPGME
+ #include <gpgme++/context.h>
+ #include <gpgme++/key.h>
++#include <gpgme++/gpgmepp_version.h>
+ #endif
+ 
+ #include <QLayoutItem>
+@@ -185,7 +186,11 @@ void SignatureDlg::updateData()
+             QByteArray fingerprint = fingerprintString.toLatin1();
+             const GpgME::Key key = context->key(fingerprint.constData(), err);
+             if (err || key.isNull() || !key.numUserIDs() || !key.numSubkeys()) {
++#if GPGMEPP_VERSION >= QT_VERSION_CHECK(1, 24, 0)
+                 qCDebug(KGET_DEBUG) << "There was an error while loading the key:" << err.asStdString();
++#else
++                qCDebug(KGET_DEBUG) << "There was an error while loading the key:" << err;
++#endif
+             } else {
+                 static const QStringList OWNERTRUST = QStringList()
+                     << i18nc("trust level", "Unknown") << i18nc("trust level", "Undefined") << i18nc("trust level", "Never") << i18nc("trust level", "Marginal")
+-- 
+GitLab
+

--- a/kde-apps/kget/kget-25.04.3.ebuild
+++ b/kde-apps/kget/kget-25.04.3.ebuild
@@ -45,6 +45,10 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 
+PATCHES=(
+	"${FILESDIR}"/kget-25.04.03-fix-gpgmepp-2.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		$(cmake_use_find_package bittorrent KTorrent6)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/961434

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
