### PR TITLE
mail-mta/msmtp: skip tests failing without USE=daemon

### DIFF
--- a/mail-mta/msmtp/files/msmtp-fix-tests-without-msmtpd.patch
+++ b/mail-mta/msmtp/files/msmtp-fix-tests-without-msmtpd.patch
@@ -1,0 +1,56 @@
+https://github.com/marlam/msmtp/pull/200
+https://bugs.gentoo.org/948087
+
+From fce1dfefd7af8175708deabc3e55f8682d181d22 Mon Sep 17 00:00:00 2001
+From: Gabi Falk <gabifalk@gmx.com>
+Date: Wed, 13 Aug 2025 09:00:00 +0000
+Subject: [PATCH] tests: skip msmtpd-dependent tests if msmtpd is not built
+
+Link: https://bugs.gentoo.org/948087
+---
+ tests/test-auth-plain.sh      | 8 +++++++-
+ tests/test-header-handling.sh | 8 +++++++-
+ 2 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test-auth-plain.sh b/tests/test-auth-plain.sh
+index 27d406e..a670dcd 100755
+--- a/tests/test-auth-plain.sh
++++ b/tests/test-auth-plain.sh
+@@ -2,9 +2,15 @@
+ 
+ set -e
+ 
++msmtpd=../src/msmtpd
++if [ ! -x $msmtpd ]; then
++	echo 'msmtpd is not built'
++	exit 77
++fi
++
+ # Start an msmtpd with PLAIN authentication
+ echo "Starting msmtpd"
+-../src/msmtpd --interface=::1 --port=12345 --auth='testuser,echo testpassword' \
++$msmtpd --interface=::1 --port=12345 --auth='testuser,echo testpassword' \
+ 	--command='cat > out-auth-plain-mail.txt; echo > out-auth-plain-rcpt.txt' &
+ MSMTPD_PID=$!
+ trap "kill $MSMTPD_PID" EXIT
+diff --git a/tests/test-header-handling.sh b/tests/test-header-handling.sh
+index e58cde4..9109bd3 100755
+--- a/tests/test-header-handling.sh
++++ b/tests/test-header-handling.sh
+@@ -2,9 +2,15 @@
+ 
+ set -e
+ 
++msmtpd=../src/msmtpd
++if [ ! -x $msmtpd ]; then
++	echo 'msmtpd is not built'
++	exit 77
++fi
++
+ # Start an msmtpd that dumps the mail and the recipient lists so we can check them
+ echo "Starting msmtpd"
+-../src/msmtpd --interface=::1 --port=12346 \
++$msmtpd --interface=::1 --port=12346 \
+ 	--command='cat > out-header-handling-mail.txt; echo > out-header-handling-rcpt.txt' &
+ MSMTPD_PID=$!
+ trap "kill $MSMTPD_PID" EXIT

--- a/mail-mta/msmtp/msmtp-1.8.28.ebuild
+++ b/mail-mta/msmtp/msmtp-1.8.28.ebuild
@@ -58,6 +58,8 @@ BDEPEND="
 
 DOCS="AUTHORS ChangeLog NEWS README THANKS doc/msmtprc*"
 
+PATCHES=( "${FILESDIR}/${PN}-fix-tests-without-msmtpd.patch" )
+
 src_prepare() {
 	# Use default Gentoo location for mail aliases
 	sed 's:/etc/aliases:/etc/mail/aliases:' \

--- a/mail-mta/msmtp/msmtp-1.8.30.ebuild
+++ b/mail-mta/msmtp/msmtp-1.8.30.ebuild
@@ -58,6 +58,8 @@ BDEPEND="
 
 DOCS="AUTHORS ChangeLog NEWS README THANKS doc/msmtprc*"
 
+PATCHES=( "${FILESDIR}/${PN}-fix-tests-without-msmtpd.patch" )
+
 src_prepare() {
 	# Use default Gentoo location for mail aliases
 	sed 's:/etc/aliases:/etc/mail/aliases:' \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/948087
Link: https://github.com/marlam/msmtp/pull/200

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
