### PR TITLE
app-admin/syslog-ng: fix config file name mangling

### DIFF
--- a/app-admin/syslog-ng/syslog-ng-4.9.0.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-4.9.0.ebuild
@@ -105,7 +105,7 @@ src_prepare() {
 
 	for f in syslog-ng.conf.gentoo.hardened.in-r1 \
 			syslog-ng.conf.gentoo.in-r2; do
-		sed -e "s/@SYSLOGNG_VERSION@/$(ver_cut 1-2)/g" "${FILESDIR}/${f}" > "${T}/${f/.in-r1/}" || die
+		sed -e "s/@SYSLOGNG_VERSION@/$(ver_cut 1-2)/g" "${FILESDIR}/${f}" > "${T}/${f/.in*/}" || die
 	done
 
 	default


### PR DESCRIPTION
The config file name mangling was hard-coded to strip a specific file suffix.
This breaks when config files have different revisions.

Closes: https://bugs.gentoo.org/961446
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
