### PR TITLE
dev-util/rocm-smi: Fix search path for librocm_smi64.so.1

### DIFF
--- a/dev-util/rocm-smi/files/rocm-smi-6.4.3-fix-library-path.patch
+++ b/dev-util/rocm-smi/files/rocm-smi-6.4.3-fix-library-path.patch
@@ -1,0 +1,22 @@
+Use standard library search path to find librocm_smi64.
+--- a/python_smi_tools/rsmiBindingsInit.py.in
++++ b/python_smi_tools/rsmiBindingsInit.py.in
+@@ -26,17 +26,7 @@ def initRsmiBindings(silent=False):
+     if (rocm_smi_lib_path != None):
+         path_librocm = rocm_smi_lib_path
+     else:
+-        path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../@CMAKE_INSTALL_LIBDIR@/librocm_smi64.so.@VERSION_MAJOR@'
+-
+-    if not os.path.isfile(path_librocm):
+-        print_silent('Unable to find %s . Trying /opt/rocm*' % path_librocm)
+-        for root, dirs, files in os.walk('/opt', followlinks=True):
+-            if 'librocm_smi64.so.@VERSION_MAJOR@' in files:
+-                path_librocm = os.path.join(os.path.realpath(root), 'librocm_smi64.so.@VERSION_MAJOR@')
+-        if os.path.isfile(path_librocm):
+-            print_silent('Using lib from %s' % path_librocm)
+-        else:
+-            print('Unable to find librocm_smi64.so.@VERSION_MAJOR@')
++        path_librocm = 'librocm_smi64.so.@VERSION_MAJOR@'
+ 
+     # ----------> TODO: Support static libs as well as SO
+     try:

--- a/dev-util/rocm-smi/rocm-smi-6.4.3-r1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-6.4.3-r1.ebuild
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-remove-example.patch
 	"${FILESDIR}"/${PN}-6.3.0-fix-flags.patch
 	"${FILESDIR}"/${PN}-6.4.1-log-exceptions.patch
+	"${FILESDIR}"/${PN}-6.4.3-fix-library-path.patch
 )
 
 CONFIG_CHECK="~HSA_AMD ~DRM_AMDGPU"
@@ -42,10 +43,10 @@ CONFIG_CHECK="~HSA_AMD ~DRM_AMDGPU"
 src_prepare() {
 	cmake_src_prepare
 
-	sed -e "s/@VERSION_MAJOR@/$(ver_cut 1)/" \
-		-e "s/@VERSION_MINOR@/$(ver_cut 2)/" \
-		-e "s/@VERSION_PATCH@/$(ver_cut 3)/" \
-		-i CMakeLists.txt || die
+	# Disable code that relies on missing .git directory.
+	# Just silences potential "git: command not found" QA warnings.
+	sed "/find_program (GIT NAMES git)/d" -i CMakeLists.txt || die
+	sed "/num_change_since_prev_pkg(\${VERSION_PREFIX})/d" -i cmake_modules/utils.cmake || die
 }
 
 src_configure() {


### PR DESCRIPTION
This copies the fix that was previously applied in rocm-smi-6.4.1-set-soversion.patch, but now patch is much smaller.

Closes: https://bugs.gentoo.org/961472

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
