### PR TITLE
sys-apps/stroke: fix build with gcc 15

### DIFF
--- a/sys-apps/stroke/files/stroke-0.1.3-gcc15.patch
+++ b/sys-apps/stroke/files/stroke-0.1.3-gcc15.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/880509
+
+--- a/src/aux.c
++++ b/src/aux.c
+@@ -292,7 +292,7 @@ lutime_symlink(const char *filename, const struct utimbuf *times)
+ 		{times->modtime, 0}
+ 	};
+ 	
+-	if(!(cwd = scwd(cwd)) ||
++	if(!(cwd = scwd()) ||
+ 	   chdir(dirname(new_str(filename))) < 0)
+ 		goto error;
+ 	

--- a/sys-apps/stroke/stroke-0.1.3-r3.ebuild
+++ b/sys-apps/stroke/stroke-0.1.3-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,10 @@ LICENSE="GPL-2+ GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
 
-PATCHES=( "${FILESDIR}/${P}-missing-header.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-missing-header.patch"
+	"${FILESDIR}/${P}-gcc15.patch"
+)
 
 src_compile() {
 	emake AR="$(tc-getAR)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/880509

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
