### PR TITLE
dev-java/openjdk: Add support for building static libraries

### DIFF
--- a/dev-java/openjdk/openjdk-17.0.16_p8.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.16_p8.ebuild
@@ -55,7 +55,7 @@ LICENSE="GPL-2-with-classpath-exception"
 SLOT="${MY_PV%%[.+]*}"
 KEYWORDS="amd64 ~arm arm64 ppc64 ~riscv x86"
 
-IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source system-bootstrap systemtap"
+IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source static-libs system-bootstrap systemtap"
 
 REQUIRED_USE="
 	javafx? ( alsa !headless-awt )
@@ -272,6 +272,7 @@ src_compile() {
 		NICE= # Use PORTAGE_NICENESS, don't adjust further down
 		$(usex doc docs '')
 		$(usex jbootstrap bootcycle-images product-images)
+		$(usex static-libs static-libs-image)
 	)
 	emake "${myemakeargs[@]}" -j1
 }
@@ -325,6 +326,12 @@ src_install() {
 		docinto html
 		dodoc -r "${S}"/build/*-release/images/docs/*
 		dosym ../../../usr/share/doc/"${PF}" /usr/share/doc/"${PN}-${SLOT}"
+	fi
+
+	if use static-libs ; then
+		cd "${S}"/build/*-release/images/static-libs || die
+		dodir "${dest}"
+		cp -pPR * "${ddest}" || die
 	fi
 }
 

--- a/dev-java/openjdk/openjdk-21.0.8_p9.ebuild
+++ b/dev-java/openjdk/openjdk-21.0.8_p9.ebuild
@@ -51,7 +51,7 @@ LICENSE="GPL-2-with-classpath-exception"
 SLOT="${MY_PV%%[.+]*}"
 KEYWORDS="amd64 arm64 ppc64 ~riscv ~x86"
 
-IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source +system-bootstrap systemtap"
+IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source static-libs +system-bootstrap systemtap"
 
 REQUIRED_USE="
 	javafx? ( alsa !headless-awt )
@@ -275,6 +275,7 @@ src_compile() {
 		NICE= # Use PORTAGE_NICENESS, don't adjust further down
 		$(usex doc docs '')
 		$(usex jbootstrap bootcycle-images product-images)
+		$(usex static-libs static-libs-image)
 	)
 	emake "${myemakeargs[@]}" -j1
 }
@@ -328,6 +329,12 @@ src_install() {
 		docinto html
 		dodoc -r "${S}"/build/*-release/images/docs/*
 		dosym ../../../usr/share/doc/"${PF}" /usr/share/doc/"${PN}-${SLOT}"
+	fi
+
+	if use static-libs ; then
+		cd "${S}"/build/*-release/images/static-libs || die
+		dodir "${dest}"
+		cp -pPR * "${ddest}" || die
 	fi
 }
 

--- a/dev-java/openjdk/openjdk-25_p31.ebuild
+++ b/dev-java/openjdk/openjdk-25_p31.ebuild
@@ -52,7 +52,7 @@ LICENSE="GPL-2-with-classpath-exception"
 SLOT="${MY_PV%%[.+]*}"
 #	KEYWORDS="" # LTS but not yet released
 
-IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source +system-bootstrap systemtap"
+IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source static-libs +system-bootstrap systemtap"
 
 REQUIRED_USE="
 	javafx? ( alsa !headless-awt )
@@ -271,6 +271,7 @@ src_compile() {
 		NICE= # Use PORTAGE_NICENESS, don't adjust further down
 		$(usex doc docs '')
 		$(usex jbootstrap bootcycle-images product-images)
+		$(usex static-libs static-libs-image)
 	)
 	emake "${myemakeargs[@]}" -j1
 }
@@ -324,6 +325,12 @@ src_install() {
 		docinto html
 		dodoc -r "${S}"/build/*-release/images/docs/*
 		dosym ../../../usr/share/doc/"${PF}" /usr/share/doc/"${PN}-${SLOT}"
+	fi
+
+	if use static-libs ; then
+		cd "${S}"/build/*-release/images/static-libs || die
+		dodir "${dest}"
+		cp -pPR * "${ddest}" || die
 	fi
 }
 

--- a/dev-java/openjdk/openjdk-26_p6.ebuild
+++ b/dev-java/openjdk/openjdk-26_p6.ebuild
@@ -52,7 +52,7 @@ LICENSE="GPL-2-with-classpath-exception"
 SLOT="${MY_PV%%[.+]*}"
 #	KEYWORDS="" # Not an LTS candidate
 
-IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source +system-bootstrap systemtap"
+IUSE="alsa big-endian cups debug doc examples headless-awt javafx +jbootstrap selinux source static-libs +system-bootstrap systemtap"
 
 REQUIRED_USE="
 	javafx? ( alsa !headless-awt )
@@ -274,6 +274,7 @@ src_compile() {
 		NICE= # Use PORTAGE_NICENESS, don't adjust further down
 		$(usex doc docs '')
 		$(usex jbootstrap bootcycle-images product-images)
+		$(usex static-libs static-libs-image)
 	)
 	emake "${myemakeargs[@]}" -j1
 }
@@ -327,6 +328,12 @@ src_install() {
 		docinto html
 		dodoc -r "${S}"/build/*-release/images/docs/*
 		dosym ../../../usr/share/doc/"${PF}" /usr/share/doc/"${PN}-${SLOT}"
+	fi
+
+	if use static-libs ; then
+		cd "${S}"/build/*-release/images/static-libs || die
+		dodir "${dest}"
+		cp -pPR * "${ddest}" || die
 	fi
 }
 


### PR DESCRIPTION
This PR add support for building the static libraries in the jdk, which are required to build GraalVM (some other libraries may need it as well).

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
