### PR TITLE
app-emulation/ski: fix glibc-2.42 - termio

### DIFF
--- a/app-emulation/ski/files/ski-1.5.0-fix_termio.patch
+++ b/app-emulation/ski/files/ski-1.5.0-fix_termio.patch
@@ -1,0 +1,49 @@
+PRs merged
+https://github.com/trofi/ski/pull/17.patch
+https://github.com/trofi/ski/pull/18.patch
+Remove occurrences of termio.h and struct termio. Bug #961423
+--- a/src/dos.c
++++ b/src/dos.c
+@@ -35,13 +35,10 @@
+ #include <sys/stat.h>
+ #include <signal.h>
+ #include <string.h>
+-#if defined(__FreeBSD__)
+ #include <termios.h>
+-#define termio  termios
++#if defined(__FreeBSD__)
+ #define TCGETA  TIOCGETA
+ #define TCSETA  TIOCSETA
+-#else
+-#include <termio.h>
+ #endif
+ #include <time.h>
+ #if defined __linux__
+@@ -140,7 +137,7 @@ Status dosInt21(BYTE func, BYTE subFunc)
+ 	break;
+     case 0x08:				/* read keyboard without echo */
+ 	if (isatty(fhmap[0])) {
+-	    struct termio origTermio, newTermio;
++	    struct termios origTermio, newTermio;
+ 
+ 	    (void)ioctl(fhmap[0], TCGETA, &origTermio);
+ 	    newTermio = origTermio;
+--- a/src/linux/syscall-linux.c
++++ b/src/linux/syscall-linux.c
+@@ -2147,14 +2147,14 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
+ 
+ 	case TCGETA:
+ 	  /* assumes host OS matches Linux/ia64 */
+-	  bytes_out = sizeof (struct termio);
++	  bytes_out = sizeof (struct termios);
+ 	  break;
+ 
+ 	case TCSETA:
+ 	case TCSETAW:
+ 	case TCSETAF:
+ 	  /* assumes host OS matches Linux/ia64 */
+-	  bytes_in = sizeof (struct termio);
++	  bytes_in = sizeof (struct termios);
+ 	  break;
+ 
+ 	case TIOCGPGRP:

--- a/app-emulation/ski/ski-1.5.0.ebuild
+++ b/app-emulation/ski/ski-1.5.0.ebuild
@@ -24,6 +24,11 @@ DEPEND="
 	dev-util/gperf
 "
 
+PATCHES=(
+	# merged, to be removed for the next version
+	"${FILESDIR}"/${P}-fix_termio.patch
+)
+
 src_configure() {
 	local myeconfargs=(
 		$(use_with debug bfd)

--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -14,10 +14,6 @@ net-misc/anydesk
 # Not ported to musl (bug #939569, https://github.com/oracle/dtrace-utils/issues/87)
 dev-debug/dtrace
 
-# PPN-SD <nicolas.parlant@parhuet.fr> (2025-07-07)
-# it requires termio.h (glibc)
-app-emulation/ski
-
 # NHOrus <jy6x2b32pie9@yahoo.com> (2025-03-13)
 # uses functions musl will not implement, bug #942215
 app-admin/sud


### PR DESCRIPTION
remove occurences of termio.h and "struct termio"

remove duplicate entry for app-emulation/ski, already masked  by https://github.com/gentoo/gentoo/commit/cd409c94313006f3dd86bd0f1559e63245da1ba3

Closes: https://bugs.gentoo.org/961423

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
