### PR TITLE
llvm-runtimes/libcxx: install GDB Pretty printers for libc++

### DIFF
--- a/llvm-runtimes/libcxx/libcxx-21.1.0.9999.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-21.1.0.9999.ebuild
@@ -191,6 +191,20 @@ multilib_src_install() {
 		dolib.so lib/libc++_shared.so
 		use static-libs && dolib.a lib/libc++_static.a
 	fi
+
+	local install_prefix=
+	is_crosspkg && install_prefix=/usr/${CTARGET}
+	insinto "${install_prefix}/usr/share/libc++/gdb"
+	doins ../libcxx/utils/gdb/libcxx/printers.py
+
+	local lib_version=$(sed -n -e 's/^LIBCXX_LIBRARY_VERSION:STRING=//p' CMakeCache.txt || die)
+	[[ -n ${lib_version} ]] || die "Could not determine LIBCXX_LIBRARY_VERSION from CMakeCache.txt"
+
+	insinto "${install_prefix}/usr/share/gdb/auto-load/usr/$(get_libdir)"
+	newins - "libc++.so.${lib_version}-gdb.py" <<-EOF
+		__import__("sys").path.insert(0, "${EPREFIX}/usr/share/libc++/gdb")
+		__import__("printers").register_libcxx_printer_loader()
+	EOF
 }
 
 # Usage: deps

--- a/llvm-runtimes/libcxx/libcxx-22.0.0.9999.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-22.0.0.9999.ebuild
@@ -191,6 +191,20 @@ multilib_src_install() {
 		dolib.so lib/libc++_shared.so
 		use static-libs && dolib.a lib/libc++_static.a
 	fi
+
+	local install_prefix=
+	is_crosspkg && install_prefix=/usr/${CTARGET}
+	insinto "${install_prefix}/usr/share/libc++/gdb"
+	doins ../libcxx/utils/gdb/libcxx/printers.py
+
+	local lib_version=$(sed -n -e 's/^LIBCXX_LIBRARY_VERSION:STRING=//p' CMakeCache.txt || die)
+	[[ -n ${lib_version} ]] || die "Could not determine LIBCXX_LIBRARY_VERSION from CMakeCache.txt"
+
+	insinto "${install_prefix}/usr/share/gdb/auto-load/usr/$(get_libdir)"
+	newins - "libc++.so.${lib_version}-gdb.py" <<-EOF
+		__import__("sys").path.insert(0, "${EPREFIX}/usr/share/libc++/gdb")
+		__import__("printers").register_libcxx_printer_loader()
+	EOF
 }
 
 # Usage: deps


### PR DESCRIPTION
[GDB Pretty printers for libc++](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.0-rc3/libcxx/docs/UserDocumentation.rst#gdb-pretty-printers-for-libc) section describes the procedure to set up GDB printers for STL data structures from libc++.

Since LLVM 21 these pretty printers work quite well, including MI-mode (enabling visualization in IDEs like vscode).

In a way, similar to python, libgobject, libstdc++ and so on, file like `/usr/share/gdb/auto-load/usr/lib64/libc++.so.1.0-gdb.py` enables [autoloading](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Auto_002dloading.html) for pretty printers.

Closes: https://bugs.gentoo.org/961530

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
