### PR TITLE
net-p2p/rtorrent: fix GREP call

### DIFF
--- a/net-p2p/rtorrent/files/rtorrent-0.15.5-find_grep.patch
+++ b/net-p2p/rtorrent/files/rtorrent-0.15.5-find_grep.patch
@@ -1,0 +1,13 @@
+https://github.com/rakshasa/rtorrent/commit/dd8281204f5365f0f6987f989e71208d3c218289
+from upstream
+configure fails with slibtool because it doesn't define GREP
+--- a/scripts/common.m4
++++ b/scripts/common.m4
+@@ -23,6 +23,7 @@ AC_DEFUN([TORRENT_WITH_SYSROOT], [
+ 
+ AC_DEFUN([TORRENT_REMOVE_UNWANTED],
+ [
++  AC_REQUIRE([AC_PROG_GREP])
+   values_to_check=`for i in $2; do echo $i; done`
+   unwanted_values=`for i in $3; do echo $i; done`
+   if test -z "${unwanted_values}"; then

--- a/net-p2p/rtorrent/rtorrent-0.15.5.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.15.5.ebuild
@@ -44,6 +44,8 @@ DOCS=( doc/rtorrent.rc )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.15.3-unbundle_json.patch
+	# fix configure w/ slibtool. to be removed for next version.
+	"${FILESDIR}"/${P}-find_grep.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
scripts/common.m4 calls $GREP at configure time.
This can cause problems with slibtool and maybe also split-usr env.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
