### PR TITLE
dev-libs/botan: add missing include for 2.19.5

### DIFF
--- a/dev-libs/botan/botan-2.19.5.ebuild
+++ b/dev-libs/botan/botan-2.19.5.ebuild
@@ -57,6 +57,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-no-distutils.patch
 	"${FILESDIR}"/${P}-boost-1.87.patch
 	"${FILESDIR}"/${P}-cloudflare.patch
+	"${FILESDIR}"/${P}-include.patch
 )
 
 python_check_deps() {

--- a/dev-libs/botan/files/botan-2.19.5-include.patch
+++ b/dev-libs/botan/files/botan-2.19.5-include.patch
@@ -1,0 +1,13 @@
+Add missing include
+See https://bugs.gentoo.org/942814
+> src/.../cli.h: error: uint8_t does not name a type
+--- a/src/cli/cli.h
++++ b/src/cli/cli.h
+@@ -8,6 +8,7 @@
+ #define BOTAN_CLI_H_
+ 
+ #include <botan/build.h>
++#include <cstdint>
+ #include <functional>
+ #include <ostream>
+ #include <map>


### PR DESCRIPTION
Add missing include with tools enabled.
Not required for higher versions.

Closes: https://bugs.gentoo.org/942814

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
