### PR TITLE
app-misc/broot: raise minimum Rust version to 1.82.0

### DIFF
--- a/app-misc/broot/broot-1.47.0.ebuild
+++ b/app-misc/broot/broot-1.47.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-RUST_MIN_VER="1.79.0"
+RUST_MIN_VER="1.82.0"
 inherit cargo shell-completion
 
 DESCRIPTION="A new way to see and navigate directory trees"


### PR DESCRIPTION
While Broot itself is happy with Rust 1.60, it depends on crates that require up to 1.82.

Closes: https://bugs.gentoo.org/961567

This pull requests only changes app-misc/broot-1.47.0, since 1.46.5 is being removed in #43433.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
