### PR TITLE
sci-ml/caffe2[rocm -flash]: Fix use of undeclared identifier 'CHECK_NOSPARSE_CONTIGUOUS_CUDA'

### DIFF
--- a/sci-ml/caffe2/caffe2-2.8.0.ebuild
+++ b/sci-ml/caffe2/caffe2-2.8.0.ebuild
@@ -147,6 +147,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-cmake.patch
 	"${FILESDIR}"/${PN}-2.7.0-glog-0.7.1.patch
 	"${FILESDIR}"/${PN}-2.7.1-aotriton-fixes.patch
+	"${FILESDIR}"/${PN}-2.8.0-rocm-minus-flash.patch
 )
 
 src_prepare() {

--- a/sci-ml/caffe2/files/caffe2-2.8.0-rocm-minus-flash.patch
+++ b/sci-ml/caffe2/files/caffe2-2.8.0-rocm-minus-flash.patch
@@ -1,0 +1,86 @@
+Fix use of undeclared identifier 'CHECK_NOSPARSE_CONTIGUOUS_CUDA' with USE='-flash'
+
+Bug: https://github.com/pytorch/pytorch/issues/160826
+--- a/aten/src/ATen/native/transformers/cuda/attention.cu
++++ b/aten/src/ATen/native/transformers/cuda/attention.cu
+@@ -71,6 +71,7 @@
+ #include <ATen/native/transformers/cuda/sdp_utils.h>
+ #include <ATen/native/transformers/sdp_utils_cpp.h>
+ 
++#include <ATen/native/transformers/flash_api_common.h>
+ #ifdef USE_FLASH_ATTENTION
+ // FlashAttention Specific Imports
+ #include <ATen/native/transformers/cuda/flash_attn/flash_api.h>
+--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
++++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+@@ -33,6 +33,7 @@
+ #include <ATen/ops/_scaled_dot_product_flash_attention_backward_native.h>
+ #endif
+ 
++#include <ATen/native/transformers/flash_api_common.h>
+ #ifdef USE_FLASH_ATTENTION
+ // FlashAttention Specific Imports
+ #include <ATen/native/transformers/cuda/flash_attn/flash_api.h>
+--- /dev/null
++++ b/aten/src/ATen/native/transformers/flash_api_common.h
+@@ -0,0 +1,28 @@
++#pragma once
++#include <cstdint>
++#include <limits>
++
++#include <ATen/core/Tensor.h>
++#include <c10/util/Exception.h>
++
++#define CHECK_NOSPARSE_CONTIGUOUS_CUDA(TENSOR)                            \
++  TORCH_CHECK(TENSOR.is_cuda(), #TENSOR " must be a CUDA tensor");     \
++  TORCH_CHECK(!TENSOR.is_sparse(), #TENSOR " must be a dense tensor"); \
++  TORCH_CHECK(TENSOR.is_contiguous());
++
++#define CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(TENSOR)                        \
++  TORCH_CHECK(TENSOR.is_cuda(), #TENSOR " must be a CUDA tensor");     \
++  TORCH_CHECK(!TENSOR.is_sparse(), #TENSOR " must be a dense tensor"); \
++  TORCH_CHECK(                                                         \
++      TENSOR.stride(-1) == 1, #TENSOR ": last dimension must be contiguous");
++
++#define CHECK_ALIGNED_PTR(PTR, ALIGNMENT) \
++  TORCH_CHECK(                         \
++      uint64_t(PTR) % ALIGNMENT == 0, #PTR " is not correctly aligned")
++
++#define ASSIGN_CHECK_OVERFLOW(A, B)                                    \
++  {                                                                    \
++    A = B;                                                             \
++    TORCH_CHECK(                                                    \
++        B < std::numeric_limits<decltype(A)>::max(), #B " overflows"); \
++  }
+--- a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
++++ b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.h
+@@ -4,28 +4,7 @@
+ #include <ATen/Context.h>
+ #include <ATen/core/Tensor.h>
+ #include <c10/util/Exception.h>
+-
+-#define CHECK_NOSPARSE_CONTIGUOUS_CUDA(TENSOR)                            \
+-  TORCH_CHECK(TENSOR.is_cuda(), #TENSOR " must be a CUDA tensor");     \
+-  TORCH_CHECK(!TENSOR.is_sparse(), #TENSOR " must be a dense tensor"); \
+-  TORCH_CHECK(TENSOR.is_contiguous());
+-
+-#define CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(TENSOR)                        \
+-  TORCH_CHECK(TENSOR.is_cuda(), #TENSOR " must be a CUDA tensor");     \
+-  TORCH_CHECK(!TENSOR.is_sparse(), #TENSOR " must be a dense tensor"); \
+-  TORCH_CHECK(                                                         \
+-      TENSOR.stride(-1) == 1, #TENSOR ": last dimension must be contiguous");
+-
+-#define CHECK_ALIGNED_PTR(PTR, ALIGNMENT) \
+-  TORCH_CHECK(                         \
+-      uint64_t(PTR) % ALIGNMENT == 0, #PTR " is not correctly aligned")
+-
+-#define ASSIGN_CHECK_OVERFLOW(A, B)                                    \
+-  {                                                                    \
+-    A = B;                                                             \
+-    TORCH_CHECK(                                                    \
+-        B < std::numeric_limits<decltype(A)>::max(), #B " overflows"); \
+-  }
++#include <ATen/native/transformers/flash_api_common.h>
+ 
+ namespace pytorch_flash {
+ 


### PR DESCRIPTION
In 2.8.0 few macros were moved in a way that breaks compilation without Flash Attention on ROCm.

Bug: https://github.com/pytorch/pytorch/issues/160826

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
