### PR TITLE
app-crypt/tpm2-abrmd: Require sys-apps/iproute[-minimal] for tests

### DIFF
--- a/app-crypt/tpm2-abrmd/tpm2-abrmd-3.0.0-r2.ebuild
+++ b/app-crypt/tpm2-abrmd/tpm2-abrmd-3.0.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,6 +26,7 @@ DEPEND="${RDEPEND}
 		app-crypt/swtpm
 		>=app-crypt/tpm2-tss-3.0.0:=
 		dev-util/cmocka
+		sys-apps/iproute2[-minimal]
 	)"
 BDEPEND="virtual/pkgconfig
 	dev-util/gdbus-codegen"


### PR DESCRIPTION
Build fix only: Require sys-apps/iproute2[-minimal] for tests (need ss)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
