### PR TITLE
dev-libs/libixion: fix build with boost-1.89.0, add python-3.14

### DIFF
--- a/dev-libs/libixion/files/libixion-0.19.0-boost-m4.patch
+++ b/dev-libs/libixion/files/libixion-0.19.0-boost-m4.patch
@@ -1,0 +1,31 @@
+Minimal diff from upstream boost.m4 (https://github.com/tsuna/boost.m4)
+to make things work with >=boost-1.89.0, which made boost_system a
+header-only library.
+
+--- a/m4/boost.m4~
++++ b/m4/boost.m4
+@@ -1130,15 +1130,20 @@ BOOST_DEFUN([String_Algo],
+ ])
+ 
+ 
+-# BOOST_SYSTEM([PREFERRED-RT-OPT])
++# BOOST_SYSTEM([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
+ # --------------------------------
+ # Look for Boost.System.  For the documentation of PREFERRED-RT-OPT, see the
+ # documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
+-# 1.35.0.
++# 1.35.0 and is header only since 1.70.
+ BOOST_DEFUN([System],
+-[BOOST_FIND_LIB([system], [$1],
++[
++if test $boost_major_version -ge 170; then
++  BOOST_FIND_HEADER([boost/system/error_code.hpp])
++else
++  BOOST_FIND_LIB([system], [$1],
+                 [boost/system/error_code.hpp],
+-                [boost::system::error_code e; e.clear();])
++                [boost::system::error_code e; e.clear();], [], [], [$2])
++fi
+ ])# BOOST_SYSTEM
+ 
+ 

--- a/dev-libs/libixion/files/libixion-0.20.0-boost-m4.patch
+++ b/dev-libs/libixion/files/libixion-0.20.0-boost-m4.patch
@@ -1,0 +1,30 @@
+Minimal diff from upstream boost.m4 (https://github.com/tsuna/boost.m4)
+to make things work with >=boost-1.89.0, which made boost_system a
+header-only library.
+
+--- a/m4/boost.m4~
++++ b/m4/boost.m4
+@@ -1328,15 +1328,20 @@ BOOST_DEFUN([String_Algo],
+ ])
+ 
+ 
+-# BOOST_SYSTEM([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
++ BOOST_SYSTEM([PREFERRED-RT-OPT], [ERROR_ON_UNUSABLE])
+ # --------------------------------
+ # Look for Boost.System.  For the documentation of PREFERRED-RT-OPT, see the
+ # documentation of BOOST_FIND_LIB above.  This library was introduced in Boost
+-# 1.35.0.
++# 1.35.0 and is header only since 1.70.
+ BOOST_DEFUN([System],
+-[BOOST_FIND_LIB([system], [$1],
++[
++if test $boost_major_version -ge 170; then
++  BOOST_FIND_HEADER([boost/system/error_code.hpp])
++else
++  BOOST_FIND_LIB([system], [$1],
+                 [boost/system/error_code.hpp],
+                 [boost::system::error_code e; e.clear();], [], [], [$2])
++fi
+ ])# BOOST_SYSTEM
+ 
+ 

--- a/dev-libs/libixion/libixion-0.19.0-r2.ebuild
+++ b/dev-libs/libixion/libixion-0.19.0-r2.ebuild
@@ -15,14 +15,12 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	MDDS_SLOT="1/2.1"
-	# Invalid as of 0.20.0, serves HTML
-	#SRC_URI="https://kohei.us/files/ixion/src/${P}.tar.xz"
-	SRC_URI="https://gitlab.com/api/v4/projects/ixion%2Fixion/packages/generic/source/${PV}/${P}.tar.xz"
+	SRC_URI="https://kohei.us/files/ixion/src/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 LICENSE="MIT"
-SLOT="0/0.20" # based on SONAME of libixion.so
+SLOT="0/0.18" # based on SONAME of libixion.so
 IUSE="debug python"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
@@ -35,7 +33,9 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-0.20.0-boost-m4.patch # bug 961528
+	"${FILESDIR}"/${PN}-0.19.0-gcc15-cstdint.patch # bug 937388
+	"${FILESDIR}"/${PN}-0.19.0-fix-win32-ifdef.patch # bug 939807
+	"${FILESDIR}"/${PN}-0.19.0-boost-m4.patch # bug 961528
 )
 
 pkg_setup() {

--- a/dev-libs/libixion/libixion-9999.ebuild
+++ b/dev-libs/libixion/libixion-9999.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
-inherit libtool python-single-r1
+PYTHON_COMPAT=( python3_{11..14} )
+inherit autotools python-single-r1
 
 DESCRIPTION="General purpose formula parser & interpreter"
 HOMEPAGE="https://gitlab.com/ixion/ixion"
@@ -12,7 +12,7 @@ HOMEPAGE="https://gitlab.com/ixion/ixion"
 if [[ ${PV} == *9999* ]]; then
 	MDDS_SLOT="1/3.0"
 	EGIT_REPO_URI="https://gitlab.com/ixion/ixion.git"
-	inherit git-r3 autotools
+	inherit git-r3
 else
 	MDDS_SLOT="1/2.1"
 	# Invalid as of 0.20.0, serves HTML
@@ -40,11 +40,7 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	if [[ ${PV} == *9999* ]]; then
-		eautoreconf
-	else
-		elibtoolize
-	fi
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
- add minimal, backwards-compatible fix to allow building with boost-1.89.0
- always run autoreconf, which implies elibtoolize
- drop python-3.10, add python-3.14 support

Closes: https://bugs.gentoo.org/961528
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
