### PR TITLE
dev-lua/luarocks: fix collision with lua-compat53

### DIFF
--- a/dev-lua/luarocks/luarocks-3.12.2-r1.ebuild
+++ b/dev-lua/luarocks/luarocks-3.12.2-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{1..4} luajit )
+
+inherit lua-single
+
+DESCRIPTION="A package manager for the Lua programming language"
+HOMEPAGE="https://luarocks.org"
+SRC_URI="https://luarocks.org/releases/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="test"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+RESTRICT="test"
+
+RDEPEND="${LUA_DEPS}
+	$(lua_gen_cond_dep 'dev-lua/compat53[${LUA_USEDEP}]' lua5-1 luajit)
+"
+
+DEPEND="
+	net-misc/curl
+	dev-libs/openssl:0
+	${RDEPEND}
+"
+
+BDEPEND="
+	virtual/pkgconfig
+	test? (
+		$(lua_gen_cond_dep 'dev-lua/busted[${LUA_USEDEP}]')
+		$(lua_gen_cond_dep 'dev-lua/busted-htest[${LUA_USEDEP}]')
+		${RDEPEND}
+	)
+"
+
+src_prepare() {
+	default
+
+	# If 'dev-lang/lua' is a new, fresh installation, no 'LUA_LIBDIR' exists,
+	# as no compiled modules are installed on a new, fresh installation,
+	# so this check must be disabled, otherwise 'configure' will fail.
+	sed -e '/LUA_LIBDIR is not a valid directory/d' -i configure || die
+
+	# unbundle lua-compat53 #961755
+	rm -r src/compat53/*.lua || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		"--prefix=${EPREFIX}/usr"
+		"--with-lua-include=$(lua_get_include_dir)"
+		"--with-lua-interpreter=${ELUA}"
+		"--with-lua-lib=$(lua_get_cmod_dir)"
+	)
+
+	# Since the configure script is handcrafted,
+	# and yells at unknown options, do not use 'econf'.
+	./configure "${myeconfargs[@]}" || die
+}
+
+src_test() {
+	busted --lua=${ELUA} || die
+}
+
+src_install() {
+	default
+
+	{ find "${D}" -type f -exec sed -i -e "s:${D}::g" {} \;; } || die
+}
+
+pkg_postinst() {
+	local lua_abi_ver
+	if use lua_single_target_luajit; then
+		lua_abi_ver="5.1"
+	else
+		lua_abi_ver=${ELUA#lua}
+	fi
+	elog
+	elog "To manage rocks for a Lua version other than the current ${CATEGORY}/${PN} default (${lua_abi_ver})"
+	elog "you can use the command-line option --lua-version, e.g."
+	elog
+	elog "    luarocks --lua-version 5.3 install luasocket"
+	elog
+	elog "(use 5.1 for luajit). Note that the relevant Lua version must already be present in the system."
+	elog
+}


### PR DESCRIPTION
avoid install lua-compat53, already in tree

Closes: https://bugs.gentoo.org/961755

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
