### PR TITLE
profiles/targets/desktop: Add pulseadio

### DIFF
--- a/profiles/targets/desktop/gnome/make.defaults
+++ b/profiles/targets/desktop/gnome/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 USE="colord eds evo gdk-pixbuf gnome gnome-keyring gnome-online-accounts gnome-shell gstreamer introspection keyring nautilus networkmanager sysprof tracker"

--- a/profiles/targets/desktop/make.defaults
+++ b/profiles/targets/desktop/make.defaults
@@ -1,4 +1,4 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="a52 aac acpi alsa avif bluetooth branding cairo cdda cdr cups dbus dri dts dvd dvdr elogind encode exif flac gif gpm gtk gui icu jpeg jpegxl lcms libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds pulseaudio qml qt6 sdl sound spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb vulkan wayland webp wxwidgets X xcb xft x264 xml xv xvid"
+USE="a52 aac acpi alsa avif bluetooth branding cairo cdda cdr cups dbus dri dts dvd dvdr elogind encode exif flac gif gpm gtk gui icu jpeg jpegxl lcms libnotify mad mng mp3 mp4 mpeg ogg opengl pipewire pango pdf png policykit ppds pulseaudio qml qt6 screencast sdl sound spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb vulkan wayland webp wxwidgets X xcb xft x264 xml xv xvid"

--- a/profiles/targets/desktop/package.use
+++ b/profiles/targets/desktop/package.use
@@ -1,6 +1,11 @@
 # Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ian Jordan <immoloism@gmail.com> (2026-01-14)
+# Use PipeWire sound server. It also acts as PulseAudio implementation for
+# packages using media-libs/libpulse (e.g. via USE="pulseaudio").
+media-video/pipewire sound-server
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2025-12-16)
 # Enable IUSE qt5 for current stable pkgs with USE-revdeps before dropping
 # it from make.defaults. # Bug #948836

--- a/profiles/targets/desktop/plasma/make.defaults
+++ b/profiles/targets/desktop/plasma/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="activities declarative dri kde kwallet networkmanager pipewire plasma policykit screencast semantic-desktop widgets"
+USE="activities declarative dri kde kwallet networkmanager plasma policykit semantic-desktop widgets"

--- a/profiles/targets/desktop/plasma/package.use
+++ b/profiles/targets/desktop/plasma/package.use
@@ -52,6 +52,3 @@ virtual/zlib minizip
 # Required by kde-plasma/plasma-meta
 kde-plasma/kwin lock
 kde-plasma/kwin-x11 lock
-
-# plasma profile never enabled pulseaudio. We're skipping to pipewire.
-media-video/pipewire sound-server


### PR DESCRIPTION
To match both the GNOME and Plasma profiles this will add pulseaudio to the normal dektop profile to give WM and the other DE's the same audio experience.

This will make it easy for users to switch to Pipewire as a bonus and allow people that wish to use ALSA only to just set -pulseaudio in their make.conf.

(Done as a second commit so easy to revert)

 profiles/targets/desktop: Add pipewire and screenshare

As per asturm suggested it makes sense to add pipewire and screenshare now that +wayland is set in the desktop profiles this also sets a p.use to use the newer sound server.

Closes: https://bugs.gentoo.org/961764

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
