### PR TITLE
gnome-extra/gnome-color-manager: Stop installing help and man files

### DIFF
--- a/gnome-extra/gnome-color-manager/gnome-color-manager-3.36.2-r2.ebuild
+++ b/gnome-extra/gnome-color-manager/gnome-color-manager-3.36.2-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit gnome.org meson virtualx xdg
+
+DESCRIPTION="GNOME color profile tools"
+HOMEPAGE="https://gitlab.gnome.org/GNOME/gnome-color-manager/"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+# Need gtk+-3.3.8 for https://bugzilla.gnome.org/show_bug.cgi?id=673331
+RDEPEND="
+	>=dev-libs/glib-2.31.10:2
+	>=x11-libs/gtk+-3.4:3[X]
+	>=x11-misc/colord-1.3.1:0=
+	>=media-libs/lcms-2.2:2
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/itstool
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	default
+	# Help consists of 3 sentences but installs 108 files
+	truncate -s0 help/meson.build || die
+	# Building man pages requires docbook2man
+	truncate -s0 man/meson.build || die
+}
+
+src_configure() {
+	# Always enable tests since they are check_PROGRAMS anyway
+	local emesonargs=(
+		$(meson_use test tests)
+	)
+	meson_src_configure
+}
+
+src_test() {
+	virtx meson_src_test
+}


### PR DESCRIPTION
There doesn't seem to be much information in these files and:

- Help consists of 3 sentences but installs 108 files
-  Building man pages requires docbook2man. Which doesn't seem common these days - for me r1 would cause the install of:
app-text/xhtml1-20020801-r6
app-text/docbook-sgml-dtd-4.2-r4:4.2
app-text/docbook-sgml-dtd-3.1-r5:3.1
app-text/docbook-sgml-dtd-4.4-r2:4.4
app-text/docbook-sgml-dtd-4.0-r5:4.0
app-text/docbook-sgml-dtd-4.1-r5:4.1
app-text/docbook-xml-simple-dtd-1.0-r3:1.0
app-text/docbook-xml-simple-dtd-4.1.2.4-r4:4.1.2.4
app-text/docbook-sgml-utils-0.6.14-r6


May fix (if they still occur in 3.36.2)
https://bugs.gentoo.org/913469
https://bugs.gentoo.org/955886

```diff
--- gnome-color-manager-3.36.2-r1.ebuild
+++ gnome-color-manager-3.36.2-r2.ebuild
@@ -9,7 +9,7 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
@@ -21,14 +21,19 @@
 	>=media-libs/lcms-2.2:2
 "
 DEPEND="${RDEPEND}"
-# docbook-sgml-{utils,dtd:4.1} needed to generate man pages
 BDEPEND="
-	app-text/docbook-sgml-dtd:4.1
-	app-text/docbook-sgml-utils
 	dev-util/itstool
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 "
+
+src_prepare() {
+	default
+	# Help consists of 3 sentences but installs 108 files
+	truncate -s0 help/meson.build || die
+	# Building man pages requires docbook2man
+	truncate -s0 man/meson.build || die
+}
 
 src_configure() {
 	# Always enable tests since they are check_PROGRAMS anyway
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
