### PR TITLE
x11-plugins/pidgin-hotkeys: update deps, fix gcc15

### DIFF
--- a/x11-plugins/pidgin-hotkeys/files/pidgin-hotkeys-0.2.4-fix_cflags.patch
+++ b/x11-plugins/pidgin-hotkeys/files/pidgin-hotkeys-0.2.4-fix_cflags.patch
@@ -1,0 +1,12 @@
+Remove debug flag
+--- a/configure.ac
++++ b/configure.ac
+@@ -50,7 +50,7 @@ AC_DEFINE_UNQUOTED(VERSION_MINOR, version_minor,
+ )
+ 
+ if test "x$GCC" = "xyes"; then
+-  CFLAGS="$CFLAGS -Wall -g3"
++  CFLAGS="$CFLAGS -Wall"
+ fi
+ AC_SUBST(CFLAGS)
+ 	

--- a/x11-plugins/pidgin-hotkeys/files/pidgin-hotkeys-0.2.4-fix_gcc15.patch
+++ b/x11-plugins/pidgin-hotkeys/files/pidgin-hotkeys-0.2.4-fix_gcc15.patch
@@ -1,0 +1,31 @@
+reported https://sourceforge.net/p/pidgin-hotkeys/patches/8/
+bool is a keyword since c23, use boolean instead
+--- a/src/hotkeys.c
++++ b/src/hotkeys.c
+@@ -216,21 +216,21 @@ free_keys(GtkWidget* widget)
+ static void
+ hotkey_set_bool(GtkWidget *widget, HotkeyEntry* key)
+ {
+-    gboolean bool;
++    gboolean boolean;
+     GdkDisplay* display;
+     GdkWindow* root;
+ 
+-    bool = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+-    purple_prefs_set_bool(key->use_pref, bool);
++    boolean = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
++    purple_prefs_set_bool(key->use_pref, boolean);
+     
+-    key->enable = bool;
++    key->enable = boolean;
+ 
+     if (key->code)
+     {
+         display = widget ? gtk_widget_get_display(widget) : gdk_display_get_default();
+         root = widget ? gtk_widget_get_root_window(widget) : gdk_get_default_root_window();
+ 
+-        if (bool && grab_key(display, root, key))
++        if (boolean && grab_key(display, root, key))
+ 	    reconfig_blist(key - hotkeys);
+         else
+ 	{

--- a/x11-plugins/pidgin-hotkeys/pidgin-hotkeys-0.2.4-r3.ebuild
+++ b/x11-plugins/pidgin-hotkeys/pidgin-hotkeys-0.2.4-r3.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Pidgin plugin to define global hotkeys for various actions"
+HOMEPAGE="https://sourceforge.net/projects/pidgin-hotkeys/"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"
+
+RDEPEND="
+	app-accessibility/at-spi2-core:2
+	dev-libs/glib:2
+	media-libs/fontconfig
+	media-libs/freetype
+	media-libs/harfbuzz:=
+	net-im/pidgin:=[gui]
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	x11-libs/pango
+	x11-libs/gtk+:2
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix_gcc15.patch
+	"${FILESDIR}"/${P}-fix_cflags.patch
+)
+
+src_prepare() {
+	default
+	# configure.ac patched
+	eautoconf
+}
+
+src_install() {
+	default
+
+	find "${D}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
update SRC_URI (redirect)

add RDEP inherited from gtk+

patches :
remove use of bool key
remove debug compiler flag

Closes: https://bugs.gentoo.org/944281

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
