### PR TITLE
x11-misc/spacefm: fix gcc15, force X11 backend

### DIFF
--- a/x11-misc/spacefm/files/spacefm-1.0.6-fix_c23.patch
+++ b/x11-misc/spacefm/files/spacefm-1.0.6-fix_c23.patch
@@ -1,0 +1,319 @@
+Fix unprototyped functions and bool key
+patches from fedora, reported https://github.com/IgnorantGuru/spacefm/pull/828 
+https://src.fedoraproject.org/rpms/spacefm/blob/rawhide/f/spacefm-1.0.6-c23-function-proto.patch
+https://src.fedoraproject.org/rpms/spacefm/blob/rawhide/f/spacefm-1.0.6-c23-bool-keyword.patch
+
+commit 52260c8dbc45c4493aea6e458f486a18f7ff8b96
+Author: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date:   Tue Jan 21 16:10:54 2025 +0900
+--- a/src/main-window.c
++++ b/src/main-window.c
+@@ -6250,7 +6250,7 @@ GtkWidget* main_task_view_new( FMMainWindow* main_window )
+ 
+ // ============== socket commands
+ 
+-gboolean bool( const char* value )
++gboolean truthy( const char* value )
+ {
+     return ( !( value && value[0] ) || !strcmp( value, "1") || 
+                     !strcmp( value, "true") || 
+@@ -6441,14 +6441,14 @@ _missing_arg:
+         }
+         else if ( !strcmp( argv[i], "window_maximized" ) )
+         {
+-            if ( bool( argv[i+1] ) )
++            if ( truthy( argv[i+1] ) )
+                 gtk_window_maximize( GTK_WINDOW( main_window ) );
+             else
+                 gtk_window_unmaximize( GTK_WINDOW( main_window ) );
+         }
+         else if ( !strcmp( argv[i], "window_fullscreen" ) )
+         {
+-            xset_set_b( "main_full", bool( argv[i+1] ) );
++            xset_set_b( "main_full", truthy( argv[i+1] ) );
+             on_fullscreen_activate( NULL, main_window );
+         }
+         else if ( !strcmp( argv[i], "screen_size" ) )
+@@ -6591,7 +6591,7 @@ _missing_arg:
+                                                                     argv[i] );
+                     return 2;
+                 }
+-                xset_set_b_panel( j, "show", bool( argv[i+1] ) );
++                xset_set_b_panel( j, "show", truthy( argv[i+1] ) );
+                 show_panels_all_windows( NULL, main_window );
+                 return 0;
+             }
+@@ -6602,9 +6602,9 @@ _missing_arg:
+             if ( use_mode )
+                 xset_set_b_panel_mode( panel, str,
+                                         main_window->panel_context[panel-1],
+-                                        bool( argv[i+1] ) );
++                                        truthy( argv[i+1] ) );
+             else
+-                xset_set_b_panel( panel, str, bool( argv[i+1] ) );
++                xset_set_b_panel( panel, str, truthy( argv[i+1] ) );
+             update_views_all_windows( NULL, file_browser );
+         }
+         else if ( !strcmp( argv[i], "panel_hslider_top" ) ||
+@@ -6709,23 +6709,23 @@ _missing_arg:
+         {
+             if ( !strcmp( argv[i] + 5, "ascend" ) )
+             {
+-                ptk_file_browser_set_sort_type( file_browser, bool( argv[i+1] ) ?
++                ptk_file_browser_set_sort_type( file_browser, truthy( argv[i+1] ) ?
+                                         GTK_SORT_ASCENDING : GTK_SORT_DESCENDING );
+                 return 0;
+             }
+             else if ( !strcmp( argv[i] + 5, "natural" ) )
+             {
+                 str = "sortx_natural";
+-                xset_set_b( str, bool( argv[i+1] ) );
++                xset_set_b( str, truthy( argv[i+1] ) );
+             }
+             else if ( !strcmp( argv[i] + 5, "case" ) )
+             {
+                 str = "sortx_case";
+-                xset_set_b( str, bool( argv[i+1] ) );
++                xset_set_b( str, truthy( argv[i+1] ) );
+             }
+             else if ( !strcmp( argv[i] + 5, "hidden_first" ) )
+             {
+-                str = bool( argv[i+1] ) ? "sortx_hidfirst" : "sortx_hidlast";
++                str = truthy( argv[i+1] ) ? "sortx_hidfirst" : "sortx_hidlast";
+                 xset_set_b( str, TRUE );
+             }
+             else if ( !strcmp( argv[i] + 5, "first" ) )
+@@ -6748,7 +6748,7 @@ _missing_arg:
+         }
+         else if ( !strcmp( argv[i], "show_thumbnails" ) )
+         {
+-            if ( app_settings.show_thumbnail != bool( argv[i+1] ) )
++            if ( app_settings.show_thumbnail != truthy( argv[i+1] ) )
+                 main_window_toggle_thumbnails_all_windows();
+         }
+         else if ( !strcmp( argv[i], "large_icons" ) )
+@@ -6757,7 +6757,7 @@ _missing_arg:
+             {
+                 xset_set_b_panel_mode( panel, "list_large",
+                                         main_window->panel_context[panel-1],
+-                                        bool( argv[i+1] ) );
++                                        truthy( argv[i+1] ) );
+                 update_views_all_windows( NULL, file_browser );
+             }
+         }
+--- a/src/settings.c
++++ b/src/settings.c
+@@ -2731,9 +2731,9 @@ gboolean xset_get_bool( const char* name, const char* var )
+ gboolean xset_get_bool_panel( int panel, const char* name, const char* var )
+ {
+     char* fullname = g_strdup_printf( "panel%d_%s", panel, name );
+-    gboolean bool = xset_get_bool( fullname, var );
++    gboolean truthy = xset_get_bool( fullname, var );
+     g_free( fullname );
+-    return bool;
++    return truthy;
+ }
+ 
+ int xset_get_int_set( XSet* set, const char* var )
+commit 86364a17a3146e23a52fcf86f748dd99b3b1cf93
+Author: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date:   Tue Jan 21 16:10:30 2025 +0900
+--- a/src/cust-dialog.c
++++ b/src/cust-dialog.c
+@@ -3806,7 +3806,7 @@ static void show_help()
+     fprintf( f, "    %s\n\n", DEFAULT_MANUAL );
+ }
+ 
+-void signal_handler()
++void signal_handler(int signal)
+ {
+     if ( signal_dialog )
+     {
+--- a/src/ptk/ptk-dir-tree-view.c
++++ b/src/ptk/ptk-dir-tree-view.c
+@@ -357,7 +357,7 @@ GtkTreeModel* get_dir_tree_model()
+ 
+     if ( G_UNLIKELY( ! dir_tree_model ) )
+     {
+-        dir_tree_model = ptk_dir_tree_new( TRUE );
++        dir_tree_model = ptk_dir_tree_new();
+         g_object_add_weak_pointer( G_OBJECT( dir_tree_model ),
+                                    ( gpointer * ) (GtkWidget *) & dir_tree_model );
+     }
+--- a/src/ptk/ptk-file-misc.c
++++ b/src/ptk/ptk-file-misc.c
+@@ -1338,7 +1338,7 @@ void on_opt_toggled( GtkMenuItem* item, MoveSet* mset )
+ void on_toggled( GtkMenuItem* item, MoveSet* mset )
+ {
+     //int (*show) () = NULL;
+-    void (*show) () = NULL;
++    void (*show) (GtkWidget *) = NULL;
+     gboolean someone_is_visible = FALSE;
+     gboolean opts_visible = FALSE;
+ 
+@@ -1406,54 +1406,54 @@ void on_toggled( GtkMenuItem* item, MoveSet* mset )
+     // entries
+     if ( xset_get_b( "move_name" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+         someone_is_visible = TRUE;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
+-    show( mset->label_name );
++        show = gtk_widget_hide;
++    show( GTK_WIDGET(mset->label_name) );
+     show( mset->scroll_name );
+     show( mset->hbox_ext );
+-    show( mset->blank_name );
++    show( GTK_WIDGET(mset->blank_name) );
+ 
+     if ( xset_get_b( "move_filename" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+         someone_is_visible = TRUE;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
+-    show( mset->label_full_name );
++        show = gtk_widget_hide;
++    show( GTK_WIDGET(mset->label_full_name) );
+     show( mset->scroll_full_name );
+-    show( mset->blank_full_name );
++    show( GTK_WIDGET(mset->blank_full_name) );
+ 
+     if ( xset_get_b( "move_parent" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+         someone_is_visible = TRUE;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
+-    show( mset->label_path );
++        show = gtk_widget_hide;
++    show( GTK_WIDGET(mset->label_path) );
+     show( mset->scroll_path );
+-    show( mset->blank_path );
++    show( GTK_WIDGET(mset->blank_path) );
+ 
+     if ( xset_get_b( "move_path" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+         someone_is_visible = TRUE;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
+-    show( mset->label_full_path );
++        show = gtk_widget_hide;
++    show( GTK_WIDGET(mset->label_full_path) );
+     show( mset->scroll_full_path );
+ 
+     if ( !mset->is_link && !mset->create_new && xset_get_b( "move_type" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
++        show = gtk_widget_hide;
+     show( mset->hbox_type );
+ 
+     gboolean new_file = FALSE;
+@@ -1468,15 +1468,15 @@ void on_toggled( GtkMenuItem* item, MoveSet* mset )
+     
+     if ( new_link || ( mset->is_link && xset_get_b( "move_target" ) ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
++        show = gtk_widget_hide;
+     show( mset->hbox_target );
+ 
+     if ( ( new_file || new_folder ) && xset_get_b( "move_template" ) )
+     {
+-        show = (GFunc)gtk_widget_show;
++        show = gtk_widget_show;
+         if ( new_file )
+         {
+             gtk_widget_show( GTK_WIDGET( mset->combo_template ) );
+@@ -1493,7 +1493,7 @@ void on_toggled( GtkMenuItem* item, MoveSet* mset )
+         }
+     }
+     else
+-        show = (GFunc)gtk_widget_hide;
++        show = gtk_widget_hide;
+     show( mset->hbox_template );
+ 
+     if ( !someone_is_visible )
+--- a/src/settings.c
++++ b/src/settings.c
+@@ -2987,7 +2987,7 @@ void xset_parse( char* line )
+     }
+ }
+ 
+-XSet* xset_set_cb( const char* name, void (*cb_func) (), gpointer cb_data )
++XSet* xset_set_cb_internal( const char* name, void (*cb_func) (GtkWidget*, gpointer), gpointer cb_data )
+ {
+     XSet* set = xset_get( name );
+     set->cb_func = cb_func;
+@@ -2995,10 +2995,10 @@ XSet* xset_set_cb( const char* name, void (*cb_func) (), gpointer cb_data )
+     return set;
+ }
+ 
+-XSet* xset_set_cb_panel( int panel, const char* name, void (*cb_func) (), gpointer cb_data )
++XSet* xset_set_cb_panel_internal( int panel, const char* name, void (*cb_func) (GtkWidget*, gpointer), gpointer cb_data )
+ {
+     char* fullname = g_strdup_printf( "panel%d_%s", panel, name );
+-    XSet* set = xset_set_cb( fullname, cb_func, cb_data );
++    XSet* set = xset_set_cb_internal( fullname, cb_func, cb_data );
+     g_free( fullname );
+     return set;
+ }
+@@ -8587,7 +8587,7 @@ gboolean xset_menu_keypress( GtkWidget* widget, GdkEventKey* event,
+ void xset_menu_cb( GtkWidget* item, XSet* set )
+ {
+     GtkWidget* parent;
+-    void (*cb_func) () = NULL;
++    void (*cb_func) (GtkWidget*, gpointer) = NULL;
+     gpointer cb_data = NULL;
+     char* title;
+     XSet* mset;  // mirror set or set
+--- a/src/settings.h
++++ b/src/settings.h
+@@ -261,7 +261,7 @@ typedef struct
+     char* menu_label;
+     int menu_style;         // not saved or read if locked
+     char* icon;
+-    void (*cb_func) ();     // not saved
++    void (*cb_func) (GtkWidget*, gpointer);     // not saved
+     gpointer cb_data;       // not saved
+     char* ob1;              // not saved
+     gpointer ob1_data;      // not saved
+@@ -415,7 +415,9 @@ XSet* xset_set_b_panel( int panel, const char* name, gboolean bval );
+ int xset_get_int( const char* name, const char* var );
+ int xset_get_int_panel( int panel, const char* name, const char* var );
+ XSet* xset_set_panel( int panel, const char* name, const char* var, const char* value );
+-XSet* xset_set_cb_panel( int panel, const char* name, void (*cb_func) (), gpointer cb_data );
++XSet* xset_set_cb_panel_internal( int panel, const char* name, void (*cb_func) (GtkWidget*, gpointer), gpointer cb_data );
++#define xset_set_cb_panel(panel, name, cb_func, cb_data) \
++        xset_set_cb_panel_internal(panel, name, (void(*)(GtkWidget*, gpointer))(cb_func), cb_data)
+ gboolean xset_get_b_set( XSet* set );
+ XSet* xset_get_panel_mode( int panel, const char* name, char mode );
+ gboolean xset_get_b_panel_mode( int panel, const char* name, char mode );
+@@ -450,7 +452,9 @@ GtkWidget* xset_add_menuitem( DesktopWindow* desktop, PtkFileBrowser* file_brows
+                                     GtkWidget* menu, GtkAccelGroup *accel_group,
+                                     XSet* set );
+ GtkWidget* xset_get_image( const char* icon, int icon_size );
+-XSet* xset_set_cb( const char* name, void (*cb_func) (), gpointer cb_data );
++XSet* xset_set_cb_internal( const char* name, void (*cb_func) (GtkWidget*, gpointer), gpointer cb_data );
++#define xset_set_cb(name, cb_func, cb_data) \
++        xset_set_cb_internal(name, (void(*)(GtkWidget*, gpointer))(cb_func), cb_data)
+ XSet* xset_set_ob1_int( XSet* set, const char* ob1, int ob1_int );
+ XSet* xset_set_ob1( XSet* set, const char* ob1, gpointer ob1_data );
+ XSet* xset_set_ob2( XSet* set, const char* ob2, gpointer ob2_data );

--- a/x11-misc/spacefm/files/spacefm-1.0.6-force_X11.patch
+++ b/x11-misc/spacefm/files/spacefm-1.0.6-force_X11.patch
@@ -1,0 +1,15 @@
+Force X11 for gtk-3
+patch from fedora :
+https://src.fedoraproject.org/rpms/spacefm/blob/rawhide/f/spacefm-1.0.5-force-x11-backend.patch
+--- spacefm-1.0.5/src/main.c.x11	2016-01-20 22:22:23.000000000 +0900
++++ spacefm-1.0.5/src/main.c	2017-04-04 18:27:28.487452290 +0900
+@@ -1327,6 +1327,9 @@
+     bind_textdomain_codeset ( GETTEXT_PACKAGE, "UTF-8" );
+     textdomain ( GETTEXT_PACKAGE );
+ #endif
++#if GTK_CHECK_VERSION(3,10,0)
++    gdk_set_allowed_backends ("x11");
++#endif
+ 
+     // load spacefm.conf
+     load_conf();

--- a/x11-misc/spacefm/metadata.xml
+++ b/x11-misc/spacefm/metadata.xml
@@ -7,7 +7,7 @@
 			<email>ignorantguru@users.sourceforge.net</email>
 			<name>IgnorantGuru</name>
 		</maintainer>
-		<changelog>https://ignorantguru.github.com/spacefm/news.html</changelog>
+		<changelog>https://ignorantguru.github.io/spacefm/news.html</changelog>
 		<doc lang="en">https://github.com/IgnorantGuru/spacefm/wiki/</doc>
 		<bugs-to>https://github.com/IgnorantGuru/spacefm/issues</bugs-to>
 		<remote-id type="sourceforge">spacefm</remote-id>

--- a/x11-misc/spacefm/spacefm-1.0.6-r5.ebuild
+++ b/x11-misc/spacefm/spacefm-1.0.6-r5.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools linux-info optfeature xdg
+
+DESCRIPTION="A multi-panel tabbed file manager"
+HOMEPAGE="https://ignorantguru.github.io/spacefm/"
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://github.com/IgnorantGuru/${PN}.git"
+	EGIT_BRANCH="next"
+	inherit git-r3
+else
+	KEYWORDS="~amd64 ~x86"
+	SRC_URI="https://github.com/IgnorantGuru/spacefm/archive/${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+IUSE="+startup-notification +video-thumbnails"
+
+RDEPEND="dev-libs/glib:2
+	dev-util/desktop-file-utils
+	virtual/udev
+	virtual/freedesktop-icon-theme
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3[X]
+	x11-libs/pango
+	x11-libs/libX11
+	x11-misc/shared-mime-info
+	startup-notification? ( x11-libs/startup-notification )
+	video-thumbnails? ( media-video/ffmpegthumbnailer )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+BDEPEND="dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-9999-include-sysmacros.patch
+	"${FILESDIR}"/${PN}-fno-common.patch
+	"${FILESDIR}"/${PN}-dash.patch #891181
+	"${FILESDIR}"/${PN}-gcc14-build-fix.patch #928492
+	"${FILESDIR}"/${P}-force_X11.patch
+	"${FILESDIR}"/${P}-fix_c23.patch #944277 #944191 #944089
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable startup-notification)
+		$(use_enable video-thumbnails)
+		--disable-hal
+		--enable-inotify
+		--disable-pixmaps
+		--with-gtk3
+	)
+	econf "${myeconfargs[@]}"
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	optfeature "mounting as non-root user" sys-apps/udevil sys-apps/pmount sys-fs/udisks
+	optfeature "supporting ftp/nfs/smb/ssh URLs in the path bar" sys-apps/udevil
+	optfeature "performing as root" x11-misc/ktsuss kde-plasma/kdesu-gui
+	# sys-apps/util-linux is required for eject
+	optfeature "other optional dependencies" sys-apps/dbus sys-process/lsof sys-apps/util-linux
+
+	if ! has_version 'sys-fs/udisks' ; then
+		elog "When using SpaceFM without udisks, and without the udisks-daemon running,"
+		elog "you may need to enable kernel polling for device media changes to be detected."
+		elog "See /usr/share/doc/${PF}/html/spacefm-manual-en.html#devices-kernpoll"
+	fi
+}


### PR DESCRIPTION
update URL for changelog in metadata

fix c23 with two patches from fedora
force X11 backend because wayland is not supported (revbump for this really needed?)

use array for econfargs

Closes: https://bugs.gentoo.org/944089
Closes: https://bugs.gentoo.org/944191
Closes: https://bugs.gentoo.org/944277

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
