### PR TITLE
app-editors/bluefish: fix deps, python, disable infbrowser plugin

### DIFF
--- a/app-editors/bluefish/bluefish-2.2.17-r1.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.17-r1.ebuild
@@ -1,0 +1,114 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} )
+
+inherit autotools python-single-r1 xdg
+
+DESCRIPTION="GTK HTML editor for the experienced web designer or programmer"
+HOMEPAGE="https://bluefish.openoffice.nl/"
+SRC_URI="https://www.bennewitz.com/bluefish/stable/source/${P}.tar.bz2"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="gucharmap nls python spell"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	dev-libs/glib:2
+	dev-libs/libxml2:=
+	sys-libs/zlib
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3
+	x11-libs/pango
+	gucharmap? ( gnome-extra/gucharmap:2.90 )
+	python? ( ${PYTHON_DEPS} )
+	spell? ( app-text/enchant:2 )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-libs/libxml2
+	virtual/pkgconfig
+	x11-libs/gdk-pixbuf
+	nls? ( sys-devel/gettext )
+"
+
+# there actually is just some broken manpage checkup -> not bother
+RESTRICT="test"
+
+PATCHES=(
+	# https://sourceforge.net/p/bluefish/tickets/111/
+	"${FILESDIR}/${PN}-2.2.9-charmap_configure.patch"
+	# https://sourceforge.net/p/bluefish/tickets/112/
+	"${FILESDIR}/${PN}-2.2.17-check_svn.patch"
+	# https://sourceforge.net/p/bluefish/tickets/114/
+	"${FILESDIR}/${PN}-2.2.17-fix_clang.patch"
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	# remove infbrowser plugin (see https://sourceforge.net/p/bluefish/tickets/113/)
+	# mainly unmaintained and with deprecated function from libxml2 (nanohttp)
+	sed -e '/infbrowser/d' -i src/Makefile.am || die
+
+	eautoreconf
+}
+
+src_configure() {
+	export CONFIG_SHELL="${BASH}"
+	local myeconfargs=(
+		--disable-update-databases
+		--disable-xml-catalog-update
+		--with-freedesktop_org-appdata="${EPREFIX}"/usr/share/metainfo
+		--without-gtk2
+		$(use_with gucharmap charmap)
+		$(use_enable nls)
+		$(use_enable spell spell-check)
+		$(use_enable python)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	if use python; then
+		python_fix_shebang "${ED}/usr/share/bluefish"
+		python_optimize "${ED}/usr/share/bluefish/plugins/zencoding"
+	fi
+
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	einfo "Adding XML catalog entries..."
+	"${EPREFIX}"/usr/bin/xmlcatalog  --noout \
+		--add 'public' 'Bluefish/DTD/Bflang' 'bflang.dtd' \
+		--add 'system' 'http://bluefish.openoffice.nl/DTD/bflang.dtd' 'bflang.dtd' \
+		--add 'rewriteURI' 'http://bluefish.openoffice.nl/DTD' '/usr/share/xml/bluefish-unstable' \
+		"${EROOT}"/etc/xml/catalog \
+		|| ewarn "Failed to add XML catalog entries."
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+
+	einfo "Removing XML catalog entries..."
+	"${EPREFIX}"/usr/bin/xmlcatalog  --noout \
+		--del 'Bluefish/DTD/Bflang' \
+		--del 'http://bluefish.openoffice.nl/DTD/bflang.dtd' \
+		--del 'http://bluefish.openoffice.nl/DTD' \
+		"${EROOT}"/etc/xml/catalog \
+		|| ewarn "Failed to remove XML catalog entries."
+}

--- a/app-editors/bluefish/files/bluefish-2.2.17-check_svn.patch
+++ b/app-editors/bluefish/files/bluefish-2.2.17-check_svn.patch
@@ -1,0 +1,49 @@
+https://sourceforge.net/p/bluefish/tickets/112/
+call svnversion only if a svn tree exists and svnversion is found
+--- a/configure.ac
++++ b/configure.ac
+@@ -151,12 +151,19 @@ AC_ARG_ENABLE(
+ )
+ 
+ dnl # make DEVELOPEMENT enabled when compiling from svn, and disabled when compiling from an exported source tree.
+-AC_MSG_CHECKING([for svn tree or exported source tree])
+ BF_want_development="no"
+-BF_svnversion=`LANG=C svnversion -n . || echo exported`
+-if test "x$BF_svnversion" != "xexported" ; then
+-	AC_MSG_RESULT([svn])
+-	BF_want_development="yes"
++AC_MSG_CHECKING([for svn tree or exported source tree])
++AM_CONDITIONAL([SVN], [false])
++if test -f .svn/entries; then
++	AC_CHECK_PROG([HAVE_SVN], [svnversion], [yes], [no])
++	if test x$HAVE_SVN = "xyes"; then
++		BF_svnversion=`LANG=C svnversion -n . 2>/dev/null`
++		AM_CONDITIONAL([SVN], [true])
++		AC_MSG_RESULT([svn])
++		BF_want_development="yes"
++	else
++		AC_MSG_WARN([svn tree found but svnversion was not found, continue as an exported tree])
++	fi
+ else
+ 	AC_MSG_RESULT([exported])
+ fi
+--- a/src/plugin_about/Makefile.am
++++ b/src/plugin_about/Makefile.am
+@@ -29,7 +29,7 @@ about_rev.h: about_rev.h.tmp
+ 	@if test ! -e $@ || test -n "`diff $< $@`" ; then cp $< $@ ; fi
+        
+ about_rev.h.tmp:
+-	@SVN_REVISION=`LANG=C svnversion -n ${top_srcdir} || echo exported` ; \
++	@SVN_TRUE@SVN_REVISION=`LANG=C svnversion -n ${top_srcdir} || echo exported` ; \
+ 	echo "/* Automatically created by the Makefile." > $@ ; \
+ 	echo " * http://bugzilla.gnome.org/show_bug.cgi?id=578719 */" >> $@ ; \
+ 	echo "#ifndef __ABOUT_REV_H_" >> $@ ; \
+@@ -37,7 +37,7 @@ about_rev.h.tmp:
+ 	echo "#ifdef SVN_REVISION" >> $@ ; \
+ 	echo "#undef SVN_REVISION" >> $@ ; \
+ 	echo "#endif /* SVN_REVISION */" >> $@ ; \
+-	if test -n $${SVN_REVISION} -a "x$${SVN_REVISION}" != "xexported" ; then \
++	if test -n "$${SVN_REVISION}" -a "x$${SVN_REVISION}" != "xexported" ; then \
+ 		echo "#define SVN_REVISION \"$${SVN_REVISION}\"" >> $@ ; \
+ 	fi ; \
+ 	echo "#endif /* __ABOUT_REV_H_ */" >> $@

--- a/app-editors/bluefish/files/bluefish-2.2.17-fix_clang.patch
+++ b/app-editors/bluefish/files/bluefish-2.2.17-fix_clang.patch
@@ -1,0 +1,17 @@
+https://sourceforge.net/p/bluefish/tickets/114/
+> xml_entity.c:238:11: error: initializing 'gchar *' (aka 'char *')
+> with an expression of type 'const gchar *' (aka 'const char *')
+> discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
+>   238 |                         gchar *nxt = g_utf8_next_char(srcp);
+>       |                                ^     ~~~~~~~~~~~~~~~~~~~~~~
+--- a/src/xml_entity.c
++++ b/src/xml_entity.c
+@@ -235,7 +235,7 @@ gchar *utf82xmlentities(const gchar *inbuf, gboolean iso8859_1, gboolean symbols
+ 			g_free(entity);
+ 			srcp = g_utf8_next_char(srcp);
+ 		} else {
+-			gchar *nxt = g_utf8_next_char(srcp);
++			const gchar *nxt = g_utf8_next_char(srcp);
+ 			outbuf = strncat(outbuf, srcp, (nxt-srcp));
+ 			srcp = nxt;
+ 		}


### PR DESCRIPTION
remove MY_P, not needed

deps :
add libs inherited from gtk in rdeps
add lxml2 in rdeps too because bluefish links against
add gdk-pixbuf in bdep because gdk-pixbuf-csource is called
remove intltool, no longer used since 2.2.14

simply call ${BASH} instead of abspath
use an array for econf

remove infbrowser plugin, mainly unmaintained and with a deprecated function
(nanohttp is deprecated in libxml2-2.13 and will be removed in libxml2-2.15)

improve python option : fix shebang and optimize, update targets (9..13 to 11..14)

sed-op for pigz ([#469480](https://bugs.gentoo.org/469480)) is no longer required since pigz-2.4 (https://github.com/madler/pigz/commit/fc10bb0)

patches :
check svnversion and fix [#765835](https://bugs.gentoo.org/765835)
fix compile with clang

Closes: https://bugs.gentoo.org/765835

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
