### PR TITLE
sys-kernel/dracut: use correct patch for 9999

### DIFF
--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -102,7 +102,7 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
 	# Gentoo specific acct-user and acct-group conf adjustments
-	"${FILESDIR}"/${PN}-106-acct-user-group-gentoo.patch
+	"${FILESDIR}"/${PN}-108-acct-user-group-gentoo.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/961625

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
