### PR TITLE
dev-java/javassist: skip testDeprecatedAttribute from BytecodeTest

### DIFF
--- a/dev-java/javassist/files/javassist-3.30.2-skip_testDeprecatedAttribute.patch
+++ b/dev-java/javassist/files/javassist-3.30.2-skip_testDeprecatedAttribute.patch
@@ -1,0 +1,24 @@
+There was 1 failure:
+1) testDeprecatedAttribute(javassist.bytecode.BytecodeTest)
+javassist.NotFoundException: suspend(..) is not found in java.lang.Thread
+	at javassist.CtClassType.getDeclaredMethod(CtClassType.java:1356)
+	at javassist.bytecode.BytecodeTest.testDeprecatedAttribute(BytecodeTest.java:315)
+
+FAILURES!!!
+Tests run: 434,  Failures: 1
+
+The failure occurs with jdk:25 and higher due to method 'suspend'
+being removed (https://bugs.openjdk.org/browse/JDK-8359053).
+The removal of 'suspend' only affects the test, so we skip the test.
+
+--- a/src/test/javassist/bytecode/BytecodeTest.java
++++ b/src/test/javassist/bytecode/BytecodeTest.java
+@@ -310,7 +310,7 @@ public class BytecodeTest extends TestCase {
+         assertEquals(0, invoke(obj, "test"));
+     }
+ 
+-    public void testDeprecatedAttribute() throws Exception {
++    public void noTestDeprecatedAttribute() throws Exception {
+         CtClass cc = loader.get("java.lang.Thread");
+         CtMethod m = cc.getDeclaredMethod("suspend");
+         MethodInfo minfo = m.getMethodInfo();

--- a/dev-java/javassist/javassist-3.30.2-r1.ebuild
+++ b/dev-java/javassist/javassist-3.30.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,8 +18,12 @@ LICENSE="Apache-2.0 LGPL-2.1 MPL-1.1"
 SLOT="3"
 KEYWORDS="amd64 arm64 ppc64 ~amd64-linux ~x86-linux"
 
+# src/main/javassist/tools/rmi/ObjectImporter.java:99: error: package java.applet does not exist
+#     public ObjectImporter(@SuppressWarnings("deprecation") java.applet.Applet applet) {
+#                                                                       ^
+# See https://bugs.openjdk.org/browse/JDK-8359053 - so we exclude jdk:26
 DEPEND="
-	>=virtual/jdk-11:*
+	|| ( virtual/jdk:25 virtual/jdk:21 virtual/jdk:17 virtual/jdk:11 )
 	test? ( dev-java/hamcrest-library:1.3 )
 "
 
@@ -28,7 +32,10 @@ RDEPEND=">=virtual/jre-1.8:*"
 DOCS=( Changes.md README.md )
 HTML_DOCS=( tutorial/{brown.css,tutorial.html,tutorial2.html,tutorial3.html} )
 
-PATCHES=( "${FILESDIR}/javassist-3.29.2-gentoo.patch" )
+PATCHES=(
+	"${FILESDIR}/javassist-3.29.2-gentoo.patch"
+	"${FILESDIR}/javassist-3.30.2-skip_testDeprecatedAttribute.patch"
+)
 
 JAVA_AUTOMATIC_MODULE_NAME="org.javassist"
 JAVA_MAIN_CLASS="javassist.CtClass"


### PR DESCRIPTION
also restricts to max jdk:25 because of still using Applet

Closes: https://bugs.gentoo.org/946905

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
