### PR TITLE
kde-apps/ktouch: Reapply drop duplicate KF6DocTools requirement

### DIFF
--- a/kde-apps/ktouch/files/ktouch-25.08.0-duplicate-kdoctools.patch
+++ b/kde-apps/ktouch/files/ktouch-25.08.0-duplicate-kdoctools.patch
@@ -1,0 +1,44 @@
+https://bugs.gentoo.org/961948
+https://bugs.gentoo.org/960368
+https://invent.kde.org/education/ktouch/-/merge_requests/45
+https://invent.kde.org/education/ktouch/-/commit/5e15072752bff5fb004e9c1681a8024fa6c4f7c4
+
+From 5e15072752bff5fb004e9c1681a8024fa6c4f7c4 Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Sat, 19 Jul 2025 12:27:48 +0200
+Subject: [PATCH] Drop duplicate required KF6DocTools dependency
+
+It is already being searched for prior to the main KF6 dependencies,
+and the docs subdir is being added conditionally, so that will have
+been the intention.
+
+Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,7 +46,6 @@ find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS
+     Config
+     ConfigWidgets
+     CoreAddons
+-    DocTools
+     I18n
+     ItemViews
+     KCMUtils
+@@ -93,7 +92,6 @@ ecm_set_disabled_deprecation_versions(QT 5.15.2  KF 5.101.0)
+ 
+ # subdirectories to build
+ ecm_optional_add_subdirectory(data)
+-ecm_optional_add_subdirectory(doc)
+ ecm_optional_add_subdirectory(src)
+ # ecm_optional_add_subdirectory(sounds)
+ ecm_optional_add_subdirectory(icons)
+@@ -101,6 +99,7 @@ ecm_optional_add_subdirectory(icons)
+ # files to install in the ktouch project root directory
+ ki18n_install(po)
+ if (KF6DocTools_FOUND)
++    ecm_optional_add_subdirectory(doc)
+     kdoctools_install(po)
+ endif()
+ install( PROGRAMS org.kde.ktouch.desktop  DESTINATION  ${KDE_INSTALL_APPDIR} )
+-- 
+GitLab
+

--- a/kde-apps/ktouch/ktouch-25.08.0.ebuild
+++ b/kde-apps/ktouch/ktouch-25.08.0.ebuild
@@ -49,6 +49,8 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-apps/kqtquickcharts-${PVCUT}:6
 "
 
+PATCHES=( "${FILESDIR}/${PN}-25.08.0-duplicate-kdoctools.patch" ) # bug 960368 and bug 961948
+
 src_configure() {
 	local mycmakeargs=(
 		-DWITHOUT_X11=$(usex !X)


### PR DESCRIPTION
The patch wasn't merged for 25.8.0, use the updated patch as accepted by upstream.

Closes: https://bugs.gentoo.org/961948

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
