### PR TITLE
dev-libs/argtable: fix c23/musl, use dot-a.eclass

### DIFF
--- a/dev-libs/argtable/argtable-2.13-r4.ebuild
+++ b/dev-libs/argtable/argtable-2.13-r4.ebuild
@@ -1,16 +1,16 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit libtool
+inherit dot-a libtool
 
 MY_PV="$(ver_rs 1 '-')"
 MY_P=${PN}${MY_PV}
 
 DESCRIPTION="An ANSI C library for parsing GNU-style command-line options with minimal fuss"
 HOMEPAGE="https://argtable.sourceforge.io"
-SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.tar.gz"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${P}/${MY_P}.tar.gz"
 S="${WORKDIR}"/${MY_P}
 
 LICENSE="LGPL-2"
@@ -25,10 +25,16 @@ PATCHES=(
 
 src_prepare() {
 	default
+
+	# not needed for glibc or musl #945723
+	rm src/getopt.h || die
+
 	elibtoolize
 }
 
 src_configure() {
+	lto-guarantee-fat
+
 	econf \
 		$(use_enable debug) \
 		$(use_enable static-libs static)
@@ -53,4 +59,5 @@ src_install() {
 	fi
 
 	find "${ED}" -name "*.la" -delete || die "failed to delete .la files"
+	strip-lto-bytecode
 }


### PR DESCRIPTION
update SRC_URI (redirect)

use dot-a.eclass to avoid installing broken static libraries w/ LTO
remove bundle getopt.h  (unneeded for glibc/musl) to avoid conflict with musl

Closes: https://bugs.gentoo.org/945723

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
