### PR TITLE
net-im/neochat: add missing test dependency

### DIFF
--- a/net-im/neochat/neochat-25.08.0.ebuild
+++ b/net-im/neochat/neochat-25.08.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="GPL-3+ handbook? ( CC-BY-SA-4.0 )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
 
-DEPEND="
+COMMON_DEPEND="
 	app-text/cmark:=
 	>=dev-libs/kirigami-addons-1.6.0:6
 	>=dev-libs/icu-61.0:=
@@ -49,7 +49,12 @@ DEPEND="
 	media-libs/kquickimageeditor:6
 	>=net-libs/libquotient-0.9.1:=
 "
-RDEPEND="${DEPEND}
+DEPEND="${COMMON_DEPEND}
+	test? (
+		>=dev-qt/qthttpserver-${QTMIN}:6
+	)
+"
+RDEPEND="${COMMON_DEPEND}
 	>=dev-qt/qt5compat-${QTMIN}:6[qml]
 	>=dev-qt/qtlocation-${QTMIN}:6
 	>=dev-qt/qtmultimedia-${QTMIN}:6[qml]


### PR DESCRIPTION
Upstream commit: 4527a6399eb1d43dba9c9feb47d571212b0ee142

https://github.com/gentoo/kde/pull/1068

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
