### PR TITLE
media-libs/opencv: Fix build with media-video/ffmpeg-8.x

### DIFF
--- a/media-libs/opencv/files/opencv-4.11.0-ffmpeg8.patch
+++ b/media-libs/opencv/files/opencv-4.11.0-ffmpeg8.patch
@@ -1,0 +1,37 @@
+https://github.com/opencv/opencv/pull/27691
+From: Alexander Smorkalov <alexander.smorkalov@opencv.ai>
+Date: Wed, 20 Aug 2025 10:53:51 +0300
+Subject: [PATCH] FFmpeg 8.0 support.
+
+--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
++++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
+@@ -685,7 +685,10 @@ void CvCapture_FFMPEG::close()
+     if( video_st )
+     {
+ #ifdef CV_FFMPEG_CODECPAR
++// avcodec_close removed in FFmpeg release 8.0
++# if (LIBAVCODEC_BUILD < CALC_FFMPEG_VERSION(62, 11, 100))
+         avcodec_close( context );
++# endif
+ #endif
+         video_st = NULL;
+     }
+@@ -2005,7 +2008,18 @@ void CvCapture_FFMPEG::get_rotation_angle()
+     rotation_angle = 0;
+ #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(57, 68, 100)
+     const uint8_t *data = 0;
++    // av_stream_get_side_data removed in FFmpeg release 8.0
++# if (LIBAVCODEC_BUILD < CALC_FFMPEG_VERSION(62, 11, 100))
+     data = av_stream_get_side_data(video_st, AV_PKT_DATA_DISPLAYMATRIX, NULL);
++# else
++    AVPacketSideData* sd = video_st->codecpar->coded_side_data;
++    int nb_sd = video_st->codecpar->nb_coded_side_data;
++    if (sd && nb_sd > 0)
++    {
++        const AVPacketSideData* mtx = av_packet_side_data_get(sd,  nb_sd, AV_PKT_DATA_DISPLAYMATRIX);
++        data = mtx->data;
++    }
++# endif
+     if (data)
+     {
+         rotation_angle = -cvRound(av_display_rotation_get((const int32_t*)data));

--- a/media-libs/opencv/opencv-4.11.0.ebuild
+++ b/media-libs/opencv/opencv-4.11.0.ebuild
@@ -386,6 +386,8 @@ PATCHES=(
 
 	"${FILESDIR}/${PN}-4.11.0-cuda-12.9.patch" # PR 27288
 
+	"${FILESDIR}/${PN}-4.11.0-ffmpeg8.patch" # PR 27691
+
 	# TODO applied in src_prepare
 	# "${FILESDIR}/${PN}_contrib-4.8.1-rgbd.patch"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/961697

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
