### PR TITLE
app-shells/nushell: fix invalid format of FILESDIR in src_prepare

### DIFF
--- a/app-shells/nushell/nushell-0.103.0.ebuild
+++ b/app-shells/nushell/nushell-0.103.0.ebuild
@@ -52,7 +52,7 @@ RESTRICT+=" test"
 QA_FLAGS_IGNORED="usr/bin/nu.*"
 
 src_prepare() {
-	use plugins || eapply "${FILESDIR/${PN}-dont-build-plugins.patch}"
+	use plugins || eapply "${FILESDIR}/${PN}-dont-build-plugins.patch"
 	default
 }
 
@@ -81,7 +81,7 @@ src_install() {
 		# Clear features to compile plugins
 		local myfeatures=()
 		cargo_src_configure
-		
+
 		cargo_src_install --path crates/nu_plugin_custom_values
 		cargo_src_install --path crates/nu_plugin_example
 		cargo_src_install --path crates/nu_plugin_formats

--- a/app-shells/nushell/nushell-0.104.1.ebuild
+++ b/app-shells/nushell/nushell-0.104.1.ebuild
@@ -52,7 +52,7 @@ RESTRICT+=" test"
 QA_FLAGS_IGNORED="usr/bin/nu.*"
 
 src_prepare() {
-	use plugins || eapply "${FILESDIR/${PN}-dont-build-plugins.patch}"
+	use plugins || eapply "${FILESDIR}/${PN}-dont-build-plugins.patch"
 	default
 }
 

--- a/app-shells/nushell/nushell-0.105.1-r1.ebuild
+++ b/app-shells/nushell/nushell-0.105.1-r1.ebuild
@@ -42,7 +42,7 @@ RESTRICT+=" test"
 QA_FLAGS_IGNORED="usr/bin/nu.*"
 
 src_prepare() {
-	use plugins || eapply "${FILESDIR/${PN}-dont-build-plugins.patch}"
+	use plugins || eapply "${FILESDIR}/${PN}-dont-build-plugins.patch"
 	default
 }
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
