### PR TITLE
dev-lang/ngn-k: Add live ebuild support for the ngn/k derivative of APL.

### DIFF
--- a/dev-lang/ngn-k/ngn-k-9999.ebuild
+++ b/dev-lang/ngn-k/ngn-k-9999.ebuild
@@ -1,0 +1,172 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# NOTE: The comments in this file are for instruction and documentation.
+# They're not meant to appear with your final, production ebuild.  Please
+# remember to remove them before submitting or committing your ebuild.  That
+# doesn't mean you can't add your own comments though.
+
+# The EAPI variable tells the ebuild format in use.
+# It is suggested that you use the latest EAPI approved by the Council.
+# The PMS contains specifications for all EAPIs. Eclasses will test for this
+# variable if they need to use features that are not universal in all EAPIs.
+# If an eclass doesn't support latest EAPI, use the previous EAPI instead.
+EAPI=8
+
+inherit git-r3
+# inherit lists eclasses to inherit functions from. For example, an ebuild
+# that needs the eautoreconf function from autotools.eclass won't work
+# without the following line:
+#inherit autotools
+#
+# Eclasses tend to list descriptions of how to use their functions properly.
+# Take a look at the eclass/ directory for more examples.
+
+# Short one-line description of this package.
+DESCRIPTION="maintained k flavor (APL variant)"
+
+# Homepage, not used by Portage directly but handy for developer reference
+HOMEPAGE="https://codeberg.org/ngn/k"
+
+# Point to any required sources; these will be automatically downloaded by
+# Portage.
+#SRC_URI="ftp://foo.example.org/${P}.tar.gz"
+EGIT_REPO_URI="https://codeberg.org/ngn/k"
+# Source directory; the dir where the sources can be found (automatically
+# unpacked) inside ${WORKDIR}.  The default  value for S is ${WORKDIR}/${P}
+# If you don't need to change it, leave the S= line out of the ebuild
+# to keep it tidy.
+#S="${WORKDIR}/${P}"
+
+
+# License of the package.  This must match the name of file(s) in the
+# licenses/ directory.  For complex license combination see the developer
+# docs on gentoo.org for details.
+#LICENSE=""
+
+# The SLOT variable is used to tell Portage if it's OK to keep multiple
+# versions of the same package installed at the same time.  For example,
+# if we have a libfoo-1.2.2 and libfoo-1.3.2 (which is not compatible
+# with 1.2.2), it would be optimal to instruct Portage to not remove
+# libfoo-1.2.2 if we decide to upgrade to libfoo-1.3.2.  To do this,
+# we specify SLOT="1.2" in libfoo-1.2.2 and SLOT="1.3" in libfoo-1.3.2.
+# emerge clean understands SLOTs, and will keep the most recent version
+# of each SLOT and remove everything else.
+# Note that normal applications should use SLOT="0" if possible, since
+# there should only be exactly one version installed at a time.
+# Do not use SLOT="", because the SLOT variable must not be empty.
+SLOT="0"
+
+# Using KEYWORDS, we can record masking information *inside* an ebuild
+# instead of relying on an external package.mask file.  Right now, you
+# should set the KEYWORDS variable for every ebuild so that it contains
+# the names of all the architectures with which the ebuild works.
+# All of the official architectures can be found in the arch.list file
+# which is in the profiles/ directory.  Usually you should just set this
+# to "~amd64".  The ~ in front of the architecture indicates that the
+# package is new and should be considered unstable until testing proves
+# its stability.  So, if you've confirmed that your ebuild works on
+# amd64 and ppc, you'd specify:
+# KEYWORDS="~amd64 ~ppc"
+# Once packages go stable, the ~ prefix is removed.
+# For binary packages, use -* and then list the archs the bin package
+# exists for.  If the package was for an x86 binary package, then
+# KEYWORDS would be set like this: KEYWORDS="-* x86"
+# Do not use KEYWORDS="*"; this is not valid in an ebuild context.
+KEYWORDS="~amd64"
+
+# Comprehensive list of any and all USE flags leveraged in the ebuild,
+# with some exceptions, e.g., ARCH specific flags like "amd64" or "ppc".
+# Not needed if the ebuild doesn't use any USE flags.
+#IUSE="gnome X"
+
+# A space delimited list of portage features to restrict. man 5 ebuild
+# for details.  Usually not needed.
+#RESTRICT="strip"
+
+
+# Run-time dependencies. Must be defined to whatever this depends on to run.
+# Example:
+#    ssl? ( >=dev-libs/openssl-1.0.2q:0= )
+#    >=dev-lang/perl-5.24.3-r1
+# It is advisable to use the >= syntax show above, to reflect what you
+# had installed on your system when you tested the package.  Then
+# other users hopefully won't be caught without the right version of
+# a dependency.
+#RDEPEND=""
+
+# Build-time dependencies that need to be binary compatible with the system
+# being built (CHOST). These include libraries that we link against.
+# The below is valid if the same run-time depends are required to compile.
+#DEPEND="${RDEPEND}"
+
+# Build-time dependencies that are executed during the emerge process, and
+# only need to be present in the native build system (CBUILD). Example:
+#BDEPEND="virtual/pkgconfig"
+
+
+# The following src_configure function is implemented as default by portage, so
+# you only need to call it if you need a different behaviour.
+#src_configure() {
+	# Most open-source packages use GNU autoconf for configuration.
+	# The default, quickest (and preferred) way of running configure is:
+	#econf
+	#
+	# You could use something similar to the following lines to
+	# configure your package before compilation.  The "|| die" portion
+	# at the end will stop the build process if the command fails.
+	# You should use this at the end of critical commands in the build
+	# process.  (Hint: Most commands are critical, that is, the build
+	# process should abort if they aren't successful.)
+	#./configure \
+	#	--host=${CHOST} \
+	#	--prefix=/usr \
+	#	--infodir=/usr/share/info \
+	#	--mandir=/usr/share/man || die
+	# Note the use of --infodir and --mandir, above. This is to make
+	# this package FHS 2.2-compliant.  For more information, see
+	#   https://wiki.linuxfoundation.org/lsb/fhs
+#}
+
+# The following src_compile function is implemented as default by portage, so
+# you only need to call it, if you need different behaviour.
+#src_compile() {
+	# emake is a script that calls the standard GNU make with parallel
+	# building options for speedier builds (especially on SMP systems).
+	# Try emake first.  It might not work for some packages, because
+	# some makefiles have bugs related to parallelism, in these cases,
+	# use emake -j1 to limit make to a single process.  The -j1 is a
+	# visual clue to others that the makefiles have bugs that have been
+	# worked around.
+
+	#emake
+#}
+
+# The following src_install function is implemented as default by portage, so
+# you only need to call it, if you need different behaviour.
+src_install() {
+	dobin k
+	# You must *personally verify* that this trick doesn't install
+	# anything outside of DESTDIR; do this by reading and
+	# understanding the install part of the Makefiles.
+	# This is the preferred way to install.
+	#emake DESTDIR="${D}" install
+
+	# When you hit a failure with emake, do not just use make. It is
+	# better to fix the Makefiles to allow proper parallelization.
+	# If you fail with that, use "emake -j1", it's still better than make.
+
+	# For Makefiles that don't make proper use of DESTDIR, setting
+	# prefix is often an alternative.  However if you do this, then
+	# you also need to specify mandir and infodir, since they were
+	# passed to ./configure as absolute paths (overriding the prefix
+	# setting).
+	#emake \
+	#	prefix="${D}"/usr \
+	#	mandir="${D}"/usr/share/man \
+	#	infodir="${D}"/usr/share/info \
+	#	libdir="${D}"/usr/$(get_libdir) \
+	#	install
+	# Again, verify the Makefiles!  We don't want anything falling
+	# outside of ${D}.
+}


### PR DESCRIPTION
Add support for the k derivative of APL. This is important because gentoo currently does not have any version of APL or its derivatives, and APL is an important language. ngn/k is a stable version of k that is minimal, easy to build and not actively modified. However, it lacks a release or versioning history. Thanks to APL orchard for suggesting ngn/k for gentoo.

Suggested-by: pmoriarty, et al. /c.f./ https://news.ycombinator.com/item?id=21652218
Signed-off-by: Sylvian Hemus <shemus@sylvianhemus.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
