### PR TITLE
app-emulation/qemu-guest-agent: add missing call to python-any-r1_pkg_setup

### DIFF
--- a/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
+++ b/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
@@ -44,6 +44,7 @@ pkg_setup() {
 	# default. Make sure it's enabled in kernel.
 	CONFIG_CHECK="~VIRTIO_CONSOLE"
 	linux-info_pkg_setup
+	python-any-r1_pkg_setup
 }
 
 src_configure() {

--- a/app-emulation/qemu-guest-agent/qemu-guest-agent-9.2.0.ebuild
+++ b/app-emulation/qemu-guest-agent/qemu-guest-agent-9.2.0.ebuild
@@ -44,6 +44,7 @@ pkg_setup() {
 	# default. Make sure it's enabled in kernel.
 	CONFIG_CHECK="~VIRTIO_CONSOLE"
 	linux-info_pkg_setup
+	python-any-r1_pkg_setup
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/962008

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
