### PR TITLE
www-servers/nginx: use default start/stop initd functions

### DIFF
--- a/www-servers/nginx/files/nginx-r6.initd
+++ b/www-servers/nginx/files/nginx-r6.initd
@@ -35,30 +35,6 @@ stop_pre() {
 	fi
 }
 
-start() {
-	ebegin "Starting NGINX"
-	set -f
-	local output
-	output="$(start-stop-daemon --start --exec "${command}" -p "${pidfile}" \
-		${start_stop_daemon_args} -- -c "${NGINX_CONFIGFILE}" -g "pid ${pidfile};" 2>&1)"
-	if ! eend $?; then
-		eerror "Failed to start NGINX, please have a look at its output below:"
-		# Delete the last line in a POSIX-compliant way because it contains
-		# "start-stop-daemon failed..."
-		printf '%s\n' "${output}" | sed '$d'
-		eerror "Starting NGINX failed, please correct the errors above"
-		return 1
-	else
-		if [ -n "${output}" ]; then
-			ewarn "NGINX has started successfuly, yet there are warnings:"
-			printf '%s\n' "${output}"
-			ewarn "Please take a notice of the warnings above"
-		fi
-		return 0
-	fi
-}
-
-
 reload() {
 	ebegin "Refreshing NGINX's configuration"
 	start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"
@@ -106,10 +82,8 @@ upgrade() {
 
 configtest() {
 	ebegin "Checking NGINX's configuration"
-	local output
-	output="$("${command}" -c "${NGINX_CONFIGFILE}" -t 2>&1)"
+	"${command}" -c "${NGINX_CONFIGFILE}" -t
 	if ! eend $?; then
-		printf '%s\n' "${output}"
 		eerror "Configuration check failed, please correct the errors above"
 		return 1
 	fi

--- a/www-servers/nginx/nginx-1.28.0-r1.ebuild
+++ b/www-servers/nginx/nginx-1.28.0-r1.ebuild
@@ -19,10 +19,10 @@ NGINX_MODULES=(
 	+stream_{upstream_hash,upstream_least_conn,upstream_random,upstream_zone}
 	stream_{ssl,realip,geoip,ssl_preread}
 )
-NGINX_UPDATE_STREAM=mainline
+NGINX_UPDATE_STREAM=stable
 NGINX_TESTS_COMMIT=06a36245e134eac985cdfc5fac982cb149f61412
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r5.initd,r1.confd}
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
 	nginx.tmpfiles
 )
 

--- a/www-servers/nginx/nginx-1.29.0-r3.ebuild
+++ b/www-servers/nginx/nginx-1.29.0-r3.ebuild
@@ -19,10 +19,10 @@ NGINX_MODULES=(
 	+stream_{upstream_hash,upstream_least_conn,upstream_random,upstream_zone}
 	stream_{ssl,realip,geoip,ssl_preread}
 )
-NGINX_UPDATE_STREAM=stable
-NGINX_TESTS_COMMIT=06a36245e134eac985cdfc5fac982cb149f61412
+NGINX_UPDATE_STREAM=mainline
+NGINX_TESTS_COMMIT=7f1e88e10dca8e4c135ab9e688df0c2484091125
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r5.initd,r1.confd}
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
 	nginx.tmpfiles
 )
 

--- a/www-servers/nginx/nginx-1.29.1-r1.ebuild
+++ b/www-servers/nginx/nginx-1.29.1-r1.ebuild
@@ -20,9 +20,9 @@ NGINX_MODULES=(
 	stream_{ssl,realip,geoip,ssl_preread}
 )
 NGINX_UPDATE_STREAM=mainline
-NGINX_TESTS_COMMIT=7f1e88e10dca8e4c135ab9e688df0c2484091125
+NGINX_TESTS_COMMIT=06a36245e134eac985cdfc5fac982cb149f61412
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r5.initd,r1.confd}
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
 	nginx.tmpfiles
 )
 

--- a/www-servers/nginx/nginx-9999.ebuild
+++ b/www-servers/nginx/nginx-9999.ebuild
@@ -22,7 +22,7 @@ NGINX_MODULES=(
 NGINX_UPDATE_STREAM=live
 NGINX_TESTS_COMMIT=live
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r5.initd,r1.confd}
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
 	nginx.tmpfiles
 )
 


### PR DESCRIPTION
capturing the output of a command means the shell is stalled until the file descriptor is closed, which means using an option such as 'error_log stderr ...;' hangs the default start, as nginx will keep the stderr file descriptor alive

there's little reason to redefine start for usual daemons, and caputring the output just so we can hide on success or wrap it in a customized error message does not seem worth the trouble

also remove the capture of output in checkpath, in there it does nothing except "hide" output on success


Bug: https://bugs.gentoo.org/show_bug.cgi?id=961964

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
