### PR TITLE
www-apps/cgit: Fix app-text/highlight compatibility

### DIFF
--- a/www-apps/cgit/cgit-1.2.3_p20240802-r2.ebuild
+++ b/www-apps/cgit/cgit-1.2.3_p20240802-r2.ebuild
@@ -58,6 +58,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${PN}-highlight.patch )
+
 pkg_setup() {
 	python_setup
 	webapp_pkg_setup

--- a/www-apps/cgit/cgit-9999-r1.ebuild
+++ b/www-apps/cgit/cgit-9999-r1.ebuild
@@ -61,6 +61,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${PN}-highlight.patch )
+
 pkg_setup() {
 	python_setup
 	webapp_pkg_setup

--- a/www-apps/cgit/cgit-9999.ebuild
+++ b/www-apps/cgit/cgit-9999.ebuild
@@ -58,6 +58,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${PN}-highlight.patch )
+
 pkg_setup() {
 	python_setup
 	webapp_pkg_setup

--- a/www-apps/cgit/files/cgit-highlight.patch
+++ b/www-apps/cgit/files/cgit-highlight.patch
@@ -1,0 +1,16 @@
+cgit's highlighter script supports newer highlight versions, but the config has
+to be patched to enable that instead of the legacy version, which does not ship
+with Gentoo any more. See: https://bugs.gentoo.org/962035
+
+--- a/filters/syntax-highlighting.sh
++++ b/filters/syntax-highlighting.sh
+@@ -115,7 +115,7 @@
+ # found (for example) on EPEL 6.
+ #
+ # This is for version 2
+-exec highlight --force -f -I -X -S "$EXTENSION" 2>/dev/null
++#exec highlight --force -f -I -X -S "$EXTENSION" 2>/dev/null
+ 
+ # This is for version 3
+-#exec highlight --force -f -I -O xhtml -S "$EXTENSION" 2>/dev/null
++exec highlight --force -f -I -O xhtml -S "$EXTENSION" 2>/dev/null


### PR DESCRIPTION
cgit's highlighter script supports newer highlight versions, but the
code had to be patched to enable that instead of the legacy version,
that does not ship with Gentoo any more.

Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
Closes: https://bugs.gentoo.org/962035

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
