### PR TITLE
dev-qt/qtwebengine: fix clang-21

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-6.9.2-clang-21.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-6.9.2-clang-21.patch
@@ -1,0 +1,42 @@
+https://issues.chromium.org/issues/423841920
+https://chromium-review.googlesource.com/c/chromium/src/+/6633292
+
+From b0ff8c3b258a8816c05bdebf472dbba719d3c491 Mon Sep 17 00:00:00 2001
+From: Hans Wennborg <hans@chromium.org>
+Date: Tue, 10 Jun 2025 09:51:47 -0700
+Subject: [PATCH] Don't return an enum from EnumSizeTraits::Count
+
+`Enum::kMaxValue + 1` may be outside the representable range of the
+enum, which Clang will treat as an error in constexpr contexts (see
+bug).
+
+Bug: 423841920
+Change-Id: I629402cf93bd8419a71f94ff9ed9340d4f88a706
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6633292
+Auto-Submit: Hans Wennborg <hans@chromium.org>
+Commit-Queue: Nico Weber <thakis@chromium.org>
+Reviewed-by: Nico Weber <thakis@chromium.org>
+Commit-Queue: Hans Wennborg <hans@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1471871}
+--- a/src/3rdparty/chromium/base/metrics/histogram_macros_internal.h
++++ b/src/3rdparty/chromium/base/metrics/histogram_macros_internal.h
+@@ -28,16 +28,16 @@
+ template <typename Enum>
+   requires(std::is_enum_v<Enum>)
+ struct EnumSizeTraits {
+-  static constexpr Enum Count() {
++  static constexpr uintmax_t Count() {
+     if constexpr (requires { Enum::kMaxValue; }) {
+       // Since the UMA histogram macros expect a value one larger than the max
+       // defined enumerator value, add one.
+-      return static_cast<Enum>(base::to_underlying(Enum::kMaxValue) + 1);
++      return static_cast<uintmax_t>(base::to_underlying(Enum::kMaxValue) + 1);
+     } else {
+       static_assert(
+           sizeof(Enum) == 0,
+           "enumerator must define kMaxValue enumerator to use this macro!");
+-      return Enum();
++      return 0;
+     }
+   }
+ };

--- a/dev-qt/qtwebengine/qtwebengine-6.9.2.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.9.2.ebuild
@@ -108,6 +108,7 @@ PATCHES=( "${WORKDIR}"/patches/${PN} )
 
 PATCHES+=(
 	# add extras as needed here, may merge in set if carries across versions
+	"${FILESDIR}"/qtwebengine-6.9.2-clang-21.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Hit this on my llvm profile machine.

This patch is probably going to needed for the rest of 6.9 branch as this patch is present in chromium >139. 6.10 is probably going to also miss this as it appears to be staying on 134 (with security patches from 139).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
