### PR TITLE
dev-libs/newt: enable py3.14

### DIFF
--- a/dev-libs/newt/newt-0.52.25-r2.ebuild
+++ b/dev-libs/newt/newt-0.52.25-r2.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} )
+
+inherit autotools python-r1 toolchain-funcs
+
+MY_PV="r$(ver_rs 1- -)"
+
+DESCRIPTION="Redhat's Newt windowing toolkit development files"
+HOMEPAGE="https://pagure.io/newt"
+SRC_URI="https://github.com/mlichvar/newt/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+S=${WORKDIR}/${PN}-${MY_PV}
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="gpm python nls tcl"
+RESTRICT="test"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="
+	>=dev-libs/popt-1.6
+	=sys-libs/slang-2*
+	gpm? ( sys-libs/gpm )
+	python? ( ${PYTHON_DEPS} )
+	tcl? ( >=dev-lang/tcl-8.5:0 )
+	"
+DEPEND="${RDEPEND}"
+BDEPEND="sys-devel/gettext"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.52.23-gold.patch
+	"${FILESDIR}"/${PN}-0.52.24-c99-fix.patch
+)
+
+src_prepare() {
+	sed -i Makefile.in \
+		-e 's|-g -o|$(CFLAGS) $(LDFLAGS) -o|g' \
+		-e 's|-shared -o|$(CFLAGS) $(LDFLAGS) &|g' \
+		-e 's|instroot|DESTDIR|g' \
+		-e 's|	make |	$(MAKE) |g' \
+		-e "s|	ar |	$(tc-getAR) |g" \
+		|| die "sed Makefile.in"
+
+	if [[ -n ${LINGUAS} ]]; then
+		local lang langs
+		for lang in ${LINGUAS}; do
+			test -r po/${lang}.po && langs="${langs} ${lang}.po"
+		done
+		sed -i po/Makefile \
+			-e "/^CATALOGS = /cCATALOGS = ${langs}" \
+			|| die "sed po/Makefile"
+	fi
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local versions=
+	getversions() {
+		versions+="${EPYTHON} "
+	}
+	use python && python_foreach_impl getversions
+
+	econf \
+		"$(use_with python '' "${versions}")" \
+		$(use_with gpm gpm-support) \
+		$(use_with tcl) \
+		$(use_enable nls)
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		install
+	use python && python_foreach_impl python_optimize
+
+	dodoc peanuts.py popcorn.py tutorial.sgml
+	doman whiptail.1
+	einstalldocs
+
+	# don't want static archives
+	rm "${ED}"/usr/$(get_libdir)/libnewt.a || die
+}


### PR DESCRIPTION
Needed to be able to enable py3.14 to dev-build/kas (https://github.com/gentoo/gentoo/pull/41131)
Also fixed: `variable S should occur before RESTRICT`

Initially I tried to avoid the new revision, but since python was a RDEPEND pkgcheck complained about it requiring a new revision.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
