### PR TITLE
dev-libs/rasqal: fix libuuid test failing due to incompatible ptr types

### DIFF
--- a/dev-libs/rasqal/files/rasqal-0.9.33-configure-libuuid-test-fix.patch
+++ b/dev-libs/rasqal/files/rasqal-0.9.33-configure-libuuid-test-fix.patch
@@ -1,0 +1,40 @@
+From 5d3a965e40c3dc8824f0b197ab904b1072ffb0a3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@gentoo.org>
+Date: Fri, 29 Aug 2025 09:24:11 +0200
+Subject: [PATCH] configure: fix libuuid test
+
+&data, where data is a uuid_t, results in a unsigned char*, but uuid_t
+needs to be passed as unsigned char (*)[16], which is a distinct type.
+This causes configure to spuriously fail to detect libuuid.
+
+conftest.c: In function 'main':
+conftest.c:74:26: error: passing argument 1 of 'uuid_clear' from incompatible pointer type [-Wincompatible-pointer-types]
+   74 |  uuid_t data; uuid_clear(&data);
+      |                          ^~~~~
+      |                          |
+      |                          unsigned char (*)[16]
+In file included from conftest.c:70:
+/usr/include/uuid/uuid.h:85:31: note: expected 'unsigned char *' but argument is of type 'unsigned char (*)[16]'
+   85 | extern void uuid_clear(uuid_t uu);
+      |                        ~~~~~~~^~
+configure:17809: $? = 1
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 120d5d22..ead1882a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -941,7 +941,7 @@ PKG_CHECK_MODULES(UUID, uuid, [
+   #if defined(UUID_LEN_BIN) && defined(UUID_VERSION)
+   FAIL
+   #endif
+-  uuid_t data; uuid_clear(&data); ]])],[have_uuid_libuuid=yes],[have_uuid_libuuid=no])
++  uuid_t data; uuid_clear(data); ]])],[have_uuid_libuuid=yes],[have_uuid_libuuid=no])
+ 
+   CPPFLAGS="$oCPPFLAGS"
+   LIBS="$oLIBS"
+-- 
+2.51.0
+

--- a/dev-libs/rasqal/rasqal-0.9.33-r4.ebuild
+++ b/dev-libs/rasqal/rasqal-0.9.33-r4.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library that handles Resource Description Framework (RDF)"
+HOMEPAGE="https://librdf.org/rasqal/"
+SRC_URI="https://download.librdf.org/source/${P}.tar.gz"
+
+LICENSE="Apache-2.0 GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="+crypt gmp +mhash pcre static-libs test xml"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=media-libs/raptor-2.0.15
+	crypt? (
+		!mhash? ( dev-libs/libgcrypt:0 )
+		mhash? ( app-crypt/mhash )
+	)
+	!gmp? ( dev-libs/mpfr:= )
+	gmp? ( dev-libs/gmp:= )
+	kernel_linux? ( >=sys-apps/util-linux-2.19 )
+	pcre? ( dev-libs/libpcre )
+	xml? ( dev-libs/libxml2:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	>=sys-devel/bison-3
+	app-alternatives/lex
+	virtual/pkgconfig
+	test? ( dev-perl/XML-DOM )
+"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+HTML_DOCS=( {NEWS,README,RELEASE}.html )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.33-configure-clang16.patch
+	"${FILESDIR}"/${PN}-0.9.33-configure-c99.patch
+	"${FILESDIR}"/${PN}-0.9.33-configure-libuuid-test-fix.patch
+)
+
+src_prepare() {
+	default
+
+	#elibtoolize # g/fbsd .so versioning
+	eautoreconf # for clang 16 patch
+}
+
+src_configure() {
+	# FIXME: From 0.9.27 to .28 --with-random-approach= was introduced, do we
+	# need a logic for it? Perhaps for dev-libs/gmp?
+	local myeconfargs=(
+		--with-decimal=$(usex gmp gmp mpfr)
+		--with-uuid-library=$(usex kernel_linux libuuid internal)
+		$(use_enable pcre)
+		--with-regex-library=$(usex pcre pcre posix)
+		$(use_enable static-libs static)
+		$(use_enable xml xml2)
+	)
+
+	if use crypt; then
+		myeconfargs+=( --with-digest-library=$(usex mhash mhash gcrypt) )
+	else
+		myeconfargs+=( --with-digest-library=internal )
+	fi
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This lead to rasqal picking OSSP UUID, leading to:

```
VDB: detected possibly incorrect RDEPEND (dev-libs/rasqal-0.9.33-r3)
dev-libs/libxml2:=  <
                    > dev-libs/ossp-uuid
media-libs/raptor   | media-libs/raptor:2
sys-apps/util-linux <
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
