### PR TITLE
media-video/obs-studio: Fix build with >=media-video/ffmpeg-8.x

### DIFF
--- a/media-video/obs-studio/files/obs-studio-31.1.2-fix-build-with-ffmpeg8.patch
+++ b/media-video/obs-studio/files/obs-studio-31.1.2-fix-build-with-ffmpeg8.patch
@@ -1,0 +1,115 @@
+https://github.com/obsproject/obs-studio/commit/69162b12ecadb3edaca0529b34da93b4df606c11
+From: Brahmajit Das <listout@listout.xyz>
+Date: Sat, 23 Aug 2025 20:32:00 +0530
+Subject: [PATCH] obs-ffmpeg: Fix build with FFMPEG 8 and above
+
+With commit https://github.com/FFmpeg/FFmpeg/commit/822432769868 FFMPEG
+has removed almost all of the FF_API_FF_PROFILE_LEVEL related defines.
+They were deprecated since 2023-09-06. This results in build failures.
+
+This is first found on Gentoo with FFMPEG pre-release version.
+
+Downstream-bug: https://bugs.gentoo.org/961699
+Signed-off-by: Brahmajit Das <listout@listout.xyz>
+--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
++++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+@@ -276,9 +276,9 @@ static bool vaapi_update(void *data, obs_data_t *settings)
+ 
+ #ifdef ENABLE_HEVC
+ 	if (enc->codec == CODEC_HEVC) {
+-		if ((profile == FF_PROFILE_HEVC_MAIN) && (info.format == VIDEO_FORMAT_P010)) {
++		if ((profile == AV_PROFILE_HEVC_MAIN) && (info.format == VIDEO_FORMAT_P010)) {
+ 			warn("Forcing Main10 for P010");
+-			profile = FF_PROFILE_HEVC_MAIN_10;
++			profile = AV_PROFILE_HEVC_MAIN_10;
+ 		}
+ 	}
+ #endif
+@@ -853,14 +853,14 @@ static void vaapi_defaults_internal(obs_data_t *settings, enum codec_type codec)
+ 	obs_data_set_default_string(settings, "vaapi_device", device);
+ #ifdef ENABLE_HEVC
+ 	if (codec == CODEC_HEVC)
+-		obs_data_set_default_int(settings, "profile", FF_PROFILE_HEVC_MAIN);
++		obs_data_set_default_int(settings, "profile", AV_PROFILE_HEVC_MAIN);
+ 	else
+ #endif
+ 		if (codec == CODEC_H264)
+-		obs_data_set_default_int(settings, "profile", FF_PROFILE_H264_HIGH);
++		obs_data_set_default_int(settings, "profile", AV_PROFILE_H264_HIGH);
+ 	else if (codec == CODEC_AV1)
+-		obs_data_set_default_int(settings, "profile", FF_PROFILE_AV1_MAIN);
+-	obs_data_set_default_int(settings, "level", FF_LEVEL_UNKNOWN);
++		obs_data_set_default_int(settings, "profile", AV_PROFILE_AV1_MAIN);
++	obs_data_set_default_int(settings, "level", AV_LEVEL_UNKNOWN);
+ 	obs_data_set_default_int(settings, "bitrate", 2500);
+ 	obs_data_set_default_int(settings, "keyint_sec", 0);
+ 	obs_data_set_default_int(settings, "bf", 0);
+@@ -914,33 +914,33 @@ static bool vaapi_device_modified(obs_properties_t *ppts, obs_property_t *p, obs
+ 		goto fail;
+ 
+ 	switch (profile) {
+-	case FF_PROFILE_H264_CONSTRAINED_BASELINE:
++	case AV_PROFILE_H264_CONSTRAINED_BASELINE:
+ 		if (!vaapi_display_h264_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileH264ConstrainedBaseline;
+ 		break;
+-	case FF_PROFILE_H264_MAIN:
++	case AV_PROFILE_H264_MAIN:
+ 		if (!vaapi_display_h264_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileH264Main;
+ 		break;
+-	case FF_PROFILE_H264_HIGH:
++	case AV_PROFILE_H264_HIGH:
+ 		if (!vaapi_display_h264_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileH264High;
+ 		break;
+-	case FF_PROFILE_AV1_MAIN:
++	case AV_PROFILE_AV1_MAIN:
+ 		if (!vaapi_display_av1_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileAV1Profile0;
+ 		break;
+ #ifdef ENABLE_HEVC
+-	case FF_PROFILE_HEVC_MAIN:
++	case AV_PROFILE_HEVC_MAIN:
+ 		if (!vaapi_display_hevc_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileHEVCMain;
+ 		break;
+-	case FF_PROFILE_HEVC_MAIN_10:
++	case AV_PROFILE_HEVC_MAIN_10:
+ 		if (!vaapi_display_hevc_supported(va_dpy, device))
+ 			goto fail;
+ 		profile = VAProfileHEVCMain10;
+@@ -1098,21 +1098,21 @@ static obs_properties_t *vaapi_properties_internal(enum codec_type codec)
+ 	list = obs_properties_add_list(props, "profile", obs_module_text("Profile"), OBS_COMBO_TYPE_LIST,
+ 				       OBS_COMBO_FORMAT_INT);
+ 	if (codec == CODEC_HEVC) {
+-		obs_property_list_add_int(list, "Main", FF_PROFILE_HEVC_MAIN);
+-		obs_property_list_add_int(list, "Main10", FF_PROFILE_HEVC_MAIN_10);
++		obs_property_list_add_int(list, "Main", AV_PROFILE_HEVC_MAIN);
++		obs_property_list_add_int(list, "Main10", AV_PROFILE_HEVC_MAIN_10);
+ 	} else if (codec == CODEC_H264) {
+-		obs_property_list_add_int(list, "Constrained Baseline", FF_PROFILE_H264_CONSTRAINED_BASELINE);
+-		obs_property_list_add_int(list, "Main", FF_PROFILE_H264_MAIN);
+-		obs_property_list_add_int(list, "High", FF_PROFILE_H264_HIGH);
++		obs_property_list_add_int(list, "Constrained Baseline", AV_PROFILE_H264_CONSTRAINED_BASELINE);
++		obs_property_list_add_int(list, "Main", AV_PROFILE_H264_MAIN);
++		obs_property_list_add_int(list, "High", AV_PROFILE_H264_HIGH);
+ 	} else if (codec == CODEC_AV1) {
+-		obs_property_list_add_int(list, "Main", FF_PROFILE_AV1_MAIN);
++		obs_property_list_add_int(list, "Main", AV_PROFILE_AV1_MAIN);
+ 	}
+ 
+ 	obs_property_set_modified_callback(list, vaapi_device_modified);
+ 
+ 	list = obs_properties_add_list(props, "level", obs_module_text("Level"), OBS_COMBO_TYPE_LIST,
+ 				       OBS_COMBO_FORMAT_INT);
+-	obs_property_list_add_int(list, "Auto", FF_LEVEL_UNKNOWN);
++	obs_property_list_add_int(list, "Auto", AV_LEVEL_UNKNOWN);
+ 	if (codec == CODEC_H264) {
+ 		obs_property_list_add_int(list, "3.0", 30);
+ 		obs_property_list_add_int(list, "3.1", 31);

--- a/media-video/obs-studio/obs-studio-31.1.2.ebuild
+++ b/media-video/obs-studio/obs-studio-31.1.2.ebuild
@@ -159,6 +159,11 @@ QA_PREBUILT="
 	usr/lib*/obs-plugins/swiftshader/libGLESv2.so
 "
 
+PATCHES=(
+	# Not needed for >31.1.2, merged upstream
+	"${FILESDIR}/${PN}-31.1.2-fix-build-with-ffmpeg8.patch"
+)
+
 pkg_setup() {
 	use lua && lua-single_pkg_setup
 	use python && python-single-r1_pkg_setup
@@ -179,8 +184,6 @@ src_unpack() {
 }
 
 src_prepare() {
-	default
-
 	# -Werror=lto-type-mismatch
 	# https://bugs.gentoo.org/867250
 	# https://github.com/obsproject/obs-studio/issues/8988


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/961699

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
