### PR TITLE
llvm-runtimes/libgcc: Call `llvm_prepend_path` unconditionally

### DIFF
--- a/llvm-runtimes/libgcc/libgcc-19.1.7-r1.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-19.1.7-r1.ebuild
@@ -58,9 +58,7 @@ src_configure() {
 	# COMPILER_RT_BUILTINS_HIDE_SYMBOLS option - compatibility with libgcc requires
 	# visibility of all symbols.
 
-	if use clang || use test; then
-		llvm_prepend_path -b "${LLVM_MAJOR}"
-	fi
+	llvm_prepend_path -b "${LLVM_MAJOR}"
 
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"

--- a/llvm-runtimes/libgcc/libgcc-20.1.8.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-20.1.8.ebuild
@@ -58,9 +58,7 @@ src_configure() {
 	# COMPILER_RT_BUILTINS_HIDE_SYMBOLS option - compatibility with libgcc requires
 	# visibility of all symbols.
 
-	if use clang || use test; then
-		llvm_prepend_path -b "${LLVM_MAJOR}"
-	fi
+	llvm_prepend_path -b "${LLVM_MAJOR}"
 
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"

--- a/llvm-runtimes/libgcc/libgcc-21.1.0.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-21.1.0.ebuild
@@ -58,9 +58,7 @@ src_configure() {
 	# COMPILER_RT_BUILTINS_HIDE_SYMBOLS option - compatibility with libgcc requires
 	# visibility of all symbols.
 
-	if use clang || use test; then
-		llvm_prepend_path -b "${LLVM_MAJOR}"
-	fi
+	llvm_prepend_path -b "${LLVM_MAJOR}"
 
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"

--- a/llvm-runtimes/libgcc/libgcc-22.0.0.9999.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-22.0.0.9999.ebuild
@@ -57,9 +57,7 @@ src_configure() {
 	# COMPILER_RT_BUILTINS_HIDE_SYMBOLS option - compatibility with libgcc requires
 	# visibility of all symbols.
 
-	if use clang || use test; then
-		llvm_prepend_path -b "${LLVM_MAJOR}"
-	fi
+	llvm_prepend_path -b "${LLVM_MAJOR}"
 
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"

--- a/llvm-runtimes/libgcc/libgcc-22.0.0_pre20250820.ebuild
+++ b/llvm-runtimes/libgcc/libgcc-22.0.0_pre20250820.ebuild
@@ -57,9 +57,7 @@ src_configure() {
 	# COMPILER_RT_BUILTINS_HIDE_SYMBOLS option - compatibility with libgcc requires
 	# visibility of all symbols.
 
-	if use clang || use test; then
-		llvm_prepend_path -b "${LLVM_MAJOR}"
-	fi
+	llvm_prepend_path -b "${LLVM_MAJOR}"
 
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"


### PR DESCRIPTION
This ebuild is meant for clang-only systems and therefore it doesn't provide the `clang` USE flag.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
