### PR TITLE
dev-vcs/mercurial: fix language in postinst elog

### DIFF
--- a/dev-vcs/mercurial/mercurial-6.7.4-r2.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.7.4-r2.ebuild
@@ -372,8 +372,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-6.7.4-r3.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.7.4-r3.ebuild
@@ -375,8 +375,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-6.8.2.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.8.2.ebuild
@@ -389,8 +389,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-6.9.4.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.9.4.ebuild
@@ -404,8 +404,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-7.0.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-7.0.3.ebuild
@@ -424,8 +424,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-7.1.ebuild
+++ b/dev-vcs/mercurial/mercurial-7.1.ebuild
@@ -441,8 +441,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"

--- a/dev-vcs/mercurial/mercurial-9999.ebuild
+++ b/dev-vcs/mercurial/mercurial-9999.ebuild
@@ -194,8 +194,8 @@ python_test() {
 pkg_postinst() {
 	use emacs && elisp-site-regen
 
-	elog "If you want to convert repositories from other tools using convert"
-	elog "extension please install correct tool:"
+	elog "If you want to convert repositories from other tools using"
+	elog "the convert extension please install the correct tool:"
 	elog "  dev-vcs/cvs"
 	elog "  dev-vcs/darcs"
 	elog "  dev-vcs/git"


### PR DESCRIPTION
Adding two times "the".

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
