### PR TITLE
dev-python/dnspython: enable DNS-over-HTTPS and DNS-over-QUIC

### DIFF
--- a/dev-python/dnspython/dnspython-2.7.0-r1.ebuild
+++ b/dev-python/dnspython/dnspython-2.7.0-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=hatchling
+PYTHON_COMPAT=( python3_{11..14} pypy3_11 )
+
+inherit distutils-r1
+
+DESCRIPTION="DNS toolkit for Python"
+HOMEPAGE="
+	https://www.dnspython.org/
+	https://github.com/rthalley/dnspython/
+	https://pypi.org/project/dnspython/
+"
+SRC_URI="
+	https://github.com/rthalley/dnspython/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="ISC"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="dnssec examples https quic"
+
+RDEPEND="
+	dnssec? (
+		>=dev-python/cryptography-41[${PYTHON_USEDEP}]
+	)
+	>=dev-python/idna-2.1[${PYTHON_USEDEP}]
+	https? (
+		>=dev-python/httpx-0.26.0[${PYTHON_USEDEP}]
+		>=dev-python/h2-4.1.0[${PYTHON_USEDEP}]
+	)
+	quic? ( >=dev-python/aioquic-0.9.25[${PYTHON_USEDEP}] )
+"
+# note: skipping DoH test deps because they require Internet anyway
+BDEPEND="
+	test? (
+		>=dev-python/cryptography-41[${PYTHON_USEDEP}]
+		>=dev-python/quart-trio-0.11.0[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+
+python_test() {
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	local -x NO_INTERNET=1
+	epytest
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}

--- a/dev-python/dnspython/metadata.xml
+++ b/dev-python/dnspython/metadata.xml
@@ -26,6 +26,12 @@ DNSPythonはPython言語用のDNSツールキットです。ほとんどのレ�
 			Use <pkg>dev-python/cryptography</pkg> to enable low-level
 			DNSSEC RSA, DSA, ECDSA and EdDSA signature validation.
 		</flag>
+		<flag name="https">
+			Enable DNS-over-HTTPS
+		</flag>
+		<flag name="quic">
+			Enable DNS-over-QUIC
+		</flag>
 	</use>
 	<stabilize-allarches/>
 	<upstream>


### PR DESCRIPTION
dnspython supports DNS-over-HTTPS since 2.0.0 [1]. dnspython supports DNS-over-QUIC since 2.3.0 [2].

[1]: https://dnspython.readthedocs.io/en/latest/whatsnew.html#id12
[2]: https://dnspython.readthedocs.io/en/latest/whatsnew.html#id8

Bug: https://bugs.gentoo.org/962204

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
