### PR TITLE
profiles/arch: drop obsolete per-package USE=vulkan masks

### DIFF
--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -201,10 +201,6 @@ media-gfx/blender optix
 # ceph, zfs not keyworded here
 app-emulation/libvirt rbd zfs
 
-# Jimi Huotari <chiitoo@gentoo.org> (2022-05-08)
-# Not keyworded here yet.
-lxqt-base/lxqt-meta desktop-portal
-
 # Matt Turner <mattst88@gentoo.org> (2022-04-18)
 # app-text/nuspell is not keyworded
 app-text/enchant nuspell

--- a/profiles/arch/arm/use.mask
+++ b/profiles/arch/arm/use.mask
@@ -56,10 +56,6 @@ acpi
 # net-wireless/wimax not tested
 wimax
 
-# Raúl Porcel <armin76@gentoo.org>
-# I've been told xfs is broken on ARM
-xfs
-
 # No hardware to test by the team
 ios
 ipod

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -355,10 +355,6 @@ sys-boot/grub -libzfs
 # bug #738042
 sys-block/tgt rbd
 
-# Benda Xu <heroxbd@gentoo.org> (2020-08-08)
-# dev-lua/busted is not keyworded yet
-dev-lua/mpack test
-
 # Robin H. Johnson <robbat2@gentoo.org> (2020-07-02)
 # Mask io-uring & zbc pending keywording
 sys-block/fio -io-uring

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -238,10 +238,6 @@ app-metrics/collectd collectd_plugins_ping
 app-metrics/collectd collectd_plugins_routeros
 app-metrics/collectd collectd_plugins_varnish
 
-# Jimi Huotari <chiitoo@gentoo.org> (2022-05-08)
-# Not keyworded here yet.
-lxqt-base/lxqt-meta desktop-portal
-
 # Matt Turner <mattst88@gentoo.org> (2022-04-18)
 # app-text/nuspell is not keyworded
 app-text/enchant nuspell

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -29,10 +29,6 @@ dev-libs/mongo-c-driver test
 # Experimental, virt-firmware is keyworded only unstable
 sys-kernel/installkernel efistub
 
-# Ionen Wolkens <ionen@gentoo.org> (2024-01-27)
-# dev-python/pyside is not stable here yet
-dev-python/qtpy pyside6
-
 # Michał Górny <mgorny@gentoo.org> (2023-04-22)
 # Needs unkeyworded dev-python/sympy
 dev-python/nbval test

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -25,10 +25,6 @@ dev-build/meson test-full
 # mongodb needed for tests which is not stable keyworded for arm64
 dev-libs/mongo-c-driver test
 
-# Sam Jamrs <sam@gentoo.org> (2024-06-07)
-# dev-libs/capstone hasn't been stabilized yet
-app-emulation/qemu capstone
-
 # Nowa Ammerlaan <nowa@gentoo.org> (2024-03-21)
 # Experimental, virt-firmware is keyworded only unstable
 sys-kernel/installkernel efistub

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -76,15 +76,6 @@ app-emulation/libvirt glusterfs rbd
 # bug #785685
 app-text/dblatex inkscape
 
-# Sam James <sam@gentoo.org> (2021-02-05)
-# Thomas Deutschmann <whissi@gentoo.org> (2017-02-14)
-# No lua stable for this arch yet
-www-servers/nginx nginx_modules_http_lua
-
-# Sam James <sam@gentoo.org> (2020-12-23)
-# Needs stable dev-lang/luajit
-kde-apps/cantor lua
-
 # Sam James <sam@gentoo.org> (2020-10-18)
 # Needs dev-tex/hevea which isn't stable yet
 media-gfx/enblend doc

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -79,7 +79,6 @@ app-text/dblatex inkscape
 # Sam James <sam@gentoo.org> (2021-02-25)
 # Roy Bamford <neddyseagoon@gentoo.org> (2021-02-25)
 # Dependencies not yet stable, migrated from p.u.m.
-app-crypt/qca botan
 gnome-base/nautilus previewer
 
 # Sam James <sam@gentoo.org> (2021-02-05)

--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -76,11 +76,6 @@ app-emulation/libvirt glusterfs rbd
 # bug #785685
 app-text/dblatex inkscape
 
-# Sam James <sam@gentoo.org> (2021-02-25)
-# Roy Bamford <neddyseagoon@gentoo.org> (2021-02-25)
-# Dependencies not yet stable, migrated from p.u.m.
-gnome-base/nautilus previewer
-
 # Sam James <sam@gentoo.org> (2021-02-05)
 # Thomas Deutschmann <whissi@gentoo.org> (2017-02-14)
 # No lua stable for this arch yet

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -39,10 +39,6 @@ gps
 # media-sound/musepack-tools not stable yet
 musepack
 
-# Mart Raudsepp <leio@gentoo.org> (2018-11-27)
-# x11-libs/fltk not stable yet
-fltk
-
 # Mart Raudsepp <leio@gentoo.org> (2017-01-28)
 # sys-auth/skey not marked stable yet
 skey

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -27,12 +27,10 @@ python_single_target_pypy3_11
 # app-misc/lirc not stable yet
 # dev-db/tokyocabinet not stable yet
 # dev-libs/libtar not stable yet
-# net-libs/ldns not stable yet
 # sci-geosciences/gpsd not stable yet
 lirc
 tokyocabinet
 libtar
-ldns
 gps
 
 # Mart Raudsepp <leio@gentoo.org> (2019-02-07)

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -301,13 +301,11 @@ llvm-runtimes/compiler-rt-sanitizers libfuzzer memprof orc profile xray
 llvm-runtimes/compiler-rt-sanitizers ctx-profile nsan rtsan
 
 # Sam James <sam@gentoo.org> (2020-10-24)
-# asm redc is only available on amd64,
-# ppc64. bug #750974.
+# asm redc is only available on amd64, ppc64. bug #750974.
 sci-mathematics/gmp-ecm custom-tune
 
 # Sam James <sam@gentoo.org> (2020-10-05)
-# Guile only supports JIT on some arches
-# (See 9.3.8 in the Guile manual)
+# Guile only supports JIT on some arches (see 9.3.8 in the Guile manual).
 dev-scheme/guile jit
 
 # Thomas Deutschmann <whissi@gentoo.org> (2020-09-07)

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -252,7 +252,7 @@ media-video/ffmpeg-compat amf
 media-video/handbrake amf
 
 # Sam James <sam@gentoo.org> (2021-11-15)
-# Only available on PPC*.
+# Only available on ppc*.
 sys-apps/util-linux rtas
 
 # James Le Cuirot <chewi@gentoo.org> (2021-10-22)

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -127,10 +127,6 @@ media-libs/libv4l bpf
 media-video/ffmpeg shaderc
 media-video/ffmpeg-compat shaderc
 
-# Violet Purcell <vimproved@inventati.org> (2023-10-12)
-# dev-build/samurai is not keyworded here.
-app-alternatives/ninja samurai
-
 # Ionen Wolkens <ionen@gentoo.org> (2023-10-09)
 # Vulkan is not available here, ffmpeg also wants libplacebo[vulkan].
 media-libs/libplacebo shaderc

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -100,10 +100,6 @@ sci-libs/symengine tcmalloc
 # https://github.com/rustsec/rustsec/issues/707
 dev-util/cargo-audit fix
 
-# Jimi Huotari <chiitoo@gentoo.org> (2022-05-08)
-# Not keyworded here yet.
-lxqt-base/lxqt-meta desktop-portal
-
 # Michał Górny <mgorny@gentoo.org> (2021-12-31)
 # Don't apply stable masks to python-exec since we're forcing every
 # impl there anyway. Please keep this in sync with use.stable.mask.

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -224,10 +224,6 @@ dev-python/ipython notebook
 dev-python/nbclient test
 dev-python/nbconvert test
 
-# Violet Purcell <vimproved@inventati.org> (2023-10-12)
-# dev-build/samurai is not keyworded here.
-app-alternatives/ninja samurai
-
 # Patrick McLean <chutzpah@gentoo.org> (2023-10-03)
 # sys-apps/s6-linux-init has not been tested on this arch
 sys-apps/openrc s6

--- a/profiles/arch/sparc/use.mask
+++ b/profiles/arch/sparc/use.mask
@@ -133,7 +133,6 @@ dmi
 ibm
 libedit
 reiserfs
-xfs
 
 # Need testing
 musepack

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -29,10 +29,6 @@ media-gfx/openvdb python
 >=dev-ml/findlib-1.9.8-r1 ocamlopt
 dev-ml/labltk ocamlopt
 
-# Conrad Kostecki <conikost@gentoo.org> (2025-04-02)
-# media-libs/libsdl3 is not keyworded
-app-emulation/faudio sdl3
-
 # NRK <nrk@disroot.org> (2025-03-17)
 # media-libs/libyuv is not keyworded
 media-libs/libavif libyuv

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -213,10 +213,6 @@ app-vim/jedi test
 # Disable 64bit builds on x86
 sys-apps/memtest86+ bios64 uefi64 iso64
 
-# Jimi Huotari <chiitoo@gentoo.org> (2022-05-08)
-# Not keyworded here yet.
-lxqt-base/lxqt-meta desktop-portal
-
 # Adel Kara Slimane <adel.ks@zegrapher.com> (2022-03-14)
 # Untested useflag on other arches, needs keywording
 media-video/ffmpeg vmaf


### PR DESCRIPTION
For a while now, we mask USE=vulkan entirely on arches where it's not available. Drop some stale per-package mask-in-base-then-unmask patterns which had e.g. mpv[vulkan] unnecessarily masked on arm64.