### PR TITLE
sci-physics/thepeg: substitute java source and target

### DIFF
--- a/sci-physics/thepeg/files/thepeg-2.2.3-java.patch
+++ b/sci-physics/thepeg/files/thepeg-2.2.3-java.patch
@@ -1,0 +1,61 @@
+
+We are changing the javac -soure value from 1.4 to java-pkg_get-source
+and java-pkg_get-target which is supported by all Java versions presently
+available in ::gentoo.
+--- a/configure.ac
++++ b/configure.ac
+@@ -123,7 +123,7 @@ AC_ARG_WITH(javagui,
+             [  --with-javagui          Compile and install the java-based GUI.])
+ 
+ if test "x$with_javagui" != "xno"; then
+-  THEPEG_HAS_JAVA([1.4], [], [with_javagui=no; AC_MSG_NOTICE([Java GUI disabled])])
++  THEPEG_HAS_JAVA([JAVA_PKG_GET_SOURCE], [], [with_javagui=no; AC_MSG_NOTICE([Java GUI disabled])])
+ fi
+ 
+ AM_CONDITIONAL([JAVAGUI], [test "x$with_javagui" != "xno"])
+--- a/java/Makefile.am
++++ b/java/Makefile.am
+@@ -11,8 +12,7 @@ JAVASOURCES = SetupThePEG.java ObjectFrame.java \
+ 
+ CLEANFILES = ThePEG.jar thepeg.sh
+ 
+-jardir = $(pkglibdir)
+-nodist_jar_DATA = ThePEG.jar
++noinst_DATA = ThePEG.jar
+ 
+ dist_noinst_DATA = $(JAVASOURCES) jar-manifest
+ 
+@@ -27,14 +27,14 @@ clean-local:
+ ThePEG:
+ 	mkdir -p ThePEG
+ 	for file in $(JAVASOURCES) jar-manifest; do \
+-           cd ThePEG; $(LN_S) ../$(srcdir)/$$file $$file; cd ..; done
++           cd ThePEG; cp ../$(srcdir)/$$file $$file; cd ..; done
+ 
+ ThePEG.jar: ThePEG $(JAVASOURCES)
+-	$(JAVAC) `for file in $(JAVASOURCES); do echo ThePEG/$$file; done`
++	$(JAVAC) -source JAVA_PKG_GET_SOURCE -target JAVA_PKG_GET_TARGET `for file in $(JAVASOURCES); do echo ThePEG/$$file; done`
+ 	$(JAR) cmf ThePEG/jar-manifest ThePEG.jar ThePEG/*.class
+ 
+ thepeg.sh: thepeg.install Makefile
+-	sed -e s:@pkglibdir[@]:$(pkglibdir):g \
++	sed -e s:@datadir[@]:$(datadir):g \
+             -e s:@bindir[@]:$(bindir):g \
+             -e s:@java[@]:$(JAVA):g $(srcdir)/thepeg.install > thepeg.sh
+ 	chmod +x thepeg.sh
+--- a/java/thepeg.install
++++ b/java/thepeg.install
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-pkglibdir=@pkglibdir@
++source @datadir@/thepeg/package.env
+ bindir=@bindir@
+ 
+ ThePEG_CMD="${bindir}/setupThePEG"
+@@ -19,4 +19,4 @@
+ 
+ 
+ 
+-exec @java@ ${HEADLESS} -jar ${pkglibdir}/ThePEG.jar ${ThePEG_CMD} "$@"
++exec @java@ ${HEADLESS} -jar ${CLASSPATH} ${ThePEG_CMD} "$@"

--- a/sci-physics/thepeg/thepeg-2.2.3-r3.ebuild
+++ b/sci-physics/thepeg/thepeg-2.2.3-r3.ebuild
@@ -43,8 +43,8 @@ RDEPEND="${CDEPEND}
 "
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.8.3-java.patch # there are todo items in the patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
+	"${FILESDIR}"/${PN}-2.2.3-java.patch
 )
 
 src_prepare() {
@@ -56,11 +56,16 @@ src_prepare() {
 		-e '/dist_pkgdata_DATA = ThePEG.el/d' \
 		lib/Makefile.am || die
 	default
+	if use java; then
+		sed -i "s/JAVA_PKG_GET_SOURCE/$(java-pkg_get-source)/g" configure.ac java/Makefile.am || die
+		sed -i "s/JAVA_PKG_GET_TARGET/$(java-pkg_get-target)/g" configure.ac java/Makefile.am || die
+	fi
 	java-pkg-opt-2_src_prepare
 	eautoreconf
 }
 
 src_configure() {
+	local -x CONFIG_SHELL=/bin/bash
 	if use java; then
 		local -x JAVAC="$(java-pkg_get-javac)"
 		local -x JAVA="$(java-config -J)"
@@ -94,7 +99,7 @@ src_install() {
 	use emacs && elisp-install ${PN} lib/ThePEG.el{,c}
 	use java && java-pkg_newjar java/ThePEG.jar
 
-	cat <<-EOF > "${T}"/50${PN}
+	cat <<-EOF > "${T}"/50${PN} || die
 	LDPATH="${EPREFIX}/usr/$(get_libdir)/ThePEG"
 	EOF
 	doenvd "${T}"/50${PN}

--- a/sci-physics/thepeg/thepeg-2.3.0-r2.ebuild
+++ b/sci-physics/thepeg/thepeg-2.3.0-r2.ebuild
@@ -47,10 +47,10 @@ RDEPEND="${CDEPEND}
 "
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-1.8.3-java.patch # there are todo items in the patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
 	"${FILESDIR}"/${PN}-2.3.0-rivet.patch # properly support rivet/yoda weights in thepeg, reported to upstream by mail.
 	"${FILESDIR}"/${PN}-2.3.0-functional.patch # https://bugs.gentoo.org/941477
+	"${FILESDIR}"/${PN}-2.2.3-java.patch
 )
 
 src_prepare() {
@@ -62,6 +62,10 @@ src_prepare() {
 		-e '/dist_pkgdata_DATA = ThePEG.el/d' \
 		lib/Makefile.am || die
 	default
+	if use java; then
+		sed -i "s/JAVA_PKG_GET_SOURCE/$(java-pkg_get-source)/g" configure.ac java/Makefile.am || die
+		sed -i "s/JAVA_PKG_GET_TARGET/$(java-pkg_get-target)/g" configure.ac java/Makefile.am || die
+	fi
 	java-pkg-opt-2_src_prepare
 	eautoreconf
 }


### PR DESCRIPTION
Follow up to https://github.com/gentoo/gentoo/pull/41851#discussion_r2068139766

Alternatively we could just remove the java support on this package, since it is not used anywhere and gets no upstream updates. I'll probably do that in the following version >2.3.0 (in however many years).

Unfortunately and unknowingly, I removed ~x86 keywords when I added 2.3.0, since I only tested it on my own ~amd64 machine without other reasons for removing it. But that makes removing 2.2.X fully more difficult, since I need to check ~x86 support before enabling it again... (same as sci-physics/yoda).

EDIT: 2.3.0 added depending on sci-physics/rivet which was never ~x86 keyworded so that was the reason for dropping it.