### PR TITLE
sci-physics/{yoda,rivet,fastjet-contrib}: keyword for ~x86, ~amd64-linux, ~x86-linux

### DIFF
--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -54,10 +54,6 @@ dev-python/qtpy remoteobjects
 # Upstream dropbox no longer producing x86 releases
 kde-apps/kdenetwork-meta dropbox
 
-# Alexander Puck Neuwirth <apn-pucky@gentoo.org> (2024-10-20)
-# sci-physics/rivet is unavailable on x86
-sci-physics/pythia rivet
-
 # Arthur Zamarin <arthurzam@gentoo.org> (2024-10-17)
 # depends on java packages, not keyworded on x86
 app-forensics/sleuthkit java

--- a/sci-physics/fastjet-contrib/fastjet-contrib-1.101-r2.ebuild
+++ b/sci-physics/fastjet-contrib/fastjet-contrib-1.101-r2.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 
 DEPEND=">=sci-physics/fastjet-3.4.1[plugins]"
 RDEPEND="${DEPEND}"

--- a/sci-physics/rivet/rivet-4.1.1.ebuild
+++ b/sci-physics/rivet/rivet-4.1.1.ebuild
@@ -22,7 +22,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://www.hepforge.org/archive/rivet/${MY_PF}.tar.gz -> ${P}.tar.gz"
 	S=${WORKDIR}/${MY_PF}
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 fi
 
 LICENSE="GPL-3+"

--- a/sci-physics/yoda/yoda-2.1.1.ebuild
+++ b/sci-physics/yoda/yoda-2.1.1.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://yoda.hepforge.org/downloads?f=${P^^}.tar.bz2 -> ${P^^}.tar.bz2"
 	S="${WORKDIR}/${P^^}"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 fi
 
 LICENSE="GPL-3"

--- a/sci-physics/yoda/yoda-9999.ebuild
+++ b/sci-physics/yoda/yoda-9999.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://yoda.hepforge.org/downloads?f=${P^^}.tar.bz2 -> ${P^^}.tar.bz2"
 	S="${WORKDIR}/${P^^}"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 fi
 
 LICENSE="GPL-3"


### PR DESCRIPTION
`~x86` has been removed from previous version in yoda without a reason (except for not explicitly testing each bump). We add it now again. I am not sure why https://bugs.gentoo.org/941638 seems to be stuck, tho.

- [x] test chroot ~x86
  - [ ] problem: https://gitlab.com/hepcedar/rivet/-/issues/573
- [ ] test prefix ~amd64-linux
- [ ] test prefix ~x86-linux
