### PR TITLE
multilib.eclass: derive BUILD_* before appending ABI flags

### DIFF
--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -487,6 +487,17 @@ multilib_toolchain_setup() {
 	local save_restore_variables=(
 		CBUILD
 		CHOST
+		BUILD_AR
+		BUILD_CC
+		BUILD_CXX
+		BUILD_LD
+		BUILD_NM
+		BUILD_OBJCOPY
+		BUILD_PKG_CONFIG
+		BUILD_RANLIB
+		BUILD_READELF
+		BUILD_STRINGS
+		BUILD_STRIP
 		AR
 		CC
 		CXX
@@ -535,6 +546,20 @@ multilib_toolchain_setup() {
 		#
 		# Make sure ${save_restore_variables[@]} list matches below.
 		export CHOST=$(get_abi_CHOST ${DEFAULT_ABI})
+
+		# Derive the build-machine toolchain variables before we
+		# override the host-machine toolchain variables.
+		export BUILD_AR="$(tc-getBUILD_AR)" # Avoid 'ar', use "${CBUILD}-ar"
+		export BUILD_CC="$(tc-getBUILD_CC)" # Default ABI
+		export BUILD_CXX="$(tc-getBUILD_CXX)" # Default ABI
+		export BUILD_LD="$(tc-getBUILD_LD)" # Default ABI
+		export BUILD_NM="$(tc-getBUILD_NM)" # Avoid 'nm', use "${CBUILD}-nm"
+		export BUILD_OBJCOPY="$(tc-getBUILD_OBJCOPY)" # Avoid 'objcopy', use "${CBUILD}-objcopy"
+		export BUILD_PKG_CONFIG="$(tc-getBUILD_PKG_CONFIG)"
+		export BUILD_RANLIB="$(tc-getBUILD_RANLIB)" # Avoid 'ranlib', use "${CBUILD}-ranlib"
+		export BUILD_READELF="$(tc-getBUILD_READELF)" # Avoid 'readelf', use "${CBUILD}-readelf"
+		export BUILD_STRINGS="$(tc-getBUILD_STRINGS)" # Avoid 'strings', use "${CBUILD}-strings"
+		export BUILD_STRIP="$(tc-getBUILD_STRIP)" # Avoid 'strip', use "${CBUILD}-strip"
 
 		export AR="$(tc-getAR)" # Avoid 'ar', use '${CHOST}-ar'
 		export CC="$(tc-getCC) $(get_abi_CFLAGS)"


### PR DESCRIPTION
Per [this comment][1] by @floppym, we cannot have `${MULTILIB_USEDEP}` in `BDEPEND` because it would break cross-compiles, as `${MULTILIB_USEDEP}` specifies ABIs of `CHOST`, not of `CBUILD`.

However, this leads to a problem, as `multilib.eclass` does not preserve the default build-machine toolchain before it appends the ABI flags to the host-machine toolchain. Thus, when `$(tc-getBUILD_CC)` later pulls a default value for `BUILD_CC` from `CC`, the ABI flags have already been appended to `CC`, and `BUILD_CC` inherits those flags, thus causing any build-time helper executables to be built for a non-default ABI, whose build-time dependencies may not be installed in `${BROOT}` since `${MULTILIB_USEDEP}` makes no sense in `BDEPEND`.

Note, the behavior is inconsistent if the user has set `BUILD_CC` and friends via their `package.env`, as then the ABI flags are *not* applied to the build-machine toolchain via defaulting from the host-machine toolchain.

This commit fixes up `multilib.eclass` so that it derives the build-machine toolchain variables _before_ it appends the ABI flags to the host-machine toolchain variables. The result is that build-time helper executables are always built for the build machine's _default_ ABI, even in the non-cross-compiling case.

[1]: https://bugs.gentoo.org/960506#c9

Bug: https://bugs.gentoo.org/960506

Note that this PR supplants a [previous attempt](https://github.com/gentoo/gentoo/pull/43377) that had made an incorrect assumption about the intended behavior.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` inexplicably says `pkgcheck scan: error: failed running git: fatal: not a git repository (or any parent up to mount point /var/db)` even though I am running it in a Git worktree.

Please note that all boxes must be checked for the pull request to be merged.
