### PR TITLE
sys-auth/sssd: Allow compile against app-crypt/mit-krb5-1.22

### DIFF
--- a/sys-auth/sssd/files/sssd-2.9.7-kerberos-1-22.patch
+++ b/sys-auth/sssd/files/sssd-2.9.7-kerberos-1-22.patch
@@ -1,0 +1,14 @@
+diff --git a/src/external/pac_responder.m4 b/src/external/pac_responder.m4
+index 90727185b..3501b6b71 100644
+--- a/src/external/pac_responder.m4
++++ b/src/external/pac_responder.m4
+@@ -23,7 +23,8 @@ then
+         Kerberos\ 5\ release\ 1.18* | \
+         Kerberos\ 5\ release\ 1.19* | \
+         Kerberos\ 5\ release\ 1.20* | \
+-        Kerberos\ 5\ release\ 1.21*)
++        Kerberos\ 5\ release\ 1.21* | \
++        Kerberos\ 5\ release\ 1.22*)
+             krb5_version_ok=yes
+             AC_MSG_RESULT([yes])
+             ;;

--- a/sys-auth/sssd/sssd-2.11.1.ebuild
+++ b/sys-auth/sssd/sssd-2.11.1.ebuild
@@ -110,6 +110,7 @@ CONFIG_CHECK="~KEYS"
 PATCHES=(
 	"${FILESDIR}/${PN}-2.8.2-krb5_pw_locked.patch"
 	"${FILESDIR}/${PN}-2.9.6-conditional-python-install.patch"
+	"${FILESDIR}/${PN}-2.9.7-kerberos-1-22.patch"
 	"${FILESDIR}/${PN}-2.10.0_beta2-fix-systemd-systemconfdir.patch"
 )
 

--- a/sys-auth/sssd/sssd-2.9.7.ebuild
+++ b/sys-auth/sssd/sssd-2.9.7.ebuild
@@ -102,6 +102,7 @@ CONFIG_CHECK="~KEYS"
 PATCHES=(
 	"${FILESDIR}/${PN}-2.8.2-krb5_pw_locked.patch"
 	"${FILESDIR}/${PN}-2.9.6-conditional-python-install.patch"
+	"${FILESDIR}/${PN}-2.9.7-kerberos-1-22.patch"
 )
 
 MULTILIB_WRAPPED_HEADERS=(


### PR DESCRIPTION
sys-auth/sssd uses an unstable API from app-crypt/mit-krb5. Because it could change at any time, upstream restricts which versions of app-crypt/mit-krb5 it will work with. So every time there's a newversion of app-crypt/mit-krb5, upstream has to check if the ABI changed and add the appropriate test for the new version.

Upstream currently cannot automate this for reasons listed in https://github.com/SSSD/sssd/issues/8068.


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
