### PR TITLE
net-p2p/syncthing: fix system init script with single-dash long options.

### DIFF
--- a/net-p2p/syncthing/files/syncthing.initd-r4
+++ b/net-p2p/syncthing/files/syncthing.initd-r4
@@ -1,0 +1,28 @@
+#!/sbin/openrc-run
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+SYNCTHING_USER=${SYNCTHING_USER:-syncthing}
+SYNCTHING_GROUP=${SYNCTHING_GROUP:-syncthing}
+SYNCTHING_HOMEDIR=${SYNCTHING_HOMEDIR:-/var/lib/syncthing/.config/syncthing}
+SYNCTHING_LOGFILE=${SYNCTHING_LOGFILE:-/var/log/syncthing/syncthing.log}
+SYNCTHING_GUI_ADDRESS=${SYNCTHING_GUI_ADDRESS:-http://127.0.0.1:8384}
+
+description="Syncthing is an open, trustworthy and decentralized cloud storage system"
+command="/usr/bin/syncthing"
+command_args="--no-browser --home=${SYNCTHING_HOMEDIR} --gui-address=${SYNCTHING_GUI_ADDRESS} ${SYNCTHING_OPTS}"
+pidfile="/run/${RC_SVCNAME}.pid"
+command_background="yes"
+command_user="${SYNCTHING_USER}:${SYNCTHING_GROUP}"
+output_log="\"${SYNCTHING_LOGFILE}\""
+error_log="\"${SYNCTHING_LOGFILE}\""
+
+depend() {
+	need localmount
+	after net
+}
+
+start_pre() {
+	checkpath -q -d -o ${SYNCTHING_USER}:${SYNCTHING_GROUP} ${SYNCTHING_HOMEDIR}
+	checkpath -q -f -o ${SYNCTHING_USER}:${SYNCTHING_GROUP} ${SYNCTHING_LOGFILE}
+}

--- a/net-p2p/syncthing/syncthing-2.0.8-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-2.0.8-r1.ebuild
@@ -88,7 +88,7 @@ src_install() {
 	systemd_dounit etc/linux-systemd/system/${PN}@.service
 	systemd_douserunit etc/linux-systemd/user/${PN}.service
 	newconfd "${FILESDIR}"/${PN}.confd-r1 ${PN}
-	newinitd "${FILESDIR}"/${PN}.initd-r3 ${PN}
+	newinitd "${FILESDIR}"/${PN}.initd-r4 ${PN}
 	exeinto /etc/user/init.d
 	newexe "${FILESDIR}"/syncthing.initd-user syncthing
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/962604

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
