### PR TITLE
media-tv/kodi: handle curl-8.16 type breakage

### DIFF
--- a/media-tv/kodi/files/kodi-21.2-fix-curl-8.16.patch
+++ b/media-tv/kodi/files/kodi-21.2-fix-curl-8.16.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/962751
+https://gitlab.alpinelinux.org/alpine/aports/-/blob/106a02411488e3f71b9f2085a4a857e4be27b9ea/community/kodi/curl-8.16.0.patch
+
+--- a/xbmc/filesystem/CurlFile.cpp
++++ b/xbmc/filesystem/CurlFile.cpp
+@@ -44,7 +44,7 @@ using namespace std::chrono_literals;
+ 
+ #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
+ 
+-curl_proxytype proxyType2CUrlProxyType[] = {
++long proxyType2CUrlProxyType[] = {
+     CURLPROXY_HTTP,   CURLPROXY_SOCKS4,          CURLPROXY_SOCKS4A,
+     CURLPROXY_SOCKS5, CURLPROXY_SOCKS5_HOSTNAME, CURLPROXY_HTTPS,
+ };
+

--- a/media-tv/kodi/files/kodi-22.0_alpha1-fix-curl-8.16.patch
+++ b/media-tv/kodi/files/kodi-22.0_alpha1-fix-curl-8.16.patch
@@ -1,0 +1,32 @@
+https://bugs.gentoo.org/962751
+https://github.com/xbmc/xbmc/pull/27224
+
+Modified to apply to 22.0_alpha1 which doesn't include.
+https://github.com/xbmc/xbmc/commit/8a27124db43ec10415b21aa6c7a15b0b6aded656
+
+From 8b44b36f7bfe6e32770c7df5f956a1da9fcaaf61 Mon Sep 17 00:00:00 2001
+From: Achill Gilgenast <achill@achill.org>
+Date: Wed, 10 Sep 2025 19:16:17 +0200
+Subject: [PATCH] [filesystem] Switch to long for CURLPROXY_* enums
+
+curl 8.16.0 bumped the enums to long, see: https://github.com/curl/curl/pull/18054
+
+This fixes the build with curl 8.16+ for the following failure:
+
+	/builds/alpine/aports/community/kodi/src/xbmc-21.2-Omega/xbmc/filesystem/CurlFile.cpp:48:5: error: cannot initialize an array element of type 'curl_proxytype' with an rvalue of type 'long'
+	   48 |     CURLPROXY_HTTP,   CURLPROXY_SOCKS4,          CURLPROXY_SOCKS4A,
+	      |     ^~~~~~~~~~~~~~
+	/usr/include/curl/curl.h:791:35: note: expanded from macro 'CURLPROXY_HTTP'
+	  791 | #define CURLPROXY_HTTP            0L /* added in 7.10, new in 7.19.4 default is
+	      |                                   ^~
+	...
+--- a/xbmc/filesystem/CurlFile.cpp
++++ b/xbmc/filesystem/CurlFile.cpp
+@@ -46,7 +46,7 @@ using namespace std::chrono_literals;
+ #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
+
+-static const auto proxyType2CUrlProxyType = std::unordered_map<XFILE::CCurlFile::ProxyType, int>{
++static const auto proxyType2CUrlProxyType = std::unordered_map<XFILE::CCurlFile::ProxyType, long>{
+     {CCurlFile::ProxyType::HTTP, CURLPROXY_HTTP},
+     {CCurlFile::ProxyType::SOCKS4, CURLPROXY_SOCKS4},
+     {CCurlFile::ProxyType::SOCKS4A, CURLPROXY_SOCKS4A},

--- a/media-tv/kodi/kodi-21.2-r5.ebuild
+++ b/media-tv/kodi/kodi-21.2-r5.ebuild
@@ -273,6 +273,7 @@ PATCHES=(
 	"${FILESDIR}"/kodi-21-optional-ffmpeg-libx11.patch
 	"${FILESDIR}"/kodi-21.1-silence-libdvdread-git.patch
 	"${FILESDIR}"/kodi-21.2-pipewire-1.4.0-fix.patch
+	"${FILESDIR}"/kodi-21.2-fix-curl-8.16.patch
 )
 
 # bug #544020

--- a/media-tv/kodi/kodi-22.0_alpha1.ebuild
+++ b/media-tv/kodi/kodi-22.0_alpha1.ebuild
@@ -273,6 +273,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/kodi-21-optional-ffmpeg-libx11.patch
 	"${FILESDIR}"/kodi-22-silence-libdvdread-git.patch
+	"${FILESDIR}"/kodi-22.0_alpha1-fix-curl-8.16.patch
 )
 
 # bug #544020


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/962751

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
