### PR TITLE
dev-libs/libassuan: Set GPGRT_CONFIG for cross compilation

### DIFF
--- a/dev-libs/libassuan/libassuan-2.5.7.ebuild
+++ b/dev-libs/libassuan/libassuan-2.5.7.ebuild
@@ -44,6 +44,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
 	)
 	econf "${myeconfargs[@]}"

--- a/dev-libs/libassuan/libassuan-3.0.0-r1.ebuild
+++ b/dev-libs/libassuan/libassuan-3.0.0-r1.ebuild
@@ -38,6 +38,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
 	)
 	econf "${myeconfargs[@]}"

--- a/dev-libs/libassuan/libassuan-3.0.1-r1.ebuild
+++ b/dev-libs/libassuan/libassuan-3.0.1-r1.ebuild
@@ -38,6 +38,7 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
 	)
 	econf "${myeconfargs[@]}"


### PR DESCRIPTION
This aids some uncommon use cases such as cross compiling this within a
gentoo prefix.

Closes: https://bugs.gentoo.org/962780
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
