### PR TITLE
sys-fs/zfs-kmod: Fix build with LLVM 21

### DIFF
--- a/sys-fs/zfs-kmod/files/zfs-kmod-2.3.3-bdev-interface.patch
+++ b/sys-fs/zfs-kmod/files/zfs-kmod-2.3.3-bdev-interface.patch
@@ -1,0 +1,60 @@
+From 9acedbaceec362d08a33ebfe7c4c7efcee81d094 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Tue, 2 Sep 2025 09:34:08 -0700
+Subject: [PATCH] config: Fix LLVM-21 -Wuninitialized-const-pointer warning
+
+LLVM-21 enables -Wuninitialized-const-pointer which results in the
+following compiler warning and the bdev_file_open_by_path() interface
+not being detected for 6.9 and newer kernels.  The blk_holder_ops
+are not used by the ZFS code so we can safely use a NULL argument
+for this check.
+
+    bdev_file_open_by_path/bdev_file_open_by_path.c:110:54: error:
+    variable 'h' is uninitialized when passed as a const pointer
+    argument here [-Werror,-Wuninitialized-const-pointer]
+
+Reviewed-by: Rob Norris <robn@despairlabs.com>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #17682
+Closes #17684
+---
+ config/kernel-blkdev.m4 | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/config/kernel-blkdev.m4 b/config/kernel-blkdev.m4
+index 83190c6fbe3f..02011bf39fb2 100644
+--- a/config/kernel-blkdev.m4
++++ b/config/kernel-blkdev.m4
+@@ -29,9 +29,8 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_GET_BY_PATH_4ARG], [
+ 		const char *path = "path";
+ 		fmode_t mode = 0;
+ 		void *holder = NULL;
+-		struct blk_holder_ops h;
+ 
+-		bdev = blkdev_get_by_path(path, mode, holder, &h);
++		bdev = blkdev_get_by_path(path, mode, holder, NULL);
+ 	])
+ ])
+ 
+@@ -48,9 +47,8 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKDEV_BDEV_OPEN_BY_PATH], [
+ 		const char *path = "path";
+ 		fmode_t mode = 0;
+ 		void *holder = NULL;
+-		struct blk_holder_ops h;
+ 
+-		bdh = bdev_open_by_path(path, mode, holder, &h);
++		bdh = bdev_open_by_path(path, mode, holder, NULL);
+ 	])
+ ])
+ 
+@@ -68,9 +66,8 @@ AC_DEFUN([ZFS_AC_KERNEL_SRC_BDEV_FILE_OPEN_BY_PATH], [
+ 		const char *path = "path";
+ 		fmode_t mode = 0;
+ 		void *holder = NULL;
+-		struct blk_holder_ops h;
+ 
+-		file = bdev_file_open_by_path(path, mode, holder, &h);
++		file = bdev_file_open_by_path(path, mode, holder, NULL);
+ 	])
+ ])
+ 

--- a/sys-fs/zfs-kmod/zfs-kmod-2.3.3.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.3.3.ebuild
@@ -61,6 +61,7 @@ PDEPEND="dist-kernel? ( ~sys-fs/zfs-${PV}[dist-kernel] )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.11-gentoo.patch
+	"${FILESDIR}"/${PN}-2.3.3-bdev-interface.patch
 )
 
 pkg_pretend() {

--- a/sys-fs/zfs-kmod/zfs-kmod-2.3.4.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.3.4.ebuild
@@ -61,6 +61,7 @@ PDEPEND="dist-kernel? ( ~sys-fs/zfs-${PV}[dist-kernel] )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.11-gentoo.patch
+	"${FILESDIR}"/${PN}-2.3.3-bdev-interface.patch
 )
 
 pkg_pretend() {

--- a/sys-fs/zfs-kmod/zfs-kmod-2.4.0_rc1.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.4.0_rc1.ebuild
@@ -61,6 +61,7 @@ PDEPEND="dist-kernel? ( ~sys-fs/zfs-${PV}[dist-kernel] )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.11-gentoo.patch
+	"${FILESDIR}"/${PN}-2.3.3-bdev-interface.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Provide a patch which fixes the bdev interface detection by fixing the -Wuninitialized-const-pointer warning from LLVM 21.

Closes: https://bugs.gentoo.org/962778

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
