### PR TITLE
dev-libs/rasqal: fix build with USE=pcre when old libpcre is not installed

### DIFF
--- a/dev-libs/rasqal/rasqal-0.9.33-r5.ebuild
+++ b/dev-libs/rasqal/rasqal-0.9.33-r5.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	!gmp? ( dev-libs/mpfr:= )
 	gmp? ( dev-libs/gmp:= )
 	kernel_linux? ( >=sys-apps/util-linux-2.19 )
-	pcre? ( dev-libs/libpcre2 )
+	pcre? ( dev-libs/libpcre2:= )
 	xml? ( dev-libs/libxml2:= )
 "
 DEPEND="${RDEPEND}"
@@ -58,7 +58,6 @@ src_configure() {
 	local myeconfargs=(
 		--with-decimal=$(usex gmp gmp mpfr)
 		--with-uuid-library=$(usex kernel_linux libuuid internal)
-		$(use_enable pcre)
 		--with-regex-library=$(usex pcre pcre2 posix)
 		$(use_enable static-libs static)
 		$(use_enable xml xml2)


### PR DESCRIPTION
The previously committed upstream patch for libpcre2 support has some dodgy behaviour wrt. the --enable-pcre flag. Instead we can let configure autodetect whatever it finds and then select the library we want (libpcre2 or posix) depending on USE.
Also properly depend on libcre2 subslot.

Closes: https://bugs.gentoo.org/962785
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
