### PR TITLE
app-i18n/libime: fix build with -Werror=odr

### DIFF
--- a/app-i18n/libime/files/libime-1.1.11-fix-kenlm-odr.patch
+++ b/app-i18n/libime/files/libime-1.1.11-fix-kenlm-odr.patch
@@ -1,0 +1,22 @@
+https://github.com/fcitx/libime/commit/39ced92b4450f49b03e38bdd6a58d1f1b9430824
+
+fix odr: build kenlm with C++20
+
+--- a/src/libime/core/CMakeLists.txt
++++ b/src/libime/core/CMakeLists.txt
+@@ -14,9 +14,14 @@ target_include_directories(kenlm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE
+ target_compile_definitions(kenlm PUBLIC -DKENLM_MAX_ORDER=3 PRIVATE -DNDEBUG)
+ target_link_libraries(kenlm PUBLIC Boost::boost PkgConfig::ZSTD)
+ set_target_properties(kenlm PROPERTIES
+-  CXX_STANDARD 11
+   POSITION_INDEPENDENT_CODE ON)
+ 
++include(CheckCXXSymbolExists)
++check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
++if(LIBCPP)
++  target_compile_definitions(kenlm PUBLIC -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
++endif()
++
+ if(UNIX)
+   check_library_exists(rt clock_gettime "clock_gettime from librt" HAVE_CLOCKGETTIME_RT)
+   if (HAVE_CLOCKGETTIME_RT)

--- a/app-i18n/libime/libime-1.1.11-r1.ebuild
+++ b/app-i18n/libime/libime-1.1.11-r1.ebuild
@@ -30,6 +30,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${P}-fix-kenlm-odr.patch )
+
 src_configure() {
 	# 957570 : remove unused kenlm CMakeLists.txt
 	rm src/libime/core/kenlm/CMakeLists.txt || die


### PR DESCRIPTION
Fixes already accepted in upstream repo

Closes: https://bugs.gentoo.org/962546
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
