### PR TITLE
net-analyzer/gvmd: fix C23 build on 24.1.0

### DIFF
--- a/net-analyzer/gvmd/gvmd-24.1.0.ebuild
+++ b/net-analyzer/gvmd/gvmd-24.1.0.ebuild
@@ -49,6 +49,10 @@ BDEPEND="
 	)
 	test? ( dev-libs/cgreen )
 "
+PATCHES=(
+	# Closes #946583
+	"${FILESDIR}/gvmd-25.2.1-fix-c23-build.patch"
+)
 
 src_prepare() {
 	cmake_src_prepare
@@ -120,10 +124,12 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "If you are upgrading from a previous version, you need to update the database version."
-	elog "Please, create the running directory and give write permission to the database user"
-	elog "then run gvmd as the gvm user with --migrate option:"
-	elog "~# mkdir /run/gvmd"
-	elog "~# setfacl -m u:gvm:rwx /run/gvmd/"
-	elog "~# sudo -u gvm gvmd --migrate"
+	if [[ ${REPLACING_VERSIONS} ]]; then
+		elog "If you are upgrading from a previous version, you need to update the database version."
+		elog "Please, create the running directory and give write permission to the database user"
+		elog "then run gvmd as the gvm user with --migrate option:"
+		elog "~# mkdir /run/gvmd"
+		elog "~# setfacl -m u:gvm:rwx /run/gvmd/"
+		elog "~# sudo -u gvm gvmd --migrate"
+	fi
 }

--- a/net-analyzer/gvmd/gvmd-25.2.1.ebuild
+++ b/net-analyzer/gvmd/gvmd-25.2.1.ebuild
@@ -125,10 +125,12 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "If you are upgrading from a previous version, you need to update the database version."
-	elog "Please, create the running directory and give write permission to the database user"
-	elog "then run gvmd as the gvm user with --migrate option:"
-	elog "~# mkdir /run/gvmd"
-	elog "~# setfacl -m u:gvm:rwx /run/gvmd/"
-	elog "~# sudo -u gvm gvmd --migrate"
+	if [[ ${REPLACING_VERSIONS} ]]; then
+		elog "If you are upgrading from a previous version, you need to update the database version."
+		elog "Please, create the running directory and give write permission to the database user"
+		elog "then run gvmd as the gvm user with --migrate option:"
+		elog "~# mkdir /run/gvmd"
+		elog "~# setfacl -m u:gvm:rwx /run/gvmd/"
+		elog "~# sudo -u gvm gvmd --migrate"
+	fi
 }


### PR DESCRIPTION
and backported only show update instructions on update
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ab0c86057b45b33b1e2fbf2e27143a8574170797

Closes: https://bugs.gentoo.org/946583

---

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
