### PR TITLE
net-ftp/proftpd: fix c23, fine-tune useflags / deps

### DIFF
--- a/net-ftp/proftpd/files/proftpd-1.3.9-fix_c23.patch
+++ b/net-ftp/proftpd/files/proftpd-1.3.9-fix_c23.patch
@@ -1,0 +1,118 @@
+PR merged https://github.com/proftpd/proftpd/pull/1979.patch
+fix c23
+see https://bugs.gentoo.org/880481 for a part
+--- a/lib/pr_fnmatch.c
++++ b/lib/pr_fnmatch.c
+@@ -355,10 +355,7 @@ is_char_class (const wchar_t *wcs)
+ 
+ 
+ int
+-pr_fnmatch (pattern, string, flags)
+-     const char *pattern;
+-     const char *string;
+-     int flags;
++pr_fnmatch (const char *pattern, const char *string, int flags)
+ {
+ # if HANDLE_MULTIBYTE
+   if (__builtin_expect (MB_CUR_MAX, 1) != 1)
+--- a/lib/pr_fnmatch_loop.c
++++ b/lib/pr_fnmatch_loop.c
+@@ -62,13 +62,8 @@ __mempcpy (void *dest, const void *src, size_t n)
+ 
+ static int
+ internal_function
+-FCT (pattern, string, string_end, no_leading_period, flags, ends)
+-     const CHAR *pattern;
+-     const CHAR *string;
+-     const CHAR *string_end;
+-     int no_leading_period;
+-     int flags;
+-     struct STRUCT *ends;
++FCT (const CHAR *pattern, const CHAR *string, const CHAR *string_end,
++	int no_leading_period, int flags, struct STRUCT *ends)
+ {
+   register const CHAR *p = pattern, *n = string;
+   register UCHAR c;
+--- a/src/memcache.c
++++ b/src/memcache.c
+@@ -325,7 +325,7 @@ static int mcache_ping_servers(pr_memcache_t *mcache) {
+ 
+   alive_server_list = NULL;
+   for (i = 0; i < server_count; i++) {
+-    memcached_server_instance_st server;
++    const memcached_instance_st *server;
+ 
+     server = memcached_server_instance_by_position(clone, i);
+ 
+@@ -448,7 +448,7 @@ static int mcache_stat_servers(pr_memcache_t *mcache) {
+           case MEMCACHED_SOME_ERRORS:
+           case MEMCACHED_SERVER_MARKED_DEAD:
+           case MEMCACHED_CONNECTION_FAILURE: {
+-            memcached_server_instance_st server;
++            const memcached_instance_st *server;
+ 
+             server = memcached_server_get_last_disconnect(mcache->mc);
+             if (server != NULL) {
+@@ -988,7 +988,7 @@ int pr_memcache_kadd(pr_memcache_t *mcache, module *m, const char *key,
+ 
+     case MEMCACHED_SERVER_MARKED_DEAD:
+     case MEMCACHED_CONNECTION_FAILURE: {
+-      memcached_server_instance_st server;
++      const memcached_instance_st *server;
+ 
+       server = memcached_server_get_last_disconnect(mcache->mc);
+       if (server != NULL) {
+@@ -1058,7 +1058,7 @@ int pr_memcache_kdecr(pr_memcache_t *mcache, module *m, const char *key,
+ 
+     case MEMCACHED_SERVER_MARKED_DEAD:
+     case MEMCACHED_CONNECTION_FAILURE: {
+-      memcached_server_instance_st server;
++      const memcached_instance_st *server;
+ 
+       server = memcached_server_get_last_disconnect(mcache->mc);
+       if (server != NULL) {
+@@ -1131,7 +1131,7 @@ void *pr_memcache_kget(pr_memcache_t *mcache, module *m, const char *key,
+ 
+       case MEMCACHED_SERVER_MARKED_DEAD:
+       case MEMCACHED_CONNECTION_FAILURE: {
+-        memcached_server_instance_st server;
++        const memcached_instance_st *server;
+ 
+         server = memcached_server_get_last_disconnect(mcache->mc);
+         if (server != NULL) {
+@@ -1213,7 +1213,7 @@ char *pr_memcache_kget_str(pr_memcache_t *mcache, module *m, const char *key,
+ 
+       case MEMCACHED_SERVER_MARKED_DEAD:
+       case MEMCACHED_CONNECTION_FAILURE: {
+-        memcached_server_instance_st server;
++        const memcached_instance_st *server;
+ 
+         server = memcached_server_get_last_disconnect(mcache->mc);
+         if (server != NULL) {
+@@ -1303,7 +1303,7 @@ int pr_memcache_kincr(pr_memcache_t *mcache, module *m, const char *key,
+ 
+     case MEMCACHED_SERVER_MARKED_DEAD:
+     case MEMCACHED_CONNECTION_FAILURE: {
+-      memcached_server_instance_st server;
++      const memcached_instance_st *server;
+ 
+       server = memcached_server_get_last_disconnect(mcache->mc);
+       if (server != NULL) {
+@@ -1368,7 +1368,7 @@ int pr_memcache_kremove(pr_memcache_t *mcache, module *m, const char *key,
+ 
+     case MEMCACHED_SERVER_MARKED_DEAD:
+     case MEMCACHED_CONNECTION_FAILURE: {
+-      memcached_server_instance_st server;
++      const memcached_instance_st *server;
+ 
+       server = memcached_server_get_last_disconnect(mcache->mc);
+       if (server != NULL) {
+@@ -1437,7 +1437,7 @@ int pr_memcache_kset(pr_memcache_t *mcache, module *m, const char *key,
+ 
+     case MEMCACHED_SERVER_MARKED_DEAD:
+     case MEMCACHED_CONNECTION_FAILURE: {
+-      memcached_server_instance_st server;
++      const memcached_instance_st *server;
+ 
+       server = memcached_server_get_last_disconnect(mcache->mc);
+       if (server != NULL) {

--- a/net-ftp/proftpd/files/proftpd-1.3.9-sftp_ssl-3.0.patch
+++ b/net-ftp/proftpd/files/proftpd-1.3.9-sftp_ssl-3.0.patch
@@ -1,0 +1,25 @@
+PR pending https://github.com/proftpd/proftpd/pull/1980.patch
+AES_ctr_128 is not supported with >=openssl-3.0
+--- a/contrib/mod_sftp/crypto.c
++++ b/contrib/mod_sftp/crypto.c
+@@ -715,8 +715,9 @@ static int do_aes_ctr(EVP_CIPHER_CTX *ctx, unsigned char *dst,
+     return 0;
+   }
+ 
+-# if OPENSSL_VERSION_NUMBER <= 0x0090704fL || \
+-     OPENSSL_VERSION_NUMBER >= 0x10100000L
++# if (OPENSSL_VERSION_NUMBER <= 0x0090704fL || \
++     OPENSSL_VERSION_NUMBER >= 0x10100000L) && \
++     OPENSSL_VERSION_NUMBER < 0x30000000L
+   /* In OpenSSL-0.9.7d and earlier, the AES CTR code did not properly handle
+    * the IV as big-endian; this would cause the dreaded "Incorrect MAC
+    * received on packet" error when using clients e.g. PuTTy.  To see
+@@ -747,7 +748,7 @@ static int do_aes_ctr(EVP_CIPHER_CTX *ctx, unsigned char *dst,
+   }
+ 
+   return 1;
+-# else
++# elif OPENSSL_VERSION_NUMBER < 0x30000000L
+   /* Thin wrapper around AES_ctr128_encrypt(). */
+   AES_ctr128_encrypt(src, dst, len, &(ace->key), ace->counter, ace->enc_counter,
+     &(ace->num));

--- a/net-ftp/proftpd/proftpd-1.3.9-r3.ebuild
+++ b/net-ftp/proftpd/proftpd-1.3.9-r3.ebuild
@@ -1,0 +1,328 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd tmpfiles toolchain-funcs
+
+MOD_CASE="0.9.1"
+MOD_CLAMAV="0.14rc2"
+MOD_DISKUSE="0.9.1"
+MOD_GSS="1.3.9"
+MOD_MSG="0.5.1"
+MOD_VROOT="0.9.12"
+
+DESCRIPTION="An advanced and very configurable FTP server"
+HOMEPAGE="
+	http://www.proftpd.org/
+	http://www.castaglia.org/proftpd/
+	https://github.com/jbenden/mod_clamav
+	https://gssmod.sourceforge.net/
+"
+SRC_URI="
+	ftp://ftp.proftpd.org/distrib/source/${P/_/}.tar.gz
+	case? ( https://github.com/Castaglia/${PN}-mod_case/archive/v${MOD_CASE}.tar.gz
+			-> mod_case-${MOD_CASE}.tar.gz )
+	clamav? ( https://github.com/jbenden/mod_clamav/archive/v${MOD_CLAMAV}.tar.gz
+			-> ${PN}-mod_clamav-${MOD_CLAMAV}.tar.gz )
+	diskuse? ( https://github.com/Castaglia/${PN}-mod_diskuse/archive/v${MOD_DISKUSE}.tar.gz
+			-> mod_diskuse-${MOD_DISKUSE}.tar.gz )
+	kerberos? ( https://downloads.sourceforge.net/gssmod/mod_gss-${MOD_GSS}.tar.gz )
+	msg? ( https://github.com/Castaglia/${PN}-mod_msg/archive/v${MOD_MSG}.tar.gz
+			-> mod_msg-${MOD_MSG}.tar.gz )
+	vroot? ( https://github.com/Castaglia/${PN}-mod_vroot/archive/v${MOD_VROOT}.tar.gz
+			-> mod_vroot-${MOD_VROOT}.tar.gz )
+"
+S="${WORKDIR}/${P/_/}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="acl authfile ban +caps case clamav copy ctrls deflate diskuse dso dynmasq exec ifsession ifversion ident
+	kerberos ldap log-forensic memcache msg mysql ncurses nls pam +pcre postgres qos radius
+	ratio readme rewrite selinux sftp shaper sitemisc snmp sodium softquota sqlite ssl tcpd test unique-id vroot"
+# Some tests are ran in chroot. Confuses sandbox.
+RESTRICT="test"
+# TODO: geoip
+REQUIRED_USE="
+	ban? ( ctrls )
+	msg? ( ctrls )
+	shaper? ( ctrls )
+
+	mysql? ( ssl )
+	postgres? ( ssl )
+	radius? ( ssl )
+	sftp? ( ssl )
+	sqlite? ( ssl )
+"
+
+COMMON_DEPEND="
+	virtual/libcrypt:=
+	acl? ( virtual/acl )
+	caps? ( sys-libs/libcap )
+	deflate? ( sys-libs/zlib )
+	kerberos? (
+		sys-fs/e2fsprogs
+		virtual/krb5
+	)
+	ldap? ( net-nds/openldap:= )
+	memcache? (
+		|| (
+			dev-libs/libmemcached-awesome
+			>=dev-libs/libmemcached-0.41
+		)
+	)
+	mysql? (
+		dev-db/mysql-connector-c:0=
+		sodium? ( dev-libs/libsodium:0= )
+	)
+	nls? ( virtual/libiconv )
+	ncurses? ( sys-libs/ncurses:0= )
+	ssl? ( dev-libs/openssl:0= )
+	pam? ( sys-libs/pam )
+	pcre? ( dev-libs/libpcre )
+	postgres? (
+		dev-db/postgresql:=
+		sodium? ( dev-libs/libsodium:0= )
+	)
+	rewrite? (
+		|| (
+			net-dns/libidn2
+			net-dns/libidn
+		)
+	)
+	sftp? ( sys-libs/zlib )
+	sqlite? (
+		dev-db/sqlite:3
+		sodium? ( dev-libs/libsodium:0= )
+	)
+"
+DEPEND="
+	${COMMON_DEPEND}
+	test? ( dev-libs/check )
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	net-ftp/ftpbase
+	clamav? ( app-antivirus/clamav )
+	selinux? ( sec-policy/selinux-ftp )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.6-use-trace.patch
+	# https://bugs.gentoo.org/953968
+	"${FILESDIR}"/${PN}-1.3.9-slibtool.patch
+	"${FILESDIR}"/${PN}-1.3.9-sftp_ssl-3.0.patch
+	# PR 1979 merged
+	"${FILESDIR}"/${PN}-1.3.9-fix_c23.patch
+)
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	# AIX only
+	authenticate
+	loginfailed
+	loginsuccess
+
+	# Deprecated/removed functions, not actually checking for this anyway
+	SSLeay_add_all_algorithms
+	# Test isn't actually checking for BIO_f_zlib
+	BIO_f_zlib
+)
+
+in_dir() {
+	pushd "${WORKDIR}/${1}" || die
+	shift
+	"$@"
+	popd
+}
+
+src_prepare() {
+	# Skip 'install-conf' / Support LINGUAS
+	sed -i -e "/install-all/s/ install-conf//" Makefile.in || die
+	sed -i -e "s/^LANGS=.*$/LANGS=${LINGUAS}/" locale/Makefile.in || die
+
+	# Prepare external modules
+	if use case; then
+		cp -v "${WORKDIR}"/${PN}-mod_case-${MOD_CASE}/mod_case.c contrib || die
+		cp -v "${WORKDIR}"/${PN}-mod_case-${MOD_CASE}/mod_case.html doc/contrib || die
+	fi
+
+	if use clamav ; then
+		in_dir mod_clamav-${MOD_CLAMAV} eapply "${FILESDIR}"/"${PN}"-1.3.9-clamav-refresh-api.patch
+		in_dir mod_clamav-${MOD_CLAMAV} eapply "${FILESDIR}"/"${PN}"-1.3.9-clamav-debool.patch
+		cp -v "${WORKDIR}"/mod_clamav-${MOD_CLAMAV}/mod_clamav.{c,h} contrib || die
+		eapply -p0 "${WORKDIR}"/mod_clamav-${MOD_CLAMAV}/001-add-mod_clamav-to-tests.patch
+	fi
+
+	if use diskuse; then
+		in_dir ${PN}-mod_diskuse-${MOD_DISKUSE} eapply "${FILESDIR}"/${PN}-1.3.6_rc4-diskuse-refresh-api.patch
+
+		# ./configure will modify files. Symlink them instead of copying
+		ln -sv "${WORKDIR}"/${PN}-mod_diskuse-${MOD_DISKUSE}/mod_diskuse.h "${S}"/contrib || die
+
+		cp -v "${WORKDIR}"/${PN}-mod_diskuse-${MOD_DISKUSE}/mod_diskuse.c "${S}"/contrib || die
+		cp -v "${WORKDIR}"/${PN}-mod_diskuse-${MOD_DISKUSE}/mod_diskuse.html "${S}"/doc/contrib || die
+	fi
+
+	if use msg; then
+		cp -v "${WORKDIR}"/${PN}-mod_msg-${MOD_MSG}/mod_msg.c contrib || die
+		cp -v "${WORKDIR}"/${PN}-mod_msg-${MOD_MSG}/mod_msg.html doc/contrib || die
+	fi
+
+	if use vroot; then
+		cp -rv "${WORKDIR}"/${PN}-mod_vroot-${MOD_VROOT} contrib/mod_vroot || die
+	fi
+
+	if use kerberos ; then
+		# in_dir mod_gss-${MOD_GSS} eapply "${FILESDIR}"/${PN}-1.3.6_rc4-gss-refresh-api.patch
+		in_dir mod_gss-${MOD_GSS} eapply "${FILESDIR}"/${PN}-1.3.9-gss-refresh-api.patch
+
+		# Support app-crypt/heimdal / Gentoo Bug #284853
+		sed -i -e "s/krb5_principal2principalname/_\0/" "${WORKDIR}"/mod_gss-${MOD_GSS}/mod_auth_gss.c.in || die
+
+		# ./configure will modify files. Symlink them instead of copying
+		ln -sv "${WORKDIR}"/mod_gss-${MOD_GSS}/mod_auth_gss.c "${S}"/contrib || die
+		ln -sv "${WORKDIR}"/mod_gss-${MOD_GSS}/mod_gss.c "${S}"/contrib || die
+		ln -sv "${WORKDIR}"/mod_gss-${MOD_GSS}/mod_gss.h "${S}"/include || die
+
+		cp -v "${WORKDIR}"/mod_gss-${MOD_GSS}/README.mod_{auth_gss,gss} "${S}" || die
+		cp -v "${WORKDIR}"/mod_gss-${MOD_GSS}/mod_gss.html "${S}"/doc/contrib || die
+		cp -v "${WORKDIR}"/mod_gss-${MOD_GSS}/rfc{1509,2228}.txt "${S}"/doc/rfc || die
+	fi
+
+	default
+
+	tc-export CC
+}
+
+src_configure() {
+	local c m
+
+	use acl && m="${m}:mod_facl"
+	use ban && m="${m}:mod_ban"
+	use case && m="${m}:mod_case"
+	use clamav && m="${m}:mod_clamav"
+	use copy && m="${m}:mod_copy"
+	use ctrls && m="${m}:mod_ctrls_admin"
+	use deflate && m="${m}:mod_deflate"
+	if use diskuse ; then
+		in_dir ${PN}-mod_diskuse-${MOD_DISKUSE} econf
+		m="${m}:mod_diskuse"
+	fi
+	use dynmasq && m="${m}:mod_dynmasq"
+	use exec && m="${m}:mod_exec"
+	use ifsession && m="${m}:mod_ifsession"
+	use ifversion && m="${m}:mod_ifversion"
+	if use kerberos ; then
+		in_dir mod_gss-${MOD_GSS} econf
+		m="${m}:mod_gss:mod_auth_gss"
+	fi
+	use ldap && m="${m}:mod_ldap"
+	use log-forensic && m="${m}:mod_log_forensic"
+	use msg && m="${m}:mod_msg"
+	if use mysql || use postgres || use sqlite ; then
+		m="${m}:mod_sql:mod_sql_passwd"
+		use mysql && m="${m}:mod_sql_mysql"
+		use postgres && m="${m}:mod_sql_postgres"
+		use sqlite && m="${m}:mod_sql_sqlite"
+	fi
+	use qos && m="${m}:mod_qos"
+	use radius && m="${m}:mod_radius"
+	use ratio && m="${m}:mod_ratio"
+	use readme && m="${m}:mod_readme"
+	use rewrite && m="${m}:mod_rewrite"
+	if use sftp ; then
+		m="${m}:mod_sftp"
+		use pam && m="${m}:mod_sftp_pam"
+		use mysql || use postgres || use sqlite && m="${m}:mod_sftp_sql"
+	fi
+	use shaper && m="${m}:mod_shaper"
+	use sitemisc && m="${m}:mod_site_misc"
+	use snmp && m="${m}:mod_snmp"
+	if use softquota ; then
+		m="${m}:mod_quotatab:mod_quotatab_file"
+		use ldap && m="${m}:mod_quotatab_ldap"
+		use radius && m="${m}:mod_quotatab_radius"
+		use mysql || use postgres || use sqlite && m="${m}:mod_quotatab_sql"
+	fi
+	if use ssl ; then
+		m="${m}:mod_tls:mod_tls_shmcache"
+		use memcache && m="${m}:mod_tls_memcache"
+	fi
+	if use tcpd ; then
+		m="${m}:mod_wrap2:mod_wrap2_file"
+		use mysql || use postgres || use sqlite && m="${m}:mod_wrap2_sql"
+	fi
+	use unique-id && m="${m}:mod_unique_id"
+	use vroot && m="${m}:mod_vroot"
+
+	if [[ -n ${PROFTP_CUSTOM_MODULES} ]]; then
+		einfo "Adding user-specified extra modules: '${PROFTP_CUSTOM_MODULES}'"
+		m="${m}:${PROFTP_CUSTOM_MODULES}"
+	fi
+
+	[[ -z ${m} ]] || c="${c} --with-modules=${m:1}"
+
+	local myeconfargs=(
+		--cache-file="${S}"/config.cache
+		--localstatedir=/run/proftpd
+		--sysconfdir=/etc/proftpd
+		--disable-strip
+		$(use_enable acl facl)
+		$(use_enable authfile auth-file)
+		$(use_enable caps cap)
+		$(use_enable ctrls)
+		$(use_enable dso)
+		$(use_enable ident)
+		$(use_enable memcache)
+		$(use_enable ncurses)
+		$(use_enable nls)
+		$(use_enable ssl openssl)
+		$(use_enable pam auth-pam)
+		$(use_enable pcre)
+		$(use_enable sodium)
+		$(use_enable test tests)
+		--enable-trace
+		--enable-shadow
+		--enable-autoshadow
+		${c:1}
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	emake api-tests -C tests
+}
+
+src_install() {
+	default
+	[[ -z ${LINGUAS-set} ]] && rm -r "${ED}"/usr/share/locale
+	rm -rf "${ED}"/run "${ED}"/var/run
+
+	newinitd "${FILESDIR}"/proftpd.initd-r1 proftpd
+	insinto /etc/proftpd
+	doins "${FILESDIR}"/proftpd.conf.sample
+
+	insinto /etc/xinetd.d
+	newins "${FILESDIR}"/proftpd.xinetd proftpd
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/${PN}.logrotate ${PN}
+
+	dodoc ChangeLog CREDITS INSTALL NEWS README* RELEASE_NOTES
+
+	docinto html
+	dodoc doc/*.html doc/contrib/*.html doc/howto/*.html doc/modules/*.html
+
+	docinto rfc
+	dodoc doc/rfc/*.txt
+
+	systemd_dounit       "${FILESDIR}"/${PN}.service
+	newtmpfiles "${FILESDIR}"/${PN}-tmpfiles.d.conf-r1 ${PN}.conf
+}
+
+pkg_postinst() {
+	# Create /var/run files at package merge time: bug #650000
+	tmpfiles_process ${PN}.conf
+}


### PR DESCRIPTION
the module 'radius' have an outdated built-in-md5 that fails with modern compilers. force md5-openssl to solve it.

deps :
only the module 'rewrite' needs idn and the two libidn/libidn2 are supported
add zlib for the modules 'deflate' and 'sftp'
the module 'kerberos' requires libcom_err from e2fsprogs
sodium is only used with sql's modules
clamav is only a runtime dep

remove a no-op sed for gss, configure.ac was renew since

patches :
fix C23 unprototyped functions (PR merged)
make conditionnal an old cipher

Closes: https://bugs.gentoo.org/880481

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
