### PR TITLE
sys-auth/pam_u2f: add missing build dep for man-pages

### DIFF
--- a/sys-auth/pam_u2f/pam_u2f-1.4.0.ebuild
+++ b/sys-auth/pam_u2f/pam_u2f-1.4.0.ebuild
@@ -18,8 +18,10 @@ RESTRICT="!test? ( test )"
 DEPEND="
 	dev-libs/libfido2:=
 	dev-libs/openssl:=
-	sys-libs/pam"
+	sys-libs/pam
+"
 RDEPEND="${DEPEND}"
+BDEPEND="app-text/asciidoc"
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/962866

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
