### PR TITLE
games-emulation/dosbox-staging: add zlib-ng support

### DIFF
--- a/games-emulation/dosbox-staging/dosbox-staging-0.82.2-r1.ebuild
+++ b/games-emulation/dosbox-staging/dosbox-staging-0.82.2-r1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 2020-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit flag-o-matic meson xdg
+
+DESCRIPTION="Modernized DOSBox soft-fork"
+HOMEPAGE="https://dosbox-staging.github.io/"
+SRC_URI="https://github.com/dosbox-staging/dosbox-staging/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="+alsa debug dynrec +fluidsynth mt-32 network opengl slirp test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="alsa? ( media-libs/alsa-lib )
+	debug? ( sys-libs/ncurses:0= )
+	fluidsynth? (
+		media-sound/fluid-soundfont
+		media-sound/fluidsynth
+	)
+	mt-32? ( media-libs/munt-mt32emu )
+	network? ( media-libs/sdl2-net )
+	opengl? ( virtual/opengl )
+	slirp? ( net-libs/libslirp )
+	media-libs/iir1
+	media-libs/libpng:0=
+	media-libs/libsdl2[joystick,opengl?,video,X]
+	media-libs/opusfile
+	media-libs/speexdsp
+	sys-libs/zlib:=
+	sys-libs/zlib-ng:=
+	!games-emulation/dosbox"
+DEPEND="${RDEPEND}"
+BDEPEND="test? ( dev-cpp/gtest )"
+
+DOCS=( AUTHORS README THANKS )
+
+src_prepare() {
+	default
+
+	# We do not have default.sf2, use actual name from fluid-soundfont
+	sed -e "s/default.sf2/FluidR3_GM.sf2/" \
+		-i src/midi/midi_fluidsynth.cpp || die
+
+	# Disable license and docs install (handled by ebuild)
+	sed -e "/licenses_dir\|doc_dir/d" -i meson.build || die
+}
+
+src_configure() {
+	# -Werror=odr
+	# https://bugs.gentoo.org/926078
+	# https://github.com/dosbox-staging/dosbox-staging/issues/3519
+	filter-lto
+
+	# xinput2 comes with libsdl2[X]
+	local emesonargs=(
+		-Duse_xinput2=true
+		-Duse_zlib_ng=native
+		$(meson_use alsa use_alsa)
+		$(meson_use debug)
+		-Ddynamic_core=$(usex dynrec dynrec dyn-x86)
+		$(meson_use fluidsynth use_fluidsynth)
+		$(meson_use mt-32 use_mt32emu)
+		$(meson_use network use_sdl2_net)
+		$(meson_use opengl use_opengl)
+		$(meson_use slirp use_slirp)
+		$(meson_feature test unit_tests)
+	)
+	meson_src_configure
+}

--- a/games-emulation/dosbox-staging/metadata.xml
+++ b/games-emulation/dosbox-staging/metadata.xml
@@ -7,8 +7,8 @@
 	</maintainer>
 	<use>
 		<flag name="dynrec">Use recompiling cpu core instead of dynamic x86/x64 specific cpu core</flag>
-		<flag name="fluidsynth">use <pkg>media-sound/fluidsynth</pkg> for MIDI emulation</flag>
-		<flag name="mt-32">use <pkg>media-libs/munt-mt32emu</pkg> for MT-32 emulation</flag>
+		<flag name="fluidsynth">Use <pkg>media-sound/fluidsynth</pkg> for MIDI emulation</flag>
+		<flag name="mt-32">Use <pkg>media-libs/munt-mt32emu</pkg> for MT-32 emulation</flag>
 		<flag name="network">Enable networking features (modem, ipx)</flag>
 		<flag name="slirp">Enable Ethernet emulation using <pkg>net-libs/libslirp</pkg></flag>
 	</use>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/962887

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
