### PR TITLE
sys-kernel/dracut: change hostonly_cmdline default back to yes

### DIFF
--- a/sys-kernel/dracut/dracut-108-r4.ebuild
+++ b/sys-kernel/dracut/dracut-108-r4.ebuild
@@ -109,6 +109,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-108-elf-parsing-fixes.patch
 	# https://github.com/dracut-ng/dracut-ng/pull/1122#issuecomment-3192110686
 	"${FILESDIR}"/${PN}-108-disable-ukify-magic.patch
+	# https://github.com/dracut-ng/dracut-ng/pull/1562
+	"${FILESDIR}"/${PN}-108-hostonly_cmdline-default-yes.patch
 )
 
 pkg_setup() {

--- a/sys-kernel/dracut/files/dracut-108-hostonly_cmdline-default-yes.patch
+++ b/sys-kernel/dracut/files/dracut-108-hostonly_cmdline-default-yes.patch
@@ -1,0 +1,23 @@
+From f0086c2f629365bdca8df76364747f7eb9799b59 Mon Sep 17 00:00:00 2001
+From: Jo Zzsi <jozzsicsataban@gmail.com>
+Date: Tue, 12 Aug 2025 07:17:52 -0400
+Subject: [PATCH] revert(efaee44): hostonly_cmdline should continue to default
+ to yes
+
+Despite the Fedora setting, let's keep the default to yes
+for distributions that do not whish to overwrite the default.
+---
+ dracut.conf.d/hostonly/10-hostonly.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/dracut.conf.d/hostonly/10-hostonly.conf b/dracut.conf.d/hostonly/10-hostonly.conf
+index c5bd9b22..72fc9299 100644
+--- a/dracut.conf.d/hostonly/10-hostonly.conf
++++ b/dracut.conf.d/hostonly/10-hostonly.conf
+@@ -1,3 +1,2 @@
+ # optimize initrd to be as small as possible for faster boot performance, tailored to the current host
+ hostonly="yes"
+-hostonly_cmdline=no
+-- 
+2.49.1
+


### PR DESCRIPTION
Changing hostonly_cmdline default should not be taken lightly. Disabling it usually requires user action, since all necessary kernel command line arguments must be specified explicitly.

Closes: https://bugs.gentoo.org/962586

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
