### PR TITLE
app-admin/syslog-summary: Change 'string.' calls

### DIFF
--- a/app-admin/syslog-summary/files/syslog-summary-1.14-fix-string-functions.patch
+++ b/app-admin/syslog-summary/files/syslog-summary-1.14-fix-string-functions.patch
@@ -1,0 +1,33 @@
+diff --git a/syslog-summary b/syslog-summary
+index df1d5b4..a4f5aaf 100755
+--- a/syslog-summary
++++ b/syslog-summary
+@@ -39,7 +39,7 @@ from __future__ import print_function
+ 
+ version = "1.14"
+ 
+-import sys, re, getopt, string
++import sys, re, getopt
+ from gzip import open as gzopen
+ from hashlib import sha1
+ from optparse import OptionParser
+@@ -97,8 +97,8 @@ def read_states(filename):
+ 		io_error(e, filename, False)
+ 		return states
+ 	for line in f:
+-		fields = string.split(line)
+-		states[fields[0]] = (string.atoi(fields[1]), fields[2])
++		fields = line.split()
++		states[fields[0]] = (fields[1].atoi(), fields[2])
+ 	f.close()
+ 	return states
+ 
+@@ -125,7 +125,7 @@ def split_date(line):
+ 		m = pat.match(line)
+ 		if m:
+ 			return line[:m.end()], line[m.end():]
+-	print("line has bad date", "<" + string.rstrip(line) + ">")
++	print("line has bad date", "<" + line.rstrip() + ">")
+ 	return None, line
+ 
+ def is_gzipped(filename):

--- a/app-admin/syslog-summary/syslog-summary-1.14-r6.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r6.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit python-single-r1
+
+DESCRIPTION="Summarizes the contents of a syslog log file"
+HOMEPAGE="https://github.com/dpaleino/syslog-summary"
+SRC_URI="https://github.com/dpaleino/syslog-summary/archive/refs/tags/${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="amd64 ~sparc x86"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-ignore-code.patch"
+	"${FILESDIR}/${P}-remove-file-magic.patch"
+	"${FILESDIR}/${P}-py3.patch"
+	"${FILESDIR}/${P}-fix-string-functions.patch"
+)
+
+src_prepare() {
+	python_fix_shebang -f syslog-summary
+
+	# Sadly, the makefile is useless for us.
+	rm Makefile || die
+
+	default
+}
+
+src_install() {
+	dobin syslog-summary
+	einstalldocs
+	doman syslog-summary.1
+
+	insinto /etc/syslog-summary
+	doins ignore.rules
+}


### PR DESCRIPTION
An update in Python removed a bunch of functions from the string module, including the 'atoi', 'split', and 'rstrip' functions, which syslog-summary uses, causing it to throw an error. The added patch changes these function calls to the appropriate format which should prevent these errors, and removes the 'string' library from the imports.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
