### PR TITLE
sci-libs/pdal: drop gtest and exclude failing test

### DIFF
--- a/sci-libs/pdal/pdal-2.9.2.ebuild
+++ b/sci-libs/pdal/pdal-2.9.2.ebuild
@@ -19,7 +19,6 @@ RESTRICT="!test? ( test )"
 BDEPEND="
 	sys-devel/gettext
 	virtual/pkgconfig
-	test? ( >=dev-cpp/gtest-1.15.0 )
 "
 RDEPEND="
 	app-arch/zstd:=
@@ -50,7 +49,7 @@ src_configure() {
 
 src_test() {
 	local myctestargs=(
-		--exclude-regex '(pgpointcloudtest|pdal_info_test|pdal_io_bpf_base_test|pdal_io_bpf_zlib_test|pdal_filters_overlay_test|pdal_filters_stats_test|pdal_app_plugin_test|pdal_merge_test|pdal_io_stac_reader_test)'
+		--exclude-regex '(pgpointcloudtest|pdal_info_test|pdal_io_bpf_base_test|pdal_io_bpf_zlib_test|pdal_io_copc_reader_test|pdal_filters_overlay_test|pdal_filters_stats_test|pdal_app_plugin_test|pdal_merge_test|pdal_io_stac_reader_test)'
 		--output-on-failure
 		-j1
 	)


### PR DESCRIPTION
gtest has been vendored upstream https://github.com/PDAL/PDAL/pull/4801

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
