### PR TITLE
net-dns/pihole-meta: add initial ebuild

### DIFF
--- a/net-dns/pihole-meta/metadata.xml
+++ b/net-dns/pihole-meta/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
- 	<maintainer type="person" proxied="yes">
+	<maintainer type="person" proxied="yes">
 		<email>carlyle.felix@gmail.com</email>
 		<name>carlyle-felix</name>
 	</maintainer>

--- a/net-dns/pihole-meta/pihole-meta-0.1.ebuild
+++ b/net-dns/pihole-meta/pihole-meta-0.1.ebuild
@@ -2,8 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-HOMEPAGE="https://pi-hole.net"
 DESCRIPTION="A metapackage for Pi-hole dependencies."
+HOMEPAGE="https://pi-hole.net"
 LICENSE="metapackage"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"


### PR DESCRIPTION
Add a metapackage for Pi-hole dependencies
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
