### PR TITLE
dev-db/mongodb: fix build issue w/ clang 20

### DIFF
--- a/dev-db/mongodb/files/mongodb-8.0.8-fix-compile-error-due-to-deleted-constructor.patch
+++ b/dev-db/mongodb/files/mongodb-8.0.8-fix-compile-error-due-to-deleted-constructor.patch
@@ -1,0 +1,28 @@
+https://jira.mongodb.org/browse/SERVER-97048
+
+From ce43ef7147fabfa5b7f14a3040a0fc19b9228d9f Mon Sep 17 00:00:00 2001
+From: James Bronsted <32047428+jpbronsted@users.noreply.github.com>
+Date: Wed, 27 Nov 2024 17:59:39 -0500
+Subject: [PATCH] SERVER-97048 fix compile error on Clang 19 due to
+ BSONColumnBuilder default constructor (#29231)
+
+GitOrigin-RevId: 82d5ad449944292fe4cfdb7a27886439725d58de
+
+diff --git a/src/mongo/bson/util/bsoncolumnbuilder.h b/src/mongo/bson/util/bsoncolumnbuilder.h
+index d9cd20e07b7..b7d36fa1b28 100644
+--- a/src/mongo/bson/util/bsoncolumnbuilder.h
++++ b/src/mongo/bson/util/bsoncolumnbuilder.h
+@@ -282,7 +282,9 @@ struct EncodingState {
+ template <class Allocator = std::allocator<void>>
+ class BSONColumnBuilder {
+ public:
+-    explicit BSONColumnBuilder(const Allocator& = {});
++    template <typename A = Allocator>
++    BSONColumnBuilder() : BSONColumnBuilder{A{}} {}
++    explicit BSONColumnBuilder(const Allocator&);
+     explicit BSONColumnBuilder(allocator_aware::BufBuilder<Allocator>, const Allocator& = {});
+ 
+     /**
+-- 
+2.49.1
+

--- a/dev-db/mongodb/files/mongodb-8.0.8-sconstruct.patch
+++ b/dev-db/mongodb/files/mongodb-8.0.8-sconstruct.patch
@@ -1,0 +1,45 @@
+check whether "-latomic" is required for composite type, see src/mongo/bson/timestamp.h,
+otherwise the build fails with:
+
+> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: build/gentoo/mongo/db/storage/wiredtiger/wiredtiger_record_store.o: in function `mongo::WiredTigerRecordStore::getEarliestOplogTimestamp(mongo::OperationContext*)':
+> /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/atomic_base.h:1002:(.text+0x7da9): undefined reference to `__atomic_compare_exchange'
+> clang++: error: linker command failed with exit code 1 (use -v to see invocation)
+
+diff --git a/SConstruct b/SConstruct
+index 2a32456..4cfb5fd 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -5369,10 +5369,33 @@ def doConfigure(myenv):
+ 
+     conf.AddTest("CheckStdAtomic", CheckStdAtomic)
+ 
++    def CheckTimestampAtomic(context, extra_message):
++        test_body = """
++        #include <atomic>
++        struct Timestamp { unsigned int t, i; };
++        template<typename T> struct AtomicWord { std::atomic<T> v; T compareAndSwap(T e, T n) { v.compare_exchange_strong(e,n); return e; } };
++        int main() {
++            AtomicWord<Timestamp> x;
++            Timestamp a{0,0}, b{1,1};
++            x.compareAndSwap(a,b);
++            return 0;
++        }
++        """
++
++        context.Message("Checking if AtomicWord<Timestamp> works{0}... ".format(extra_message))
++
++        ret = context.TryLink(textwrap.dedent(test_body), ".cpp")
++        context.Result(ret)
++        return ret
++
++    conf.AddTest("CheckTimestampAtomic", CheckTimestampAtomic)
++
+     def check_all_atomics(extra_message=''):
+         for t in ('int64_t', 'uint64_t', 'int32_t', 'uint32_t'):
+             if not conf.CheckStdAtomic(t, extra_message):
+                 return False
++        if not conf.CheckTimestampAtomic(extra_message):
++            return False
+         return True
+ 
+     if not check_all_atomics():

--- a/dev-db/mongodb/mongodb-8.0.12.ebuild
+++ b/dev-db/mongodb/mongodb-8.0.12.ebuild
@@ -75,6 +75,8 @@ PATCHES=(
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.6-fixes-for-boost-1.85.patch"
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.4-scons.patch"
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.6-use-tenacity.patch"
+	"${FILESDIR}/${PN}-8.0.8-sconstruct.patch"
+	"${FILESDIR}/${PN}-8.0.8-fix-compile-error-due-to-deleted-constructor.patch"
 	"${FILESDIR}/boost_issue_402.patch"
 	"${FILESDIR}/${PN}-8.0.12-sconstruct.patch"
 )

--- a/dev-db/mongodb/mongodb-8.0.8.ebuild
+++ b/dev-db/mongodb/mongodb-8.0.8.ebuild
@@ -77,6 +77,8 @@ PATCHES=(
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.4-scons.patch"
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.6-mozjs-remove-unused-constructor.patch"
 	"${WORKDIR}/mongodb-8.0.8-patches/${PN}-8.0.6-use-tenacity.patch"
+	"${FILESDIR}/${PN}-8.0.8-sconstruct.patch"
+	"${FILESDIR}/${PN}-8.0.8-fix-compile-error-due-to-deleted-constructor.patch"
 )
 
 python_check_deps() {


### PR DESCRIPTION
upstream patch is applied, otherwise the build w/ clang 20 fails with:

> src/mongo/bson/util/bsoncolumnbuilder.h:285:49: error: call to deleted constructor of 'const mongo::TrackingAllocator<void> &'

However, the build still fails with:

> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: build/gentoo/mongo/db/storage/wiredtiger/wiredtiger_record_store.o: in function `mongo::WiredTigerRecordStore::getEarliestOplogTimestamp(mongo::OperationContext*)':
> /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/atomic_base.h:1002:(.text+0x7da9): undefined reference to `__atomic_compare_exchange'
> clang++: error: linker command failed with exit code 1 (use -v to see invocation)

The reason is that Timestamp is a composite type, which requires -latomic when building with clang++ and libstdc++. Mongodb's SConstruct only checks for some basic types ('int64_t', 'uint64_t', 'int32_t', 'uint32_t'), so this case is not detected.

Test case below:

```
$ cat a.cc
#include <atomic>
struct Timestamp { unsigned int t, i; };
template<typename T> struct AtomicWord {
    std::atomic<T> v;
    T compareAndSwap(T e, T n) {
        v.compare_exchange_strong(e,n); return e;
    }
};
int main() {
    AtomicWord<Timestamp> x;
    Timestamp a{0,0}, b{1,1};
    x.compareAndSwap(a,b);
    return 0;
}

$ clang++ -stdlib=libstdc++ a.cc
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: /tmp/a-1e3f91.o: in function `std::atomic<Timestamp>::compare_exchange_strong(Timestamp&, Timestamp, std::memory_order, std::memory_order)': a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x222): undefined reference to `__atomic_compare_exchange' 
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x28d): undefined reference to `__atomic_compare_exchange' 
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x2f8): undefined reference to `__atomic_compare_exchange' 
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x3c1): undefined reference to `__atomic_compare_exchange' 
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x42c): undefined reference to `__atomic_compare_exchange' 
/usr/bin/x86_64-pc-linux-gnu-ld.bfd: /tmp/a-1e3f91.o:a.cc:(.text._ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_[_ZNSt6atomicI9TimestampE23compare_exchange_strongERS0_S0_St12memory_orderS3_]+0x497): more undefined references to `__atomic_compare_exchange' follow clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
