### PR TITLE
eclass/nginx.eclass: change /var/tmp/nginx -> /var/cache/nginx

### DIFF
--- a/eclass/nginx.eclass
+++ b/eclass/nginx.eclass
@@ -612,7 +612,7 @@ nginx_src_configure() {
 		conf="${conf%%-temp-path*}"
 		conf="${conf#--http-}"
 		nginx_flags+=(
-			"--http-${conf}-temp-path=${EPREFIX}/var/tmp/nginx/${conf//-/_}_temp"
+			"--http-${conf}-temp-path=${EPREFIX}/var/cache/nginx/${conf//-/_}_temp"
 		)
 	done < <(econf_ngx --help 2>/dev/null | grep -E -- '--http-([A-Za-z]+-?)+-temp-path')
 	unset conf _txt
@@ -939,11 +939,7 @@ nginx_pkg_postinst() {
 	local file
 	for file in "${NGINX_MISC_FILES[@]}"; do
 		if [[ ${file} == *.tmpfiles ]]; then
-			# NGINX wrtites to /var/tmp/nginx as root during startup, therefore
-			# we abuse tmpfiles_process to pass the '--remove' option.
-			# This is done in order to clean possibly non-empty /var/tmp/nginx
-			# directory in world-writable /var/tmp.
-			tmpfiles_process --remove "${PN}-tmp.conf"
+			tmpfiles_process "${PN}-tmp.conf"
 			break
 		fi
 	done

--- a/www-servers/nginx/files/nginx-r1.tmpfiles
+++ b/www-servers/nginx/files/nginx-r1.tmpfiles
@@ -1,0 +1,4 @@
+d /var/cache/nginx 0755 root root
+
+# Clean up the cache only on boot to not break running NGINX
+e! /var/cache/nginx/ - - - 0

--- a/www-servers/nginx/nginx-1.28.0-r2.ebuild
+++ b/www-servers/nginx/nginx-1.28.0-r2.ebuild
@@ -22,8 +22,7 @@ NGINX_MODULES=(
 NGINX_UPDATE_STREAM=stable
 NGINX_TESTS_COMMIT=06a36245e134eac985cdfc5fac982cb149f61412
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
-	nginx.tmpfiles
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd,r1.tmpfiles}
 )
 
 inherit nginx

--- a/www-servers/nginx/nginx-1.29.0-r4.ebuild
+++ b/www-servers/nginx/nginx-1.29.0-r4.ebuild
@@ -22,8 +22,7 @@ NGINX_MODULES=(
 NGINX_UPDATE_STREAM=mainline
 NGINX_TESTS_COMMIT=7f1e88e10dca8e4c135ab9e688df0c2484091125
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
-	nginx.tmpfiles
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd,r1.tmpfiles}
 )
 
 inherit nginx

--- a/www-servers/nginx/nginx-1.29.1-r2.ebuild
+++ b/www-servers/nginx/nginx-1.29.1-r2.ebuild
@@ -22,8 +22,7 @@ NGINX_MODULES=(
 NGINX_UPDATE_STREAM=mainline
 NGINX_TESTS_COMMIT=06a36245e134eac985cdfc5fac982cb149f61412
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
-	nginx.tmpfiles
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd,r1.tmpfiles}
 )
 
 inherit nginx

--- a/www-servers/nginx/nginx-9999.ebuild
+++ b/www-servers/nginx/nginx-9999.ebuild
@@ -22,8 +22,7 @@ NGINX_MODULES=(
 NGINX_UPDATE_STREAM=live
 NGINX_TESTS_COMMIT=live
 NGINX_MISC_FILES=(
-	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd}
-	nginx.tmpfiles
+	nginx-{r2.logrotate,r2.service,r4.conf,r6.initd,r1.confd,r1.tmpfiles}
 )
 
 inherit nginx


### PR DESCRIPTION
Comes with a revbump of `nginx.tmpfiles` and every `nginx.eclass` consumer.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
