### PR TITLE
dev-lang/rust-bin: fix patchelf for prefix

### DIFF
--- a/dev-lang/rust-bin/rust-bin-1.85.0-r1.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.85.0-r1.ebuild
@@ -204,8 +204,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done

--- a/dev-lang/rust-bin/rust-bin-1.85.1.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.85.1.ebuild
@@ -204,8 +204,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done

--- a/dev-lang/rust-bin/rust-bin-1.86.0-r1.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.86.0-r1.ebuild
@@ -205,8 +205,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done

--- a/dev-lang/rust-bin/rust-bin-1.88.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.88.0.ebuild
@@ -206,8 +206,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done

--- a/dev-lang/rust-bin/rust-bin-1.89.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.89.0.ebuild
@@ -206,8 +206,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done

--- a/dev-lang/rust-bin/rust-bin-9999.ebuild
+++ b/dev-lang/rust-bin/rust-bin-9999.ebuild
@@ -202,8 +202,8 @@ rust_native_abi_install() {
 
 	if use prefix; then
 		local interpreter=$(patchelf --print-interpreter "${EPREFIX}"/bin/bash)
-		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/${SLOT}/bin"
-		find "${ED}/opt/${SLOT}/bin" -type f -print0 | \
+		ebegin "Changing interpreter to ${interpreter} for Gentoo prefix at ${ED}/opt/rust-bin-${SLOT}/bin"
+		find "${ED}/opt/rust-bin-${SLOT}/bin" -type f -print0 | \
 			while IFS=  read -r -d '' filename; do
 				patchelf_for_bin ${filename} ${interpreter} \; || die
 			done


### PR DESCRIPTION
Was already partly fixed in d9b69b495e07f21b8a49f38f87fed5babd3a9476

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

