### PR TITLE
sys-auth/libfprint: Fix fpi_byte_writer_change_pos not defined with LLD

### DIFF
--- a/sys-auth/libfprint/files/libfprint-1.94.9-tod-fix-linking-with-lld.patch
+++ b/sys-auth/libfprint/files/libfprint-1.94.9-tod-fix-linking-with-lld.patch
@@ -1,0 +1,23 @@
+From 7619e0292b242a2628979b8317573c80a9f0bf6a Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <listout@listout.xyz>
+Date: Sat, 20 Sep 2025 10:14:33 +0530
+Subject: [PATCH] fix fpi_byte_writer_change_pos not defined with clang
+
+On clang, linking with LLD fails.
+ld.lld: error: version script assignment of 'LIBFPRINT_TOD_1_1.94' to symbol 'fpi_byte_writer_change_pos' failed: symbol not defined
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+
+Signed-off-by: Brahmajit Das <listout@listout.xyz>
+--- a/libfprint/tod/libfprint-tod.ver.in
++++ b/libfprint/tod/libfprint-tod.ver.in
+@@ -238,7 +238,6 @@ global:
+ 
+ LIBFPRINT_TOD_@tod_soversion@_1.94 {
+ global:
+-    fpi_byte_writer_change_pos;
+     fpi_device_critical_enter;
+     fpi_device_critical_leave;
+     fpi_device_resume;
+-- 
+2.51.0
+

--- a/sys-auth/libfprint/libfprint-1.94.9-r1.ebuild
+++ b/sys-auth/libfprint/libfprint-1.94.9-r1.ebuild
@@ -69,6 +69,10 @@ src_unpack() {
 }
 
 src_configure() {
+	if use tod && tc-ld-is-lld; then
+		eapply "${FILESDIR}/${PN}-1.94.9-tod-fix-linking-with-lld.patch"
+	fi
+
 	# TODO: wire up test deps (cairo, pygobject, etc) for extra tests
 	# currently skipped.
 	local emesonargs=(


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
