### PR TITLE
www-client/opera-*: bump ffmpeg-chromium version

### DIFF
--- a/www-client/opera-beta/opera-beta-122.0.5643.6-r1.ebuild
+++ b/www-client/opera-beta/opera-beta-122.0.5643.6-r1.ebuild
@@ -42,7 +42,7 @@ fi
 # Commit ref from `strings libffmpeg.so | grep -F "FFmpeg version"` matches this Chromium version
 # used to select the correct ffmpeg-chromium version (corresponds to a major version of Chromium)
 # Does not need to be updated for every new version of Opera, only when it breaks
-CHROMIUM_VERSION="137"
+CHROMIUM_VERSION="138"
 SRC_URI="${SRC_URI_BASE[@]/%//${PV}/linux/${MY_PN}_${PV}_amd64.${OPERA_ARCHIVE_EXT}}"
 S=${WORKDIR}
 

--- a/www-client/opera-developer/opera-developer-123.0.5658.0-r1.ebuild
+++ b/www-client/opera-developer/opera-developer-123.0.5658.0-r1.ebuild
@@ -42,7 +42,7 @@ fi
 # Commit ref from `strings libffmpeg.so | grep -F "FFmpeg version"` matches this Chromium version
 # used to select the correct ffmpeg-chromium version (corresponds to a major version of Chromium)
 # Does not need to be updated for every new version of Opera, only when it breaks
-CHROMIUM_VERSION="137"
+CHROMIUM_VERSION="138"
 SRC_URI="${SRC_URI_BASE[@]/%//${PV}/linux/${MY_PN}_${PV}_amd64.${OPERA_ARCHIVE_EXT}}"
 S=${WORKDIR}
 

--- a/www-client/opera/opera-122.0.5643.51-r1.ebuild
+++ b/www-client/opera/opera-122.0.5643.51-r1.ebuild
@@ -42,7 +42,7 @@ fi
 # Commit ref from `strings libffmpeg.so | grep -F "FFmpeg version"` matches this Chromium version
 # used to select the correct ffmpeg-chromium version (corresponds to a major version of Chromium)
 # Does not need to be updated for every new version of Opera, only when it breaks
-CHROMIUM_VERSION="137"
+CHROMIUM_VERSION="138"
 SRC_URI="${SRC_URI_BASE[@]/%//${PV}/linux/${MY_PN}_${PV}_amd64.${OPERA_ARCHIVE_EXT}}"
 S=${WORKDIR}
 


### PR DESCRIPTION
Video playback broken due to a mismatch.

Closes: https://bugs.gentoo.org/962982

@Kangie Tested the latest version of each package. All were affected. Test was trying to watch youtube and seeing if the tab crashes. I didn't check older versions. From the bug it appears this has been broken for two versions atleast.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
