### PR TITLE
net-dns/dnsdist: disable LTO for mixed C++/Rust configuration

### DIFF
--- a/net-dns/dnsdist/dnsdist-2.0.1.ebuild
+++ b/net-dns/dnsdist/dnsdist-2.0.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{11..14} )
 RUST_MIN_VER=1.85.1
 RUST_OPTIONAL=1
 
-inherit cargo flag-o-matic lua-single python-any-r1
+inherit cargo flag-o-matic lua-single python-any-r1 toolchain-funcs
 
 DESCRIPTION="A highly DNS-, DoS- and abuse-aware loadbalancer"
 HOMEPAGE="https://www.dnsdist.org/index.html"
@@ -76,6 +76,13 @@ src_prepare() {
 src_configure() {
 	# bug #822855
 	append-lfs-flags
+
+	# There is currently no reliable way to handle mixed C++/Rust + LTO
+	# correctly: https://bugs.gentoo.org/963128
+	if use yaml && tc-is-lto ; then
+		ewarn "Disabling LTO because of mixed C++/Rust toolchains."
+		filter-lto
+	fi
 
 	# some things can only be enabled/disabled by defines
 	! use dnstap && append-cppflags -DDISABLE_PROTOBUF


### PR DESCRIPTION
There is currently no good or reliable way to make this work, due to myriad combinations of compilers, linkers and limitations of the Rust toolchain.

Closes: https://bugs.gentoo.org/963128
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
