### PR TITLE
net-dns/redis-knot: fix configure w/ libbpf

### DIFF
--- a/net-dns/redis-knot/redis-knot-3.5.0.ebuild
+++ b/net-dns/redis-knot/redis-knot-3.5.0.ebuild
@@ -45,7 +45,7 @@ src_prepare() {
 }
 
 src_configure() {
-	econf --disable-daemon --disable-modules --disable-utilities --enable-redis=module
+	econf --disable-daemon --disable-modules --disable-utilities --disable-xdp --enable-redis=module
 }
 
 src_compile() {


### PR DESCRIPTION
automagic trap: if libbpf is detected, xdp is enabled w/o checking if libxdp (xdp-tools) is installed

disable xdp because nothing is needed here

Closes: https://bugs.gentoo.org/963176

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
