### PR TITLE
net-libs/libmicrohttpd: fix testing with curl-8.16

### DIFF
--- a/net-libs/libmicrohttpd/files/libmicrohttpd-0.9.76-fix-test-with-curl-8-16.patch
+++ b/net-libs/libmicrohttpd/files/libmicrohttpd-0.9.76-fix-test-with-curl-8-16.patch
@@ -1,0 +1,32 @@
+From b03f13f32c2547b050f88e0a5ad758734c9be96c Mon Sep 17 00:00:00 2001
+From: "Evgeny Grin (Karlson2k)" <k2k@narod.ru>
+Date: Sun, 21 Sep 2025 16:20:49 +0200
+Subject: test_get_close_keep_alive: a minimal fix for curl 8.16
+
+curl 8.16 is silently dropping second 'Connection: ' header from
+requests, making some of the checks in the test unreliable.
+
+See https://bugs.gnunet.org/view.php?id=10403
+---
+ src/testcurl/test_get_close_keep_alive.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/testcurl/test_get_close_keep_alive.c b/src/testcurl/test_get_close_keep_alive.c
+index 243a8087..0e70a348 100644
+--- a/src/testcurl/test_get_close_keep_alive.c
++++ b/src/testcurl/test_get_close_keep_alive.c
+@@ -919,6 +919,11 @@ performTestQueries (struct MHD_Daemon *d, uint16_t d_port)
+     if ((! ! res_close) != (! ! conn_close))
+       continue; /* Another mode is in test currently */
+ 
++#if CURL_AT_LEAST_VERSION (8,16,0)
++    if ((f_client_close) && (f_client_k_alive))
++      continue;
++#endif /* CURL >= 8.16.0 */
++
+     mhd_add_close = f_mhd_close;
+     mhd_set_10_cmptbl = f_10_cmptbl;
+     mhd_set_10_server = f_10_server;
+-- 
+cgit v1.2.3
+

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.77-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.77-r1.ebuild
@@ -35,6 +35,7 @@ DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.9.76-fix-test_tricky-libcurl.patch # Gentoo Bug #953520
+	"${FILESDIR}"/${PN}-0.9.76-fix-test-with-curl-8-16.patch # Gentoo Bug #962980
 )
 
 # All checks in libmicrohttpd's configure are correct

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.77.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.77.ebuild
@@ -29,6 +29,7 @@ DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.9.76-fix-test_tricky-libcurl.patch # Gentoo Bug #953520
+	"${FILESDIR}"/${PN}-0.9.76-fix-test-with-curl-8-16.patch # Gentoo Bug #962980
 )
 
 # All checks in libmicrohttpd's configure are correct

--- a/net-libs/libmicrohttpd/libmicrohttpd-1.0.1-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-1.0.1-r1.ebuild
@@ -35,6 +35,7 @@ DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.9.76-fix-test_tricky-libcurl.patch # Gentoo Bug #953520
+	"${FILESDIR}"/${PN}-0.9.76-fix-test-with-curl-8-16.patch # Gentoo Bug #962980
 )
 
 # All checks in libmicrohttpd's configure are correct

--- a/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
@@ -29,6 +29,7 @@ DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.9.76-fix-test_tricky-libcurl.patch # Gentoo Bug #953520
+	"${FILESDIR}"/${PN}-0.9.76-fix-test-with-curl-8-16.patch # Gentoo Bug #962980
 )
 
 # All checks in libmicrohttpd's configure are correct


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/962980

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
