### PR TITLE
net-irc/ngircd: fix c23

### DIFF
--- a/net-irc/ngircd/ngircd-27.ebuild
+++ b/net-irc/ngircd/ngircd-27.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/alexbarton.asc
-inherit tmpfiles systemd verify-sig
+inherit flag-o-matic tmpfiles systemd verify-sig
 
 DESCRIPTION="An IRC server written from scratch"
 HOMEPAGE="https://ngircd.barton.de/"
@@ -71,6 +71,7 @@ src_prepare() {
 }
 
 src_configure() {
+	append-cppflags -DPROTOTYPES # fix c23
 	local myeconfargs=(
 		--sysconfdir="${EPREFIX}"/etc/${PN}
 


### PR DESCRIPTION
>./../portab/portab.h:42:24: note: expanded from macro
>      'PARAMS'
>   42 | #  define PARAMS(args) ()
>      |                        ^
>In file included from tool.c:33:
>./tool.h:24:13: error: a function declaration without a
>      prototype is deprecated in all versions of C and is treated as a
>      zero-parameter prototype in C23, conflicting with a subsequent definition
>      [-Werror,-Wdeprecated-non-prototype]
>   24 | GLOBAL void ngt_TrimStr PARAMS((char *String ));
>      |             ^

ifdef PROTOTYPES is here, let's use it

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
