### PR TITLE
net-libs/libident: update EAPI 7->8,fix c23

### DIFF
--- a/net-libs/libident/files/libident-0.32-fix_c23.patch
+++ b/net-libs/libident/files/libident-0.32-fix_c23.patch
@@ -1,0 +1,12 @@
+https://bugs.gentoo.org/943962
+--- a/id_query.c
++++ b/id_query.c
+@@ -33,7 +33,7 @@
+ 
+ int id_query (ident_t *id, int lport, int fport, struct timeval *timeout)
+ {
+-    RETSIGTYPE (*old_sig)();
++    RETSIGTYPE (*old_sig)(int sig);
+     int res;
+     char buf[80];
+     fd_set ws;

--- a/net-libs/libident/libident-0.32-r2.ebuild
+++ b/net-libs/libident/libident-0.32-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Small library to interface to the Ident protocol server"
+HOMEPAGE="http://www.simphalempin.com/dev/libident/"
+SRC_URI="http://people.via.ecp.fr/~rem/libident/${P}.tar.bz2"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="test"
+# Interactive tests only.
+RESTRICT="!test? ( test ) test"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.32-fix_c23.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(use_enable test testers)
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
rm "A" from the description

not reported, upstream is dead

Closes: https://bugs.gentoo.org/943962

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
