### PR TITLE
dev-libs/openssl: Add USE="brotli zlib zstd"

### DIFF
--- a/dev-libs/openssl/openssl-3.5.2.ebuild
+++ b/dev-libs/openssl/openssl-3.5.2.ebuild
@@ -37,12 +37,15 @@ S="${WORKDIR}"/${MY_P}
 
 LICENSE="Apache-2.0"
 SLOT="0/$(ver_cut 1)" # .so version of libssl/libcrypto
-IUSE="+asm cpu_flags_x86_sse2 fips ktls +quic rfc3779 sctp static-libs test tls-compression vanilla weak-ssl-ciphers"
+IUSE="+asm brotli cpu_flags_x86_sse2 fips ktls +quic rfc3779 sctp static-libs test tls-compression vanilla weak-ssl-ciphers zlib zstd"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
 	!<net-misc/openssh-9.2_p1-r3
+	brotli? ( app-arch/brotli[${MULTILIB_USEDEP}] )
 	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
+	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+	zstd? ( app-arch/zstd[${MULTILIB_USEDEP}] )
 "
 BDEPEND+="
 	>=dev-lang/perl-5
@@ -179,6 +182,7 @@ multilib_src_configure() {
 		${sslout}
 
 		$(multilib_is_native_abi || echo "no-docs")
+		$(use_ssl brotli)
 		$(use cpu_flags_x86_sse2 || echo "no-sse2")
 		enable-camellia
 		enable-ec
@@ -198,6 +202,8 @@ multilib_src_configure() {
 		$(use test || echo "no-tests")
 		$(use_ssl tls-compression zlib)
 		$(use_ssl weak-ssl-ciphers)
+		$(use_ssl zlib)
+		$(use_ssl zstd)
 
 		--prefix="${EPREFIX}"/usr
 		--openssldir="${EPREFIX}"${SSL_CNF_DIR}

--- a/dev-libs/openssl/openssl-3.5.9999.ebuild
+++ b/dev-libs/openssl/openssl-3.5.9999.ebuild
@@ -37,12 +37,15 @@ S="${WORKDIR}"/${MY_P}
 
 LICENSE="Apache-2.0"
 SLOT="0/$(ver_cut 1)" # .so version of libssl/libcrypto
-IUSE="+asm cpu_flags_x86_sse2 fips ktls +quic rfc3779 sctp static-libs test tls-compression vanilla weak-ssl-ciphers"
+IUSE="+asm brotli cpu_flags_x86_sse2 fips ktls +quic rfc3779 sctp static-libs test tls-compression vanilla weak-ssl-ciphers zlib zstd"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
 	!<net-misc/openssh-9.2_p1-r3
+	brotli? ( app-arch/brotli[${MULTILIB_USEDEP}] )
 	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
+	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+	zstd? ( app-arch/zstd[${MULTILIB_USEDEP}] )
 "
 BDEPEND+="
 	>=dev-lang/perl-5
@@ -179,6 +182,7 @@ multilib_src_configure() {
 		${sslout}
 
 		$(multilib_is_native_abi || echo "no-docs")
+		$(use_ssl brotli)
 		$(use cpu_flags_x86_sse2 || echo "no-sse2")
 		enable-camellia
 		enable-ec
@@ -198,6 +202,8 @@ multilib_src_configure() {
 		$(use test || echo "no-tests")
 		$(use_ssl tls-compression zlib)
 		$(use_ssl weak-ssl-ciphers)
+		$(use_ssl zlib)
+		$(use_ssl zstd)
 
 		--prefix="${EPREFIX}"/usr
 		--openssldir="${EPREFIX}"${SSL_CNF_DIR}


### PR DESCRIPTION
These USE flags enable the compilation of internal support for compression algorithms within the OpenSSL stack, from a software perspective these are necessary if software uses the BIO_f_zlib(), BIO_f_brotli() or BIO_f_zstd() functions.

It's also useful for RFC 8879 TLS Certificate Compression, which for example is possible in www-servers/nginx-1.29.x and newer with the `ssl_certificate_compression on;` configuration option.

If OpenSSL is configured without compression methods, that directive will cause startup warnings on nginx.

Bug: https://bugs.gentoo.org/943254

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
