### PR TITLE
net-proxy/ziproxy: EAPI 7 -> 8, fix c23

### DIFF
--- a/net-proxy/ziproxy/files/ziproxy-3.3.2-fix_gcc15.patch
+++ b/net-proxy/ziproxy/files/ziproxy-3.3.2-fix_gcc15.patch
@@ -1,0 +1,13 @@
+see https://sourceforge.net/p/ziproxy/bugs/37/
+fix c23 https://bugs.gentoo.org/943947
+--- a/src/image.c
++++ b/src/image.c
+@@ -1216,7 +1216,7 @@ int jpg2bitmap(char *inbuf, int insize,
+ 	return IMG_RET_OK;
+ }
+ 
+-static boolean jpeg_dest_empty_output_buffer()
++static boolean jpeg_dest_empty_output_buffer(struct jpeg_compress_struct *)
+ {
+ 		return FALSE; //output file larger than original..
+ }

--- a/net-proxy/ziproxy/ziproxy-3.3.2-r1.ebuild
+++ b/net-proxy/ziproxy/ziproxy-3.3.2-r1.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic
+
+DESCRIPTION="Forwarding, non-caching, compressing web proxy server"
+HOMEPAGE="https://ziproxy.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${P}/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~riscv ~sparc ~x86"
+IUSE="sasl xinetd"
+
+RDEPEND="
+	acct-group/ziproxy
+	acct-user/ziproxy
+	media-libs/giflib:=
+	media-libs/libpng:=
+	media-libs/libjpeg-turbo:=
+	sys-libs/zlib
+	sasl? ( dev-libs/cyrus-sasl )
+	xinetd? ( virtual/inetd )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Fix-clang-build-errors.patch
+	"${FILESDIR}"/${P}-fix_gcc15.patch
+)
+
+src_prepare() {
+	default
+
+	# fix sample config file
+	sed -i \
+		-e "s:/var/ziproxy/:${EPREFIX}/var/lib/ziproxy/:g" \
+		etc/ziproxy/ziproxy.conf || die
+
+	# fix sample xinetd config
+	sed -i \
+		-e "s:/usr/bin/:/usr/sbin/:g" \
+		-e "s:\(.*port.*\):\1\n\ttype\t\t\t= UNLISTED:g" \
+		-e "s:root:ziproxy:g" \
+		etc/xinetd.d/ziproxy || die
+}
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/861863
+	# Upstream is sourceforge and has been dead for 3 years. No upstream bug reported.
+	filter-lto
+
+	# fix -Wincompatible-pointer-types-discards-qualifiers
+	append-cppflags -DUSE_CUSTOM_STRING_ROUTINES=OFF
+
+	local myeconfargs=(
+		--without-jasper
+		$(use_with sasl sasl2)
+		--with-cfgfile="${EPREFIX}"/etc/ziproxy/ziproxy.conf
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	dodir /usr/sbin
+	mv -vf "${ED}"/usr/{,s}bin/ziproxy || die
+
+	dobin src/tools/ziproxy_genhtml_stats.sh
+
+	newinitd "${FILESDIR}"/${PN}.initd-r1 ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}
+
+	insinto /etc
+	doins -r etc/ziproxy
+
+	insinto /var/lib/ziproxy/error
+	doins var/ziproxy/error/*.html
+
+	if use xinetd; then
+		insinto /etc/xinetd.d
+		doins etc/xinetd.d/ziproxy
+	fi
+
+	diropts -m0750 -o ziproxy -g ziproxy
+	keepdir /var/log/ziproxy
+}


### PR DESCRIPTION
update HOMEPAGE http+S
update SRC_URI (redirect)
update EAPI 7 -> 8
fix c23
remove a no-op sed
use myeconfargs array

Closes: https://bugs.gentoo.org/943947

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
