### PR TITLE
x11-libs/pango: add dev-libs/gobject-introspection as BDEPEND

### DIFF
--- a/x11-libs/pango/pango-1.56.4-r1.ebuild
+++ b/x11-libs/pango/pango-1.56.4-r1.ebuild
@@ -39,7 +39,12 @@ BDEPEND="
 	dev-util/glib-utils
 	virtual/pkgconfig
 	dev-python/docutils
-	gtk-doc? ( dev-util/gi-docgen )
+	gtk-doc? (
+		introspection? (
+			>=dev-libs/gobject-introspection-1.83.2
+			dev-util/gi-docgen
+		)
+	)
 	test? ( media-fonts/cantarell )
 "
 

--- a/x11-libs/pango/pango-1.56.4-r2.ebuild
+++ b/x11-libs/pango/pango-1.56.4-r2.ebuild
@@ -39,7 +39,12 @@ BDEPEND="
 	dev-util/glib-utils
 	virtual/pkgconfig
 	dev-python/docutils
-	gtk-doc? ( dev-util/gi-docgen )
+	gtk-doc? (
+		introspection? (
+			>=dev-libs/gobject-introspection-1.83.2
+			dev-util/gi-docgen
+		)
+	)
 	test? ( media-fonts/cantarell )
 "
 

--- a/x11-libs/pango/pango-1.57.0.ebuild
+++ b/x11-libs/pango/pango-1.57.0.ebuild
@@ -39,7 +39,12 @@ BDEPEND="
 	dev-util/glib-utils
 	virtual/pkgconfig
 	dev-python/docutils
-	gtk-doc? ( dev-util/gi-docgen )
+	gtk-doc? (
+		introspection? (
+			>=dev-libs/gobject-introspection-1.83.2
+			dev-util/gi-docgen
+		)
+	)
 	test? ( media-fonts/cantarell )
 "
 


### PR DESCRIPTION
Both `dev-libs/gobject-introspection` and `dev-util/gi-docgen` are
required at build time to generate the documentation

Closes: https://bugs.gentoo.org/959579
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
