### PR TITLE
media-gfx/valentina: QA mv install-root in src_install

### DIFF
--- a/media-gfx/valentina/valentina-1.0.0.ebuild
+++ b/media-gfx/valentina/valentina-1.0.0.ebuild
@@ -53,7 +53,7 @@ qbs_config() {
 
 src_configure() {
 	# setup the toolchain in a profile 'mytoolchain'
-	edo qbs setup-toolchains $(tc-getCC) mytoolchain
+	edo qbs setup-toolchains "$(tc-getCC)" mytoolchain
 
 	# create a profile 'gentoo' with 'mytoolchain' inherited
 	edo qbs setup-qt "$(qt6_get_bindir)"/qmake gentoo
@@ -70,7 +70,7 @@ src_configure() {
 	# define global options
 	qbs_config preferences.jobs "$(get_makeopts_jobs)"
 	qbs_config qbs.installPrefix "${EPREFIX}/usr"
-	qbs_config qbs.installRoot "${D}"
+	qbs_config qbs.sysroot "${ESYSROOT}"
 
 	# define system flags
 	qbs_config cpp.cppFlags "$(qbs_format_flags ${CPPFLAGS})"
@@ -112,7 +112,7 @@ src_test() {
 }
 
 src_install() {
-	edo qbs install "${qbsargs[@]}" --no-build
+	edo qbs install "${qbsargs[@]}" --no-build --install-root "${D}"
 
 	dodoc AUTHORS.txt ChangeLog.txt README.md
 


### PR DESCRIPTION
Because "${D}" should not be used in src_configure
Use "${ESYSROOT}"

Freshly built just in case.

@a17r,  thank you for catching me up

See https://github.com/gentoo/gentoo/pull/43499#issuecomment-3329146146

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
