### PR TITLE
net-misc/r8125: Fix PTP with kernel >=6.16

### DIFF
--- a/net-misc/r8125/files/r8125-9.016.00-ptp-linux-6.16.patch
+++ b/net-misc/r8125/files/r8125-9.016.00-ptp-linux-6.16.patch
@@ -1,0 +1,30 @@
+From 2f8c3c336aba02cfd8a0ebf2c4f348d6196906c2 Mon Sep 17 00:00:00 2001
+From: "Evgeny Grin (Karlson2k)" <k2k@drgrin.dev>
+Date: Wed, 24 Sep 2025 20:02:20 +0200
+Subject: [PATCH] Fix build with PTP with kernels >=6.16
+
+---
+ src/r8125_ptp.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/r8125_ptp.c b/src/r8125_ptp.c
+index 457fa6d..41cc2a2 100644
+--- a/src/r8125_ptp.c
++++ b/src/r8125_ptp.c
+@@ -1213,8 +1213,13 @@ void rtl8125_ptp_init(struct rtl8125_private *tp)
+         switch (tp->HwSuppPtpVer) {
+         case 3:
+                 tp->pps_enable = 0;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0)
++                hrtimer_setup(&tp->pps_timer, rtl8125_phy_hrtimer_for_pps, CLOCK_MONOTONIC,
++                              HRTIMER_MODE_REL);
++#else
+                 hrtimer_init(&tp->pps_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+                 tp->pps_timer.function = rtl8125_phy_hrtimer_for_pps;
++#endif
+                 break;
+         default:
+                 break;
+-- 
+2.49.1
+

--- a/net-misc/r8125/r8125-9.016.00.ebuild
+++ b/net-misc/r8125/r8125-9.016.00.ebuild
@@ -18,6 +18,7 @@ IUSE="down-speed-100 fiber hw-acceleration hw-optim-tx +eee +giga-lite +multi-tx
 
 PATCHES=(
 	"${FILESDIR}/${P}-fix-build-with-firmware.patch"
+	"${FILESDIR}/${P}-ptp-linux-6.16.patch" # Gentoo bug 963364
 )
 
 CONFIG_CHECK="~!R8169"

--- a/net-misc/r8125/r8125-9.016.01.ebuild
+++ b/net-misc/r8125/r8125-9.016.01.ebuild
@@ -18,6 +18,7 @@ IUSE="dash down-speed-100 fiber hw-acceleration hw-optim-tx +eee +giga-lite +mul
 
 PATCHES=(
 	"${FILESDIR}/${PN}-9.016.00-fix-build-with-firmware.patch"
+	"${FILESDIR}/${PN}-9.016.00-ptp-linux-6.16.patch" # Gentoo bug 963364
 )
 
 CONFIG_CHECK="~!R8169"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/963364

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
