### PR TITLE
dev-db/redis: fix build w/ clang

### DIFF
--- a/dev-db/redis/redis-8.2.0.ebuild
+++ b/dev-db/redis/redis-8.2.0.ebuild
@@ -94,7 +94,7 @@ src_configure() {
 
 	# Linenoise can't be built with -std=c99, see https://bugs.gentoo.org/451164
 	# also, don't define ANSI/c99 for lua twice
-	sed -i -e "s:-std=c99::g" deps/linenoise/Makefile deps/Makefile || die
+	sed -i -e "s:-std=c99::g" deps{,/fast_float,/linenoise}/Makefile || die
 }
 
 src_compile() {

--- a/dev-db/redis/redis-8.2.1.ebuild
+++ b/dev-db/redis/redis-8.2.1.ebuild
@@ -94,7 +94,7 @@ src_configure() {
 
 	# Linenoise can't be built with -std=c99, see https://bugs.gentoo.org/451164
 	# also, don't define ANSI/c99 for lua twice
-	sed -i -e "s:-std=c99::g" deps/linenoise/Makefile deps/Makefile || die
+	sed -i -e "s:-std=c99::g" deps{,/fast_float,/linenoise}/Makefile || die
 }
 
 src_compile() {


### PR DESCRIPTION
When using "-std=c99" while compiling C++, g++ only issues a warning:

> cc1plus: warning: command-line option '-std=c99' is valid for C/ObjC but not for C++

However, clang++ reports an error:

> error: invalid argument '-std=c99' not allowed with 'C++

Therefore, remove "-std=c99" for deps/fast_float/Makefile as well, otherwise the build fails with:

> clang: error: no such file or directory: '../deps/fast_float/libfast_float.a

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
