### PR TITLE
media-gfx/tuxpaint: fix Make installing to wrong doc dir

### DIFF
--- a/media-gfx/tuxpaint/files/tuxpaint-0.9.31-r2-Makefile.patch
+++ b/media-gfx/tuxpaint/files/tuxpaint-0.9.31-r2-Makefile.patch
@@ -1,0 +1,158 @@
+# Replace "lib" with GENTOO_LIBDIR, remove .gz suffixes and 
+# replace ImageMagick calls by GraphicsMagick calls.
+--- a/Makefile
++++ b/Makefile
+@@ -111,7 +111,7 @@ ifdef HOST
+     # We set PKG_CONFIG_LIBDIR instead of PKG_CONFIG_PATH because we want to
+     # *change* where pkg-config looks for .pc files instead of adding to the
+     # default path which may have libraries that aren't for HOST.
+-    export PKG_CONFIG_LIBDIR:=$(HOSTROOT)/lib/pkgconfig
++    export PKG_CONFIG_LIBDIR:=$(HOSTROOT)/$(GENTOO_LIBDIR)/pkgconfig
+   endif
+ endif
+ 
+@@ -177,14 +177,14 @@ windows_ARCH_CFLAGS:=
+ macos_ARCH_CFLAGS:=-isysroot $(SDKROOT) -I$(SDKROOT)/usr/include -I$(HOSTROOT)/include -mmacosx-version-min=$(MINVER) -arch $(subst $() $(), -arch ,$(ARCHS)) -w -headerpad_max_install_names -DHAVE_STRCASESTR
+ ios_ARCH_CFLAGS:=-isysroot $(SDKROOT) -I$(SDKROOT)/usr/include -I$(HOSTROOT)/include $(MINVEROPT) -arch $(subst $() $(), -arch ,$(ARCHS)) -w -fPIC -DHAVE_STRCASESTR -DUNLINK_ONLY
+ beos_ARCH_CFLAGS:=
+-linux_ARCH_CFLAGS:=
++linux_ARCH_CFLAGS:=${CFLAGS}
+ ARCH_CFLAGS:=$($(OS)_ARCH_CFLAGS)
+ 
+ windows_ARCH_LDFLAGS:=
+ macos_ARCH_LDFLAGS:=-isysroot $(SDKROOT) -L$(HOSTROOT)/lib -mmacosx-version-min=$(MINVER) -arch $(subst $() $(), -arch ,$(ARCHS))
+ ios_ARCH_LDFLAGS:=-isysroot $(SDKROOT) -L$(HOSTROOT)/lib $(MINVEROPT) -arch $(subst $() $(), -arch ,$(ARCHS))
+ beos_ARCH_LDFLAGS:=
+-linux_ARCH_LDFLAGS:=
++linux_ARCH_LDFLAGS:=${LDFLAGS}
+ ARCH_LDFLAGS:=$($(OS)_ARCH_LDFLAGS)
+ LDFLAGS:=$(ARCH_LDFLAGS)
+ 
+@@ -213,7 +213,7 @@ ARCH_HEADERS:=$($(OS)_ARCH_HEADERS)
+ windows_PREFIX:=/usr/local
+ macos_PREFIX:=Resources
+ ios_PREFIX:=.
+-linux_PREFIX:=/usr/local
++linux_PREFIX:=${EPREFIX}/usr
+ PREFIX:=$($(OS)_PREFIX)
+ 
+ # Root directory to place files when creating packages.
+@@ -247,10 +247,10 @@ LIBDIR=$(PREFIX)
+ 
+ # Magic Tool plug-ins
+ INCLUDE_PREFIX:=$(DESTDIR)$(PREFIX)/include
+-MAGIC_PREFIX:=$(DESTDIR)$(LIBDIR)/lib$(LIBDIRSUFFIX)/tuxpaint/plugins
++MAGIC_PREFIX:=$(DESTDIR)$(LIBDIR)/$(GENTOO_LIBDIR)/tuxpaint/plugins
+ 
+ # Docs and man page:
+ DOC_PREFIX:=$(DESTDIR)$(PREFIX)/share/doc/tuxpaint-$(VER_VERSION)
+ MAN_PREFIX:=$(DESTDIR)$(PREFIX)/share/man
+ DEVMAN_PREFIX:=$(DESTDIR)$(PREFIX)/share/man
+ 
+@@ -381,7 +381,7 @@ MOUSE_CFLAGS:=-Isrc/$(MOUSEDIR) -D$(CURSOR_SHAPES)_CURSOR_SHAPES
+ # are 132x80.  On larger screens, they will be bigger (since the New dialog
+ # is always 4x4 thumbnails); therefore, generating larger thumbs, which can
+ # be still be scaled down fairly quickly (esp. complicated SVG ones).
+-CONVERT_OPTS:=-alpha Background -alpha Off +depth -resize "!264x160" -background white -interlace none
++CONVERT_OPTS:=-resize 264x160 -background white -extent 0x0 -interlace none
+ 
+ .SUFFIXES:
+ 
+@@ -575,11 +575,7 @@ endif
+ windows_ARCH_INSTALL:=
+ macos_ARCH_INSTALL:=install-macbundle
+ ios_ARCH_INSTALL:=install-iosbundle
+-ifeq ($(PACKAGE_ONLY),yes)
+-	linux_ARCH_INSTALL:=install-pkgxdg install-man install-importscript install-bash-completion
+-else
+-	linux_ARCH_INSTALL:=install-xdg install-man install-importscript install-bash-completion
+-endif
++linux_ARCH_INSTALL:=install-man install-importscript install-bash-completion
+ ARCH_INSTALL:=$($(OS)_ARCH_INSTALL)
+ 
+ # "make install" installs all of the various parts
+@@ -763,12 +759,12 @@ uninstall:	uninstall-i18n
+ 	-rm $(BIN_PREFIX)/tuxpaint-import
+ 	-rm -r $(DATA_PREFIX)
+ 	-rm -r $(DOC_PREFIX)
+-	-rm $(MAN_PREFIX)/man1/tuxpaint.1.gz
+-	-rm $(MAN_PREFIX)/*/man1/tuxpaint.1.gz
+-	-rm $(MAN_PREFIX)/man1/tuxpaint-import.1.gz
+-	-rm $(MAN_PREFIX)/*/man1/tuxpaint-import.1.gz
+-	-rm $(MAN_PREFIX)/man1/tp-magic-config.1.gz
+-	-rm $(MAN_PREFIX)/*/man1/tp-magic-config.1.gz
++	-rm $(MAN_PREFIX)/man1/tuxpaint.1
++	-rm $(MAN_PREFIX)/*/man1/tuxpaint.1
++	-rm $(MAN_PREFIX)/man1/tuxpaint-import.1
++	-rm $(MAN_PREFIX)/*/man1/tuxpaint-import.1
++	-rm $(MAN_PREFIX)/man1/tp-magic-config.1
++	-rm $(MAN_PREFIX)/*/man1/tp-magic-config.1
+ 	-rm -f -r $(CONFDIR)
+ 	-rm $(COMPLETIONDIR)/tuxpaint-completion.bash
+ 	-rm -r $(MAGIC_PREFIX)
+@@ -869,11 +865,11 @@ $(THUMB_STARTERS):
+ 	@mkdir -p starters/.thumbs
+ 	@if [ "x" != "x"$(STARTER_BACK_NAME) ] ; \
+ 	then \
+-		composite $(STARTER_NAME) $(STARTER_BACK_NAME) obj/tmp_$(notdir $(STARTER_NAME)).png ; \
+-		$(CONVERT) $(CONVERT_OPTS) obj/tmp_$(notdir $(STARTER_NAME)).png $@ 2> /dev/null ; \
++		gm composite $(STARTER_NAME) $(STARTER_BACK_NAME) obj/tmp_$(notdir $(STARTER_NAME)).png 2> /dev/null ; \
++		gm convert $(CONVERT_OPTS) obj/tmp_$(notdir $(STARTER_NAME)).png $@ || echo "($@ failed)" ; \
+ 		rm obj/tmp_$(notdir $(STARTER_NAME)).png ; \
+ 	else \
+-		$(CONVERT) $(CONVERT_OPTS) $(STARTER_NAME) $@ 2> /dev/null || ( echo "($@ failed)" ; rm -f $@ ) ; \
++		gm convert $(CONVERT_OPTS) $(STARTER_NAME) $@ 2> /dev/null || ( echo "($@ failed)" ; rm $@ ) ; \
+ 	fi
+ 
+ $(INSTALLED_THUMB_STARTERS): $(DATA_PREFIX)/%: % install-example-starters-dirs
+@@ -928,7 +924,7 @@ TEMPLATE_NAME=$(or $(wildcard $(subst templates/.thumbs,templates,$(@:-t.png=.sv
+ $(THUMB_TEMPLATES):
+ 	@printf "."
+ 	@mkdir -p templates/.thumbs
+-	@$(CONVERT) $(CONVERT_OPTS) $(TEMPLATE_NAME) $@ 2> /dev/null || ( echo "($@ failed)" ; rm -f $@ ) ; \
++	@gm convert $(CONVERT_OPTS) $(TEMPLATE_NAME) $@ 2> /dev/null || ( echo "($@ failed)" ; rm $@ ) ; \
+ 
+ $(INSTALLED_THUMB_TEMPLATES): $(DATA_PREFIX)/%: %
+ 	@install -D -m 644 $< $@ || ( echo "NO THUMB $<" )
+@@ -1072,9 +1068,9 @@ install-dlls:
+ 	@cp -R win32/etc/ $(BIN_PREFIX)
+ 	@echo
+ 	@echo "...Installing Library Modules..."
+-	@mkdir -p $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders
+-	@cp $(MINGW_DIR)/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders
+-	@strip -s $(BIN_PREFIX)/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll
++	@mkdir -p $(BIN_PREFIX)/$(GENTOO_LIBDIR)/gdk-pixbuf-2.0/2.10.0/loaders
++	@cp $(MINGW_DIR)/$(GENTOO_LIBDIR)/gdk-pixbuf-2.0/2.10.0/loaders/*.dll $(BIN_PREFIX)/$(GENTOO_LIBDIR)/gdk-pixbuf-2.0/2.10.0/loaders
++	@strip -s $(BIN_PREFIX)/$(GENTOO_LIBDIR)/gdk-pixbuf-2.0/2.10.0/loaders/*.dll
+ 
+ # Install symlink:
+ .PHONY: install-haiku
+@@ -1149,24 +1145,20 @@ install-man:
+ 	@install -d $(MAN_PREFIX)/man1
+ 	@# tuxpaint.1
+ 	@cp man/en/tuxpaint.1 $(MAN_PREFIX)/man1/
+-	@gzip -f $(MAN_PREFIX)/man1/tuxpaint.1
+-	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tuxpaint.1.gz
++	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tuxpaint.1
+ 	@# tuxpaint-import.1
+ 	@cp man/en/tuxpaint-import.1 $(MAN_PREFIX)/man1/
+-	@gzip -f $(MAN_PREFIX)/man1/tuxpaint-import.1
+-	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tuxpaint-import.1.gz
++	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tuxpaint-import.1
+ 	@# tp-magic-config.1
+ 	@cp man/en/tp-magic-config.1 $(MAN_PREFIX)/man1/
+-	@gzip -f $(MAN_PREFIX)/man1/tp-magic-config.1
+-	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tp-magic-config.1.gz
++	@chmod a+rx,g-w,o-w $(MAN_PREFIX)/man1/tp-magic-config.1
+ 	@echo
+ 	for l in `ls -d man/*.UTF-8 | cut -d '/' -f 2`; do \
+ 		DEST=$(MAN_PREFIX)/$$l/man1 ; \
+ 		echo "...Installing $$l man pages into $$DEST..." ; \
+ 		install -d $$DEST ; \
+ 		cp man/$$l/tuxpaint.1 $$DEST ; \
+-		gzip -f $$DEST/tuxpaint.1 ; \
+-		chmod a+rx,g-w,o-w $$DEST/tuxpaint.1.gz ; \
++		chmod a+rx,g-w,o-w $$DEST/tuxpaint.1 ; \
+ 	done
+ 	@# FIXME: The other man pages aren't localizable yet -bjk 2021.08.14
+ 

--- a/media-gfx/tuxpaint/tuxpaint-0.9.31-r2.ebuild
+++ b/media-gfx/tuxpaint/tuxpaint-0.9.31-r2.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop optfeature toolchain-funcs xdg
+
+DESCRIPTION="Drawing program designed for young children"
+HOMEPAGE="https://www.tuxpaint.org/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+S="${WORKDIR}"/${P}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="
+	app-text/libpaper:=
+	dev-libs/fribidi
+	gnome-base/librsvg:2
+	media-gfx/libimagequant
+	>=media-libs/freetype-2:2
+	>=media-libs/libpng-1.2:0=
+	media-libs/libsdl2[X,joystick]
+	media-libs/sdl2-gfx
+	media-libs/sdl2-image[png]
+	media-libs/sdl2-mixer
+	media-libs/sdl2-pango
+	media-libs/sdl2-ttf
+	sys-libs/zlib
+	x11-libs/cairo
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/gperf
+	media-gfx/graphicsmagick[jpeg,png]
+	sys-devel/gettext
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PF}-Makefile.patch
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)" GENTOO_LIBDIR="$(get_libdir)" PF="${PF}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" DOC_PREFIX="${ED}/usr/share/doc/${PF}" GENTOO_LIBDIR="$(get_libdir)" install
+
+	local file size
+	for file in data/images/icon[0-9]*x[0-9]*.png; do
+		size=${file##*/icon}
+		size=${size%%x*}
+		newicon -s "${size}" "${file}" tux4kids-tuxpaint.png
+	done
+
+	newmenu src/tuxpaint.desktop tux4kids-tuxpaint.desktop
+	dodoc docs/*.txt docs/en/*.txt
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	optfeature "additional graphic stamps" media-gfx/tuxpaint-stamps
+}


### PR DESCRIPTION
- Remove DOC_PREFIX from Makefile patch and set it in emake call instead
- Clean up doc handling in src_install, removing explicit usage of prefix /usr in the process

Closes: https://bugs.gentoo.org/963376

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
