### PR TITLE
dev-util/flatpak-builder: deps fix 1.4.6

### DIFF
--- a/dev-util/flatpak-builder/flatpak-builder-1.4.6.ebuild
+++ b/dev-util/flatpak-builder/flatpak-builder-1.4.6.ebuild
@@ -13,7 +13,6 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 IUSE="doc +yaml"
 
 RDEPEND="
-	>=sys-apps/flatpak-0.99.1
 	>=dev-util/ostree-2019.5:=
 	>=dev-libs/elfutils-0.8.12:=
 	>=dev-libs/glib-2.44:2=
@@ -21,7 +20,6 @@ RDEPEND="
 	dev-libs/json-glib:=
 	net-misc/curl:=
 	yaml? ( dev-libs/libyaml:= )
-	dev-libs/appstream[compose(-)]
 "
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
* Curiously enough, flatpak-builder does no longer depend on sys-apps/flatpak, nor on dev-libs/appstream:

```
localpc /var/cache/distfiles # qlist -e flatpak-builder | xargs scanelf -BF '%n'
libelf.so.1,libyaml-0.so.2,libostree-1.so.1,libjson-glib-1.0.so.0,libgio-2.0.so.0,libgobject-2.0.so.0,libglib-2.0.so.0,libxml2.so.2,libcurl.so.4,libc.so.6 /usr/bin/flatpak-builder
libdw.so.1,libelf.so.1,libc.so.6 /usr/libexec/flatpak-builder-debugedit
```


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.