### PR TITLE
media-sound/cdtool: fix c23, add missing include

### DIFF
--- a/media-sound/cdtool/cdtool-2.1.8-r2.ebuild
+++ b/media-sound/cdtool/cdtool-2.1.8-r2.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 inherit autotools
 
 DESCRIPTION="collection of command-line utilities to control cdrom devices"
-HOMEPAGE="http://hinterhof.net/cdtool/"
-SRC_URI="http://hinterhof.net/cdtool/dist/${P}.tar.gz"
+HOMEPAGE="https://hinterhof.net/cdtool/"
+SRC_URI="https://hinterhof.net/cdtool/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -18,6 +18,7 @@ RDEPEND="!media-sound/cdplay"
 PATCHES=(
 	"${FILESDIR}/${P}-glibc-2.10.patch"
 	"${FILESDIR}/${P}-fix-build-system.patch"
+	"${FILESDIR}/${P}-fix_c23.patch"
 )
 
 src_prepare() {

--- a/media-sound/cdtool/files/cdtool-2.1.8-fix_c23.patch
+++ b/media-sound/cdtool/files/cdtool-2.1.8-fix_c23.patch
@@ -1,0 +1,66 @@
+use getopt from glibc/musl, bug 945335
+add missing include, bugs 712586, 896426
+fix unprototype functions
+--- a/commands.c
++++ b/commands.c
+@@ -26,6 +26,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <signal.h>
++#include <fcntl.h>
+ 
+ #include "config.h"
+ #include "cdtool.h"
+--- a/shuffle.c
++++ b/shuffle.c
+@@ -59,7 +59,7 @@
+  *       you don't like a song.  
+  */
+ /************************************************************************/
+-void huphdl ()
++void huphdl (int signum)
+ {
+     signal (SIGHUP, huphdl);
+     iNext = TRUE;
+@@ -79,7 +79,7 @@
+  *       stop playing, remove its PID file, and exit. 
+  */
+ /************************************************************************/
+-void inthdl ()
++void inthdl (int signum)
+ {
+     signal (SIGINT, inthdl);
+     iDone = TRUE;
+--- a/cdown.c
++++ b/cdown.c
+@@ -652,8 +653,6 @@
+ /************************************************************************/
+ int main(int argc, char *argv[]) {
+ 
+-  extern int	optind, getopt();
+-  extern char	*optarg;
+   int		iListMode   = FALSE;
+   int           error       = 0;
+   char          *pszHost    = NULL;
+--- a/cdctrl.c
++++ b/cdctrl.c
+@@ -247,8 +248,6 @@
+ int main (int argc, char *argv[])
+ {
+     cdtool_t cdtool;
+-    extern int optind, getopt();
+-    extern char *optarg;
+     char *device = NULL;
+     int opt=1;
+ 
+--- a/cdtool.c
++++ b/cdtool.c
+@@ -68,8 +69,6 @@
+ {
+   cdtool_t      cdtool;
+   int		info=I_AUDIOSTATUS, error=0, opt, trk0=0, trk1=0;
+-  extern int	optind, getopt();
+-  extern char	*optarg;
+ 
+   char p_format = P_LONG;
+   char *device = NULL;


### PR DESCRIPTION
update HOMEPAGE/SRC_URI http+S

Closes: https://bugs.gentoo.org/712586
Closes: https://bugs.gentoo.org/896426
Closes: https://bugs.gentoo.org/945335

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
