### PR TITLE
net-misc/portfwd: fix c23, new initd

### DIFF
--- a/net-misc/portfwd/files/portfwd-0.29-fix_c23.patch
+++ b/net-misc/portfwd/files/portfwd-0.29-fix_c23.patch
@@ -1,0 +1,191 @@
+don't use bundled getopt, bug #945521
+remove register keyword, bug #921659
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = getopt src tools doc
++SUBDIRS = src tools doc
+ 
+ docdir = $(prefix)/doc/portfwd
+ doc_DATA = COPYING README CREDITS TODO
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -8,8 +8,6 @@ portfwd_SOURCES = addr.cc from_addr.cc host_map.cc portfwd.cc \
+ 	proto_map.cc forward.cc port_pair.cc  solve.cc \
+ 	yconf.c lexconf.c util.cc fd_set.cc
+ 
+-LDADD = getopt.o getopt1.o
+-
+ yconf.c: conf.y
+ 	$(YACC) -v -d -o $@ $<
+ 
+--- a/src/lexconf.c
++++ b/src/lexconf.c
+@@ -759,9 +759,9 @@ extern int yylex (void);
+  */
+ YY_DECL
+ {
+-	register yy_state_type yy_current_state;
+-	register char *yy_cp, *yy_bp;
+-	register int yy_act;
++	yy_state_type yy_current_state;
++	char *yy_cp, *yy_bp;
++	int yy_act;
+     
+ #line 94 "conf.lex"
+ 
+@@ -814,7 +814,7 @@ YY_DECL
+ yy_match:
+ 		do
+ 			{
+-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
++			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+ 			if ( yy_accept[yy_current_state] )
+ 				{
+ 				(yy_last_accepting_state) = yy_current_state;
+@@ -1207,9 +1207,9 @@ case YY_STATE_EOF(INITIAL):
+  */
+ static int yy_get_next_buffer (void)
+ {
+-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+-	register char *source = (yytext_ptr);
+-	register int number_to_move, i;
++    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
++	char *source = (yytext_ptr);
++	int number_to_move, i;
+ 	int ret_val;
+ 
+ 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
+@@ -1333,14 +1333,14 @@ static int yy_get_next_buffer (void)
+ 
+     static yy_state_type yy_get_previous_state (void)
+ {
+-	register yy_state_type yy_current_state;
+-	register char *yy_cp;
++	yy_state_type yy_current_state;
++	char *yy_cp;
+     
+ 	yy_current_state = (yy_start);
+ 
+ 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
+ 		{
+-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
++		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+ 		if ( yy_accept[yy_current_state] )
+ 			{
+ 			(yy_last_accepting_state) = yy_current_state;
+@@ -1365,10 +1365,10 @@ static int yy_get_next_buffer (void)
+  */
+     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
+ {
+-	register int yy_is_jam;
+-    	register char *yy_cp = (yy_c_buf_p);
++	int yy_is_jam;
++    	char *yy_cp = (yy_c_buf_p);
+ 
+-	register YY_CHAR yy_c = 1;
++	YY_CHAR yy_c = 1;
+ 	if ( yy_accept[yy_current_state] )
+ 		{
+ 		(yy_last_accepting_state) = yy_current_state;
+@@ -1386,9 +1386,9 @@ static int yy_get_next_buffer (void)
+ 	return yy_is_jam ? 0 : yy_current_state;
+ }
+ 
+-    static void yyunput (int c, register char * yy_bp )
++    static void yyunput (int c, char * yy_bp )
+ {
+-	register char *yy_cp;
++	char *yy_cp;
+     
+     yy_cp = (yy_c_buf_p);
+ 
+@@ -1398,10 +1398,10 @@ static int yy_get_next_buffer (void)
+ 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
+ 		{ /* need to shift things up to make room */
+ 		/* +2 for EOB chars. */
+-		register int number_to_move = (yy_n_chars) + 2;
+-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
++		int number_to_move = (yy_n_chars) + 2;
++		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+ 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
+-		register char *source =
++		char *source =
+ 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
+ 
+ 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
+@@ -1978,7 +1978,7 @@ int yylex_destroy  (void)
+ #ifndef yytext_ptr
+ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+ {
+-	register int i;
++	int i;
+     	for ( i = 0; i < n; ++i )
+ 		s1[i] = s2[i];
+ }
+@@ -1987,7 +1987,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+ #ifdef YY_NEED_STRLEN
+ static int yy_flex_strlen (yyconst char * s )
+ {
+-	register int n;
++	int n;
+     	for ( n = 0; s[n]; ++n )
+ 		;
+ 
+--- a/src/yconf.c
++++ b/src/yconf.c
+@@ -318,7 +318,7 @@ union yyalloc
+ #   define YYCOPY(To, From, Count)		\
+       do					\
+ 	{					\
+-	  register YYSIZE_T yyi;		\
++	  YYSIZE_T yyi;		\
+ 	  for (yyi = 0; yyi < (Count); yyi++)	\
+ 	    (To)[yyi] = (From)[yyi];		\
+ 	}					\
+@@ -798,7 +798,7 @@ yystrlen (yystr)
+      const char *yystr;
+ #   endif
+ {
+-  register const char *yys = yystr;
++  const char *yys = yystr;
+ 
+   while (*yys++ != '\0')
+     continue;
+@@ -823,8 +823,8 @@ yystpcpy (yydest, yysrc)
+      const char *yysrc;
+ #   endif
+ {
+-  register char *yyd = yydest;
+-  register const char *yys = yysrc;
++  char *yyd = yydest;
++  const char *yys = yysrc;
+ 
+   while ((*yyd++ = *yys++) != '\0')
+     continue;
+@@ -954,8 +954,8 @@ yyparse ()
+ #endif
+ {
+   
+-  register int yystate;
+-  register int yyn;
++  int yystate;
++  int yyn;
+   int yyresult;
+   /* Number of tokens to shift before error messages enabled.  */
+   int yyerrstatus;
+@@ -973,12 +973,12 @@ yyparse ()
+   /* The state stack.  */
+   short	yyssa[YYINITDEPTH];
+   short *yyss = yyssa;
+-  register short *yyssp;
++  short *yyssp;
+ 
+   /* The semantic value stack.  */
+   YYSTYPE yyvsa[YYINITDEPTH];
+   YYSTYPE *yyvs = yyvsa;
+-  register YYSTYPE *yyvsp;
++  YYSTYPE *yyvsp;
+ 
+ 
+ 

--- a/net-misc/portfwd/files/portfwd-2.init
+++ b/net-misc/portfwd/files/portfwd-2.init
@@ -1,0 +1,17 @@
+#!/sbin/openrc-run
+# Copyright 2025 Gentoo Authors
+# # Distributed under the terms of the GNU General Public License v2
+
+: ${PORTFWD_CONFIG:=/etc/portfwd.cfg}
+
+name="porfwd"
+description="Port Forwarding Daemon"
+command="/usr/sbin/portfwd"
+command_args="--foreground --config ${PORTFWD_CONFIG} ${PORTFWD_OPTS}"
+command_background=true
+pidfile="/run/${RC_SVCNAME}.pid"
+required_files="${PORTFWD_CONFIG}"
+
+depend() {
+	need net
+}

--- a/net-misc/portfwd/portfwd-0.29-r3.ebuild
+++ b/net-misc/portfwd/portfwd-0.29-r3.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools systemd
+
+DESCRIPTION="Port Forwarding Daemon"
+HOMEPAGE="https://portfwd.sourceforge.net"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.29-build-system.patch
+	"${FILESDIR}"/${PN}-0.29-fix_c23.patch
+)
+
+src_prepare() {
+	default
+
+	# bug 945521, use header from glibc/musl instead
+	rm getopt/getopt.h || die
+
+	mv configure.in configure.ac || die # bug 822075
+
+	eautoreconf
+}
+
+src_install() {
+	default
+
+	dodoc cfg/*
+
+	newinitd "${FILESDIR}"/${PN}-2.init ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}
+	systemd_dounit "${FILESDIR}"/${PN}.service
+}


### PR DESCRIPTION
update HOMEPAGE http+S
update SRC_URI (redirect)

don't use bundled getopt
remove register keyword (c17)
rename configure.in to configure.ac
refresh initd w/o bashism

Really don't know if anyone is using it anymore.

Closes: https://bugs.gentoo.org/822075
Closes: https://bugs.gentoo.org/849284
Closes: https://bugs.gentoo.org/921659
Closes: https://bugs.gentoo.org/945521

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
