### PR TITLE
dev-util/flatpak-builder: revbump 1.4.6-r2, deps fix

### DIFF
--- a/dev-util/flatpak-builder/flatpak-builder-1.4.6-r2.ebuild
+++ b/dev-util/flatpak-builder/flatpak-builder-1.4.6-r2.ebuild
@@ -19,6 +19,7 @@ RDEPEND="
 	>=dev-libs/libxml2-2.4:=
 	dev-libs/json-glib:=
 	net-misc/curl:=
+	>=sys-apps/flatpak-0.99.1
 	yaml? ( dev-libs/libyaml:= )
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
* fixing false flag for dependency on flatpak.
* Closes: https://bugs.gentoo.org/963485

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.