### PR TITLE
net-im/telegram-desktop: Find datafiles in ESYSROOT instead of EPREFIX

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-5.12.3-r6.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-5.12.3-r6.ebuild
@@ -128,7 +128,7 @@ src_configure() {
 	# XDG_DATA_DIRS variable causes all sorts of weirdness with cppgir:
 	# - bug 909038: can't read from flatpak directories (fixed upstream)
 	# - bug 920819: system-wide directories ignored when variable is set
-	export XDG_DATA_DIRS="${EPREFIX}/usr/share"
+	export XDG_DATA_DIRS="${ESYSROOT}/usr/share"
 
 	# Evil flag (bug #919201)
 	filter-flags -fno-delete-null-pointer-checks

--- a/net-im/telegram-desktop/telegram-desktop-6.0.2-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-6.0.2-r1.ebuild
@@ -142,7 +142,7 @@ src_configure() {
 	# XDG_DATA_DIRS variable causes all sorts of weirdness with cppgir:
 	# - bug 909038: can't read from flatpak directories (fixed upstream)
 	# - bug 920819: system-wide directories ignored when variable is set
-	export XDG_DATA_DIRS="${EPREFIX}/usr/share"
+	export XDG_DATA_DIRS="${ESYSROOT}/usr/share"
 
 	# Evil flag (bug #919201)
 	filter-flags -fno-delete-null-pointer-checks

--- a/net-im/telegram-desktop/telegram-desktop-6.1.3.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-6.1.3.ebuild
@@ -142,7 +142,7 @@ src_configure() {
 	# XDG_DATA_DIRS variable causes all sorts of weirdness with cppgir:
 	# - bug 909038: can't read from flatpak directories (fixed upstream)
 	# - bug 920819: system-wide directories ignored when variable is set
-	export XDG_DATA_DIRS="${EPREFIX}/usr/share"
+	export XDG_DATA_DIRS="${ESYSROOT}/usr/share"
 
 	# Evil flag (bug #919201)
 	filter-flags -fno-delete-null-pointer-checks


### PR DESCRIPTION
This will aid cross-compilation.

No revbump, if it compiled correctly before it'll compile the same now.

Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
