### PR TITLE
app-text/libabw: add `dev-util/gperf` to `BDEPEND`

### DIFF
--- a/app-text/libabw/libabw-0.1.3-r1.ebuild
+++ b/app-text/libabw/libabw-0.1.3-r1.ebuild
@@ -13,6 +13,7 @@ KEYWORDS="amd64 ~arm arm64 ~loong ppc64 ~riscv x86"
 IUSE="doc"
 
 BDEPEND="
+	dev-util/gperf
 	virtual/pkgconfig
 	doc? ( app-text/doxygen )
 "


### PR DESCRIPTION
The build depends on the presence of `gperf`.

<details><summary>Build output without <code>dev-util/gperf</code> installed</summary>

```
[32m * [39;49;00mPackage:    app-text/libabw-0.1.3-r1:0
[32m * [39;49;00mRepository: gentoo
[32m * [39;49;00mMaintainer: office@gentoo.org
[32m * [39;49;00mUSE:        abi_x86_64 amd64 elibc_glibc kernel_linux
[32m * [39;49;00mFEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
[32m * [39;49;00mPackage:    app-text/libabw-0.1.3-r1:0
[32m * [39;49;00mRepository: gentoo
[32m * [39;49;00mMaintainer: office@gentoo.org
[32m * [39;49;00mUSE:        abi_x86_64 amd64 elibc_glibc kernel_linux
[32m * [39;49;00mFEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking 'libabw-0.1.3.tar.xz' to /var/tmp/portage/app-text/libabw-0.1.3-r1/work
>>> Source unpacked in /var/tmp/portage/app-text/libabw-0.1.3-r1/work
>>> Preparing source in /var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3 ...
 * econf: updating libabw-0.1.3/config.guess with /usr/share/gnuconfig/config.guess
 * econf: updating libabw-0.1.3/config.sub with /usr/share/gnuconfig/config.sub
./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --datarootdir=/usr/share --disable-dependency-tracking --disable-silent-rules --disable-static --docdir=/usr/share/doc/libabw-0.1.3-r1 --htmldir=/usr/share/doc/libabw-0.1.3-r1/html --with-sysroot=/ --libdir=/usr/lib64 --without-docs
checking for a BSD-compatible install... /usr/lib/portage/python3.13/ebuild-helpers/xattr/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking whether make supports the include directive... yes (GNU style)
checking for x86_64-pc-linux-gnu-gcc... x86_64-pc-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... none needed
checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... yes
checking dependency style of x86_64-pc-linux-gnu-gcc... none
checking for x86_64-pc-linux-gnu-ar... x86_64-pc-linux-gnu-ar
checking the archiver (x86_64-pc-linux-gnu-ar) interface... ar
checking for x86_64-pc-linux-gnu-gcc... (cached) x86_64-pc-linux-gnu-gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... (cached) yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... (cached) none needed
checking whether x86_64-pc-linux-gnu-gcc understands -c and -o together... (cached) yes
checking dependency style of x86_64-pc-linux-gnu-gcc... (cached) none
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for x86_64-pc-linux-gnu-g++... x86_64-pc-linux-gnu-g++
checking whether we are using the GNU C++ compiler... yes
checking whether x86_64-pc-linux-gnu-g++ accepts -g... yes
checking dependency style of x86_64-pc-linux-gnu-g++... none
checking whether ln -s works... yes
checking whether make sets $(MAKE)... (cached) yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking for ld used by x86_64-pc-linux-gnu-gcc... /usr/x86_64-pc-linux-gnu/bin/ld
checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/x86_64-pc-linux-gnu-nm -B
checking the name lister (/usr/bin/x86_64-pc-linux-gnu-nm -B) interface... BSD nm
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-pc-linux-gnu/bin/ld option to reload object files... -r
checking for x86_64-pc-linux-gnu-objdump... x86_64-pc-linux-gnu-objdump
checking how to recognize dependent libraries... pass_all
checking for x86_64-pc-linux-gnu-dlltool... x86_64-pc-linux-gnu-dlltool
checking how to associate runtime and link libraries... printf %s\n
checking for x86_64-pc-linux-gnu-ar... (cached) x86_64-pc-linux-gnu-ar
checking for archiver @FILE support... @
checking for x86_64-pc-linux-gnu-strip... x86_64-pc-linux-gnu-strip
checking for x86_64-pc-linux-gnu-ranlib... x86_64-pc-linux-gnu-ranlib
checking command to parse /usr/bin/x86_64-pc-linux-gnu-nm -B output from x86_64-pc-linux-gnu-gcc object... ok
checking for sysroot... /
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for x86_64-pc-linux-gnu-mt... no
checking for mt... no
checking if : is a manifest tool... no
checking for ANSI C header files... no
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if x86_64-pc-linux-gnu-gcc supports -fno-rtti -fno-exceptions... no
checking for x86_64-pc-linux-gnu-gcc option to produce PIC... -fPIC -DPIC
checking if x86_64-pc-linux-gnu-gcc PIC flag -fPIC -DPIC works... yes
checking if x86_64-pc-linux-gnu-gcc static flag -static works... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... yes
checking if x86_64-pc-linux-gnu-gcc supports -c -o file.o... (cached) yes
checking whether the x86_64-pc-linux-gnu-gcc linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking how to run the C++ preprocessor... x86_64-pc-linux-gnu-g++ -E
checking for ld used by x86_64-pc-linux-gnu-g++... /usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64
checking if the linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the x86_64-pc-linux-gnu-g++ linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for x86_64-pc-linux-gnu-g++ option to produce PIC... -fPIC -DPIC
checking if x86_64-pc-linux-gnu-g++ PIC flag -fPIC -DPIC works... yes
checking if x86_64-pc-linux-gnu-g++ static flag -static works... yes
checking if x86_64-pc-linux-gnu-g++ supports -c -o file.o... yes
checking if x86_64-pc-linux-gnu-g++ supports -c -o file.o... (cached) yes
checking whether the x86_64-pc-linux-gnu-g++ linker (/usr/x86_64-pc-linux-gnu/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether x86_64-pc-linux-gnu-g++ supports C++11 features by default... yes
checking for __attribute__((format))... yes
checking for native Win32... no
checking for Win32 platform in general... no
checking for -fvisibility=hidden compiler flag... yes
checking for Darwin (Mac OS X) platform... no
checking for x86_64-pc-linux-gnu-pkg-config... /usr/bin/x86_64-pc-linux-gnu-pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for REVENGE... yes
checking for LIBXML... yes
checking for ZLIB... yes
checking for boost/algorithm/string.hpp... yes
checking for boost/optional.hpp... yes
checking for boost/spirit/include/qi.hpp... yes
checking for REVENGE_GENERATORS... yes
checking for REVENGE_STREAM... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating src/Makefile
config.status: creating src/conv/Makefile
config.status: creating src/conv/html/Makefile
config.status: creating src/conv/html/abw2html.rc
config.status: creating src/conv/raw/Makefile
config.status: creating src/conv/raw/abw2raw.rc
config.status: creating src/conv/text/Makefile
config.status: creating src/conv/text/abw2text.rc
config.status: creating src/fuzz/Makefile
config.status: creating src/lib/Makefile
config.status: creating src/lib/libabw.rc
config.status: creating inc/Makefile
config.status: creating inc/libabw/Makefile
config.status: creating docs/Makefile
config.status: creating docs/doxygen/Makefile
config.status: creating build/Makefile
config.status: creating build/win32/Makefile
config.status: creating libabw-0.1.pc
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
configure:
==============================================================================
Build configuration:
	debug:           no
	docs:            no
	fuzzers:         no
	tools:           yes
	werror:          no
==============================================================================

>>> Source configured.
>>> Compiling source in /var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3 ...
make -j16 
make  all-recursive
Making all in build
Making all in win32
make[3]: Nothing to be done for 'all'.
make[3]: Nothing to be done for 'all-am'.
Making all in inc
Making all in libabw
make[3]: Nothing to be done for 'all'.
make[3]: Nothing to be done for 'all-am'.
Making all in src
Making all in lib
make[3]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh /var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/missing perl ../../src/lib/gentoken.pl ../../src/lib/tokens.txt \
	tokens.h tokens.gperf
make[3]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[3]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh /var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/missing gperf --compare-strncmp -C -m 20 tokens.gperf \
	| /usr/bin/sed -e 's/(char\*)0/(char\*)0, 0/g' -e 's/register //g' > tokenhash.h
/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/missing: line 81: gperf: command not found
WARNING: 'gperf' is missing on your system.
         You might have modified some files without having the proper
         tools for further handling them.  Check the 'README' file, it
         often tells you about the needed prerequisites for installing
         this package.  You may also peek at any GNU archive site, in
         case some other package contains this missing 'gperf' program.
make[3]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make  all-am
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWXMLTokenMap.lo ABWXMLTokenMap.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWXMLTokenMap.cpp  -fPIC -DPIC -o .libs/ABWXMLTokenMap.o
ABWXMLTokenMap.cpp: In static member function ‘static int libabw::ABWXMLTokenMap::getTokenId(const xmlChar*)’:
ABWXMLTokenMap.cpp:22:9: error: ‘xmltoken’ does not name a type
   22 |   const xmltoken *token = Perfect_Hash::in_word_set((const char *)name, (unsigned int)xmlStrlen(name));
      |         ^~~~~~~~
ABWXMLTokenMap.cpp:23:7: error: ‘token’ was not declared in this scope
   23 |   if (token)
      |       ^~~~~
ABWXMLTokenMap.cpp:20:55: warning: unused parameter ‘name’ [-Wunused-parameter]
   20 | int libabw::ABWXMLTokenMap::getTokenId(const xmlChar *name)
      |                                        ~~~~~~~~~~~~~~~^~~~
make[4]: *** [Makefile:543: ABWXMLTokenMap.lo] Error 1
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: *** Waiting for unfinished jobs....
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o libabw_internal.lo libabw_internal.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c libabw_internal.cpp  -fPIC -DPIC -o .libs/libabw_internal.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWZlibStream.lo ABWZlibStream.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWZlibStream.cpp  -fPIC -DPIC -o .libs/ABWZlibStream.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o AbiDocument.lo AbiDocument.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c AbiDocument.cpp  -fPIC -DPIC -o .libs/AbiDocument.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWXMLHelper.lo ABWXMLHelper.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWXMLHelper.cpp  -fPIC -DPIC -o .libs/ABWXMLHelper.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWOutputElements.lo ABWOutputElements.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWOutputElements.cpp  -fPIC -DPIC -o .libs/ABWOutputElements.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWStylesCollector.lo ABWStylesCollector.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWStylesCollector.cpp  -fPIC -DPIC -o .libs/ABWStylesCollector.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWParser.lo ABWParser.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWParser.cpp  -fPIC -DPIC -o .libs/ABWParser.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWCollector.lo ABWCollector.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWCollector.cpp  -fPIC -DPIC -o .libs/ABWCollector.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[4]: Entering directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
/bin/sh ../../libtool  --tag=CXX   --mode=compile x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../..    -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2  -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c -o ABWContentCollector.lo ABWContentCollector.cpp
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../.. -I../../inc -I/usr/include/librevenge-0.0 -I/usr/include/libxml2 -DNDEBUG -DLIBABW_BUILD=1 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -pipe -march=native -O3 -fno-semantic-interposition -fvisibility=hidden -DLIBABW_VISIBILITY -Wall -Wextra -pedantic -Wshadow -Wunused-variable -Weffc++ -c ABWContentCollector.cpp  -fPIC -DPIC -o .libs/ABWContentCollector.o
make[4]: Leaving directory '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3/src/lib'
make[3]: *** [Makefile:427: all] Error 2
make[2]: *** [Makefile:387: all-recursive] Error 1
make[1]: *** [Makefile:496: all-recursive] Error 1
make: *** [Makefile:407: all] Error 2
 [31;01m*[0m ERROR: app-text/libabw-0.1.3-r1::gentoo failed (compile phase):
 [31;01m*[0m   emake failed
 [31;01m*[0m 
 [31;01m*[0m If you need support, post the output of `emerge --info '=app-text/libabw-0.1.3-r1::gentoo'`,
 [31;01m*[0m the complete build log and the output of `emerge -pqv '=app-text/libabw-0.1.3-r1::gentoo'`.
 [31;01m*[0m The complete build log is located at '/var/tmp/portage/app-text/libabw-0.1.3-r1/temp/build.log'.
 [31;01m*[0m The ebuild environment file is located at '/var/tmp/portage/app-text/libabw-0.1.3-r1/temp/environment'.
 [31;01m*[0m Working directory: '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3'
 [31;01m*[0m S: '/var/tmp/portage/app-text/libabw-0.1.3-r1/work/libabw-0.1.3'
```
</details> 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
