### PR TITLE
sci-chemistry/gnome-chemistry-utils: fix underlinking w/ slibtool

### DIFF
--- a/sci-chemistry/gnome-chemistry-utils/files/gnome-chemistry-utils-fix_underlinking.patch
+++ b/sci-chemistry/gnome-chemistry-utils/files/gnome-chemistry-utils-fix_underlinking.patch
@@ -1,0 +1,30 @@
+https://bugs.gentoo.org/913669
+fix underlinking with slibtool
+--- a/plugins/loaders/cdx/Makefile.am
++++ b/plugins/loaders/cdx/Makefile.am
+@@ -18,8 +18,9 @@ gcu_loader_cdx_LTLIBRARIES = cdx.la
+ cdx_la_LDFLAGS = -module -avoid-version -no-undefined
+ 
+ cdx_la_LIBADD = \
+-		$(gsf_LIBS) \
+-		$(top_builddir)/libs/gcu/libgcu-@GCU_API_VER@.la
++		$(gtk_LIBS) $(gsf_LIBS) \
++ 		$(top_builddir)/libs/gcu/libgcu-@GCU_API_VER@.la \
++		$(top_builddir)/libs/gcp/libgcp-@GCU_API_VER@.la
+ 
+ cdx_la_SOURCES =	\
+ 	cdx.cc
+--- a/plugins/loaders/cdxml/Makefile.am
++++ b/plugins/loaders/cdxml/Makefile.am
+@@ -17,8 +17,9 @@ gcu_loader_cdxml_LTLIBRARIES = cdxml.la
+ cdxml_la_LDFLAGS = -module -avoid-version -no-undefined
+ 
+ cdxml_la_LIBADD = \
+-		$(gsf_LIBS) $(goffice_LIBS) \
+-		$(top_builddir)/libs/gcu/libgcu-@GCU_API_VER@.la
++ 		$(gtk_LIBS) $(gsf_LIBS) $(goffice_LIBS) \
++		$(top_builddir)/libs/gcu/libgcu-@GCU_API_VER@.la \
++		$(top_builddir)/libs/gcp/libgcp-@GCU_API_VER@.la
+ 
+ cdxml_la_SOURCES =	\
+ 	cdxml.cc

--- a/sci-chemistry/gnome-chemistry-utils/gnome-chemistry-utils-0.14.17_p6-r4.ebuild
+++ b/sci-chemistry/gnome-chemistry-utils/gnome-chemistry-utils-0.14.17_p6-r4.ebuild
@@ -61,6 +61,9 @@ src_prepare() {
 	# Disable tests for manpages
 	eapply "${FILESDIR}"/${PN}-disable_tests_man.patch
 
+	# bug 913669 fix underlinking with slibtool
+	eapply "${FILESDIR}"/${PN}-fix_underlinking.patch
+
 	sed -e "s:pkg-config:$(tc-getPKG_CONFIG):g" \
 		-i configure.ac || die
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/913669

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
