### PR TITLE
www-client/uget: fix c23 and crash when changing sort

### DIFF
--- a/www-client/uget/files/uget-2.2.3-fix_c23.patch
+++ b/www-client/uget/files/uget-2.2.3-fix_c23.patch
@@ -1,0 +1,13 @@
+bugs https://bugs.gentoo.org/944225 https://bugs.gentoo.org/944274
+fix unprototyped function
+--- a/ui-gtk/UgtkSettingDialog.h
++++ b/ui-gtk/UgtkSettingDialog.h
+@@ -75,7 +75,7 @@ struct UgtkSettingDialog
+ 	struct UgtkMediaWebsiteForm   media_website;
+ };
+ 
+-UgtkSettingDialog*  ugtk_setting_dialog_new ();
++UgtkSettingDialog*  ugtk_setting_dialog_new (const gchar* title, GtkWindow* parent);
+ void                ugtk_setting_dialog_free (UgtkSettingDialog* sdialog);
+ 
+ void  ugtk_setting_dialog_run (UgtkSettingDialog* dialog, UgtkApp* app);

--- a/www-client/uget/files/uget-2.2.3-fix_crash_sorting.patch
+++ b/www-client/uget/files/uget-2.2.3-fix_crash_sorting.patch
@@ -1,0 +1,15 @@
+fix crash when changing sort
+https://github.com/ugetdm/uget/issues/40
+patch from upstream: 0c5b01
+--- a/ui-gtk/UgtkApp-callback.c
++++ b/ui-gtk/UgtkApp-callback.c
+@@ -549,6 +549,9 @@ static void node_updated (UgetNode* child)
+ 	UgtkApp*     app;
+ 
+ 	node = child->parent;
++	if(node == NULL) {
++		return;
++	}
+ 	app = node->control->notifier->data;
+ 	if (node == (UgetNode*) app->traveler.category.model->root) {
+ 		// category changed

--- a/www-client/uget/metadata.xml
+++ b/www-client/uget/metadata.xml
@@ -12,7 +12,7 @@
 		<flag name="aria2">Enable support for <pkg>net-misc/aria2</pkg> through xmlrpc.
 			You'll find the plugin in the app's settings.</flag>
 		<flag name="control-socket">Enable JSON-RPC over unix domain socket</flag>
-		<flag name="openssl">Use <pkg>dev-libs/openssl</pkg> instead of <pkg>net-libs/gnutls</pkg></flag>
+		<flag name="openssl">Use <pkg>dev-libs/openssl</pkg> instead of <pkg>dev-libs/libgcrypt</pkg></flag>
 		<flag name="rss">Enable uGet feed messages</flag>
 	</use>
 	<upstream>

--- a/www-client/uget/uget-2.2.3-r1.ebuild
+++ b/www-client/uget/uget-2.2.3-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools optfeature xdg
+
+DESCRIPTION="Download manager using gtk+ and libcurl"
+HOMEPAGE="https://github.com/ugetdm/uget"
+SRC_URI="https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/${PV}/${P}-1.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+IUSE="appindicator control-socket gstreamer libnotify nls openssl rss"
+
+RDEPEND="
+	dev-libs/glib:2
+	net-misc/curl
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3
+	x11-libs/pango
+	appindicator? ( dev-libs/libayatana-appindicator )
+	gstreamer? ( media-libs/gstreamer:1.0 )
+	libnotify? ( x11-libs/libnotify )
+	!openssl? ( dev-libs/libgcrypt:0= )
+	openssl? ( dev-libs/openssl:0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.1-fno-common.patch
+	# https://github.com/ugetdm/uget/issues/49
+	"${FILESDIR}"/${PN}-2.2.1-ayatana.patch
+	"${FILESDIR}"/${PN}-2.2.3-broken-curl-check.patch
+	# https://github.com/ugetdm/uget/issues/40
+	"${FILESDIR}"/${PN}-2.2.3-fix_crash_sorting.patch
+	"${FILESDIR}"/${PN}-2.2.3-fix_c23.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		$(use_enable appindicator)
+		$(use_enable control-socket unix_socket)
+		$(use_enable gstreamer)
+		$(use_enable libnotify notify)
+		$(use_enable nls)
+		$(use_enable rss rss_notify)
+		$(use_with !openssl gnutls)
+		$(use_with openssl)
+	)
+
+	econf "${myconf[@]}"
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	optfeature "aria2 plugin" net-misc/aria2[xmlrpc]
+}


### PR DESCRIPTION
update HOMEPAGE : [www.ugetdm.com](http://www.ugetdm.com/) is dead (404), [ugetdm.com](https://ugetdm.com) redirects to the [github repo](https://github.com/ugetdm/uget)
no remote-id for github because it contains only a README
update SRC_URI (redirect)

useflags reworked :
remove gnutls, it only requires libgcrypt, req-use is removed too, libgcrypt/openssl is handled by the useflag openssl
move aria2 in optfeature, it's just called as a runtime-plugin

deps :
remove libcpre, not required
add deps inherited by gtk+:3

patches :
fix c23 unprototyped function
fix a crash when changing sort (upstream)

Closes: https://bugs.gentoo.org/944225
Closes: https://bugs.gentoo.org/944274

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
