### PR TITLE
Add multilib support to `dev-cpp/catch` and fix test on `dev-libs/spdlog`

### DIFF
--- a/dev-cpp/catch/catch-1.12.2-r3.ebuild
+++ b/dev-cpp/catch/catch-1.12.2-r3.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	MY_P=${PN^}-${PV}
 	SRC_URI="https://github.com/catchorg/Catch2/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
-	KEYWORDS="~amd64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 	S="${WORKDIR}/${PN^}2-${PV}"
 fi
@@ -24,6 +24,10 @@ LICENSE="Boost-1.0"
 SLOT="1"
 IUSE="test"
 RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.12.2-glibc-2.34-sigstksz.patch
+)
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/dev-cpp/catch/catch-2.13.10-r1.ebuild
+++ b/dev-cpp/catch/catch-2.13.10-r1.ebuild
@@ -3,36 +3,42 @@
 
 EAPI=8
 
-inherit cmake-multilib
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit cmake-multilib python-any-r1
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/catchorg/Catch2.git"
-	EGIT_BRANCH="Catch1.x"
 else
-	MY_P=${PN^}-${PV}
+	MY_P=${PN^}2-${PV}
 	SRC_URI="https://github.com/catchorg/Catch2/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
-	KEYWORDS="~amd64 ~ppc64 ~x86"
+	S="${WORKDIR}/${MY_P}"
 
-	S="${WORKDIR}/${PN^}2-${PV}"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 DESCRIPTION="Modern C++ header-only framework for unit-tests"
 HOMEPAGE="https://github.com/catchorg/Catch2"
 
 LICENSE="Boost-1.0"
-SLOT="1"
+SLOT="0"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-multilib_src_configure() {
-	local mycmakeargs=(
-		-DNO_SELFTEST=$(usex !test)
-	)
-	cmake_src_configure
+BDEPEND="test? ( ${PYTHON_DEPS} )"
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
 }
 
-multilib_src_install() {
-	cmake_src_install
-	dodoc -r docs/.
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DCATCH_ENABLE_WERROR=OFF
+		-DBUILD_TESTING=$(usex test)
+	)
+	use test &&
+		mycmakeargs+=( -DPYTHON_EXECUTABLE="${PYTHON}" )
+
+	cmake_src_configure
 }

--- a/dev-cpp/catch/catch-3.8.1-r1.ebuild
+++ b/dev-cpp/catch/catch-3.8.1-r1.ebuild
@@ -3,36 +3,44 @@
 
 EAPI=8
 
-inherit cmake-multilib
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit cmake-multilib python-any-r1
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/catchorg/Catch2.git"
-	EGIT_BRANCH="Catch1.x"
 else
-	MY_P=${PN^}-${PV}
+	MY_P=${PN^}2-${PV}
 	SRC_URI="https://github.com/catchorg/Catch2/archive/v${PV}.tar.gz -> ${MY_P}.tar.gz"
-	KEYWORDS="~amd64 ~ppc64 ~x86"
+	S="${WORKDIR}/${MY_P}"
 
-	S="${WORKDIR}/${PN^}2-${PV}"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 DESCRIPTION="Modern C++ header-only framework for unit-tests"
 HOMEPAGE="https://github.com/catchorg/Catch2"
 
 LICENSE="Boost-1.0"
-SLOT="1"
+SLOT="0"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-multilib_src_configure() {
-	local mycmakeargs=(
-		-DNO_SELFTEST=$(usex !test)
-	)
-	cmake_src_configure
+BDEPEND="test? ( ${PYTHON_DEPS} )"
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
 }
 
-multilib_src_install() {
-	cmake_src_install
-	dodoc -r docs/.
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DCATCH_DEVELOPMENT_BUILD=ON
+		-DCATCH_ENABLE_WERROR=OFF
+		-DCATCH_BUILD_TESTING=$(usex test)
+	)
+	use test && mycmakeargs+=(
+		-DPYTHON_EXECUTABLE="${PYTHON}"
+	)
+
+	cmake_src_configure
 }

--- a/dev-cpp/catch/catch-9999.ebuild
+++ b/dev-cpp/catch/catch-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit cmake python-any-r1
+inherit cmake-multilib python-any-r1
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -32,7 +32,7 @@ pkg_setup() {
 	use test && python-any-r1_pkg_setup
 }
 
-src_configure() {
+multilib_src_configure() {
 	local mycmakeargs=(
 		-DCATCH_DEVELOPMENT_BUILD=ON
 		-DCATCH_ENABLE_WERROR=OFF

--- a/dev-libs/spdlog/spdlog-1.15.1-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.15.1-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+DESCRIPTION="Fast C++ logging library"
+HOMEPAGE="https://github.com/gabime/spdlog"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/gabime/${PN}"
+else
+	SRC_URI="https://github.com/gabime/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0/$(ver_cut 1-2)"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	virtual/pkgconfig
+	test? (
+		>=dev-cpp/catch-3.4.0[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="
+	dev-libs/libfmt:=[${MULTILIB_USEDEP}]
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-force_external_fmt.patch"
+)
+
+multilib_src_prepare() {
+	cmake_src_prepare
+	rm -r include/spdlog/fmt/bundled || die "Failed to delete bundled libfmt"
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DSPDLOG_BUILD_BENCH=no
+		-DSPDLOG_BUILD_EXAMPLE=no
+		-DSPDLOG_FMT_EXTERNAL=yes
+		-DSPDLOG_BUILD_SHARED=yes
+		-DSPDLOG_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}

--- a/dev-libs/spdlog/spdlog-1.15.3-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.15.3-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+DESCRIPTION="Fast C++ logging library"
+HOMEPAGE="https://github.com/gabime/spdlog"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/gabime/${PN}"
+else
+	SRC_URI="https://github.com/gabime/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0/$(ver_cut 1-2)"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	virtual/pkgconfig
+	test? (
+		>=dev-cpp/catch-3.4.0[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="
+	>=dev-libs/libfmt-11.0.2:=[${MULTILIB_USEDEP}]
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-force_external_fmt.patch"
+)
+
+multilib_src_prepare() {
+	cmake_src_prepare
+	rm -r include/spdlog/fmt/bundled || die "Failed to delete bundled libfmt"
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DSPDLOG_BUILD_BENCH=no
+		-DSPDLOG_BUILD_EXAMPLE=no
+		-DSPDLOG_FMT_EXTERNAL=yes
+		-DSPDLOG_BUILD_SHARED=yes
+		-DSPDLOG_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
This add multilib support to `dev-cpp/catch`. 
This fix compile error on package with multilib support, such as spdlog, and require catch as dependency.

Fixes: https://bugs.gentoo.org/962994

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
