### PR TITLE
dev-db/dbeaver-bin: fix virtual/jre dependency

### DIFF
--- a/dev-db/dbeaver-bin/dbeaver-bin-25.1.4-r1.ebuild
+++ b/dev-db/dbeaver-bin/dbeaver-bin-25.1.4-r1.ebuild
@@ -19,7 +19,7 @@ LICENSE="Apache-2.0 EPL-1.0 BSD"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64"
 
-RDEPEND=">=virtual/jre-17:*"
+RDEPEND=">=virtual/jre-21:*"
 
 QA_PREBUILT="
 	opt/${MY_PN}-ce.*

--- a/dev-db/dbeaver-bin/dbeaver-bin-25.2.0-r1.ebuild
+++ b/dev-db/dbeaver-bin/dbeaver-bin-25.2.0-r1.ebuild
@@ -19,7 +19,7 @@ LICENSE="Apache-2.0 EPL-1.0 BSD"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64"
 
-RDEPEND=">=virtual/jre-17:*"
+RDEPEND=">=virtual/jre-21:*"
 
 QA_PREBUILT="
 	opt/${MY_PN}-ce.*


### PR DESCRIPTION
DBeaver 25 requires JRE 21.

Closes: https://bugs.gentoo.org/963609

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
