### PR TITLE
sys-libs/pam: give unix_chpwd CAP_DAC_READ_SEARCH

### DIFF
--- a/sys-libs/pam/pam-1.7.1-r1.ebuild
+++ b/sys-libs/pam/pam-1.7.1-r1.ebuild
@@ -187,5 +187,5 @@ pkg_postinst() {
 
 	# The pam_unix module needs to check the password of the user which requires
 	# read access to /etc/shadow only.
-	fcaps -m u+s cap_dac_override sbin/unix_chkpwd
+	fcaps -m u+s cap_dac_read_search sbin/unix_chkpwd
 }


### PR DESCRIPTION
CAP_DAC_OVERRIDE is overkill; we only need read access to /etc/shadow.

Closes: https://bugs.gentoo.org/963110