### PR TITLE
dev-util/patchutils: add missing Python runtime dependency

### DIFF
--- a/dev-util/patchutils/patchutils-0.4.4-r1.ebuild
+++ b/dev-util/patchutils/patchutils-0.4.4-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit autotools toolchain-funcs
+PYTHON_COMPAT=( python3_{11..14} )
+
+inherit autotools python-single-r1 toolchain-funcs
 
 DESCRIPTION="Collection of tools that operate on patch files"
 HOMEPAGE="https://cyberelk.net/tim/software/patchutils/"
@@ -13,20 +15,27 @@ LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="pcre"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="pcre? ( dev-libs/libpcre2:= )"
+RDEPEND="
+	!<app-shells/bash-completion-2.16.0-r3
+	pcre? ( dev-libs/libpcre2:= )
+	${PYTHON_DEPS}
+"
 DEPEND="
 	${RDEPEND}
 	elibc_musl? ( >=sys-libs/error-standalone-2.0 )
 "
 BDEPEND="virtual/pkgconfig"
-RDEPEND+="
-	!<app-shells/bash-completion-2.16.0-r3
-"
+
+pkg_setup() {
+	python-single-r1_pkg_setup
+}
 
 src_prepare() {
 	default
 	eautoreconf
+	python_fix_shebang patchview
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/963651
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
