### PR TITLE
app-office/dia: use std=gnu17, while waiting for gtk-3 release

### DIFF
--- a/app-office/dia/dia-0.97.3-r4.ebuild
+++ b/app-office/dia/dia-0.97.3-r4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 GNOME2_EAUTORECONF="yes"
-inherit gnome2
+inherit flag-o-matic gnome2 toolchain-funcs
 
 DESCRIPTION="Diagram/flowchart creation program"
 HOMEPAGE="https://wiki.gnome.org/Apps/Dia"
@@ -42,7 +42,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.97.0-gnome-doc.patch #159381 , upstream #470812 #558690
 	"${FILESDIR}"/${PN}-0.97.2-underlinking.patch #420685, upstream #678761
-	"${FILESDIR}"/${PN}-0.97.3-freetype_pkgconfig.patch #654814, upstream https://gitlab.gnome.org/GNOME/dia/merge_requests/1
+	"${FILESDIR}"/${PN}-0.97.3-freetype_pkgconfig.patch #654814, upstream PR 1
 	"${FILESDIR}"/${PN}-0.97.3-slibtool.patch
 	"${FILESDIR}"/${PN}-0.97.3-configure-clang16.patch
 	"${FILESDIR}"/${PN}-0.97.3-c99.patch
@@ -67,6 +67,8 @@ src_prepare() {
 }
 
 src_configure() {
+	append-cflags -std=gnu17 # bugs 943791 948501
+	tc-export PKG_CONFIG
 	# --exec-prefix makes Python look for modules in the Prefix
 	# --enable-gnome only adds support for deprecated stuff, bug #442294
 	# https://bugzilla.redhat.com/show_bug.cgi?id=996759


### PR DESCRIPTION
use std=gnu17, while waiting for gtk-3 snapshot with meson (in few days maybe)
QA, line w/ too much characters
export PKG_CONFIG

Closes: https://bugs.gentoo.org/943791
Closes: https://bugs.gentoo.org/948501

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
