### PR TITLE
sys-libs/ncurses: Fix cross-compilation without `tic`

### DIFF
--- a/sys-libs/ncurses/ncurses-6.5_p20250329.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250329.ebuild
@@ -345,7 +345,7 @@ do_configure() {
 	# See comments in src_configure.
 	if [[ ${target} != "cross" ]] ; then
 		local cross_path="${WORKDIR}/cross"
-		[[ -d ${cross_path} ]] && export TIC_PATH="${cross_path}/progs/tic"
+		[[ -d ${cross_path} ]] && export TIC="${cross_path}/progs/tic"
 	fi
 
 	ECONF_SOURCE="${S}" econf "${conf[@]}" "$@"

--- a/sys-libs/ncurses/ncurses-6.5_p20250531-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250531-r1.ebuild
@@ -351,7 +351,7 @@ do_configure() {
 	# See comments in src_configure.
 	if [[ ${target} != "cross" ]] ; then
 		local cross_path="${WORKDIR}/cross"
-		[[ -d ${cross_path} ]] && export TIC_PATH="${cross_path}/progs/tic"
+		[[ -d ${cross_path} ]] && export TIC="${cross_path}/progs/tic"
 	fi
 
 	ECONF_SOURCE="${S}" econf "${conf[@]}" "$@"

--- a/sys-libs/ncurses/ncurses-6.5_p20250802.ebuild
+++ b/sys-libs/ncurses/ncurses-6.5_p20250802.ebuild
@@ -359,7 +359,7 @@ do_configure() {
 	# See comments in src_configure.
 	if [[ ${target} != "cross" ]] ; then
 		local cross_path="${WORKDIR}/cross"
-		[[ -d ${cross_path} ]] && export TIC_PATH="${cross_path}/progs/tic"
+		[[ -d ${cross_path} ]] && export TIC="${cross_path}/progs/tic"
 	fi
 
 	ECONF_SOURCE="${S}" econf "${conf[@]}" "$@"


### PR DESCRIPTION
When `tic` is not available on the host during cross-compilation, this
ebuild relies on a codepath that compiles a temporary copy of `tic`.

Recent versions of ncurses use TIC as a path to the tic binary, instead
of TIC_PATH.

Closes: https://bugs.gentoo.org/963660
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
