### PR TITLE
dev-util/flatpak-builder: revbump 1.4.6-r3, added appstream[compose]

### DIFF
--- a/dev-util/flatpak-builder/flatpak-builder-1.4.6-r3.ebuild
+++ b/dev-util/flatpak-builder/flatpak-builder-1.4.6-r3.ebuild
@@ -3,17 +3,21 @@
 
 EAPI=8
 
-SRC_URI="https://github.com/flatpak/${PN}/releases/download/${PV}/${P}.tar.xz"
 DESCRIPTION="Tool to build flatpaks from source"
-HOMEPAGE="http://flatpak.org/"
+HOMEPAGE="https://flatpak.org/"
+SRC_URI="https://github.com/flatpak/${PN}/releases/download/${PV}/${P}.tar.xz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 IUSE="doc +yaml"
 
+# dev-util/flatpak and dev-libs/appstream are runtime dependencies of flatpak-builder
+# their binaries are actively being used by flatpak-builder as is
+# qa-vdb returns false-positive warnings
 RDEPEND="
 	>=dev-util/ostree-2019.5:=
+	dev-libs/appstream[compose]
 	>=dev-libs/elfutils-0.8.12:=
 	>=dev-libs/glib-2.44:2=
 	>=dev-libs/libxml2-2.4:=


### PR DESCRIPTION
* Closes: https://bugs.gentoo.org/963659
* Error faced:

`checking for appstreamcli... appstreamcli
checking whether appstreamcli has compose support... no
configure: error: appstreamcli must have compose support enabled and installed`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
