### PR TITLE
net-misc/remmina: Fix building GVNC plugin

### DIFF
--- a/net-misc/remmina/remmina-1.4.40-r3.ebuild
+++ b/net-misc/remmina/remmina-1.4.40-r3.ebuild
@@ -1,0 +1,106 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+MY_P="${PN^}-v${PV}"
+inherit cmake python-single-r1 xdg
+
+DESCRIPTION="A GTK+ RDP, SPICE, VNC and SSH client"
+HOMEPAGE="https://remmina.org/"
+SRC_URI="https://gitlab.com/Remmina/Remmina/-/archive/v${PV}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2+-with-openssl-exception"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
+IUSE="+appindicator crypt cups examples keyring gvnc kwallet nls python spice ssh rdp vnc wayland webkit zeroconf X"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} ) || ( X wayland )"
+
+COMMON_DEPEND="
+	dev-libs/glib:2
+	dev-libs/json-glib
+	dev-libs/libpcre2
+	dev-libs/libsodium:=
+	dev-libs/openssl:0=
+	x11-libs/gdk-pixbuf
+	x11-libs/gtk+:3[X?,wayland?]
+	X? (
+		x11-libs/libX11
+		x11-libs/libxkbfile
+	)
+	appindicator? ( dev-libs/libayatana-appindicator )
+	crypt? ( dev-libs/libgcrypt:0= )
+	keyring? ( app-crypt/libsecret )
+	gvnc? ( net-libs/gtk-vnc[pulseaudio] )
+	kwallet? ( kde-frameworks/kwallet:6 )
+	python? ( ${PYTHON_DEPS} )
+	rdp? ( >=net-misc/freerdp-3.11.0:3=
+		cups? ( net-print/cups:= ) )
+	spice? ( net-misc/spice-gtk[gtk3] )
+	ssh? ( net-libs/libssh:0=[sftp]
+		x11-libs/vte:2.91 )
+	vnc? ( net-libs/libvncserver[jpeg] )
+	webkit? ( net-libs/webkit-gtk:4.1 )
+	zeroconf? ( >=net-dns/avahi-0.8-r2[dbus,gtk] )
+"
+DEPEND="
+	${COMMON_DEPEND}
+	spice? ( app-emulation/spice-protocol )
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	virtual/freedesktop-icon-theme
+"
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+DOCS=( AUTHORS CHANGELOG.md README.md THANKS.md )
+
+PATCHES=(
+	"${FILESDIR}/${P}-libssh-no.patch"
+	"${FILESDIR}/${P}-kf6wallet.patch" # bug 950750; TODO: upstream
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	xdg_environment_reset
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DHAVE_LIBAPPINDICATOR=$(usex appindicator ON OFF)
+		-DWITH_AVAHI=$(usex zeroconf)
+		-DWITH_CUPS=$(usex cups)
+		-DWITH_EXAMPLES=$(usex examples)
+		-DWITH_FREERDP=$(usex rdp)
+		-DWITH_FREERDP3=ON
+		-DWITH_GCRYPT=$(usex crypt)
+		-DWITH_GETTEXT=$(usex nls)
+		-DWITH_GVNC=$(usex gvnc)
+		-DWITH_ICON_CACHE=OFF
+		-DWITH_KF6WALLET=$(usex kwallet)
+		-DWITH_LIBSECRET=$(usex keyring)
+		-DWITH_LIBSSH=$(usex ssh)
+		-DWITH_LIBVNCSERVER=$(usex vnc)
+		-DWITH_PYTHONLIBS=$(usex python ON OFF)
+		-DWITH_SPICE=$(usex spice)
+		-DWITH_TRANSLATIONS=$(usex nls)
+		-DWITH_UPDATE_DESKTOP_DB=OFF
+		-DWITH_VTE=$(usex ssh)
+		-DWITH_WWW=$(usex webkit)
+		-DWITH_X2GO=OFF
+		# when this feature is stable, add python eclass usage to optionally enable
+		-DWITH_PYTHON=OFF
+	)
+	cmake_src_configure
+}

--- a/net-misc/remmina/remmina-1.4.41-r1.ebuild
+++ b/net-misc/remmina/remmina-1.4.41-r1.ebuild
@@ -1,0 +1,105 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+MY_P="${PN^}-v${PV}"
+inherit cmake python-single-r1 xdg
+
+DESCRIPTION="A GTK+ RDP, SPICE, VNC and SSH client"
+HOMEPAGE="https://remmina.org/"
+SRC_URI="https://gitlab.com/Remmina/Remmina/-/archive/v${PV}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2+-with-openssl-exception"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
+IUSE="+appindicator crypt cups examples keyring gvnc kwallet nls python spice ssh rdp vnc wayland webkit zeroconf X"
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} ) || ( X wayland )"
+
+COMMON_DEPEND="
+	dev-libs/glib:2
+	dev-libs/json-glib
+	dev-libs/libpcre2
+	dev-libs/libsodium:=
+	dev-libs/openssl:0=
+	x11-libs/gdk-pixbuf
+	x11-libs/gtk+:3[X?,wayland?]
+	X? (
+		x11-libs/libX11
+		x11-libs/libxkbfile
+	)
+	appindicator? ( dev-libs/libayatana-appindicator )
+	crypt? ( dev-libs/libgcrypt:0= )
+	keyring? ( app-crypt/libsecret )
+	gvnc? ( net-libs/gtk-vnc[pulseaudio] )
+	kwallet? ( kde-frameworks/kwallet:6 )
+	python? ( ${PYTHON_DEPS} )
+	rdp? ( >=net-misc/freerdp-3.11.0:3=
+		cups? ( net-print/cups:= ) )
+	spice? ( net-misc/spice-gtk[gtk3] )
+	ssh? ( net-libs/libssh:0=[sftp]
+		x11-libs/vte:2.91 )
+	vnc? ( net-libs/libvncserver[jpeg] )
+	webkit? ( net-libs/webkit-gtk:4.1 )
+	zeroconf? ( >=net-dns/avahi-0.8-r2[dbus,gtk] )
+"
+DEPEND="
+	${COMMON_DEPEND}
+	spice? ( app-emulation/spice-protocol )
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	virtual/freedesktop-icon-theme
+"
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+DOCS=( AUTHORS CHANGELOG.md README.md THANKS.md )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.4.40-kf6wallet.patch" # bug 950750; TODO: upstream
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	xdg_environment_reset
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DHAVE_LIBAPPINDICATOR=$(usex appindicator ON OFF)
+		-DWITH_AVAHI=$(usex zeroconf)
+		-DWITH_CUPS=$(usex cups)
+		-DWITH_EXAMPLES=$(usex examples)
+		-DWITH_FREERDP=$(usex rdp)
+		-DWITH_FREERDP3=ON
+		-DWITH_GCRYPT=$(usex crypt)
+		-DWITH_GETTEXT=$(usex nls)
+		-DWITH_GVNC=$(usex gvnc)
+		-DWITH_ICON_CACHE=OFF
+		-DWITH_KF6WALLET=$(usex kwallet)
+		-DWITH_LIBSECRET=$(usex keyring)
+		-DWITH_LIBSSH=$(usex ssh)
+		-DWITH_LIBVNCSERVER=$(usex vnc)
+		-DWITH_PYTHONLIBS=$(usex python ON OFF)
+		-DWITH_SPICE=$(usex spice)
+		-DWITH_TRANSLATIONS=$(usex nls)
+		-DWITH_UPDATE_DESKTOP_DB=OFF
+		-DWITH_VTE=$(usex ssh)
+		-DWITH_WWW=$(usex webkit)
+		-DWITH_X2GO=OFF
+		# when this feature is stable, add python eclass usage to optionally enable
+		-DWITH_PYTHON=OFF
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
This PR fixes building Remmina's GVNC plugin.
To enable the plugin, cmake needs `-DWITH_GVNC=ON`. In addition, it checks for gvncpulse and won't build the plugin if is missing. Remmina fails silently here and simply skips building the plugin.

pkgcheck suggests the this change needs a revbump. Let me know if this is correct and I'll happily amend this PR.
However, I don't think it makes sense. Given that currently, it is not possible to build the GVNC plugin at all, it does not seem to have a lot of users on Gentoo. People who do not enable the plugin will not benefit from a revbump.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
