### PR TITLE
kernel-install.eclass: Fix updating symlinks with -p kernels

### DIFF
--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -263,10 +263,15 @@ kernel-install_can_update_symlink() {
 	# strip KV_LOCALVERSION, we want to update the old kernels not using
 	# KV_LOCALVERSION suffix and the new kernels using it
 	symlink_ver=${symlink_ver%${KV_LOCALVERSION}}
+	symlink_ver=${symlink_ver/-p/_p}
+	# strip -p* revision
+	local symlink_ver_no_rev=${symlink_ver%_p[0-9]*}
+	local rev=${symlink_ver#${symlink_ver_no_rev}}
+	rev=${rev#_p}
 
-	# if ${symlink_ver} contains anything but numbers (e.g. an extra
-	# suffix), it's not our kernel, so leave it alone
-	[[ -n ${symlink_ver//[0-9.]/} ]] && return 1
+	# if ${symlink_ver} contained anything but numbers and revision (e.g.
+	# an extra suffix), it's not our kernel, so leave it alone
+	[[ -n ${symlink_ver_no_rev//[0-9.]/} || -n ${rev//[0-9]/} ]] && return 1
 
 	local symlink_pkg=${CATEGORY}/${PN}-${symlink_ver}
 	# if the current target is either being replaced, or still


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/963683
