### PR TITLE
app-misc/nnn: Fix DeprecatedInsinto with dofishcomp, dozshcomp

### DIFF
--- a/app-misc/nnn/nnn-5.0.ebuild
+++ b/app-misc/nnn/nnn-5.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit bash-completion-r1 flag-o-matic toolchain-funcs xdg
+inherit flag-o-matic shell-completion toolchain-funcs xdg
 
 DESCRIPTION="The missing terminal file browser for X"
 HOMEPAGE="https://github.com/jarun/nnn"
@@ -60,11 +60,9 @@ src_install() {
 
 	newbashcomp misc/auto-completion/bash/nnn-completion.bash nnn
 
-	insinto /usr/share/fish/vendor_completions.d
-	doins misc/auto-completion/fish/nnn.fish
+	dofishcomp misc/auto-completion/fish/nnn.fish
 
-	insinto /usr/share/zsh/site-functions
-	doins misc/auto-completion/zsh/_nnn
+	dozshcomp misc/auto-completion/zsh/_nnn
 
 	einstalldocs
 

--- a/app-misc/nnn/nnn-5.1.ebuild
+++ b/app-misc/nnn/nnn-5.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 flag-o-matic toolchain-funcs xdg
+inherit flag-o-matic shell-completion toolchain-funcs xdg
 
 DESCRIPTION="The missing terminal file browser for X"
 HOMEPAGE="https://github.com/jarun/nnn"
@@ -56,11 +56,9 @@ src_install() {
 
 	newbashcomp misc/auto-completion/bash/nnn-completion.bash nnn
 
-	insinto /usr/share/fish/vendor_completions.d
-	doins misc/auto-completion/fish/nnn.fish
+	dofishcomp misc/auto-completion/fish/nnn.fish
 
-	insinto /usr/share/zsh/site-functions
-	doins misc/auto-completion/zsh/_nnn
+	dozshcomp misc/auto-completion/zsh/_nnn
 
 	einstalldocs
 


### PR DESCRIPTION
Removed deprecated uses of insinto and replaced with dofishcomp and dozshcomp from shell-completion.eclass.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
