### PR TITLE
x11-terms/alacritty: Fix DeprecatedInsinto with shell-completion.eclass

### DIFF
--- a/x11-terms/alacritty/alacritty-0.15.1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.15.1.ebuild
@@ -285,7 +285,7 @@ MY_PV="${PV//_rc/-rc}"
 
 RUST_MIN_VER="1.74.1"
 
-inherit bash-completion-r1 cargo desktop
+inherit cargo desktop shell-completion
 
 DESCRIPTION="GPU-accelerated terminal emulator"
 HOMEPAGE="https://alacritty.org"
@@ -378,11 +378,9 @@ src_install() {
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 
-	insinto /usr/share/fish/vendor_completions.d/
-	doins extra/completions/alacritty.fish
+	dofishcomp extra/completions/alacritty.fish
 
-	insinto /usr/share/zsh/site-functions
-	doins extra/completions/_alacritty
+	dozshcomp extra/completions/_alacritty
 
 	domenu extra/linux/Alacritty.desktop
 	newicon extra/logo/compat/alacritty-term.svg Alacritty.svg

--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2017-2024 Gentoo Authors
+# Copyright 2017-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ MY_PV="${PV//_rc/-rc}"
 
 RUST_MIN_VER="1.74.1"
 
-inherit bash-completion-r1 cargo desktop
+inherit cargo desktop shell-completion
 
 DESCRIPTION="GPU-accelerated terminal emulator"
 HOMEPAGE="https://alacritty.org"
@@ -100,11 +100,9 @@ src_install() {
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 
-	insinto /usr/share/fish/vendor_completions.d/
-	doins extra/completions/alacritty.fish
+	dofishcomp extra/completions/alacritty.fish
 
-	insinto /usr/share/zsh/site-functions
-	doins extra/completions/_alacritty
+	dozshcomp extra/completions/_alacritty
 
 	domenu extra/linux/Alacritty.desktop
 	newicon extra/logo/compat/alacritty-term.svg Alacritty.svg


### PR DESCRIPTION
Removed instances of DeprecatedInsinto and replaced with dofishcomp and dozshcomp from shell-completion.eclass.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
