### PR TITLE
sci-astronomy/stellarium: remove stale cmake var

### DIFF
--- a/sci-astronomy/stellarium/stellarium-25.3.ebuild
+++ b/sci-astronomy/stellarium/stellarium-25.3.ebuild
@@ -112,7 +112,6 @@ src_configure() {
 	filter-lto # https://bugs.gentoo.org/862249
 
 	local mycmakeargs=(
-		-DCCACHE_PROGRAM=no
 		-DCPM_LOCAL_PACKAGES_ONLY=yes
 		-DUSE_BUNDLED_QTCOMPRESS=no
 		-DENABLE_CCACHE=no


### PR DESCRIPTION
They changed how ccache is enabled; I added new var, but forgot to remove old var

Closes: https://bugs.gentoo.org/963739

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
