### PR TITLE
media-plugins/vdr-markad: fix build failure

### DIFF
--- a/media-plugins/vdr-markad/vdr-markad-4.2.15.ebuild
+++ b/media-plugins/vdr-markad/vdr-markad-4.2.15.ebuild
@@ -39,6 +39,6 @@ src_install() {
 	cd "${S}/.." || die
 	emake install DESTDIR="${D}"
 
-	cd "${WORKDIR}/${VDRPLUGIN}-${PV}" || die
+	S="${WORKDIR}/vdr-plugin-markad-${PV}/"
 	dodoc README HISTORY
 }


### PR DESCRIPTION
initial ebuild was faulty, dont know how this could happen...

Closes: https://bugs.gentoo.org/963786

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
