### PR TITLE
dev-libs/libgcrypt: Set GPGRT_CONFIG for cross compilation

### DIFF
--- a/dev-libs/libgcrypt/libgcrypt-1.10.2.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.10.2.ebuild
@@ -136,6 +136,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.10.3-r1.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.10.3-r1.ebuild
@@ -134,6 +134,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.10.3-r2.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.10.3-r2.ebuild
@@ -140,6 +140,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.11.0-r1.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.11.0-r1.ebuild
@@ -134,6 +134,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.11.0-r2.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.11.0-r2.ebuild
@@ -141,6 +141,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.11.1.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.11.1.ebuild
@@ -154,6 +154,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then

--- a/dev-libs/libgcrypt/libgcrypt-1.11.2.ebuild
+++ b/dev-libs/libgcrypt/libgcrypt-1.11.2.ebuild
@@ -150,6 +150,7 @@ multilib_src_configure() {
 		$(use asm || echo "--disable-asm")
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	if use kernel_linux; then


### PR DESCRIPTION
This aids some uncommon use cases such as cross compiling this within a
gentoo prefix.

Closes: https://bugs.gentoo.org/963810
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
