### PR TITLE
dev-libs/libksba: Set GPGRT_CONFIG for cross compilation

### DIFF
--- a/dev-libs/libksba/libksba-1.6.7.ebuild
+++ b/dev-libs/libksba/libksba-1.6.7.ebuild
@@ -49,6 +49,7 @@ my_src_configure() {
 
 		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
 		LIBGCRYPT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-libgcrypt-config"
+		GPGRT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpgrt-config"
 	)
 
 	econf "${myeconfargs[@]}"


### PR DESCRIPTION
This aids some uncommon use cases such as cross compiling this within a
gentoo prefix.

Closes: https://bugs.gentoo.org/963811
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
