### PR TITLE
media-libs/noise-suppression-for-voice: Skip CMake <3.5 QA checks

### DIFF
--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.10-r2.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.10-r2.ebuild
@@ -1,7 +1,11 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
+# Bug #957490 - all CMakeLists.txt files that are used during the build
+# require CMake 3.5 or later.
+CMAKE_QA_COMPAT_SKIP=yes
 
 inherit cmake flag-o-matic
 

--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
@@ -1,7 +1,11 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
+# Bug #957490 - all CMakeLists.txt files that are used during the build
+# require CMake 3.5 or later.
+CMAKE_QA_COMPAT_SKIP=yes
 
 inherit cmake flag-o-matic
 


### PR DESCRIPTION
All CMakeLists.txt files used for the build require CMake 3.5 or later.

Closes: https://bugs.gentoo.org/957490

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
