### PR TITLE
dev-java/jflex: remove the wrong "use doc"

### DIFF
--- a/dev-java/jflex/jflex-1.9.1-r1.ebuild
+++ b/dev-java/jflex/jflex-1.9.1-r1.ebuild
@@ -93,7 +93,7 @@ jflex_compile() {
 		-d src/main/java \
 		--skel src/main/jflex/skeleton.nested \
 		src/main/jflex/LexScan.flex || die
-	use doc && java-pkg-simple_src_compile
+	java-pkg-simple_src_compile
 }
 
 src_compile() {
@@ -126,17 +126,17 @@ src_test() {
 }
 
 src_install() {
-	if use doc; then
-		dodoc doc/*.pdf
-		docinto html
-		dodoc doc/*.{css,html} doc/COPYRIGHT
-	fi
-
 	java-pkg-simple_src_install
 
 	use ant-task && java-pkg_register-ant-task
 
 	use examples && java-pkg_doexamples examples
+
+	if use doc; then
+		dodoc doc/*.pdf
+		docinto html
+		dodoc doc/*.{css,html} doc/COPYRIGHT
+	fi
 
 	if use vim-syntax; then
 		insinto /usr/share/vim/vimfiles/syntax


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/963844

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
