### PR TITLE
www-client/firefox: bump libaom dependency

### DIFF
--- a/www-client/firefox/firefox-140.3.1.ebuild
+++ b/www-client/firefox/firefox-140.3.1.ebuild
@@ -161,7 +161,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	sndio? ( >=media-sound/sndio-1.8.0-r1 )
 	system-av1? (
 		>=media-libs/dav1d-1.0.0:=
-		>=media-libs/libaom-1.0.0:=
+		>=media-libs/libaom-3.10.0:=
 	)
 	system-harfbuzz? (
 		>=media-libs/harfbuzz-2.8.1:0=

--- a/www-client/firefox/firefox-143.0.3.ebuild
+++ b/www-client/firefox/firefox-143.0.3.ebuild
@@ -157,7 +157,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	sndio? ( >=media-sound/sndio-1.8.0-r1 )
 	system-av1? (
 		>=media-libs/dav1d-1.0.0:=
-		>=media-libs/libaom-1.0.0:=
+		>=media-libs/libaom-3.10.0:=
 	)
 	system-harfbuzz? (
 		>=media-libs/harfbuzz-2.8.1:0=

--- a/www-client/firefox/firefox-143.0.ebuild
+++ b/www-client/firefox/firefox-143.0.ebuild
@@ -157,7 +157,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	sndio? ( >=media-sound/sndio-1.8.0-r1 )
 	system-av1? (
 		>=media-libs/dav1d-1.0.0:=
-		>=media-libs/libaom-1.0.0:=
+		>=media-libs/libaom-3.10.0:=
 	)
 	system-harfbuzz? (
 		>=media-libs/harfbuzz-2.8.1:0=


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/956826

Current firefox uses `libwebrtc`, which depends on `libaom-3.10`

Since https://github.com/mozilla-firefox/firefox/commit/641ed93659e5159753592c64172e82e516d2ec4e `webrtc` uses AV1E_SET_POSTENCODE_DROP_RTC, which was added in https://aomedia.googlesource.com/aom/+/55740da9a581c3cf110df16697295b69240a28d0

I don't think that there is a need in ebuild version or revision bumping, because it will not affect people with new libaom version, and people without it could not install firefox with `system-av1` USE flag as well

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
