### PR TITLE
sys-kernel/linux-headers: Add rsync to BDEPEND

### DIFF
--- a/sys-kernel/linux-headers/linux-headers-5.10-r2.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-5.10-r2.ebuild
@@ -20,7 +20,8 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc
 
 BDEPEND="
 	app-arch/xz-utils
-	dev-lang/perl"
+	dev-lang/perl
+	net-misc/rsync"
 
 [[ -n ${PATCH_VER} ]] && PATCHES=( "${WORKDIR}"/${PATCH_PV} )
 

--- a/sys-kernel/linux-headers/linux-headers-5.15-r3.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-5.15-r3.ebuild
@@ -19,7 +19,8 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc
 
 BDEPEND="
 	app-arch/xz-utils
-	dev-lang/perl"
+	dev-lang/perl
+	net-misc/rsync"
 
 # bug #816762
 RESTRICT="test"

--- a/sys-kernel/linux-headers/linux-headers-5.4-r2.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-5.4-r2.ebuild
@@ -20,7 +20,8 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc
 
 BDEPEND="
 	app-arch/xz-utils
-	dev-lang/perl"
+	dev-lang/perl
+	net-misc/rsync"
 
 [[ -n ${PATCH_VER} ]] && PATCHES=( "${WORKDIR}"/${PATCH_PV} )
 

--- a/sys-kernel/linux-headers/linux-headers-6.1.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.1.ebuild
@@ -18,7 +18,8 @@ S="${WORKDIR}/linux-${PV}"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 
 BDEPEND="app-arch/xz-utils
-	dev-lang/perl"
+	dev-lang/perl
+	net-misc/rsync"
 
 [[ -n ${PATCH_VER} ]] && PATCHES=( "${WORKDIR}"/${PATCH_PV} )
 

--- a/sys-kernel/linux-headers/linux-headers-6.10.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.11.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.12.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.12.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.13.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.13.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.14.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.14.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.15.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.15.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.16-r2.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.16-r2.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.16.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.16.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.17-r1.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.17-r1.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.6-r1.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.6-r1.ebuild
@@ -22,6 +22,7 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.8-r1.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {

--- a/sys-kernel/linux-headers/linux-headers-6.9.ebuild
+++ b/sys-kernel/linux-headers/linux-headers-6.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,6 +22,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv 
 BDEPEND="
 	app-arch/xz-utils
 	dev-lang/perl
+	net-misc/rsync
 "
 
 src_unpack() {


### PR DESCRIPTION
**Please note: I have no idea if this will cause any circular dependencies in catalyst or similar. I doubt it will, but I'm not 100% sure.** Also, should I revbump for this?

```
This program is usually *always* available in gentoo, being a direct
dependency of portage, and some other system packages. Still, it's
useful to list dependencies like this in bootstrap scenarios.

It is my belief that this dependency was introduced in 5.3, with the
following commit:
https://github.com/torvalds/linux/commit/59b2bd05f5f4dc62979c2e82ddd384f07e8f10bc

Closes: https://bugs.gentoo.org/963902
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
```
