### PR TITLE
gui-wm/sway: systemd use flag sets XDG_CURRENT_DESKTOP=sway

### DIFF
--- a/gui-wm/sway/files/50-systemd-user.conf
+++ b/gui-wm/sway/files/50-systemd-user.conf
@@ -1,0 +1,10 @@
+# sway does not set DISPLAY & WAYLAND_DISPLAY in the systemd user environment
+# Effectively Arch Linux's 50-systemd-user.conf, which is adapted from xorg's 50-systemd-user.sh
+
+# Upstream does not want to set XDG_CURRENT_DESKTOP
+# Instead choosing for maintainers to do so.
+exec systemctl --user set-environment XDG_CURRENT_DESKTOP=sway
+exec systemctl --user import-enviornment DISPLAY SWAYSOCK WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
+
+exec hash dbus-update-activation-environment 2>/dev/null && \
+  dbus-update-activation-environment --systemd DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP=sway WAYLAND_DISPLAY

--- a/gui-wm/sway/sway-1.10.1.ebuild
+++ b/gui-wm/sway/sway-1.10.1.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+man +swaybar +swaynag tray wallpapers X"
+IUSE="+man +swaybar +swaynag tray wallpapers X systemd"
 REQUIRED_USE="tray? ( swaybar )"
 
 DEPEND="
@@ -46,6 +46,7 @@ DEPEND="
 		x11-libs/libxcb:0=
 		x11-libs/xcb-util-wm
 	)
+	systemd? ( sys-apps/systemd )
 "
 # x11-libs/xcb-util-wm needed for xcb-iccm
 if [[ ${PV} == 9999 ]]; then
@@ -94,6 +95,10 @@ src_install() {
 	meson_src_install
 	insinto /usr/share/xdg-desktop-portal
 	doins "${FILESDIR}/sway-portals.conf"
+	if use systemd; then
+		insinto /etc/sway/config.d
+		doins "${FILESDIR}/50-systemd-user.conf"
+	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Signed-off-by: wqvi <137255931+wqvi@users.noreply.github.com>

gui-wm/sway: systemd use flag sets XDG_CURRENT_DESKTOP=sway

When running sway from the login terminal, XDG_CURRENT_DESKTOP will not be set. In order to achieve this easily, I propose adding the systemd use flag to automatically install a config file into /etc/sway/config.d, which is automatically included by the default sway configuration file.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
