### PR TITLE
dev-lang/zig: fix build error for 9999

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -119,11 +119,6 @@ src_prepare() {
 		# "--system" mode is not used during bootstrap.
 	fi
 
-	# Remove "limit memory usage" flags, it's already verified by
-	# CHECKREQS_MEMORY and causes unneccessary errors. Upstream set them
-	# according to CI OOM failures, which are not applicable to normal Gentoo build.
-	sed -i -e '/\.max_rss = .*,/d' build.zig || die
-
 	sed -i '/exe\.allow_so_scripts = true;/d' build.zig || die
 }
 


### PR DESCRIPTION
Upstream changed behavior so that the "max_rss" field in one line of their build.zig is now required:
https://www.github.com/ziglang/zig/pull/25402

Drop the command removing it, as it is no longer needed. "max_rss" errors were downgraded to warnings in:
https://www.github.com/ziglang/zig/pull/23525

Upstream suggestion:
https://www.github.com/ziglang/zig/issues/25659

Closes: https://bugs.gentoo.org/964953

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
