### PR TITLE
dev-db/mariadb: set default collation to upstream default utf8mb4_uca…

### DIFF
--- a/dev-db/mariadb/mariadb-11.8.3-r2.ebuild
+++ b/dev-db/mariadb/mariadb-11.8.3-r2.ebuild
@@ -436,7 +436,7 @@ src_configure() {
 		elif ! use latin1 ; then
 			mycmakeargs+=(
 				-DDEFAULT_CHARSET=utf8mb4
-				-DDEFAULT_COLLATION=utf8mb4_unicode_520_ci
+				-DDEFAULT_COLLATION=utf8mb4_uca1400_ai_ci
 			)
 		else
 			mycmakeargs+=(

--- a/dev-db/mariadb/mariadb-11.8.3-r3.ebuild
+++ b/dev-db/mariadb/mariadb-11.8.3-r3.ebuild
@@ -437,7 +437,7 @@ src_configure() {
 		elif ! use latin1 ; then
 			mycmakeargs+=(
 				-DDEFAULT_CHARSET=utf8mb4
-				-DDEFAULT_COLLATION=utf8mb4_unicode_520_ci
+				-DDEFAULT_COLLATION=utf8mb4_uca1400_ai_ci
 			)
 		else
 			mycmakeargs+=(

--- a/dev-db/mariadb/mariadb-11.8.5.ebuild
+++ b/dev-db/mariadb/mariadb-11.8.5.ebuild
@@ -437,7 +437,7 @@ src_configure() {
 		elif ! use latin1 ; then
 			mycmakeargs+=(
 				-DDEFAULT_CHARSET=utf8mb4
-				-DDEFAULT_COLLATION=utf8mb4_unicode_520_ci
+				-DDEFAULT_COLLATION=utf8mb4_uca1400_ai_ci
 			)
 		else
 			mycmakeargs+=(

--- a/dev-db/mariadb/mariadb-12.0.2-r1.ebuild
+++ b/dev-db/mariadb/mariadb-12.0.2-r1.ebuild
@@ -437,7 +437,7 @@ src_configure() {
 		elif ! use latin1 ; then
 			mycmakeargs+=(
 				-DDEFAULT_CHARSET=utf8mb4
-				-DDEFAULT_COLLATION=utf8mb4_unicode_520_ci
+				-DDEFAULT_COLLATION=utf8mb4_uca1400_ai_ci
 			)
 		else
 			mycmakeargs+=(


### PR DESCRIPTION
MariaDB changed the default collation to utf8mb4_uca1400_ai_ci as of 11.8. This commit syncs ebuild default with upstream defaults.

Bug: https://bugs.gentoo.org/966087
See: https://mariadb.com/docs/release-notes/community-server/11.8/what-is-mariadb-118#character-sets

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
