### PR TITLE
sys-apps/uutils-coreutils: Drop a libselinux workaround

### DIFF
--- a/sys-apps/uutils-coreutils/uutils-coreutils-0.7.0.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-0.7.0.ebuild
@@ -101,8 +101,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		# runcon chcon require selinux, but upstream broke the SELINUX_ENABLED logic
-		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who") $(usev !selinux "runcon chcon")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 
 		# bug #963516
 		LIBSTDBUF_DIR="${EPREFIX}/usr/libexec/${PN}"

--- a/sys-apps/uutils-coreutils/uutils-coreutils-0.8.0.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-0.8.0.ebuild
@@ -101,8 +101,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		# runcon chcon require selinux, but upstream broke the SELINUX_ENABLED logic
-		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who") $(usev !selinux "runcon chcon")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 
 		# bug #963516
 		LIBSTDBUF_DIR="${EPREFIX}/usr/libexec/${PN}"

--- a/sys-apps/uutils-coreutils/uutils-coreutils-9999.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-9999.ebuild
@@ -100,8 +100,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		# runcon chcon require selinux, but upstream broke the SELINUX_ENABLED logic
-		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who") $(usev !selinux "runcon chcon")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 
 		# bug #963516
 		LIBSTDBUF_DIR="${EPREFIX}/usr/libexec/${PN}"


### PR DESCRIPTION
Drop a workaround for SELINUX_PROGS fixed at upstream.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
