### PR TITLE
net-analyzer/sngrep: fix CVE-2023-31981, CVE-2023-31982 & CVE-2023-36192

### DIFF
--- a/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-31981.patch
+++ b/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-31981.patch
@@ -1,0 +1,25 @@
+From 038a65883551fdccc0bb86600309bb85d2251f98 Mon Sep 17 00:00:00 2001
+From: Kaian <kaian@irontec.com>
+Date: Wed, 1 Mar 2023 12:55:10 +0100
+Subject: [PATCH] capture: properly validate capture length calculated from IP
+ headers #430
+
+---
+ src/capture.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/capture.c b/src/capture.c
+index 825ee126..00570638 100644
+--- a/src/capture.c
++++ b/src/capture.c
+@@ -616,6 +616,10 @@ capture_packet_reasm_ip(capture_info_t *capinfo, const struct pcap_pkthdr *heade
+         }
+     }
+ 
++    // Check maximum capture len
++    if (*caplen > MAX_CAPTURE_LEN)
++        return NULL;
++
+     // If no fragmentation
+     if (ip_frag == 0) {
+         // Just create a new packet with given network data

--- a/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-31982.patch
+++ b/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-31982.patch
@@ -1,0 +1,30 @@
+From be410d0f6a9a3994448959581e5bd4a3b26fb7cd Mon Sep 17 00:00:00 2001
+From: Kaian <kaian@irontec.com>
+Date: Fri, 3 Mar 2023 12:49:17 +0100
+Subject: [PATCH] capture: validate frame has at least IP header before
+ assembly #431
+
+---
+ src/capture.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/capture.c b/src/capture.c
+index 00570638..7145b50a 100644
+--- a/src/capture.c
++++ b/src/capture.c
+@@ -620,6 +620,15 @@ capture_packet_reasm_ip(capture_info_t *capinfo, const struct pcap_pkthdr *heade
+     if (*caplen > MAX_CAPTURE_LEN)
+         return NULL;
+ 
++    // Check frame has at least IP header length
++    if (ip_ver == 4 && header->caplen < sizeof(struct ip))
++        return NULL;
++
++#ifdef USE_IPV6
++    if (ip_ver == 6 && header->caplen < sizeof(struct ip6_hdr))
++        return NULL;
++#endif
++
+     // If no fragmentation
+     if (ip_frag == 0) {
+         // Just create a new packet with given network data

--- a/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-36192.patch
+++ b/net-analyzer/sngrep/files/sngrep-1.6.0-CVE-2023-36192.patch
@@ -1,0 +1,42 @@
+From ad1daf15c8387bfbb48097c25197bf330d2d98fc Mon Sep 17 00:00:00 2001
+From: Kaian <kaian@irontec.com>
+Date: Fri, 9 Jun 2023 14:29:29 +0200
+Subject: [PATCH] capture: properly validate WS packet payload size #438
+
+---
+ src/capture.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/src/capture.c b/src/capture.c
+index 62ff08fb..3cbabeeb 100644
+--- a/src/capture.c
++++ b/src/capture.c
+@@ -901,8 +901,8 @@ capture_ws_check_packet(packet_t *packet)
+     size_payload = packet_payloadlen(packet);
+     payload = packet_payload(packet);
+ 
+-    // Check we have payload
+-    if (size_payload == 0)
++    // Check we have enough payload (base)
++    if (size_payload == 0 || size_payload <= 2)
+         return 0;
+ 
+     // Flags && Opcode
+@@ -931,8 +931,17 @@ capture_ws_check_packet(packet_t *packet)
+             return 0;
+     }
+ 
++    // Check we have enough payload (base + extended payload headers)
++    if ((int32_t) size_payload - ws_off <= 0) {
++        return 0;
++    }
++
+     // Get Masking key if mask is enabled
+     if (ws_mask) {
++        // Check we have enough payload (base + extended payload headers + mask)
++        if ((int32_t) size_payload - ws_off - 4 <= 0) {
++            return 0;
++        }
+         memcpy(ws_mask_key, (payload + ws_off), 4);
+         ws_off += 4;
+     }

--- a/net-analyzer/sngrep/files/sngrep-1.6.0-capture_launch_thread.patch
+++ b/net-analyzer/sngrep/files/sngrep-1.6.0-capture_launch_thread.patch
@@ -1,0 +1,39 @@
+From a64525441d00e8e0472ca98fc779692ab2b17c8c Mon Sep 17 00:00:00 2001
+From: Kaian <kaian@irontec.com>
+Date: Wed, 20 Dec 2023 10:27:51 +0100
+Subject: [PATCH] cc: remove parameters from msg_create and
+ capture_launch_thread definition #471
+
+---
+ src/capture.c | 3 ++-
+ src/sip.c     | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/capture.c b/src/capture.c
+index 89249746..6d19d3d1 100644
+--- a/src/capture.c
++++ b/src/capture.c
+@@ -1039,8 +1039,9 @@ capture_close()
+ }
+ 
+ int
+-capture_launch_thread(capture_info_t *capinfo)
++capture_launch_thread()
+ {
++    capture_info_t *capinfo = NULL;
+     //! capture thread attributes
+     pthread_attr_t attr;
+     pthread_attr_init(&attr);
+diff --git a/src/sip.c b/src/sip.c
+index 20a2d81d..c8b1e2cb 100644
+--- a/src/sip.c
++++ b/src/sip.c
+@@ -349,7 +349,7 @@ sip_check_packet(packet_t *packet)
+         return NULL;
+ 
+     // Create a new message from this data
+-    if (!(msg = msg_create((const char*) payload)))
++    if (!(msg = msg_create()))
+         return NULL;
+ 
+     // Get Method and request for the following checks

--- a/net-analyzer/sngrep/sngrep-1.6.0-r1.ebuild
+++ b/net-analyzer/sngrep/sngrep-1.6.0-r1.ebuild
@@ -26,6 +26,13 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-31981.patch"
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-31982.patch"
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-36192.patch"
+	"${FILESDIR}/${PN}-1.6.0-capture_launch_thread.patch"
+	)
+
 src_prepare() {
 	default
 

--- a/net-analyzer/sngrep/sngrep-1.7.0.ebuild
+++ b/net-analyzer/sngrep/sngrep-1.7.0.ebuild
@@ -26,6 +26,13 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-31981.patch"
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-31982.patch"
+	"${FILESDIR}/${PN}-1.6.0-CVE-2023-36192.patch"
+	"${FILESDIR}/${PN}-1.6.0-capture_launch_thread.patch"
+	)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/906112
Closes: https://bugs.gentoo.org/918590

<!-- Please put the pull request description above -->

CVE-2023-31981 (https://github.com/irontec/sngrep/issues/430):

Sngrep v1.6.0 was discovered to contain a stack buffer overflow via the function packet_set_payload at /src/packet.c.

CVE-2023-31982 (https://github.com/irontec/sngrep/issues/431):

Sngrep v1.6.0 was discovered to contain a heap buffer overflow via the function capture_packet_reasm_ip at /src/capture.c.

CVE-2023-36192:

Sngrep v1.6.0 was discovered to contain a heap buffer overflow via the function capture_ws_check_packet at /src/capture.c.

This update fixes CVE-2023-31981, CVE-2023-31982 and CVE-2023-36192 for 1.6.0 and 1.7.0.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
