### PR TITLE
dev-lang/zig: moved to Codeberg

### DIFF
--- a/dev-lang/zig-bin/metadata.xml
+++ b/dev-lang/zig-bin/metadata.xml
@@ -10,7 +10,7 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">ziglang/zig</remote-id>
-		<bugs-to>https://github.com/ziglang/zig/issues</bugs-to>
+		<remote-id type="codeberg">ziglang/zig</remote-id>
+		<bugs-to>https://codeberg.org/ziglang/zig/issues</bugs-to>
 	</upstream>
 </pkgmetadata>

--- a/dev-lang/zig-bin/zig-bin-0.10.1-r3.ebuild
+++ b/dev-lang/zig-bin/zig-bin-0.10.1-r3.ebuild
@@ -8,7 +8,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/minisig-keys/zig-software-foundation.pub
 inherit verify-sig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 SRC_URI="
 	amd64? ( https://ziglang.org/download/${PV}/zig-linux-x86_64-${PV}.tar.xz )
 	arm? ( https://ziglang.org/download/${PV}/zig-linux-armv7a-${PV}.tar.xz )

--- a/dev-lang/zig-bin/zig-bin-0.13.0.ebuild
+++ b/dev-lang/zig-bin/zig-bin-0.13.0.ebuild
@@ -8,7 +8,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/minisig-keys/zig-software-foundation.pub
 inherit verify-sig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 SRC_URI="
 	amd64? ( https://ziglang.org/download/${PV}/zig-linux-x86_64-${PV}.tar.xz )
 	arm? ( https://ziglang.org/download/${PV}/zig-linux-armv7a-${PV}.tar.xz )

--- a/dev-lang/zig-bin/zig-bin-0.14.1.ebuild
+++ b/dev-lang/zig-bin/zig-bin-0.14.1.ebuild
@@ -8,7 +8,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/minisig-keys/zig-software-foundation.pub
 inherit verify-sig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 SRC_URI="
 	amd64? ( https://ziglang.org/download/${PV}/zig-x86_64-linux-${PV}.tar.xz )
 	arm? ( https://ziglang.org/download/${PV}/zig-armv7a-linux-${PV}.tar.xz )

--- a/dev-lang/zig-bin/zig-bin-0.15.1.ebuild
+++ b/dev-lang/zig-bin/zig-bin-0.15.1.ebuild
@@ -8,7 +8,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/minisig-keys/zig-software-foundation.pub
 inherit verify-sig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 SRC_URI="
 	amd64? ( https://ziglang.org/download/${PV}/zig-x86_64-linux-${PV}.tar.xz )
 	arm? ( https://ziglang.org/download/${PV}/zig-arm-linux-${PV}.tar.xz )

--- a/dev-lang/zig-bin/zig-bin-0.15.2.ebuild
+++ b/dev-lang/zig-bin/zig-bin-0.15.2.ebuild
@@ -8,7 +8,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/minisig-keys/zig-software-foundation.pub
 inherit verify-sig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 SRC_URI="
 	amd64? ( https://ziglang.org/download/${PV}/zig-x86_64-linux-${PV}.tar.xz )
 	arm? ( https://ziglang.org/download/${PV}/zig-arm-linux-${PV}.tar.xz )

--- a/dev-lang/zig/metadata.xml
+++ b/dev-lang/zig/metadata.xml
@@ -14,7 +14,7 @@
 		<flag name="llvm">Build with LLVM backend and extensions enabled.</flag>
 	</use>
 	<upstream>
-		<remote-id type="github">ziglang/zig</remote-id>
-		<bugs-to>https://github.com/ziglang/zig/issues</bugs-to>
+		<remote-id type="codeberg">ziglang/zig</remote-id>
+		<bugs-to>https://codeberg.org/ziglang/zig/issues</bugs-to>
 	</upstream>
 </pkgmetadata>

--- a/dev-lang/zig/zig-0.13.0-r3.ebuild
+++ b/dev-lang/zig/zig-0.13.0-r3.ebuild
@@ -12,9 +12,9 @@ ZIG_OPTIONAL=1
 inherit check-reqs cmake flag-o-matic edo llvm-r2 toolchain-funcs zig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/ https://github.com/ziglang/zig/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 if [[ ${PV} == 9999 ]]; then
-	EGIT_REPO_URI="https://github.com/ziglang/zig.git"
+	EGIT_REPO_URI="https://codeberg.org/ziglang/zig.git"
 	inherit git-r3
 else
 	VERIFY_SIG_METHOD=minisig
@@ -56,7 +56,7 @@ BUILD_DIR="${WORKDIR}/${P}_build"
 # Zig requires zstd and zlib compression support in LLVM, if using LLVM backend.
 # (non-LLVM backends don't require these)
 # They are not required "on their own", so please don't add them here.
-# You can check https://github.com/ziglang/zig-bootstrap in future, to see
+# You can check https://codeberg.org/ziglang/zig-bootstrap in future, to see
 # options that are passed to LLVM CMake building (excluding "static" ofc).
 LLVM_DEPEND="$(llvm_gen_dep '
 	llvm-core/clang:${LLVM_SLOT}
@@ -80,7 +80,7 @@ PATCHES=(
 # zig.eclass does not set this for us since we use ZIG_OPTIONAL=1
 QA_FLAGS_IGNORED="usr/.*/zig/${PV}/bin/zig"
 
-# Since commit https://github.com/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
+# Since commit https://codeberg.org/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
 # Zig uses self-hosted compiler only
 CHECKREQS_MEMORY="4G"
 

--- a/dev-lang/zig/zig-0.14.1.ebuild
+++ b/dev-lang/zig/zig-0.14.1.ebuild
@@ -12,9 +12,9 @@ ZIG_OPTIONAL=1
 inherit check-reqs cmake flag-o-matic edo llvm-r2 toolchain-funcs zig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/ https://github.com/ziglang/zig/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 if [[ ${PV} == 9999 ]]; then
-	EGIT_REPO_URI="https://github.com/ziglang/zig.git"
+	EGIT_REPO_URI="https://codeberg.org/ziglang/zig.git"
 	inherit git-r3
 else
 	VERIFY_SIG_METHOD=minisig
@@ -56,7 +56,7 @@ BUILD_DIR="${WORKDIR}/${P}_build"
 # Zig requires zstd and zlib compression support in LLVM, if using LLVM backend.
 # (non-LLVM backends don't require these)
 # They are not required "on their own", so please don't add them here.
-# You can check https://github.com/ziglang/zig-bootstrap in future, to see
+# You can check https://codeberg.org/ziglang/zig-bootstrap in future, to see
 # options that are passed to LLVM CMake building (excluding "static" ofc).
 LLVM_DEPEND="$(llvm_gen_dep '
 	llvm-core/clang:${LLVM_SLOT}
@@ -78,7 +78,7 @@ PATCHES=(
 # zig.eclass does not set this for us since we use ZIG_OPTIONAL=1
 QA_FLAGS_IGNORED="usr/.*/zig/${PV}/bin/zig"
 
-# Since commit https://github.com/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
+# Since commit https://codeberg.org/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
 # Zig uses self-hosted compiler only
 CHECKREQS_MEMORY="4G"
 

--- a/dev-lang/zig/zig-0.15.1.ebuild
+++ b/dev-lang/zig/zig-0.15.1.ebuild
@@ -12,9 +12,9 @@ ZIG_OPTIONAL=1
 inherit check-reqs cmake flag-o-matic edo llvm-r2 toolchain-funcs zig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/ https://github.com/ziglang/zig/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 if [[ ${PV} == 9999 ]]; then
-	EGIT_REPO_URI="https://github.com/ziglang/zig.git"
+	EGIT_REPO_URI="https://codeberg.org/ziglang/zig.git"
 	inherit git-r3
 else
 	VERIFY_SIG_METHOD=minisig
@@ -56,7 +56,7 @@ BUILD_DIR="${WORKDIR}/${P}_build"
 # Zig requires zstd and zlib compression support in LLVM, if using LLVM backend.
 # (non-LLVM backends don't require these)
 # They are not required "on their own", so please don't add them here.
-# You can check https://github.com/ziglang/zig-bootstrap in future, to see
+# You can check https://codeberg.org/ziglang/zig-bootstrap in future, to see
 # options that are passed to LLVM CMake building (excluding "static" ofc).
 LLVM_DEPEND="$(llvm_gen_dep '
 	llvm-core/clang:${LLVM_SLOT}
@@ -78,7 +78,7 @@ PATCHES=(
 # zig.eclass does not set this for us since we use ZIG_OPTIONAL=1
 QA_FLAGS_IGNORED="usr/.*/zig/${PV}/bin/zig"
 
-# Since commit https://github.com/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
+# Since commit https://codeberg.org/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
 # Zig uses self-hosted compiler only
 CHECKREQS_MEMORY="4G"
 

--- a/dev-lang/zig/zig-0.15.2.ebuild
+++ b/dev-lang/zig/zig-0.15.2.ebuild
@@ -12,9 +12,9 @@ ZIG_OPTIONAL=1
 inherit check-reqs cmake flag-o-matic edo llvm-r2 toolchain-funcs zig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/ https://github.com/ziglang/zig/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 if [[ ${PV} == 9999 ]]; then
-	EGIT_REPO_URI="https://github.com/ziglang/zig.git"
+	EGIT_REPO_URI="https://codeberg.org/ziglang/zig.git"
 	inherit git-r3
 else
 	VERIFY_SIG_METHOD=minisig
@@ -56,7 +56,7 @@ BUILD_DIR="${WORKDIR}/${P}_build"
 # Zig requires zstd and zlib compression support in LLVM, if using LLVM backend.
 # (non-LLVM backends don't require these)
 # They are not required "on their own", so please don't add them here.
-# You can check https://github.com/ziglang/zig-bootstrap in future, to see
+# You can check https://codeberg.org/ziglang/zig-bootstrap in future, to see
 # options that are passed to LLVM CMake building (excluding "static" ofc).
 LLVM_DEPEND="$(llvm_gen_dep '
 	llvm-core/clang:${LLVM_SLOT}
@@ -74,7 +74,7 @@ DOCS=( "README.md" "doc/build.zig.zon.md" )
 # zig.eclass does not set this for us since we use ZIG_OPTIONAL=1
 QA_FLAGS_IGNORED="usr/.*/zig/${PV}/bin/zig"
 
-# Since commit https://github.com/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
+# Since commit https://codeberg.org/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
 # Zig uses self-hosted compiler only
 CHECKREQS_MEMORY="4G"
 

--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -12,9 +12,9 @@ ZIG_OPTIONAL=1
 inherit check-reqs cmake flag-o-matic edo llvm-r2 toolchain-funcs zig
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"
-HOMEPAGE="https://ziglang.org/ https://github.com/ziglang/zig/"
+HOMEPAGE="https://ziglang.org/ https://codeberg.org/ziglang/zig/"
 if [[ ${PV} == 9999 ]]; then
-	EGIT_REPO_URI="https://github.com/ziglang/zig.git"
+	EGIT_REPO_URI="https://codeberg.org/ziglang/zig.git"
 	inherit git-r3
 else
 	VERIFY_SIG_METHOD=minisig
@@ -56,7 +56,7 @@ BUILD_DIR="${WORKDIR}/${P}_build"
 # Zig requires zstd and zlib compression support in LLVM, if using LLVM backend.
 # (non-LLVM backends don't require these)
 # They are not required "on their own", so please don't add them here.
-# You can check https://github.com/ziglang/zig-bootstrap in future, to see
+# You can check https://codeberg.org/ziglang/zig-bootstrap in future, to see
 # options that are passed to LLVM CMake building (excluding "static" ofc).
 LLVM_DEPEND="$(llvm_gen_dep '
 	llvm-core/clang:${LLVM_SLOT}
@@ -74,7 +74,7 @@ DOCS=( "README.md" "doc/build.zig.zon.md" )
 # zig.eclass does not set this for us since we use ZIG_OPTIONAL=1
 QA_FLAGS_IGNORED="usr/.*/zig/${PV}/bin/zig"
 
-# Since commit https://github.com/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
+# Since commit https://codeberg.org/ziglang/zig/commit/e7d28344fa3ee81d6ad7ca5ce1f83d50d8502118
 # Zig uses self-hosted compiler only
 CHECKREQS_MEMORY="4G"
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

https://ziglang.org/news/migrating-from-github-to-codeberg/

Links to PRs and issues in eclass-es and ebuilds were not changed, because they were not moved to Codeberg (intentonally, see article above)

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
