### PR TITLE
media-plugins/frei0r-plugins: add ffmpeg to opencv USE deps

### DIFF
--- a/media-plugins/frei0r-plugins/frei0r-plugins-2.4.1-r1.ebuild
+++ b/media-plugins/frei0r-plugins/frei0r-plugins-2.4.1-r1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 IUSE="doc +facedetect +scale0tilt"
 
 RDEPEND="x11-libs/cairo[${MULTILIB_USEDEP}]
-	facedetect? ( >=media-libs/opencv-2.3.0:=[contrib,contribdnn,features2d,${MULTILIB_USEDEP}] )
+	facedetect? ( >=media-libs/opencv-2.3.0:=[contrib,contribdnn,features2d,ffmpeg,${MULTILIB_USEDEP}] )
 	scale0tilt? ( >=media-libs/gavl-1.2.0[${MULTILIB_USEDEP}] )"
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
Fixes the following build failure:
```
frei0r-2.4.1/src/filter/facebl0r/facebl0r.cpp: In member function ‘cv::RotatedRect TrackedObj::camshift_track_face()’: frei0r-2.4.1/src/filter/facebl0r/facebl0r.cpp:248:30: error: ‘CamShift’ was not declared in this scope
  248 |   cv::RotatedRect curr_box = CamShift(prob, prev_rect,
      |                              ^~~~~~~~
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
