### PR TITLE
dev-python/mypy: add test dep dev-python/python-tests for Python 3.14+

### DIFF
--- a/dev-python/mypy/mypy-1.18.2-r1.ebuild
+++ b/dev-python/mypy/mypy-1.18.2-r1.ebuild
@@ -43,6 +43,7 @@ BDEPEND="
 		>=dev-python/attrs-18.0[${PYTHON_USEDEP}]
 		>=dev-python/filelock-3.3.0[${PYTHON_USEDEP}]
 		>=dev-python/lxml-4.9.1[${PYTHON_USEDEP}]
+		dev-python/test[${PYTHON_USEDEP}]
 	)
 "
 

--- a/dev-python/mypy/mypy-1.19.0-r1.ebuild
+++ b/dev-python/mypy/mypy-1.19.0-r1.ebuild
@@ -44,6 +44,7 @@ BDEPEND="
 		>=dev-python/attrs-18.0[${PYTHON_USEDEP}]
 		>=dev-python/filelock-3.3.0[${PYTHON_USEDEP}]
 		>=dev-python/lxml-4.9.1[${PYTHON_USEDEP}]
+		dev-python/test[${PYTHON_USEDEP}]
 	)
 "
 


### PR DESCRIPTION
The mypy testsuite gained dependency on `test.support` since the linked commit, so add the dep to all versions marked PYTHON_COMPAT=python3_14.

Link: https://github.com/python/mypy/commit/3330b421f89a5b76e3ec87f317af990e225c8f15

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
