### PR TITLE
dev-lang/php: Fix GH-20528: Regression breaks mysql connexion using an IPv6 address enclosed in square brackets

### DIFF
--- a/dev-lang/php/files/php-gh-20528-fix.patch
+++ b/dev-lang/php/files/php-gh-20528-fix.patch
@@ -1,0 +1,81 @@
+From 9d71c1e0b60cd152a47528dbe514efc443fce920 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Thu, 20 Nov 2025 02:58:45 +0100
+Subject: [PATCH] Fix GH-20528: Regression breaks mysql connexion using an IPv6
+ address enclosed in square brackets
+
+---
+ ext/mysqli/tests/mysqli_connect_port.phpt | 31 +++++++++++++++++++++++
+ ext/mysqlnd/mysqlnd_connection.c          | 17 ++++++++++---
+ 2 files changed, 45 insertions(+), 3 deletions(-)
+ create mode 100644 ext/mysqli/tests/mysqli_connect_port.phpt
+
+diff --git a/ext/mysqli/tests/mysqli_connect_port.phpt b/ext/mysqli/tests/mysqli_connect_port.phpt
+new file mode 100644
+index 0000000000000..cb7fd1d8d1628
+--- /dev/null
++++ b/ext/mysqli/tests/mysqli_connect_port.phpt
+@@ -0,0 +1,31 @@
++--TEST--
++mysqli_connect() with port in host
++--EXTENSIONS--
++mysqli
++--SKIPIF--
++<?php
++require_once 'skipifconnectfailure.inc';
++?>
++--FILE--
++<?php
++    require_once 'connect.inc';
++
++	// using port / host arguments
++    if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
++        printf("Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
++            $host, $user, $db, $port, $socket);
++	}
++
++    mysqli_close($link);
++
++	// using port in host
++    if (!$link = mysqli_connect("$host:$port", $user, $passwd, $db, "1$port", $socket)) {
++        printf("Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
++            "$host:$port", $user, $db, "1$port", $socket);
++	}
++
++    mysqli_close($link);
++?>
++Done
++--EXPECTF--
++Done
+diff --git a/ext/mysqlnd/mysqlnd_connection.c b/ext/mysqlnd/mysqlnd_connection.c
+index d8e7304e9665f..8268034e8b798 100644
+--- a/ext/mysqlnd/mysqlnd_connection.c
++++ b/ext/mysqlnd/mysqlnd_connection.c
+@@ -553,13 +553,24 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_scheme)(MYSQLND_CONN_DATA * conn, MYSQLND_
+ 			port = 3306;
+ 		}
+ 
+-		/* ipv6 addresses are in the format [address]:port */
+ 		if (hostname.s[0] != '[' && mysqlnd_fast_is_ipv6_address(hostname.s)) {
++			/* IPv6 without square brackets so without port */
+ 			transport.l = mnd_sprintf(&transport.s, 0, "tcp://[%s]:%u", hostname.s, port);
+ 		} else {
+-			/* Not ipv6, but could already contain a port number, in which case we should not add an extra port.
++			char *p;
++
++			/* IPv6 addresses are in the format [address]:port */
++			if (hostname.s[0] == '[') { /* IPv6 */
++				p = strchr(hostname.s, ']');
++				if (p && p[1] != ':') {
++					p = NULL;
++				}
++			} else { /* IPv4 or name */
++				p = strchr(hostname.s, ':');
++			}
++			/* Could already contain a port number, in which case we should not add an extra port.
+ 			 * See GH-8978. In a port doubling scenario, the first port would be used so we do the same to keep BC. */
+-			if (strchr(hostname.s, ':')) {
++			if (p) {
+ 				/* TODO: Ideally we should be able to get rid of this workaround in the future. */
+ 				transport.l = mnd_sprintf(&transport.s, 0, "tcp://%s", hostname.s);
+ 			} else {

--- a/dev-lang/php/php-8.3.28-r1.ebuild
+++ b/dev-lang/php/php-8.3.28-r1.ebuild
@@ -32,8 +32,8 @@ IUSE="${IUSE}
 IUSE="${IUSE} acl apparmor argon2 avif bcmath berkdb bzip2 calendar
 	capstone cdb +ctype curl debug
 	enchant exif ffi +fileinfo +filter
-	+flatfile ftp gd gdbm gmp +iconv inifile
-	intl iodbc ipv6 +jit jpeg ldap ldap-sasl libedit lmdb
+	+flatfile ftp gd gdbm gmp +iconv imap inifile
+	intl iodbc ipv6 +jit jpeg kerberos ldap ldap-sasl libedit lmdb
 	mhash mssql mysql mysqli nls
 	odbc +opcache +opcache-jit pcntl pdo +phar +posix postgres png
 	qdbm readline selinux +session session-mm sharedmem
@@ -86,7 +86,9 @@ COMMON_DEPEND="
 	gdbm? ( sys-libs/gdbm:0= )
 	gmp? ( dev-libs/gmp:0= )
 	iconv? ( virtual/libiconv )
+	imap? ( net-libs/c-client[kerberos=,ssl=] )
 	intl? ( dev-libs/icu:= )
+	kerberos? ( virtual/krb5 )
 	ldap? ( net-nds/openldap:= )
 	ldap-sasl? ( dev-libs/cyrus-sasl )
 	libedit? ( dev-libs/libedit )
@@ -132,7 +134,9 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
+	"${FILESDIR}/php-8.3.9-gd-cachevars.patch"
 	"${FILESDIR}/php-8.4.14-libpcre2-testfix.patch"
+	"${FILESDIR}/php-gh-20528-fix.patch"
 )
 
 PHP_MV="$(ver_cut 1)"
@@ -211,7 +215,7 @@ pkg_setup() {
 src_prepare() {
 	default
 
-	# In php-8.x, the FPM pool configuration files have been split off
+	# In php-7.x, the FPM pool configuration files have been split off
 	# of the main config. By default the pool config files go in
 	# e.g. /etc/php-fpm.d, which isn't slotted. So here we move the
 	# include directory to a subdirectory "fpm.d" of $PHP_INI_DIR. Later
@@ -245,6 +249,12 @@ src_prepare() {
 	   sapi/cli/tests/bug78323.phpt \
 	   || die
 
+	# This is a memory usage test with hard-coded limits. Whenever the
+	# limits are surpassed... they get increased... but in the meantime,
+	# the tests fail. This is not really a test that end users should
+	# be running pre-install, in my opinion. Bug 927461.
+	rm ext/fileinfo/tests/bug78987.phpt || die
+
 	# Most tests failing with an external libgd have been fixed,
 	# but there are a few stragglers:
 	#
@@ -259,15 +269,6 @@ src_prepare() {
 	   ext/gd/tests/bug65148.phpt \
 	   ext/gd/tests/bug73272.phpt \
 	   || die
-
-	# Test requires USE=cdb, so we have to skip it when
-	# the cdb USE flag is unset
-	#
-	#  * https://github.com/php/php-src/issues/19706
-	#
-	if ! use cdb; then
-		rm ext/dba/tests/gh19706.phpt
-	fi
 
 	# One-off, somebody forgot to update a version constant
 	rm ext/reflection/tests/ReflectionZendExtension.phpt || die
@@ -331,6 +332,7 @@ src_configure() {
 			$(use elibc_glibc || use elibc_musl || echo "${EPREFIX}/usr"))
 		$(use_enable intl)
 		$(use_enable ipv6)
+		$(use_with kerberos)
 		$(use_with xml libxml)
 		$(use_enable unicode mbstring)
 		$(use_with ssl openssl)
@@ -342,6 +344,7 @@ src_configure() {
 		$(use_with postgres pgsql "$("${PG_CONFIG:-true}" --bindir)/..")
 		$(use_enable posix)
 		$(use_with selinux fpm-selinux)
+		$(use_with spell pspell "${EPREFIX}/usr")
 		$(use_enable simplexml)
 		$(use_enable sharedmem shmop)
 		$(use_with snmp snmp "${EPREFIX}/usr")
@@ -407,6 +410,14 @@ src_configure() {
 		php_cv_lib_gd_gdImageCreateFromWebp=$(usex webp)
 		php_cv_lib_gd_gdImageCreateFromXpm=$(usex xpm)
 	)
+
+	# IMAP support
+	if use imap ; then
+		our_conf+=(
+			$(use_with imap imap "${EPREFIX}/usr")
+			$(use_with ssl imap-ssl "${EPREFIX}/usr")
+		)
+	fi
 
 	# LDAP support
 	if use ldap ; then

--- a/dev-lang/php/php-8.5.0-r1.ebuild
+++ b/dev-lang/php/php-8.5.0-r1.ebuild
@@ -32,10 +32,10 @@ IUSE="${IUSE}
 IUSE="${IUSE} acl apparmor argon2 avif bcmath berkdb bzip2 calendar
 	capstone cdb +ctype curl debug
 	enchant exif ffi +fileinfo +filter
-	+flatfile ftp gd gdbm gmp +iconv imap inifile
-	intl iodbc ipv6 +jit jpeg kerberos ldap ldap-sasl libedit lmdb
+	+flatfile ftp gd gdbm gmp +iconv inifile
+	intl iodbc ipv6 +jit jpeg ldap ldap-sasl libedit lmdb
 	mhash mssql mysql mysqli nls
-	odbc +opcache +opcache-jit pcntl pdo +phar +posix postgres png
+	odbc +opcache-jit pcntl pdo +phar +posix postgres png
 	qdbm readline selinux +session session-mm sharedmem
 	+simplexml snmp soap sockets sodium spell sqlite ssl
 	sysvipc systemd test tidy +tokenizer tokyocabinet truetype unicode
@@ -86,9 +86,7 @@ COMMON_DEPEND="
 	gdbm? ( sys-libs/gdbm:0= )
 	gmp? ( dev-libs/gmp:0= )
 	iconv? ( virtual/libiconv )
-	imap? ( net-libs/c-client[kerberos=,ssl=] )
 	intl? ( dev-libs/icu:= )
-	kerberos? ( virtual/krb5 )
 	ldap? ( net-nds/openldap:= )
 	ldap-sasl? ( dev-libs/cyrus-sasl )
 	libedit? ( dev-libs/libedit )
@@ -134,8 +132,8 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
-	"${FILESDIR}/php-8.3.9-gd-cachevars.patch"
 	"${FILESDIR}/php-8.4.14-libpcre2-testfix.patch"
+	"${FILESDIR}/php-gh-20528-fix.patch"
 )
 
 PHP_MV="$(ver_cut 1)"
@@ -181,14 +179,6 @@ php_install_ini() {
 	dodir "${PHP_EXT_INI_DIR#${EPREFIX}}"
 	dodir "${PHP_EXT_INI_DIR_ACTIVE#${EPREFIX}}"
 
-	if use opcache; then
-		elog "Adding opcache to $PHP_EXT_INI_DIR"
-		echo "zend_extension = opcache.so" >> \
-			 "${D}/${PHP_EXT_INI_DIR}"/opcache.ini
-		dosym "../ext/opcache.ini" \
-			  "${PHP_EXT_INI_DIR_ACTIVE#${EPREFIX}}/opcache.ini"
-	fi
-
 	# SAPI-specific handling
 	if [[ "${sapi}" == "fpm" ]] ; then
 		einfo "Installing FPM config files php-fpm.conf and www.conf"
@@ -214,7 +204,7 @@ pkg_setup() {
 src_prepare() {
 	default
 
-	# In php-7.x, the FPM pool configuration files have been split off
+	# In php-8.x, the FPM pool configuration files have been split off
 	# of the main config. By default the pool config files go in
 	# e.g. /etc/php-fpm.d, which isn't slotted. So here we move the
 	# include directory to a subdirectory "fpm.d" of $PHP_INI_DIR. Later
@@ -248,12 +238,6 @@ src_prepare() {
 	   sapi/cli/tests/bug78323.phpt \
 	   || die
 
-	# This is a memory usage test with hard-coded limits. Whenever the
-	# limits are surpassed... they get increased... but in the meantime,
-	# the tests fail. This is not really a test that end users should
-	# be running pre-install, in my opinion. Bug 927461.
-	rm ext/fileinfo/tests/bug78987.phpt || die
-
 	# Most tests failing with an external libgd have been fixed,
 	# but there are a few stragglers:
 	#
@@ -268,6 +252,15 @@ src_prepare() {
 	   ext/gd/tests/bug65148.phpt \
 	   ext/gd/tests/bug73272.phpt \
 	   || die
+
+	# Test requires USE=cdb, so we have to skip it when
+	# the cdb USE flag is unset
+	#
+	#  * https://github.com/php/php-src/issues/19706
+	#
+	if ! use cdb; then
+		rm ext/dba/tests/gh19706.phpt
+	fi
 
 	# One-off, somebody forgot to update a version constant
 	rm ext/reflection/tests/ReflectionZendExtension.phpt || die
@@ -331,19 +324,16 @@ src_configure() {
 			$(use elibc_glibc || use elibc_musl || echo "${EPREFIX}/usr"))
 		$(use_enable intl)
 		$(use_enable ipv6)
-		$(use_with kerberos)
 		$(use_with xml libxml)
 		$(use_enable unicode mbstring)
 		$(use_with ssl openssl)
 		$(use_enable pcntl)
 		$(use_enable phar)
 		$(use_enable pdo)
-		$(use_enable opcache)
 		$(use_enable opcache-jit)
 		$(use_with postgres pgsql "$("${PG_CONFIG:-true}" --bindir)/..")
 		$(use_enable posix)
 		$(use_with selinux fpm-selinux)
-		$(use_with spell pspell "${EPREFIX}/usr")
 		$(use_enable simplexml)
 		$(use_enable sharedmem shmop)
 		$(use_with snmp snmp "${EPREFIX}/usr")
@@ -409,14 +399,6 @@ src_configure() {
 		php_cv_lib_gd_gdImageCreateFromWebp=$(usex webp)
 		php_cv_lib_gd_gdImageCreateFromXpm=$(usex xpm)
 	)
-
-	# IMAP support
-	if use imap ; then
-		our_conf+=(
-			$(use_with imap imap "${EPREFIX}/usr")
-			$(use_with ssl imap-ssl "${EPREFIX}/usr")
-		)
-	fi
 
 	# LDAP support
 	if use ldap ; then
@@ -609,7 +591,6 @@ src_install() {
 	cd "${WORKDIR}/sapis-build/$first_sapi" || die
 	emake INSTALL_ROOT="${D}" \
 		install-build install-headers install-programs
-	use opcache && emake INSTALL_ROOT="${D}" install-modules
 
 	# Create the directory where we'll put version-specific php scripts
 	keepdir "/usr/share/php${PHP_MV}"


### PR DESCRIPTION
Fixup for https://github.com/gentoo/gentoo/pull/44815 by backporting https://github.com/php/php-src/commit/9d71c1e0b60cd152a47528dbe514efc443fce920 to all current ebuilds.

See https://github.com/php/php-src/issues/20528 for reference.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
