### PR TITLE
eclass/*.eclass: Add support for EAPI 9

### DIFF
--- a/eclass/ada.eclass
+++ b/eclass/ada.eclass
@@ -6,7 +6,7 @@
 # Ada team <ada@gentoo.org>
 # @AUTHOR:
 # Tupone Alfredo <tupone@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: An eclass for Ada packages
 # @DESCRIPTION:
 # This eclass set the IUSE and REQUIRED_USE to request the ADA_TARGET
@@ -23,13 +23,13 @@
 #
 # Mostly copied from python-single-r1.eclass
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_ADA_ECLASS} ]]; then
 _ADA_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic
 

--- a/eclass/alternatives.eclass
+++ b/eclass/alternatives.eclass
@@ -6,7 +6,7 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Alastair Tse <liquidx@gentoo.org> (03 Oct 2003)
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Creates symlink to the latest version of multiple slotted packages.
 # @DESCRIPTION:
 # When a package is SLOT'ed, very often we need to have a symlink to the
@@ -41,13 +41,13 @@
 # link to. It is probably more robust against version upgrades. You should
 # consider using this unless you are want to do something special.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_ALTERNATIVES_ECLASS} ]]; then
 _ALTERNATIVES_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: SOURCE
 # @DEFAULT_UNSET

--- a/eclass/apache-2.eclass
+++ b/eclass/apache-2.eclass
@@ -6,11 +6,16 @@
 # apache-bugs@gentoo.org
 # @AUTHOR:
 # polynomial-c@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides a common set of functions for apache-2.x ebuilds
 # @DESCRIPTION:
 # This eclass handles apache-2.x ebuild functions such as LoadModule generation
 # and inter-module dependency checking.
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 LUA_COMPAT=( lua5-{1..4} )
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/apache-httpd.asc
@@ -19,11 +24,6 @@ inherit verify-sig
 
 [[ ${CATEGORY}/${PN} != www-servers/apache ]] \
 	&& die "Do not use this eclass with anything else than www-servers/apache ebuilds!"
-
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 # settings which are version specific go in here:
 case $(ver_cut 1-2) in

--- a/eclass/apache-module.eclass
+++ b/eclass/apache-module.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: apache-module.eclass
 # @MAINTAINER:
 # apache-bugs@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides a common set of functions for apache modules
 # @DESCRIPTION:
 # This eclass handles apache modules in a sane way.
@@ -48,7 +48,7 @@ if [[ -z ${_APACHE_MODULE_ECLASS} ]]; then
 _APACHE_MODULE_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -8,17 +8,17 @@
 # Doug Goldstein <cardoe@gentoo.org>
 # Georgy Yakovlev <gyakovlev@gentoo.org>
 # Matt Jolly <kangie@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: rust
 # @BLURB: common functions and variables for cargo builds
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_CARGO_ECLASS} ]]; then
 _CARGO_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ -n ${RUST_NEEDS_LLVM} ]]; then
 	inherit llvm-r1

--- a/eclass/check-reqs.eclass
+++ b/eclass/check-reqs.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2024 Gentoo Authors
+# Copyright 2004-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: check-reqs.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Bo Ørsted Andresen <zlin@gentoo.org>
 # Original Author: Ciaran McCreesh <ciaranm@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides a uniform way of handling ebuilds with very high build requirements
 # @DESCRIPTION:
 # This eclass provides a uniform way of handling ebuilds which have very high
@@ -42,7 +42,7 @@ if [[ -z ${_CHECK_REQS_ECLASS} ]]; then
 _CHECK_REQS_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/chromium-2.eclass
+++ b/eclass/chromium-2.eclass
@@ -6,18 +6,18 @@
 # Chromium Project <chromium@gentoo.org>
 # @AUTHOR:
 # Mike Gilbert <floppym@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Shared functions for chromium and google-chrome
 
+if [[ -z ${_CHROMIUM_2_ECLASS} ]]; then
+_CHROMIUM_2_ECLASS=1
+
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 inherit linux-info
-
-if [[ -z ${_CHROMIUM_2_ECLASS} ]]; then
-_CHROMIUM_2_ECLASS=1
 
 if [[ ${PN} == chromium ]]; then
 	IUSE+=" custom-cflags"

--- a/eclass/cmake-multilib.eclass
+++ b/eclass/cmake-multilib.eclass
@@ -6,7 +6,7 @@
 # Michał Górny <mgorny@gentoo.org>
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: cmake multilib-minimal
 # @BLURB: cmake wrapper for multilib builds
 # @DESCRIPTION:
@@ -27,7 +27,7 @@
 : "${CMAKE_ECLASS:=cmake}"
 
 case ${EAPI} in
-	8)
+	8|9)
 		case ${CMAKE_ECLASS} in
 			cmake) ;;
 			*)

--- a/eclass/common-lisp-3.eclass
+++ b/eclass/common-lisp-3.eclass
@@ -4,19 +4,19 @@
 # @ECLASS: common-lisp-3.eclass
 # @MAINTAINER:
 # Common Lisp project <common-lisp@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: functions to support the installation of Common Lisp libraries
 # @DESCRIPTION:
 # Since Common Lisp libraries share similar structure, this eclass aims
 # to provide a simple way to write ebuilds with these characteristics.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_COMMON_LISP_3_ECLASS} ]]; then
 _COMMON_LISP_3_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: CLIMPLEMENTATIONS
 # @DESCRIPTION:

--- a/eclass/cron.eclass
+++ b/eclass/cron.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: cron.eclass
@@ -6,7 +6,7 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Original Author: Aaron Walker <ka0ttic@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Some functions for cron
 # @DESCRIPTION:
 # Purpose: The main motivation for this eclass was to simplify
@@ -17,13 +17,13 @@
 # NOTE on defaults: the default settings in the below functions were
 # chosen based on the most common setting among cron ebuilds.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_CRON_ECLASS} ]]; then
 _CRON_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic
 

--- a/eclass/db-use.eclass
+++ b/eclass/db-use.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # This is a common location for functions that aid the use of sys-libs/db
 #
@@ -8,17 +8,19 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Paul de Vrieze <pauldv@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: This is a common location for functions that aid the use of sys-libs/db
 # @DESCRIPTION:
 # This eclass is designed to provide helpful functions for depending on
 # sys-libs/db.
 
-# multilib is used for get_libname in all EAPI
 case ${EAPI} in
-	7|8) inherit multilib ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
+
+# multilib is used for get_libname in all EAPI
+inherit multilib
 
 #Convert a version to a db slot
 db_ver_to_slot() {

--- a/eclass/db.eclass
+++ b/eclass/db.eclass
@@ -1,19 +1,19 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: db.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Internal eclass used by sys-libs/db ebuilds
-
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_DB_ECLASS} ]]; then
 _DB_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multilib multiprocessing
 

--- a/eclass/depend.apache.eclass
+++ b/eclass/depend.apache.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: depend.apache.eclass
 # @MAINTAINER:
 # apache-bugs@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Functions to allow ebuilds to depend on apache
 # @DESCRIPTION:
 # This eclass handles depending on apache in a sane way and provides information
@@ -44,7 +44,7 @@ if [[ -z ${_DEPEND_APACHE_ECLASS} ]]; then
 _DEPEND_APACHE_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -6,7 +6,7 @@
 # Distribution Kernel Project <dist-kernel@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Utility functions related to Distribution Kernels
 # @DESCRIPTION:
 # This eclass provides various utility functions related to Distribution
@@ -22,7 +22,7 @@
 if [[ ! ${_DIST_KERNEL_UTILS} ]]; then
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on the work of: Krzysztof Pawlik <nelchael@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: python-r1 python-single-r1
 # @BLURB: A simple eclass to build Python packages using distutils.
 # @DESCRIPTION:
@@ -196,6 +196,7 @@ _DISTUTILS_R1_ECLASS=1
 
 case ${EAPI} in
 	8) inherit eapi9-pipestatus ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/docs.eclass
+++ b/eclass/docs.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: docs.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Nowa Ammerlaan <nowa@gentoo.org>
 # Based on the work of: Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: A simple eclass to build documentation.
 # @DESCRIPTION:
 # A simple eclass providing basic functions and variables to build
@@ -58,7 +58,7 @@
 # @CODE
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/dot-a.eclass
+++ b/eclass/dot-a.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Sam James <sam@gentoo.org>
 # Eli Schwartz <eschwartz@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Functions to handle stripping LTO bytecode out of static archives.
 # @DESCRIPTION:
 # This eclass provides functions to strip LTO bytecode out of static archives
@@ -40,13 +40,14 @@
 #     default
 #     strip-lto-bytecode
 # }
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_DOT_A_ECLASS} ]] ; then
 _DOT_A_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic toolchain-funcs
 

--- a/eclass/dotnet-pkg-base.eclass
+++ b/eclass/dotnet-pkg-base.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Anna Figueiredo Gomes <navi@vlhl.dev>
 # Maciej Barć <xgqt@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: nuget
 # @BLURB: common functions and variables for builds using .NET SDK
 # @DESCRIPTION:
@@ -22,15 +22,16 @@
 # This eclass does not export any phase functions, for that see
 # the "dotnet-pkg" eclass.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_DOTNET_PKG_BASE_ECLASS} ]] ; then
 _DOTNET_PKG_BASE_ECLASS=1
 
-inherit edo multiprocessing nuget
+case ${EAPI} in
+	8) inherit edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+inherit multiprocessing nuget
 
 # @ECLASS_VARIABLE: DOTNET_VERBOSITY
 # @USER_VARIABLE

--- a/eclass/dotnet-pkg.eclass
+++ b/eclass/dotnet-pkg.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: dotnet-pkg.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Anna Figueiredo Gomes <navi@vlhl.dev>
 # Maciej Barć <xgqt@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: dotnet-pkg-base nuget
 # @BLURB: common functions and variables for .NET packages
 # @DESCRIPTION:
@@ -33,13 +33,13 @@
 # - the main project file (*.proj) that builds the project has to be specified
 #   by the "DOTNET_PROJECT" variable.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_DOTNET_PKG_ECLASS} ]] ; then
 _DOTNET_PKG_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit dotnet-pkg-base
 

--- a/eclass/dune.eclass
+++ b/eclass/dune.eclass
@@ -8,19 +8,22 @@
 # ML <ml@gentoo.org>
 # @AUTHOR:
 # Rafael Kitover <rkitover@gmail.com>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides functions for installing Dune packages.
 # @DESCRIPTION:
 # Provides dependencies on Dune and OCaml and default src_compile, src_test and
 # src_install for Dune-based packages.
 
+if [[ -z ${_DUNE_ECLASS} ]]; then
+_DUNE_ECLASS=1
+
 case ${EAPI} in
-	7|8) ;;
+	7|8) inherit edo ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-if [[ -z ${_DUNE_ECLASS} ]]; then
-_DUNE_ECLASS=1
+inherit multiprocessing
 
 # @ECLASS_VARIABLE: DUNE_PKG_NAME
 # @PRE_INHERIT
@@ -28,8 +31,6 @@ _DUNE_ECLASS=1
 # Sets the actual Dune package name, if different from Gentoo package name.
 # Set before inheriting the eclass.
 : "${DUNE_PKG_NAME:=${PN}}"
-
-inherit edo multiprocessing
 
 # Do not complain about CFLAGS etc since ml projects do not use them.
 QA_FLAGS_IGNORED='.*'

--- a/eclass/ecm-common.eclass
+++ b/eclass/ecm-common.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: ecm-common.eclass
 # @MAINTAINER:
 # kde@gentoo.org
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: cmake
 # @BLURB: Standalone CMake calling std. ECM macros to install common files only.
 # @DESCRIPTION:
@@ -15,13 +15,13 @@
 # files package.
 # Conventionally we will use ${PN}-common for these split packages.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_ECM_COMMON_ECLASS} ]]; then
 _ECM_COMMON_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit cmake
 

--- a/eclass/ecm.eclass
+++ b/eclass/ecm.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: ecm.eclass
 # @MAINTAINER:
 # kde@gentoo.org
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: cmake virtualx
 # @BLURB: Support eclass for packages that use KDE Frameworks with ECM.
 # @DESCRIPTION:
@@ -21,13 +21,13 @@
 # This eclass's phase functions are not intended to be mixed and matched, so if
 # any phase functions are overridden the version here should also be called.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_ECM_ECLASS} ]]; then
 _ECM_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: CMAKE_ECM_MODE
 # @DESCRIPTION:

--- a/eclass/emboss-r3.eclass
+++ b/eclass/emboss-r3.eclass
@@ -8,7 +8,7 @@
 # Original author: Author Olivier Fisette <ofisette@gmail.com>
 # Next gen author: Justin Lecher <jlec@gentoo.org>
 # Next gen author: Ted Tanberry <ted.tanberry@gmail.com>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Use this to easy install EMBOSS and EMBASSY programs (EMBOSS add-ons).
 # @DESCRIPTION:
 # The inheriting ebuild must provide EBO_DESCRIPTION before the inherit line.
@@ -33,13 +33,13 @@
 #
 # Defaults to the upstream name of the module.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_EMBOSS_R3_ECLASS} ]]; then
 _EMBOSS_R3_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic
 

--- a/eclass/fcaps.eclass
+++ b/eclass/fcaps.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: fcaps.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: function to set POSIX file-based capabilities
 # @DESCRIPTION:
 # This eclass provides a function to set file-based capabilities on binaries.
@@ -29,13 +29,13 @@
 # )
 # @CODE
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_FCAPS_ECLASS} ]]; then
 _FCAPS_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 IUSE="+filecaps"
 

--- a/eclass/findlib.eclass
+++ b/eclass/findlib.eclass
@@ -6,18 +6,18 @@
 # ML <ml@gentoo.org>
 # @AUTHOR:
 # Original author: Matthieu Sozeau <mattam@gentoo.org> (retired)
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: ocamlfind (a.k.a. findlib) eclass
 # @DESCRIPTION:
 # ocamlfind (a.k.a. findlib) eclass
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_FINDLIB_ECLASS} ]] ; then
 _FINDLIB_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # Do not complain about CFLAGS etc since ML projects do not use them.
 QA_FLAGS_IGNORED='.*'

--- a/eclass/font-ebdftopcf.eclass
+++ b/eclass/font-ebdftopcf.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: font-ebdftopcf.eclass
@@ -6,19 +6,19 @@
 # fonts@gentoo.org
 # @AUTHOR:
 # Robin H. Johnson <robbat2@gentoo.org>
-# @SUPPORTED_EAPIS: 7
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass to make PCF font generator from BDF uniform and optimal
 # @DESCRIPTION:
 # The manpage for this eclass is in media-gfx/ebdftopcf.
 # Inherit this eclass after font.eclass
 
-case ${EAPI} in
-	7) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_FONT_EBDFTOPCF_ECLASS} ]]; then
 _FONT_EBDFTOPCF_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # Make dependence on Xorg optional
 IUSE="X"

--- a/eclass/font.eclass
+++ b/eclass/font.eclass
@@ -4,16 +4,16 @@
 # @ECLASS: font.eclass
 # @MAINTAINER:
 # fonts@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass to make font installation uniform
-
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_FONT_ECLASS} ]]; then
 _FONT_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: FONT_SUFFIX
 # @DEFAULT_UNSET

--- a/eclass/fortran-2.eclass
+++ b/eclass/fortran-2.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author Justin Lecher <jlec@gentoo.org>
 # Test functions provided by Sebastien Fabbro and Kacper Kowalik
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Simplify fortran compiler management
 # @DESCRIPTION:
 # If you need a fortran compiler, then you should be inheriting this eclass.
@@ -30,7 +30,7 @@ if [[ -z ${_FORTRAN_2_ECLASS} ]]; then
 _FORTRAN_2_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/freedict.eclass
+++ b/eclass/freedict.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: freedict.eclass
@@ -6,19 +6,19 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Original author: Seemant Kulleen <seemant@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Ease the installation of freedict translation dictionaries
 # @DESCRIPTION:
 # This eclass exists to ease the installation of freedict translation
 # dictionaries.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_FREEDICT_ECLASS} ]]; then
 _FREEDICT_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: FREEDICT_P
 # @DESCRIPTION:

--- a/eclass/gap-pkg.eclass
+++ b/eclass/gap-pkg.eclass
@@ -1,4 +1,4 @@
-# Copyright 2024 Gentoo Authors
+# Copyright 2024-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: gap-pkg.eclass
@@ -9,7 +9,7 @@
 # @AUTHOR:
 # François Bissey <frp.bissey@gmail.com>
 # Michael Orlitzky <mjo@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Simplify the installation of GAP packages.
 # @DESCRIPTION:
 # The main purpose of this eclass is to build and install GAP packages
@@ -46,7 +46,7 @@ if [[ -z ${_GAP_PKG_ECLASS} ]]; then
 _GAP_PKG_ECLASS=1
 
 case ${EAPI} in
-	8) ;;
+	8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ghc-package.eclass
@@ -6,18 +6,18 @@
 # "Gentoo's Haskell Language team" <haskell@gentoo.org>
 # @AUTHOR:
 # Original Author: Andres Loeh <kosmikus@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: This eclass helps with the Glasgow Haskell Compiler's package configuration utility.
 # @DESCRIPTION:
 # Helper eclass to handle ghc installation/upgrade/deinstallation process.
 
-inherit multiprocessing
-
 # Maintain version-testing compatibility with ebuilds not using EAPI 7.
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
+
+inherit multiprocessing
 
 # GHC uses it's own native code generator. Portage's
 # QA check generates false positive because it assumes

--- a/eclass/gkrellm-plugin.eclass
+++ b/eclass/gkrellm-plugin.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: gkrellm-plugin.eclass
@@ -8,7 +8,7 @@
 # Original author: Jim Ramsay <lack@gentoo.org>
 # EAPI 6 author: David Seifert <soap@gentoo.org>
 # EAPI 8 author: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Provides src_install used by (almost) all gkrellm plugins
 # @DESCRIPTION:
 # - Sets up default dependencies
@@ -31,13 +31,13 @@
 # An optional list of docs to be installed, in addition to the default
 # DOCS variable which is respected too.  Has to be a bash array.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_GKRELLM_PLUGIN_ECLASS} ]]; then
 _GKRELLM_PLUGIN_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multilib
 

--- a/eclass/gnustep-2.eclass
+++ b/eclass/gnustep-2.eclass
@@ -1,23 +1,23 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: gnustep-2.eclass
 # @MAINTAINER:
 # GNUstep Herd <gnustep@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: gnustep-base
 # @BLURB: eclass for GNUstep Apps, Frameworks, and Bundles build
 # @DESCRIPTION:
 # This eclass sets up GNUstep environment to properly install
 # GNUstep packages
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_GNUSTEP_2_ECLASS} ]] ; then
 _GNUSTEP_2_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit gnustep-base
 

--- a/eclass/gnustep-base.eclass
+++ b/eclass/gnustep-base.eclass
@@ -4,19 +4,19 @@
 # @ECLASS: gnustep-base.eclass
 # @MAINTAINER:
 # GNUstep Herd <gnustep@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Internal handling of GNUstep packages
 # @DESCRIPTION:
 # Inner gnustep eclass, should only be inherited directly by gnustep-base
 # packages
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_GNUSTEP_BASE_ECLASS} ]] ; then
 _GNUSTEP_BASE_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic toolchain-funcs
 

--- a/eclass/guile-single.eclass
+++ b/eclass/guile-single.eclass
@@ -1,4 +1,4 @@
-# Copyright 2024 Gentoo Authors
+# Copyright 2024-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: guile-single.eclass
@@ -6,7 +6,7 @@
 # Gentoo Scheme project <scheme@gentoo.org>
 # @AUTHOR:
 # Author: Arsen Arsenović <arsen@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: guile-utils
 # @BLURB: Utilities for packages that build against a single Guile.
 # @DESCRIPTION:
@@ -104,13 +104,13 @@
 # }
 # @CODE
 
-case "${EAPI}" in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ ! "${_GUILE_SINGLE_ECLASS}" ]]; then
 _GUILE_SINGLE_ECLASS=1
+
+case "${EAPI}" in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit guile-utils
 

--- a/eclass/guile-utils.eclass
+++ b/eclass/guile-utils.eclass
@@ -6,7 +6,7 @@
 # Gentoo Scheme project <scheme@gentoo.org>
 # @AUTHOR:
 # Author: Arsen Arsenović <arsen@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Common code between GNU Guile-related eclasses and ebuilds.
 # @DESCRIPTION:
 # This eclass contains various bits of common code between
@@ -15,13 +15,13 @@
 #
 # Inspired by prior work in the Gentoo Python ecosystem.
 
-case "${EAPI}" in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ ! "${_GUILE_UTILS_ECLASS}" ]]; then
 _GUILE_UTILS_ECLASS=1
+
+case "${EAPI}" in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit toolchain-funcs
 

--- a/eclass/guile.eclass
+++ b/eclass/guile.eclass
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: guile.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Arsen Arsenović <arsen@gentoo.org>
 # Inspired by prior work in the Gentoo Python ecosystem.
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: guile-utils
 # @BLURB: Utilities for packages multi-implementation Guile packages.
 # @DESCRIPTION:
@@ -85,13 +85,13 @@
 # DEPEND="${RDEPEND}"
 # @CODE
 
-case "${EAPI}" in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ ! "${_GUILE_ECLASS}" ]]; then
 _GUILE_ECLASS=1
+
+case "${EAPI}" in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit guile-utils multibuild
 

--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Original author: Andres Loeh <kosmikus@gentoo.org>
 # Original author: Duncan Coutts <dcoutts@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: for packages that make use of the Haskell Common Architecture for Building Applications and Libraries (cabal)
 # @DESCRIPTION:
 # Basic instructions:
@@ -41,7 +41,7 @@
 #                  is fixed.
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/java-vm-2.eclass
+++ b/eclass/java-vm-2.eclass
@@ -1,22 +1,22 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-vm-2.eclass
 # @MAINTAINER:
 # java@gentoo.org
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Java Virtual Machine eclass
 # @DESCRIPTION:
 # This eclass provides functionality which assists with installing
 # virtual machines, and ensures that they are recognized by java-config.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_JAVA_VM_2_ECLASS} ]]; then
 _JAVA_VM_2_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multilib pax-utils prefix xdg-utils
 

--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -8,7 +8,7 @@
 # John Mylchreest <johnm@gentoo.org>
 # Mike Pagano <mpagano@gentoo.org>
 # <so many, many others, please add yourself>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass for kernel packages
 # @DESCRIPTION:
 # This is the kernel.eclass rewrite for a clean base regarding the 2.6
@@ -300,7 +300,7 @@
 inherit crossdev estack multiprocessing optfeature toolchain-funcs
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -6,7 +6,7 @@
 # Distribution Kernel Project <dist-kernel@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: kernel-install
 # @BLURB: Build mechanics for Distribution Kernels
 # @DESCRIPTION:
@@ -28,13 +28,13 @@
 # kernel's release version and Gentoo's tooling. This is set by
 # kernel-build_src_configure() once we have a kernel.release file.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_KERNEL_BUILD_ECLASS} ]]; then
 _KERNEL_BUILD_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 PYTHON_COMPAT=( python3_{12..14} )
 

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -6,7 +6,7 @@
 # Distribution Kernel Project <dist-kernel@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: dist-kernel-utils
 # @BLURB: Installation mechanics for Distribution Kernels
 # @DESCRIPTION:
@@ -54,6 +54,7 @@ _KERNEL_INSTALL_ECLASS=1
 
 case ${EAPI} in
 	8) inherit eapi9-pipestatus ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/latex-package.eclass
+++ b/eclass/latex-package.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Matthew Turk <satai@gentoo.org>
 # Martin Ehmsen <ehmsen@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: An eclass for easy installation of LaTeX packages
 # @DESCRIPTION:
 # This eClass is designed to be easy to use and implement.  The vast majority of
@@ -51,16 +51,15 @@
 # you must either grab each file individually, or find a place to mirror an
 # archive of them.  (iBiblio)
 
-case ${EAPI} in
-	7) inherit eapi8-dosym ;;
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LATEX_PACKAGE_ECLASS} ]]; then
 _LATEX_PACKAGE_ECLASS=1
 
-inherit edo
+case ${EAPI} in
+	7) inherit eapi8-dosym edo ;;
+	8) inherit edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 RDEPEND="virtual/latex-base"
 BDEPEND="${RDEPEND}

--- a/eclass/libretro-core.eclass
+++ b/eclass/libretro-core.eclass
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 Gentoo Authors
+# Copyright 2018-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: libretro-core.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Cecil Curry <leycec@gmail.com>
 # Craig Andrews <candrews@gentoo.org>
-# @SUPPORTED_EAPIS: 7
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Simplify libretro core ebuilds
 # @DESCRIPTION:
 # The libretro eclass is designed to streamline the construction of
@@ -34,13 +34,13 @@
 # SLOT="0"
 # @CODE
 
-case ${EAPI} in
-	7) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LIBRETRO_CORE_ECLASS} ]]; then
 _LIBRETRO_CORE_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 IUSE="debug"
 

--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -6,7 +6,7 @@
 # kernel@gentoo.org
 # @AUTHOR:
 # Original author: John Mylchreest <johnm@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: eclass used for accessing kernel related information
 # @DESCRIPTION:
 # This eclass is used as a central eclass for accessing kernel
@@ -27,13 +27,13 @@
 # get_version
 # get_running_version
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LINUX_INFO_ECLASS} ]]; then
 _LINUX_INFO_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # A Couple of env vars are available to effect usage of this eclass
 # These are as follows:

--- a/eclass/llvm-r2.eclass
+++ b/eclass/llvm-r2.eclass
@@ -6,7 +6,7 @@
 # Michał Górny <mgorny@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: llvm-utils
 # @BLURB: Provide LLVM_SLOT to build against slotted LLVM
 # @DESCRIPTION:
@@ -46,13 +46,13 @@
 # "
 # @CODE
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LLVM_R2_ECLASS} ]]; then
 _LLVM_R2_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit llvm-utils multilib
 

--- a/eclass/lua-single.eclass
+++ b/eclass/lua-single.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: lua-single.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Marek Szuba <marecki@gentoo.org>
 # Based on python-single-r1.eclass by Michał Górny <mgorny@gentoo.org> et al.
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: lua-utils
 # @BLURB: An eclass for Lua packages not installed for multiple implementations.
 # @DESCRIPTION:
@@ -62,13 +62,13 @@
 # }
 # @CODE
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LUA_SINGLE_ECLASS} ]]; then
 _LUA_SINGLE_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ ${_LUA_ECLASS} ]]; then
 	die 'lua-single.eclass cannot be used with lua.eclass.'

--- a/eclass/lua-utils.eclass
+++ b/eclass/lua-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: lua-utils.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Marek Szuba <marecki@gentoo.org>
 # Based on python-utils-r1.eclass by Michał Górny <mgorny@gentoo.org> et al.
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Utility functions for packages with Lua parts
 # @DESCRIPTION:
 # A utility eclass providing functions to query Lua implementations,
@@ -16,13 +16,13 @@
 # This eclass neither sets any metadata variables nor exports any phase
 # functions. It can be inherited safely.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LUA_UTILS_ECLASS} ]]; then
 _LUA_UTILS_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit toolchain-funcs
 

--- a/eclass/lua.eclass
+++ b/eclass/lua.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: lua.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Marek Szuba <marecki@gentoo.org>
 # Based on python-r1.eclass by Michał Górny <mgorny@gentoo.org> et al.
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: lua-utils
 # @BLURB: A common eclass for Lua packages
 # @DESCRIPTION:
@@ -50,13 +50,13 @@
 # }
 # @CODE
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_LUA_ECLASS} ]]; then
 _LUA_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ ${_LUA_SINGLE_ECLASS} ]]; then
 	die 'lua.eclass cannot be used with lua-single.eclass.'

--- a/eclass/mate-desktop.org.eclass
+++ b/eclass/mate-desktop.org.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mate-desktop.org.eclass
@@ -6,19 +6,19 @@
 # mate@gentoo.org
 # @AUTHOR:
 # Authors: NP-Hardass <NP-Hardass@gentoo.org> based upon the gnome.org eclass.
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Helper eclass for mate-desktop.org hosted archives
 # @DESCRIPTION:
 # Provide a default SRC_URI and EGIT_REPO_URI for MATE packages as well as
 # exporting some useful values like the MATE_BRANCH
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_MATE_DESKTOP_ORG_ECLASS} ]]; then
 _MATE_DESKTOP_ORG_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3

--- a/eclass/mate.eclass
+++ b/eclass/mate.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mate.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Authors: NP-Hardass <NP-Hardass@gentoo.org> based upon the gnome2
 # and autotools-utils eclasses
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: mate-desktop.org
 # @BLURB: Provides phases for MATE based packages.
 # @DESCRIPTION:
@@ -15,13 +15,13 @@
 # MATE framework. Occasionally acts as a wrapper to gnome2 due to the
 # fact that MATE is a GNOME fork. For additional functions, see gnome2-utils.eclass.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_MATE_ECLASS} ]]; then
 _MATE_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # Inherit happens below after declaration of GNOME2_LA_PUNT
 

--- a/eclass/meson-multilib.eclass
+++ b/eclass/meson-multilib.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: meson-multilib.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
 # Matt Turner <mattst88@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: meson multilib-minimal
 # @BLURB: meson wrapper for multilib builds
 # @DESCRIPTION:
@@ -21,13 +21,13 @@
 # in multilib-minimal, yet they ought to call appropriate meson
 # phase rather than 'default'.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_MESON_MULTILIB_ECLASS} ]] ; then
 _MESON_MULTILIB_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit meson multilib-minimal
 

--- a/eclass/mono-env.eclass
+++ b/eclass/mono-env.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mono-env.eclass
 # @MAINTAINER:
 # maintainer-needed@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Set environment variables commonly used by dotnet packages.
 # @DESCRIPTION:
 # Set environment variables commonly used by dotnet packages.
@@ -13,7 +13,7 @@ if [[ -z ${_MONO_ENV_ECLASS} ]] ; then
 _MONO_ENV_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/mount-boot-utils.eclass
+++ b/eclass/mount-boot-utils.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: mount-boot-utils.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: functions for packages that install files into /boot or the ESP
 # @DESCRIPTION:
 # This eclass is really only useful for bootloaders and kernel installation.
@@ -29,7 +29,7 @@
 # EFI System Partition only.
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/mount-boot.eclass
+++ b/eclass/mount-boot.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: mount-boot.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: eclass for packages that install files into /boot or the ESP
 # @DESCRIPTION:
 # This eclass is really only useful for bootloaders and kernel installation.
@@ -17,7 +17,7 @@
 # the pkg_pretend and pkg_{pre,post}{inst,rm} phases.
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/mozcoreconf-v6.eclass
+++ b/eclass/mozcoreconf-v6.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mozcoreconf-v6.eclass
 # @MAINTAINER:
 # Mozilla team <mozilla@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: core options and configuration functions for mozilla
 # @DESCRIPTION:
 #
@@ -15,13 +15,13 @@
 # This is an eclass-generated variable that defines the rpath that the mozilla
 # product will be installed in.  Read-only
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_MOZCORECONF_V6_ECLASS} ]]; then
 _MOZCORECONF_V6_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit toolchain-funcs flag-o-matic python-any-r1
 

--- a/eclass/mozextension.eclass
+++ b/eclass/mozextension.eclass
@@ -1,19 +1,19 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mozextension.eclass
 # @MAINTAINER:
 # Mozilla team <mozilla@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Install extensions for use in Mozilla products.
-
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_MOZEXTENSION_ECLASS} ]]; then
 _MOZEXTENSION_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: MOZEXTENSION_TARGET
 # @DESCRIPTION:

--- a/eclass/mozlinguas-v2.eclass
+++ b/eclass/mozlinguas-v2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mozlinguas-v2.eclass
@@ -7,20 +7,20 @@
 # @AUTHOR:
 # Nirbheek Chauhan <nirbheek@gentoo.org>
 # Ian Stakenvicius <axs@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Handle language packs for mozilla products
 # @DESCRIPTION:
 # Sets IUSE according to MOZ_LANGS (language packs available). Also exports
 # src_unpack, src_compile and src_install for use in ebuilds, and provides
 # supporting functions for langpack generation and installation.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_MOZLINGUAS_V2_ECLASS} ]]; then
 _MOZLINGUAS_V2_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit mozextension
 

--- a/eclass/multilib-minimal.eclass
+++ b/eclass/multilib-minimal.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: multilib-minimal.eclass
 # @MAINTAINER:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: multilib-build
 # @BLURB: wrapper for multilib builds providing convenient multilib_src_* functions
 # @DESCRIPTION:
@@ -29,7 +29,7 @@ if [[ -z ${_MULTILIB_MINIMAL_ECLASS} ]]; then
 _MULTILIB_MINIMAL_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/multilib.eclass
+++ b/eclass/multilib.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: multilib.eclass
 # @MAINTAINER:
 # toolchain@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: This eclass is for all functions pertaining to handling multilib configurations.
 # @DESCRIPTION:
 # This eclass is for all functions pertaining to handling multilib configurations.
@@ -13,7 +13,7 @@ if [[ -z ${_MULTILIB_ECLASS} ]]; then
 _MULTILIB_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/myspell-r2.eclass
+++ b/eclass/myspell-r2.eclass
@@ -6,7 +6,7 @@
 # Conrad Kostecki <conikost@gentoo.org>
 # @AUTHOR:
 # Tomáš Chvátal <scarabeus@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: An eclass to streamline the construction of ebuilds for new Myspell dictionaries.
 # @DESCRIPTION:
 # The myspell-r2 eclass is designed to streamline the construction of ebuilds for
@@ -37,7 +37,7 @@
 # @CODE
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/netsurf.eclass
+++ b/eclass/netsurf.eclass
@@ -1,16 +1,16 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: netsurf.eclass
 # @MAINTAINER:
 # mjo@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Handle buildsystem of www.netsurf-browser.org components
 # @DESCRIPTION:
 # Handle settings build environment for netsurf build system
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/ninja-utils.eclass
+++ b/eclass/ninja-utils.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
 # Mike Gilbert <floppym@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: common bits to run app-alternatives/ninja builder
 # @DESCRIPTION:
 # This eclass provides a single function -- eninja -- that can be used
@@ -17,13 +17,13 @@
 # be used indirectly by the eclasses for other build systems (CMake,
 # Meson).
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_NINJA_UTILS_ECLASS} ]]; then
 _NINJA_UTILS_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: NINJA
 # @PRE_INHERIT

--- a/eclass/nuget.eclass
+++ b/eclass/nuget.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Anna Figueiredo Gomes <navi@vlhl.dev>
 # Maciej Barć <xgqt@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: common functions and variables for handling .NET NuGets
 # @DESCRIPTION:
 # This eclass is designed to provide support for .NET NuGet's ".nupkg" files.
@@ -17,13 +17,13 @@
 # This eclass does not export any phase functions, for that see
 # the "dotnet-pkg" eclass.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_NUGET_ECLASS} ]] ; then
 _NUGET_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: NUGET_SYSTEM_NUGETS
 # @DESCRIPTION:

--- a/eclass/office-ext-r1.eclass
+++ b/eclass/office-ext-r1.eclass
@@ -6,18 +6,18 @@
 # The office team <office@gentoo.org>
 # @AUTHOR:
 # Tomáš Chvátal <scarabeus@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass for installing libreoffice extensions
 # @DESCRIPTION:
 # Eclass for easing maintenance of libreoffice extensions.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_OFFICE_EXT_R1_ECLASS} ]]; then
 _OFFICE_EXT_R1_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: OFFICE_REQ_USE
 # @PRE_INHERIT

--- a/eclass/opam.eclass
+++ b/eclass/opam.eclass
@@ -7,14 +7,14 @@
 # ML <ml@gentoo.org>
 # @AUTHOR:
 # Alexis Ballier <aballier@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides functions for installing opam packages.
 # @DESCRIPTION:
 # Provides dependencies on opam and ocaml, opam-install and a default
 # src_install for opam-based packages.
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/pam.eclass
+++ b/eclass/pam.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: pam.eclass
@@ -6,19 +6,19 @@
 # base-system@gentoo.org
 # @AUTHOR:
 # Diego Pettenò <flameeyes@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Handles pam related tasks
 # @DESCRIPTION:
 # This eclass contains functions to install pamd configuration files and
 # pam modules.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_PAM_ECLASS} ]]; then
 _PAM_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic
 

--- a/eclass/pax-utils.eclass
+++ b/eclass/pax-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: pax-utils.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Kevin F. Quinn <kevquinn@gentoo.org>
 # Author: Anthony G. Basile <blueness@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: functions to provide PaX markings for hardened kernels
 # @DESCRIPTION:
 #
@@ -25,7 +25,7 @@ if [[ -z ${_PAX_UTILS_ECLASS} ]]; then
 _PAX_UTILS_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/perl-functions.eclass
+++ b/eclass/perl-functions.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: perl-functions.eclass
@@ -8,7 +8,7 @@
 # Seemant Kulleen <seemant@gentoo.org>
 # Andreas K. Huettel <dilfridge@gentoo.org>
 # Kent Fredric <kentnl@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: helper functions eclass for perl modules
 # @DESCRIPTION:
 # The perl-functions eclass is designed to allow easier installation of perl
@@ -20,7 +20,7 @@ if [[ -z ${_PERL_FUNCTIONS_ECLASS} ]]; then
 _PERL_FUNCTIONS_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/perl-module.eclass
+++ b/eclass/perl-module.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Seemant Kulleen <seemant@gentoo.org>
 # Andreas K. Hüttel <dilfridge@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: perl-functions
 # @BLURB: eclass for installing Perl module distributions
 # @DESCRIPTION:
@@ -24,7 +24,7 @@ case ${EAPI} in
 		inherit multiprocessing perl-functions toolchain-funcs
 		PERL_EXPF="src_prepare src_configure src_compile src_test src_install"
 		;;
-	8)
+	8|9)
 		inherit multiprocessing perl-functions readme.gentoo-r1 toolchain-funcs
 		PERL_EXPF="src_prepare src_configure src_compile src_test src_install"
 		;;

--- a/eclass/php-ext-pecl-r3.eclass
+++ b/eclass/php-ext-pecl-r3.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: php-ext-pecl-r3.eclass
 # @MAINTAINER:
 # Gentoo PHP team <php-bugs@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: php-ext-source-r3
 # @BLURB: A uniform way to install PECL extensions
 # @DESCRIPTION:
@@ -12,13 +12,13 @@
 # way of installing PECL extensions. For more information about PECL,
 # see https://pecl.php.net/
 
-case ${EAPI:-0} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_PHP_EXT_PECL_R3_ECLASS} ]] ; then
 _PHP_EXT_PECL_R3_ECLASS=1
+
+case ${EAPI:-0} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: PHP_EXT_PECL_PKG
 # @PRE_INHERIT

--- a/eclass/php-ext-source-r3.eclass
+++ b/eclass/php-ext-source-r3.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: php-ext-source-r3.eclass
 # @MAINTAINER:
 # Gentoo PHP team <php-bugs@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Compile and install standalone PHP extensions.
 # @DESCRIPTION:
 # A unified interface for compiling and installing standalone PHP
@@ -13,7 +13,7 @@
 inherit autotools
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/php-pear-r2.eclass
+++ b/eclass/php-pear-r2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: php-pear-r2.eclass
@@ -6,7 +6,7 @@
 # Gentoo PHP Team <php-bugs@gentoo.org>
 # @AUTHOR:
 # Author: Brian Evans <grknight@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provides means for an easy installation of PEAR packages.
 # @DESCRIPTION:
 # This eclass provides means for an easy installation of PEAR packages.
@@ -18,7 +18,7 @@ if [[ -z ${_PHP_PEAR_R2_ECLASS} ]]; then
 _PHP_PEAR_R2_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/postgres-multi.eclass
+++ b/eclass/postgres-multi.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: postgres-multi.eclass
@@ -6,7 +6,7 @@
 # PostgreSQL <pgsql-bugs@gentoo.org>
 # @AUTHOR:
 # Aaron W. Swenson <titanofold@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: multibuild postgres
 # @BLURB: An eclass to build PostgreSQL-related packages against multiple slots
 # @DESCRIPTION:
@@ -14,13 +14,13 @@
 # build and install for one or more PostgreSQL slots as specified by
 # POSTGRES_TARGETS use flags.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_POSTGRES_MULTI_ECLASS} ]]; then
 _POSTGRES_MULTI_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multibuild postgres
 

--- a/eclass/postgres.eclass
+++ b/eclass/postgres.eclass
@@ -6,7 +6,7 @@
 # PostgreSQL <pgsql-bugs@gentoo.org>
 # @AUTHOR:
 # Aaron W. Swenson <titanofold@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: An eclass for PostgreSQL-related packages
 # @DESCRIPTION:
 # This eclass provides common utility functions that many
@@ -14,13 +14,13 @@
 # currently selected PostgreSQL slot is within a range, adding a system
 # user to the postgres system group, and generating dependencies.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_POSTGRES_ECLASS} ]]; then
 _POSTGRES_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: _POSTGRES_ALL_VERSIONS
 # @INTERNAL

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -6,7 +6,7 @@
 # Michał Górny <mgorny@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: A helper eclass to generate PyPI source URIs
 # @DESCRIPTION:
 # The pypi.eclass can be used to easily obtain URLs for artifacts
@@ -44,13 +44,13 @@
 # S=${WORKDIR}/${P^}
 # @CODE
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_PYPI_ECLASS} ]]; then
 _PYPI_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: PYPI_NO_NORMALIZE
 # @PRE_INHERIT

--- a/eclass/python-any-r1.eclass
+++ b/eclass/python-any-r1.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on work of: Krzysztof Pawlik <nelchael@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: python-utils-r1
 # @BLURB: An eclass for packages having build-time dependency on Python.
 # @DESCRIPTION:
@@ -38,13 +38,13 @@
 # For more information, please see the Python Guide:
 # https://projects.gentoo.org/python/guide/
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_PYTHON_ANY_R1_ECLASS} ]]; then
 _PYTHON_ANY_R1_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ ${_PYTHON_R1_ECLASS} ]]; then
 	die 'python-any-r1.eclass can not be used with python-r1.eclass.'

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on work of: Krzysztof Pawlik <nelchael@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: python-utils-r1
 # @BLURB: A common, simple eclass for Python packages.
 # @DESCRIPTION:
@@ -34,7 +34,7 @@ if [[ -z ${_PYTHON_R1_ECLASS} ]]; then
 _PYTHON_R1_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/python-single-r1.eclass
+++ b/eclass/python-single-r1.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: python-single-r1.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on work of: Krzysztof Pawlik <nelchael@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: python-utils-r1
 # @BLURB: An eclass for Python packages not installed for multiple implementations.
 # @DESCRIPTION:
@@ -37,13 +37,13 @@
 # For more information, please see the Python Guide:
 # https://projects.gentoo.org/python/guide/
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_PYTHON_SINGLE_R1_ECLASS} ]]; then
 _PYTHON_SINGLE_R1_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ ${_PYTHON_R1_ECLASS} ]]; then
 	die 'python-single-r1.eclass can not be used with python-r1.eclass.'

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on work of: Krzysztof Pawlik <nelchael@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Utility functions for packages with Python parts.
 # @DESCRIPTION:
 # A utility eclass providing functions to query Python implementations,
@@ -27,11 +27,12 @@ if [[ -z ${_PYTHON_UTILS_R1_ECLASS} ]]; then
 _PYTHON_UTILS_R1_ECLASS=1
 
 case ${EAPI} in
-	7|8) inherit eapi9-pipestatus ;;
+	7) inherit eapi8-dosym eapi9-pipestatus ;;
+	8) inherit eapi9-pipestatus ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-[[ ${EAPI} == 7 ]] && inherit eapi8-dosym
 inherit multiprocessing toolchain-funcs
 
 # @ECLASS_VARIABLE: _PYTHON_ALL_IMPLS

--- a/eclass/qmail.eclass
+++ b/eclass/qmail.eclass
@@ -1,19 +1,19 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: qmail.eclass
 # @MAINTAINER:
 # Rolf Eike Beer <eike@sf-mail.de>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: common qmail functions
-
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_QMAIL_ECLASS} ]]; then
 _QMAIL_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic toolchain-funcs fixheadtails
 

--- a/eclass/qt6-build.eclass
+++ b/eclass/qt6-build.eclass
@@ -4,19 +4,19 @@
 # @ECLASS: qt6-build.eclass
 # @MAINTAINER:
 # qt@gentoo.org
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: cmake
 # @BLURB: Eclass for Qt6 split ebuilds.
 # @DESCRIPTION:
 # This eclass contains various functions that are used when building Qt6.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_QT6_BUILD_ECLASS} ]]; then
 _QT6_BUILD_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 [[ ${CATEGORY} != dev-qt ]] &&
 	die "${ECLASS} is only to be used for building Qt6"

--- a/eclass/rebar-utils.eclass
+++ b/eclass/rebar-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: rebar-utils.eclass
@@ -6,19 +6,19 @@
 # Florian Schmaus <flow@gentoo.org>
 # @AUTHOR:
 # Amadeusz Żołnowski <aidecoe@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Auxiliary functions for using dev-util/rebar.
 # @DESCRIPTION:
 # This eclass provides a set of axiliary functions commonly needed
 # when building Erlang/OTP packages with rebar.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_REBAR_UTILS_ECLASS} ]]; then
 _REBAR_UTILS_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: REBAR_APP_SRC
 # @DESCRIPTION:

--- a/eclass/rebar.eclass
+++ b/eclass/rebar.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: rebar.eclass
@@ -6,7 +6,7 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Amadeusz Żołnowski <aidecoe@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: rebar-utils
 # @BLURB: Build Erlang/OTP projects using dev-util/rebar.
 # @DESCRIPTION:
@@ -20,13 +20,13 @@
 # targets. The eclass workarounds some of these problems. It handles
 # installation in a generic way for Erlang/OTP structured projects.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_REBAR_ECLASS} ]]; then
 _REBAR_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit rebar-utils
 

--- a/eclass/rebar3.eclass
+++ b/eclass/rebar3.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: rebar3.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Amadeusz Żołnowski <aidecoe@gentoo.org>
 # Anna (cybertailor) Vyalkova <cyber+gentoo@sysrq.in>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: rebar-utils
 # @BLURB: Build Erlang/OTP projects using dev-util/rebar:3.
 # @DESCRIPTION:
@@ -21,15 +21,16 @@
 # targets. The eclass workarounds some of these problems. It handles
 # installation in a generic way for Erlang/OTP structured projects.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_REBAR3_ECLASS} ]]; then
 _REBAR3_ECLASS=1
 
-inherit edo rebar-utils
+case ${EAPI} in
+	8) inherit edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+inherit rebar-utils
 
 RDEPEND="dev-lang/erlang:="
 DEPEND="${RDEPEND}"

--- a/eclass/rpm.eclass
+++ b/eclass/rpm.eclass
@@ -4,16 +4,17 @@
 # @ECLASS: rpm.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: convenience class for extracting RPMs
-
-case ${EAPI} in
-	7|8) inherit eapi9-pipestatus ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_RPM_ECLASS} ]] ; then
 _RPM_ECLASS=1
+
+case ${EAPI} in
+	7|8) inherit eapi9-pipestatus ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit estack toolchain-funcs
 

--- a/eclass/rust-toolchain.eclass
+++ b/eclass/rust-toolchain.eclass
@@ -4,14 +4,14 @@
 # @ECLASS: rust-toolchain.eclass
 # @MAINTAINER:
 # Rust Project <rust@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: helps map gentoo arches to rust ABIs
 # @DESCRIPTION:
 # This eclass contains helper functions, to aid in proper rust-ABI handling for
 # various gentoo arches.
 
 case ${EAPI} in
-	8) ;;
+	8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/rust.eclass
+++ b/eclass/rust.eclass
@@ -6,7 +6,7 @@
 # Matt Jolly <kangie@gentoo.org>
 # @AUTHOR:
 # Matt Jolly <kangie@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Utility functions to build against slotted Rust
 # @DESCRIPTION:
 # An eclass to reliably depend on a Rust or Rust/LLVM combination for
@@ -43,13 +43,13 @@
 #
 # @CODE
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_RUST_ECLASS} ]]; then
 _RUST_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 if [[ -n ${RUST_NEEDS_LLVM} ]]; then
 	inherit llvm-r1

--- a/eclass/s6.eclass
+++ b/eclass/s6.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: s6.eclass
 # @MAINTAINER:
 # William Hubbs <williamh@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: helper functions to install s6 services
 # @DESCRIPTION:
 # This eclass provides helpers to install s6 services.
@@ -26,7 +26,7 @@
 # @CODE
 
 case ${EAPI} in
-	8) ;;
+	8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/savedconfig.eclass
+++ b/eclass/savedconfig.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: savedconfig.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: common API for saving/restoring complex configuration files
 # @DESCRIPTION:
 # It is not uncommon to come across a package which has a very fine
@@ -30,13 +30,13 @@
 # 4. Emerge the package with just USE=savedconfig to get the custom
 # build.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_SAVEDCONFIG_ECLASS} ]]; then
 _SAVEDCONFIG_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit portability
 

--- a/eclass/sec-keys.eclass
+++ b/eclass/sec-keys.eclass
@@ -6,7 +6,7 @@
 # Eli Schwartz <eschwartz@gentoo.org>
 # @AUTHOR:
 # Eli Schwartz <eschwartz@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Provides a uniform way of handling ebuilds which package PGP key material
 # @DESCRIPTION:
 # This eclass provides a streamlined approach to finding suitable source
@@ -35,15 +35,14 @@
 # SRC_URI+="https://awhite.com/awhite.gpg -> awhite-${PV}.gpg"
 # @CODE
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ ! ${_SEC_KEYS_ECLASS} ]]; then
 _SEC_KEYS_ECLASS=1
 
-inherit eapi9-pipestatus edo
+case ${EAPI} in
+	8) inherit eapi9-pipestatus edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: SEC_KEYS_VALIDPGPKEYS
 # @PRE_INHERIT

--- a/eclass/secureboot.eclass
+++ b/eclass/secureboot.eclass
@@ -6,7 +6,7 @@
 # Nowa Ammerlaan <nowa@gentoo.org>
 # @AUTHOR:
 # Author: Nowa Ammerlaan <nowa@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: A small eclass to sign efi files for Secure Boot
 # @DESCRIPTION:
 # Eclass for packages that install .efi files. A use flag and two user
@@ -39,7 +39,7 @@
 # secureboot_auto_sign can be used to ensure that the signed version is used.
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/selinux-policy-2.eclass
+++ b/eclass/selinux-policy-2.eclass
@@ -7,7 +7,7 @@
 # @ECLASS: selinux-policy-2.eclass
 # @MAINTAINER:
 # selinux@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: This eclass supports the deployment of the various SELinux modules in sec-policy
 # @DESCRIPTION:
 # The selinux-policy-2.eclass supports deployment of the various SELinux modules
@@ -18,13 +18,13 @@
 # Also, it supports for bundling patches to make the whole thing just a bit more
 # manageable.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_SELINUX_POLICY_2_ECLASS} ]]; then
 _SELINUX_POLICY_2_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: MODS
 # @DESCRIPTION:

--- a/eclass/ssl-cert.eclass
+++ b/eclass/ssl-cert.eclass
@@ -6,7 +6,7 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Max Kalika <max@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass for SSL certificates
 # @DESCRIPTION:
 # This eclass implements a standard installation procedure for installing
@@ -14,13 +14,13 @@
 # @EXAMPLE:
 # "install_cert /foo/bar" installs ${ROOT}/foo/bar.{key,csr,crt,pem}
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_SSL_CERT_ECLASS} ]]; then
 _SSL_CERT_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: SSL_CERT_MANDATORY
 # @PRE_INHERIT

--- a/eclass/ssl-cert.eclass
+++ b/eclass/ssl-cert.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ssl-cert.eclass
@@ -21,8 +21,6 @@ esac
 
 if [[ -z ${_SSL_CERT_ECLASS} ]]; then
 _SSL_CERT_ECLASS=1
-
-inherit edo
 
 # @ECLASS_VARIABLE: SSL_CERT_MANDATORY
 # @PRE_INHERIT
@@ -130,9 +128,9 @@ get_base() {
 #
 gen_key() {
 	local base=$(get_base "$1")
-	nonfatal edob -m "Generating ${SSL_BITS} bit RSA key${1:+ for CA}" \
-		openssl genrsa -out "${base}.key" "${SSL_BITS}"
-	return $?
+	ebegin "Generating ${SSL_BITS} bit RSA key${1:+ for CA}"
+	openssl genrsa -out "${base}.key" "${SSL_BITS}"
+	eend $?
 }
 
 # @FUNCTION: gen_csr
@@ -144,10 +142,10 @@ gen_key() {
 #
 gen_csr() {
 	local base=$(get_base "$1")
-	nonfatal edob -m "Generating Certificate Signing Request${1:+ for CA}" \
-		openssl req -config "${SSL_CONF}" -new \
-			-key "${base}.key" -out "${base}.csr"
-	return $?
+	ebegin "Generating Certificate Signing Request${1:+ for CA}"
+	openssl req -config "${SSL_CONF}" -new \
+		-key "${base}.key" -out "${base}.csr"
+	eend $?
 }
 
 # @FUNCTION: gen_crt
@@ -162,20 +160,20 @@ gen_csr() {
 gen_crt() {
 	local base=$(get_base "$1")
 	if [ "${1}" ] ; then
-		nonfatal edob -m "Generating self-signed X.509 Certificate for CA" \
-			openssl x509 -extfile "${SSL_CONF}" \
-				-${SSL_MD} \
-				-days ${SSL_DAYS} -req -signkey "${base}.key" \
-				-in "${base}.csr" -out "${base}.crt"
+		ebegin "Generating self-signed X.509 Certificate for CA"
+		openssl x509 -extfile "${SSL_CONF}" \
+			-${SSL_MD} \
+			-days ${SSL_DAYS} -req -signkey "${base}.key" \
+			-in "${base}.csr" -out "${base}.crt"
 	else
 		local ca=$(get_base 1)
-		nonfatal edob -m "Generating authority-signed X.509 Certificate" \
-			openssl x509 -extfile "${SSL_CONF}" \
-				-days ${SSL_DAYS} -req -CAserial "${SSL_SERIAL}" \
-				-CAkey "${ca}.key" -CA "${ca}.crt" -${SSL_MD} \
-				-in "${base}.csr" -out "${base}.crt"
+		ebegin "Generating authority-signed X.509 Certificate"
+		openssl x509 -extfile "${SSL_CONF}" \
+			-days ${SSL_DAYS} -req -CAserial "${SSL_SERIAL}" \
+			-CAkey "${ca}.key" -CA "${ca}.crt" -${SSL_MD} \
+			-in "${base}.csr" -out "${base}.crt"
 	fi
-	return $?
+	eend $?
 }
 
 # @FUNCTION: gen_pem

--- a/eclass/stardict.eclass
+++ b/eclass/stardict.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: stardict.eclass
@@ -6,7 +6,7 @@
 # No maintainer <maintainer-needed@gentoo.org>
 # @AUTHOR:
 # Alastair Tse <liquidx@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Convenience class to do stardict dictionary installations.
 # @DESCRIPTION:
 # Usage:
@@ -16,15 +16,14 @@
 #      * DICT_PREFIX   -  SRC_URI prefix, like "dictd_www.mova.org_"
 #      * DICT_SUFFIX   -  SRC_URI after the prefix.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_STARDICT_ECLASS} ]] ; then
 _STARDICT_ECLASS=1
 
-inherit edo
+case ${EAPI} in
+	8) inherit edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 RESTRICT="strip"
 

--- a/eclass/subversion.eclass
+++ b/eclass/subversion.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: subversion.eclass
@@ -6,19 +6,21 @@
 # Akinori Hattori <hattya@gentoo.org>
 # @AUTHOR:
 # Original Author: Akinori Hattori <hattya@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Fetch software sources from subversion repositories
 # @DESCRIPTION:
 # The subversion eclass provides functions to fetch software sources
 # from subversion repositories.
 
+if [[ -z ${_SUBVERSION_ECLASS} ]]; then
+_SUBVERSION_ECLASS=1
+
 case ${EAPI} in
-	7|8) inherit estack ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-if [[ -z ${_SUBVERSION_ECLASS} ]]; then
-_SUBVERSION_ECLASS=1
+inherit estack
 
 PROPERTIES+=" live"
 

--- a/eclass/systemd.eclass
+++ b/eclass/systemd.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: systemd.eclass
 # @MAINTAINER:
 # systemd@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: helper functions to install systemd units
 # @DESCRIPTION:
 # This eclass provides a set of functions to install unit files for
@@ -28,7 +28,7 @@ if [[ -z ${_SYSTEMD_ECLASS} ]]; then
 _SYSTEMD_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/texlive-common.eclass
+++ b/eclass/texlive-common.eclass
@@ -20,8 +20,6 @@ case ${EAPI} in
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-inherit edo
-
 if [[ -z ${_TEXLIVE_COMMON_ECLASS} ]]; then
 _TEXLIVE_COMMON_ECLASS=1
 
@@ -215,9 +213,9 @@ etexmf-update() {
 efmtutil-sys() {
 	if has_version 'app-text/texlive-core' ; then
 		if [[ -z ${ROOT} && -x "${EPREFIX}"/usr/bin/fmtutil-sys ]] ; then
-			edob -m "Rebuilding TexLive formats" \
-				 -l fmtutils-sys-all \
-				 "${EPREFIX}"/usr/bin/fmtutil-sys --all
+			ebegin "Rebuilding TeX Live formats"
+			"${EPREFIX}"/usr/bin/fmtutil-sys --all &> /dev/null
+			eend $? || die -n "fmtutil-sys returned non-zero exit status $?"
 		else
 			ewarn "Cannot run fmtutil-sys for some reason."
 			ewarn "Your formats might be inconsistent with your installed ${PN} version"

--- a/eclass/texlive-common.eclass
+++ b/eclass/texlive-common.eclass
@@ -6,7 +6,7 @@
 # tex@gentoo.org
 # @AUTHOR:
 # Original Author: Alexis Ballier <aballier@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provide various functions used by both texlive-core and texlive modules
 # @DESCRIPTION:
 # Purpose: Provide various functions used by both texlive-core and texlive
@@ -14,14 +14,15 @@
 #
 # Note that this eclass *must* not assume the presence of any standard tex too
 
+if [[ -z ${_TEXLIVE_COMMON_ECLASS} ]]; then
+_TEXLIVE_COMMON_ECLASS=1
+
 case ${EAPI} in
 	7) inherit eapi8-dosym eapi9-pipestatus ;;
 	8) inherit eapi9-pipestatus ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
-
-if [[ -z ${_TEXLIVE_COMMON_ECLASS} ]]; then
-_TEXLIVE_COMMON_ECLASS=1
 
 # @ECLASS_VARIABLE: CTAN_MIRROR_URL
 # @USER_VARIABLE

--- a/eclass/texlive-module.eclass
+++ b/eclass/texlive-module.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: texlive-module.eclass
@@ -6,7 +6,7 @@
 # tex@gentoo.org
 # @AUTHOR:
 # Original Author: Alexis Ballier <aballier@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Provide generic install functions so that modular texlive's texmf ebuild will only have to inherit this eclass
 # @DESCRIPTION:
 # Purpose: Provide generic install functions so that modular texlive's texmf ebuilds will
@@ -71,15 +71,16 @@
 # Information to display about the package.
 # e.g. for enabling/disabling a feature
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_TEXLIVE_MODULE_ECLASS} ]]; then
 _TEXLIVE_MODULE_ECLASS=1
 
-inherit eapi9-pipestatus texlive-common
+case ${EAPI} in
+	7|8) inherit eapi9-pipestatus ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+inherit texlive-common
 
 HOMEPAGE="https://www.tug.org/texlive/"
 

--- a/eclass/tmpfiles.eclass
+++ b/eclass/tmpfiles.eclass
@@ -8,7 +8,7 @@
 # @AUTHOR:
 # Mike Gilbert <floppym@gentoo.org>
 # William Hubbs <williamh@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Functions related to tmpfiles.d files
 # @DESCRIPTION:
 # This eclass provides functionality related to installing and
@@ -56,7 +56,7 @@ if [[ -z ${_TMPFILES_ECLASS} ]]; then
 _TMPFILES_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/toolchain-autoconf.eclass
+++ b/eclass/toolchain-autoconf.eclass
@@ -4,19 +4,19 @@
 # @ECLASS: toolchain-autoconf.eclass
 # @MAINTAINER:
 # <base-system@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Common code for dev-build/autoconf ebuilds
 # @DESCRIPTION:
 # This eclass contains the common phase functions migrated from
 # dev-build/autoconf eblits.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_TOOLCHAIN_AUTOCONF_ECLASS} ]]; then
 _TOOLCHAIN_AUTOCONF_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: TC_AUTOCONF_BREAK_INFOS
 # @DESCRIPTION:

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: toolchain.eclass
 # @MAINTAINER:
 # Toolchain Ninjas <toolchain@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Common code for sys-devel/gcc ebuilds
 # @DESCRIPTION:
 # Common code for sys-devel/gcc ebuilds (and occasionally GCC forks, like
@@ -14,18 +14,19 @@
 if [[ -z ${_TOOLCHAIN_ECLASS} ]]; then
 _TOOLCHAIN_ECLASS=1
 
-RUST_OPTIONAL="1"
-
 # See tc_version_is_at_least below wrt old EAPIs vs old GCCs.
 case ${EAPI} in
-	8) ;;
+	8) inherit edo ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
+
+RUST_OPTIONAL="1"
 
 DESCRIPTION="The GNU Compiler Collection"
 HOMEPAGE="https://gcc.gnu.org/"
 
-inherit edo flag-o-matic gnuconfig libtool multilib pax-utils rust toolchain-funcs prefix
+inherit flag-o-matic gnuconfig libtool multilib pax-utils rust toolchain-funcs prefix
 
 [[ -n ${TOOLCHAIN_HAS_TESTS} ]] && inherit python-any-r1
 

--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -6,18 +6,19 @@
 # Arthur Zamarin <arthurzam@gentoo.org>
 # @AUTHOR:
 # Matthew Smith <matthew@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Common functions and variables for Tree Sitter grammars
-
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
 
 if [[ -z ${_TREE_SITTER_GRAMMAR_ECLASS} ]]; then
 _TREE_SITTER_GRAMMAR_ECLASS=1
 
-inherit edo multilib toolchain-funcs
+case ${EAPI} in
+	8) inherit edo ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+inherit multilib toolchain-funcs
 
 SRC_URI="https://github.com/tree-sitter/${PN}/archive/${TS_PV:-v${PV}}.tar.gz
 	-> ${P}.tar.gz"

--- a/eclass/udev.eclass
+++ b/eclass/udev.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: udev.eclass
 # @MAINTAINER:
 # systemd@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Default eclass for determining udev directories.
 # @DESCRIPTION:
 # Default eclass for determining udev directories.
@@ -40,7 +40,7 @@ if [[ -z ${_UDEV_ECLASS} ]]; then
 _UDEV_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: unpacker.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: helpers for extraneous file formats and consistent behavior across EAPIs
 # @DESCRIPTION:
 # Some extraneous file formats are not part of PMS, or are only in certain
@@ -15,13 +15,14 @@
 #  - merge rpm unpacking
 #  - support partial unpacks?
 
-case ${EAPI} in
-	7|8) inherit eapi9-pipestatus ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_UNPACKER_ECLASS} ]]; then
 _UNPACKER_ECLASS=1
+
+case ${EAPI} in
+	7|8) inherit eapi9-pipestatus ;;
+	9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multiprocessing toolchain-funcs
 

--- a/eclass/vala.eclass
+++ b/eclass/vala.eclass
@@ -6,7 +6,7 @@
 # gnome@gentoo.org
 # @AUTHOR:
 # Alexandre Rostovtsev <tetromino@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Sets up the environment for using a specific version of vala.
 # @DESCRIPTION:
 # This eclass sets up commonly used environment variables for using a specific
@@ -14,13 +14,13 @@
 # packages whose build systems assume the existence of certain unversioned vala
 # executables, pkgconfig files, etc., which Gentoo does not provide.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_VALA_ECLASS} ]] ; then
 _VALA_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit flag-o-matic
 

--- a/eclass/vcs-clean.eclass
+++ b/eclass/vcs-clean.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vcs-clean.eclass
@@ -6,14 +6,14 @@
 # base-system@gentoo.org
 # @AUTHOR:
 # Benedikt Böhm <hollow@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: helper functions to remove VCS directories
 
 if [[ -z ${_VCS_CLEAN_ECLASS} ]] ; then
 _VCS_CLEAN_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vdr-plugin-2.eclass
@@ -9,7 +9,7 @@
 # Joerg Bornkessel <hd_brummy@gentoo.org>
 # Christian Ruppert <idl0r@gentoo.org>
 # (undisclosed contributors)
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: common vdr plugin ebuild functions
 # @DESCRIPTION:
 # Eclass for easing maintenance of vdr plugin ebuilds
@@ -64,7 +64,7 @@ if [[ -z ${_VDR_PLUGIN_2_ECLASS} ]]; then
 _VDR_PLUGIN_2_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/vim-spell.eclass
+++ b/eclass/vim-spell.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-spell.eclass
@@ -6,7 +6,7 @@
 # Vim Maintainers <vim@gentoo.org>
 # @AUTHOR:
 # Ciaran McCreesh <ciaranm@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass for managing Vim spell files.
 # @DESCRIPTION:
 # How to make a vim spell file package using prebuilt spell lists
@@ -66,7 +66,7 @@ if [[ -z ${_VIM_SPELL_ECLASS} ]] ; then
 _VIM_SPELL_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/waf-utils.eclass
+++ b/eclass/waf-utils.eclass
@@ -8,20 +8,20 @@
 # Original Author: Gilles Dartiguelongue <eva@gentoo.org>
 # Various improvements based on cmake-utils.eclass: Tomáš Chvátal <scarabeus@gentoo.org>
 # Proper prefix support: Jonathan Callen <jcallen@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: common ebuild functions for waf-based packages
 # @DESCRIPTION:
 # The waf-utils eclass contains functions that make creating ebuild for
 # waf-based packages much easier.
 # Its main features are support of common portage default settings.
 
-case ${EAPI} in
-	7|8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_WAF_UTILS_ECLASS} ]]; then
 _WAF_UTILS_ECLASS=1
+
+case ${EAPI} in
+	7|8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit multilib sysroot toolchain-funcs multiprocessing
 

--- a/eclass/webapp.eclass
+++ b/eclass/webapp.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: webapp.eclass
 # @MAINTAINER:
 # web-apps@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: functions for installing applications to run under a web server
 # @DESCRIPTION:
 # The webapp eclass contains functions to handle web applications with
@@ -14,7 +14,7 @@ if [[ -z ${_WEBAPP_ECLASS} ]]; then
 _WEBAPP_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/wine.eclass
+++ b/eclass/wine.eclass
@@ -6,7 +6,7 @@
 # Wine <wine@gentoo.org>
 # @AUTHOR:
 # Ionen Wolkens <ionen@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Common functions for app-emuluation/wine-* ebuilds
 # @DESCRIPTION:
 # Given the large amount of Wine ebuilds (and variants) that need
@@ -18,13 +18,13 @@
 # Wine, but there is currently no garantee that eclass changes may
 # not break these ebuilds now and then without real warnings
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_WINE_ECLASS} ]]; then
 _WINE_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 inherit autotools flag-o-matic multilib prefix toolchain-funcs wrapper
 

--- a/eclass/wrapper.eclass
+++ b/eclass/wrapper.eclass
@@ -4,14 +4,14 @@
 # @ECLASS: wrapper.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: create a shell wrapper script
 
 if [[ -z ${_WRAPPER_ECLASS} ]]; then
 _WRAPPER_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/wxwidgets.eclass
+++ b/eclass/wxwidgets.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: wxwidgets.eclass
 # @MAINTAINER:
 # wxwidgets@gentoo.org
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Manages build configuration for wxGTK-using packages.
 # @DESCRIPTION:
 # This eclass sets up the proper environment for ebuilds using the wxGTK
@@ -21,13 +21,13 @@
 # The configuration chosen is based on the version required and the flags
 # wxGTK was built with.
 
-case ${EAPI} in
-	8) ;;
-	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
-esac
-
 if [[ -z ${_WXWIDGETS_ECLASS} ]]; then
 _WXWIDGETS_ECLASS=1
+
+case ${EAPI} in
+	8|9) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
 
 # @ECLASS_VARIABLE: WX_GTK_VER
 # @PRE_INHERIT

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2024 Gentoo Authors
+# Copyright 2004-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: xdg-utils.eclass
@@ -7,7 +7,7 @@
 # freedesktop-bugs@gentoo.org
 # @AUTHOR:
 # Original author: Gilles Dartiguelongue <eva@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Auxiliary functions commonly used by XDG compliant packages.
 # @DESCRIPTION:
 # This eclass provides a set of auxiliary functions needed by most XDG
@@ -18,7 +18,7 @@
 #  * XDG mime information database management
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/xdg.eclass
+++ b/eclass/xdg.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: xdg.eclass
@@ -6,7 +6,7 @@
 # freedesktop-bugs@gentoo.org
 # @AUTHOR:
 # Original author: Gilles Dartiguelongue <eva@gentoo.org>
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @PROVIDES: xdg-utils
 # @BLURB: Provides phases for XDG compliant packages.
 # @DESCRIPTION:
@@ -17,7 +17,7 @@ if [[ -z ${_XDG_ECLASS} ]]; then
 _XDG_ECLASS=1
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -126,7 +126,7 @@ xdg_pkg_postrm() {
 fi
 
 case ${EAPI} in
-	6|7)
+	7)
 		EXPORT_FUNCTIONS src_prepare
 		;;
 	*)

--- a/eclass/zig-utils.eclass
+++ b/eclass/zig-utils.eclass
@@ -6,7 +6,7 @@
 # Eric Joldasov <bratishkaerik@landless-city.net>
 # @AUTHOR:
 # Eric Joldasov <bratishkaerik@landless-city.net>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @BLURB: Prepare Zig toolchain and set global variables
 # @DESCRIPTION:
 # Prepare Zig toolchain and set global variables.
@@ -23,11 +23,12 @@ if [[ -z ${_ZIG_UTILS_ECLASS} ]]; then
 _ZIG_UTILS_ECLASS=1
 
 case ${EAPI} in
-	8) ;;
+	8) inherit edo ;;
+	9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-inherit edo flag-o-matic linux-info
+inherit flag-o-matic linux-info
 
 # @ECLASS_VARIABLE: ZIG_SLOT
 # @PRE_INHERIT

--- a/eclass/zig.eclass
+++ b/eclass/zig.eclass
@@ -8,7 +8,7 @@
 # Alfred Wingate <parona@protonmail.com>
 # Violet Purcell <vi@vimproved.dev>
 # Eric Joldasov <bratishkaerik@landless-city.net>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 8 9
 # @PROVIDES: zig-utils
 # @BLURB: Functions for working with ZBS (Zig Build System)
 # @DESCRIPTION:
@@ -50,7 +50,7 @@ if [[ -z ${_ZIG_ECLASS} ]]; then
 _ZIG_ECLASS=1
 
 case ${EAPI} in
-	8) ;;
+	8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 


### PR DESCRIPTION
Status of EAPI 9 support
------------------------

- ✅ = in Gentoo repository
- 🗸 = acknowledged, but waiting for support in inherited eclass
- 🪦 = deprecated / dead
- ⛔ = will not be ported to EAPI 9
- ❌ = dropped from PR (by maintainer's request)

| eclass              | status |    | eclass              | status |    | eclass              | status |
| ------------------- | ------ | -- | ------------------- | ------ | -- | ------------------- | ------ |
| acct-group          | ✅     |    | golang-vcs-snapshot | 🪦     |    | preserve-libs       | ✅     |
| acct-user           | ✅     |    | greadme             | ✅     |    | pypi                |        |
| ada                 |        |    | gstreamer-meson     | ❌     |    | python-r1           |        |
| alternatives        |        |    | guile               |        |    | python-any-r1       |        |
| apache-2            |        |    | guile-single        |        |    | python-single-r1    |        |
| apache-module       |        |    | guile-utils         |        |    | python-utils-r1     |        |
| app-alternatives    | ✅     |    | haskell-cabal       |        |    | qmail               |        |
| aspell-dict-r1      | ✅     |    | java-osgi           | 🪦     |    | qmake-utils         | ✅     |
| autotools           | ✅     |    | java-pkg-2          | ✅     |    | qt-utils            | ✅     |
| bash-completion-r1  | ⛔     |    | java-pkg-opt-2      | ✅     |    | qt6-build           | 🗸      |
| branding            | ✅     |    | java-pkg-simple     | ✅     |    | readme.gentoo-r1    | ✅     |
| cargo               |        |    | java-utils-2        | ✅     |    | rebar               |        |
| cdrom               | ✅     |    | java-vm-2           |        |    | rebar-utils         |        |
| check-reqs          |        |    | junit5              | ✅     |    | rebar3              |        |
| chromium-2          |        |    | kde.org             | ✅     |    | rocm                | ❌     |
| cmake               | ❌     |    | kernel-2            |        |    | rpm                 |        |
| cmake-multilib      |        |    | kernel-build        |        |    | ruby-fakegem        | ❌     |
| common-lisp-3       |        |    | kernel-install      |        |    | ruby-ng             | ❌     |
| cron                |        |    | latex-package       |        |    | ruby-ng-gnome2      | ❌     |
| crossdev            | ✅     |    | libretro-core       |        |    | ruby-single         | ❌     |
| cuda                | ❌     |    | libtool             | ✅     |    | ruby-utils          | ❌     |
| cvs                 | ✅     |    | linux-info          |        |    | rust                |        |
| db                  |        |    | linux-mod-r1        | ❌     |    | rust-toolchain      |        |
| db-use              |        |    | llvm                | 🪦     |    | s6                  |        |
| depend.apache       |        |    | llvm-r1             | 🪦     |    | savedconfig         |        |
| desktop             | ✅     |    | llvm-r2             | 🗸      |    | scons-utils         | ✅     |
| dist-kernel-utils   |        |    | llvm-utils          | ✅     |    | sec-keys            |        |
| distutils-r1        |        |    | llvm.org            | ❌     |    | secureboot          |        |
| docs                |        |    | lua                 |        |    | selinux-policy-2    |        |
| dot-a               |        |    | lua-single          |        |    | sgml-catalog-r1     | ✅     |
| dotnet              | 🪦     |    | lua-utils           |        |    | shell-completion    | ✅     |
| dotnet-pkg          |        |    | mate                |        |    | ssl-cert            |        |
| dotnet-pkg-base     |        |    | mate-desktop.org    |        |    | stardict            |        |
| dune                |        |    | mercurial           | ✅     |    | strip-linguas       | ✅     |
| eapi8-dosym         | ⛔     |    | meson               | ❌     |    | subversion          |        |
| eapi9-pipestatus    | ⛔     |    | meson-multilib      |        |    | sysroot             | ✅     |
| eapi9-ver           | ⛔     |    | mono-env            |        |    | systemd             |        |
| ecm                 |        |    | mount-boot          |        |    | texlive-common      |        |
| ecm-common          |        |    | mount-boot-utils    |        |    | texlive-module      |        |
| edo                 | ⛔     |    | mozcoreconf-v6      |        |    | tmpfiles            |        |
| edos2unix           | ✅     |    | mozextension        |        |    | toolchain           | 🗸      |
| elisp               | ✅     |    | mozlinguas-v2       |        |    | toolchain-autoconf  |        |
| elisp-common        | ✅     |    | multibuild          | ✅     |    | toolchain-funcs     | ✅     |
| emboss-r3           |        |    | multilib            |        |    | tree-sitter-grammar |        |
| estack              | ✅     |    | multilib-build      | ✅     |    | udev                |        |
| fcaps               |        |    | multilib-minimal    |        |    | unpacker            |        |
| ffmpeg-compat       | ✅     |    | multiprocessing     | ✅     |    | user-info           | ✅     |
| findlib             |        |    | myspell-r2          |        |    | usr-ldscript        | ❌     |
| fixheadtails        | ✅     |    | netsurf             |        |    | vala                |        |
| flag-o-matic        | ✅     |    | nginx               | ✅     |    | vcs-clean           |        |
| font                |        |    | nginx-module        | ✅     |    | vcs-snapshot        | ✅     |
| font-ebdftopcf      |        |    | ninja-utils         |        |    | vdr-plugin-2        |        |
| fortran-2           |        |    | nuget               |        |    | verify-sig          | ✅     |
| frameworks.kde.org  | ✅     |    | office-ext-r1       |        |    | vim-doc             | ⛔     |
| freedict            |        |    | opam                |        |    | vim-plugin          | ❌     |
| gap-pkg             |        |    | optfeature          | ✅     |    | vim-spell           |        |
| gear.kde.org        | ✅     |    | out-of-source       | ✅     |    | virtualx            | ❌     |
| ghc-package         |        |    | out-of-source-utils | ✅     |    | waf-utils           |        |
| git-r3              | ✅     |    | pam                 |        |    | webapp              |        |
| gkrellm-plugin      |        |    | pax-utils           |        |    | wine                | 🗸      |
| gnome.org           | ❌     |    | perl-functions      |        |    | wrapper             |        |
| gnome2              | ❌     |    | perl-module         |        |    | wxwidgets           |        |
| gnome2-utils        | ❌     |    | php-ext-pecl-r3     |        |    | xdg                 |        |
| gnuconfig           | ✅     |    | php-ext-source-r3   |        |    | xdg-utils           |        |
| gnustep-2           |        |    | php-pear-r2         |        |    | xemacs-packages     | ✅     |
| gnustep-base        |        |    | plasma.kde.org      | ✅     |    | xorg-3              | ✅     |
| go-env              | ✅     |    | plocale             | ✅     |    | xorg-meson          | ✅     |
| go-module           | ✅     |    | portability         | ✅     |    | zig                 |        |
| golang-base         | 🪦     |    | postgres            |        |    | zig-utils           |        |
| golang-build        | 🪦     |    | postgres-multi      |        |    |                     |        |
| golang-vcs          | 🪦     |    | prefix              | ✅     |    |                     |        |

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- ✅ I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- ✅ I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- ✅ This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- ✅ I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
