### PR TITLE
app-mobilephone/gammu: fix tests and cmake warnings

### DIFF
--- a/app-mobilephone/gammu/files/gammu-1.42.0-prevent-osx-lib-usage.patch
+++ b/app-mobilephone/gammu/files/gammu-1.42.0-prevent-osx-lib-usage.patch
@@ -1,0 +1,28 @@
+From https://github.com/gammu/gammu/commit/6d0638c93a1a5e4f5e4cf35a81e40dd835a75be6
+From: Victor Kustov <ktrace@yandex.ru>
+Date: Mon, 2 Feb 2026 18:26:00 +0300
+Subject: [PATCH] Prevent find OSX libs with Linux env
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -282,12 +282,14 @@ if (WITH_BLUETOOTH)
+ 		set(BLUETOOTH_SEARCH TRUE)
+ 	    endif (HAVE_SDP_SERVICE_SEARCH_ATTRIBUTE AND HAVE_BT_DEVINQUIRY)
+         endif (BSD_BLUE_FOUND)
+-        find_package (OSXBluetooth)
+-        if (OSX_BLUE_FOUND)
+-            set(BLUETOOTH_FOUND ON)
+-            set(BLUETOOTH_SEARCH FALSE)
+-            message(STATUS "Using OSX Bluetooth stack")
+-        endif (OSX_BLUE_FOUND)
++        if (APPLE)
++            find_package (OSXBluetooth)
++            if (OSX_BLUE_FOUND)
++                set(BLUETOOTH_FOUND ON)
++                set(BLUETOOTH_SEARCH FALSE)
++                message(STATUS "Using OSX Bluetooth stack")
++            endif (OSX_BLUE_FOUND)
++        endif (APPLE)
+     endif (WIN32 AND NOT CYGWIN)
+ else (WITH_BLUETOOTH)
+     set(BLUETOOTH_FOUND FALSE)

--- a/app-mobilephone/gammu/files/gammu-1.42.0-up-cmake4.patch
+++ b/app-mobilephone/gammu/files/gammu-1.42.0-up-cmake4.patch
@@ -1,0 +1,55 @@
+From https://github.com/gammu/gammu/commit/1a144c5549f3c39c2fa040e4acb1f0b3b187cac2
+From: Victor Kustov <ktrace@yandex.ru>
+Date: Mon, 2 Feb 2026 17:54:21 +0300
+Subject: [PATCH] Replace deprecated function
+
+--- a/smsd/CMakeTests.txt
++++ b/smsd/CMakeTests.txt
+@@ -48,9 +48,9 @@ if (WITH_BACKUP)
+                 add_test(NAME "smsd-daemon-${_driver}-pid" COMMAND gammu-smsd -c "${CMAKE_CURRENT_BINARY_DIR}/smsd-test-${_driver}/.smsdrc" -X 3 -p ${CMAKE_CURRENT_BINARY_DIR}/smsd-test-${_driver}/smsd.pid)
+             endif()
+             if (HAVE_ALARM AND HAVE_SETGID AND HAVE_GETPWNAM AND HAVE_GETGRNAM AND HAVE_SETUID AND HAVE_INITGROUPS)
+-                exec_program(id ARGS -g OUTPUT_VARIABLE MY_GROUP)
++                execute_process(COMMAND id -g OUTPUT_VARIABLE MY_GROUP OUTPUT_STRIP_TRAILING_WHITESPACE)
+                 add_test(NAME "smsd-daemon-${_driver}-gid" COMMAND gammu-smsd -c "${CMAKE_CURRENT_BINARY_DIR}/smsd-test-${_driver}/.smsdrc" -X 3 -G ${MY_GROUP})
+-                exec_program(id ARGS -gn OUTPUT_VARIABLE MY_GROUP_NAME)
++                execute_process(COMMAND id -gn OUTPUT_VARIABLE MY_GROUP_NAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+                 add_test(NAME "smsd-daemon-${_driver}-gid-name" COMMAND gammu-smsd -c "${CMAKE_CURRENT_BINARY_DIR}/smsd-test-${_driver}/.smsdrc" -X 3 -G ${MY_GROUP_NAME})
+             endif()
+         endif()
+From https://github.com/gammu/gammu/commit/1d5a49dcade1a87722947137cdaf545e5f368ac6
+From: Victor Kustov <ktrace@yandex.ru>
+Date: Mon, 2 Feb 2026 19:09:09 +0300
+Subject: [PATCH] Drop unneeded in CMake 4.0
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Copyright (c) 2007 - 2018 Michal Cihar
+ # vim: expandtab sw=4 ts=4 sts=4:
+ 
+-cmake_minimum_required (VERSION 3.0)
++cmake_minimum_required (VERSION 4.0)
+ INCLUDE (CMakeForceCompiler)
+ 
+ project (Gammu C)
+@@ -10,11 +10,6 @@ project (Gammu C)
+ # Where to lookup modules
+ set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+ 
+-# Silent some warnings from CMake 2.6
+-cmake_policy(SET CMP0003 NEW)
+-cmake_policy(SET CMP0009 NEW)
+-cmake_policy(SET CMP0110 NEW)
+-
+ option (COVERAGE "Add flags for Coverage analysis" OFF)
+ 
+ option (ONLINE_TESTING "Enable testing of parts which use remote servers" OFF)
+@@ -792,7 +787,6 @@ install (
+ # Testing and dashboard
+ include(CTest)
+ enable_testing()
+-include(Dart)
+ 
+ # Packaging support
+ set (CPACK_PACKAGE_NAME "Gammu")

--- a/app-mobilephone/gammu/gammu-1.42.0-r1.ebuild
+++ b/app-mobilephone/gammu/gammu-1.42.0-r1.ebuild
@@ -31,12 +31,17 @@ DEPEND="
 	${COMMON_DEPEND}
 	irda? ( virtual/os-headers )
 "
+BDEPEND="
+	>=dev-build/cmake-4.0
+"
 RDEPEND="
 	${COMMON_DEPEND}
 	dev-util/dialog
 "
 PATCHES=(
 	"${FILESDIR}/${P}-CMP0110-policy.patch"
+	"${FILESDIR}/${P}-up-cmake4.patch"
+	"${FILESDIR}/${P}-prevent-osx-lib-usage.patch"
 	"${FILESDIR}/${P}-gammu-detect.patch"
 	"${FILESDIR}/${P}-fortify-source-3.patch"
 )
@@ -59,7 +64,7 @@ src_configure() {
 }
 
 src_test() {
-	addwrite "/var/lock/LCK..bar"
+	addwrite "/run/lock/LCK..bar"
 	LD_LIBRARY_PATH="${BUILD_DIR}/libgammu" cmake_src_test -j1
 }
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->
- fix check of lockfile (correct addwrite to /run/lock)
- fix CMake minimum version to 4.0
- replace exec_program to execute_process
- workaround for OSX BT framework detection
- comment out deprecated Dart
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
