### PR TITLE
Add KERNEL_VERBOSE option to control verbosity output

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -19,6 +19,12 @@
 # CONFIG_EFI_ZBOOT enabled. This effects the name of the kernel image on
 # arm64 and riscv. Mainly useful for sys-kernel/gentoo-kernel-bin.
 
+# @ECLASS_VARIABLE: KERNEL_VERBOSE
+# @USER_VARIABLE
+# @DESCRIPTION:
+# Set to 0 to disable verbose messages during compilation.
+: "${KERNEL_VERBOSE:=1}"
+
 if [[ ! ${_DIST_KERNEL_UTILS} ]]; then
 
 case ${EAPI} in
@@ -95,7 +101,10 @@ dist-kernel_install_kernel() {
 		"${version}" "${image}" "${map}" "${dir}"
 	)
 	if has_version ">=sys-kernel/installkernel-56"; then
-		installkernel_args+=( "${@:5}" --verbose )
+		installkernel_args+=( "${@:5}" )
+		if [[ ${KERNEL_VERBOSE} != 0 ]]; then
+			installkernel_args+=( --verbose )
+		fi
 	fi
 
 	local success=

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -149,6 +149,12 @@ REQUIRED_USE="secureboot? ( modules-sign )"
 # - emergency
 # - rescue
 
+# @ECLASS_VARIABLE: KERNEL_VERBOSE
+# @USER_VARIABLE
+# @DESCRIPTION:
+# Set to 0 to disable verbose messages during compilation.
+: "${KERNEL_VERBOSE:=1}"
+
 if [[ ${KERNEL_IUSE_GENERIC_UKI} ]]; then
 	BDEPEND+="
 		generic-uki? ( ${!INITRD_PACKAGES[@]} )
@@ -253,8 +259,11 @@ kernel-build_src_configure() {
 	fi
 
 	tc-export_build_env
+	local v
+	[[ ${KERNEL_VERBOSE} != 0 ]] && v=1
+
 	MAKEARGS=(
-		V=1
+		${v+V=1}
 		WERROR=0
 
 		HOSTCC="$(tc-getBUILD_CC)"

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -166,6 +166,12 @@ fi
 #
 # Default if unset: auto-detection, typically same as the current CHOST
 
+# @ECLASS_VARIABLE: KERNEL_VERBOSE
+# @USER_VARIABLE
+# @DESCRIPTION:
+# Set to 0 to disable verbose messages during compilation.
+: "${KERNEL_VERBOSE:=1}"
+
 # @ECLASS_VARIABLE: MODULES_EXTRA_EMAKE
 # @USER_VARIABLE
 # @DEFAULT_UNSET
@@ -1314,12 +1320,15 @@ _modules_sanity_objtool() {
 # @DESCRIPTION:
 # Sets the MODULES_MAKEARGS global array.
 _modules_set_makeargs() {
+	local v
+	[[ ${KERNEL_VERBOSE^^} != 0 ]] && v=1
+
 	MODULES_MAKEARGS=(
 		ARCH="$(tc-arch-kernel)"
 
-		V=1
+		${v+V=1}
 		# normally redundant with V, but some custom Makefiles override it
-		KBUILD_VERBOSE=1
+		${v+KBUILD_VERBOSE=1}
 
 		# unrealistic when building modules that often have slow releases,
 		# but note that the kernel will still pass some -Werror=bad-thing


### PR DESCRIPTION
Following other similar variables like `NINJA_VERBOSE` or `CMAKE_VERBOSE` this adds `KERNEL_VERBOSE` option to control kernel and module build verbosity.

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
