### PR TITLE
🩹 media-libs/openimageio: fix hallucinated jpegxl in 2.5.19.1

### DIFF
--- a/media-libs/openimageio/openimageio-2.5.19.1.ebuild
+++ b/media-libs/openimageio/openimageio-2.5.19.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -136,10 +136,6 @@ src_prepare() {
 
 	if ! use jpeg2k; then
 		rm -r "src/jpeg2000.imageio" || die
-	fi
-
-	if ! use jpegxl; then
-		rm -r "src/jpegxl.imageio" || die
 	fi
 
 	if ! use raw; then


### PR DESCRIPTION
_Hello everyone,_

**OpenImageIO** [2.5.19.1](https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v2.5.19.1) [doesn't support](https://github.com/AcademySoftwareFoundation/OpenImageIO/tree/v2.5.19.1/src/jpegxl.imageio) **JPEG XL**.
**JPEG XL** support was introduced in https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/41a26caa4f6412eae732403881204931dded3245 and released in [3.0.0.3](https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.0.0.3).

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

<details><summary>pkgcheck scan --commits --net</summary>
<p>

```
media-libs/openimageio
  UnstableOnly: for arches: [ arm, arm64, ppc64 ], all versions are unstable: [ 2.5.18.0, 2.5.19.0, 2.5.19.1, 3.0.6.1, 3.0.8.1, 3.0.8.1-r1, 3.0.8.1-r2, 3.0.11.0, 3.1.7.0-r1 ]
  PythonCompatUpdate: version 2.5.18.0: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 2.5.18.0: slot(0) keywords are overshadowed by versions: 3.0.8.1, 3.0.8.1-r2
  PythonCompatUpdate: version 2.5.19.0: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 2.5.19.0: slot(0) keywords are overshadowed by versions: 2.5.19.1, 3.0.6.1, 3.0.8.1, 3.0.8.1-r1, 3.0.8.1-r2, 3.0.11.0, 3.1.7.0-r1
  PythonCompatUpdate: version 2.5.19.1: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 2.5.19.1: slot(0) keywords are overshadowed by versions: 3.0.6.1, 3.0.8.1, 3.0.8.1-r1, 3.0.8.1-r2, 3.0.11.0, 3.1.7.0-r1
  PythonCompatUpdate: version 3.0.6.1: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 3.0.6.1: slot(0) keywords are overshadowed by versions: 3.0.8.1, 3.0.8.1-r1, 3.0.8.1-r2, 3.0.11.0, 3.1.7.0-r1
  PythonCompatUpdate: version 3.0.8.1: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 3.0.8.1: slot(0) keywords are overshadowed by version: 3.0.8.1-r2
  RedundantVersion: version 3.0.8.1-r1: slot(0) keywords are overshadowed by versions: 3.0.8.1-r2, 3.0.11.0, 3.1.7.0-r1
  PotentialStable: version 3.0.8.1-r2: slot(0), stabled arch: [ amd64 ], potentials: [ ~arm, ~arm64, ~ppc64 ]
  PythonCompatUpdate: version 3.0.11.0: PYTHON_COMPAT update available: python3_14
  RedundantVersion: version 3.0.11.0: slot(0) keywords are overshadowed by version: 3.1.7.0-r1
```

</p>
</details> 
