### PR TITLE
net-proxy/haproxy: future init.d improvements

### DIFF
--- a/net-proxy/haproxy/files/haproxy.initd-r10
+++ b/net-proxy/haproxy/files/haproxy.initd-r10
@@ -1,0 +1,93 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig"
+extra_started_commands="reload"
+
+command="/usr/sbin/haproxy"
+
+pidfile="${HAPROXY_PIDFILE:-/run/${SVCNAME}.pid}"
+
+configs=
+
+if [ -z "${CONFIGS}" ]; then
+	if [ -f "/etc/haproxy/${SVCNAME}.cfg" ]; then
+		CONFIGS=/etc/haproxy/${SVCNAME}.cfg
+	elif [ -f "/etc/${SVCNAME}.cfg" ]; then
+		CONFIGS=/etc/${SVCNAME}.cfg # Deprecated
+	fi
+fi
+
+for conf in $CONFIGS; do
+	configs="${configs} -f ${conf}"
+done
+
+command_args="-D -W -p ${pidfile} ${configs} ${HAPROXY_OPTS}"
+
+depend() {
+	need net
+	use dns logger
+}
+
+checkconfig() {
+	local conf path
+
+	if [ -z "${CONFIGS}" ]; then
+		eerror "No config(s) has been specified"
+		return 1
+	fi
+
+	for conf in $CONFIGS; do
+		if [ ! -f "${conf}" ]; then
+			eerror "${conf} does not exist!"
+			return 1
+		fi
+	done
+
+	ebegin "Checking ${CONFIGS}"
+	$command -q -c $command_args
+	eend $?
+
+	# Pre-create folders for unix binds.
+	for path in $(sed -nre 's,^[[:space:]]*bind[[:space:]]+(/[^[:space:]]+)([[:space:]].*)?$,\1,p' $CONFIGS); do
+		checkpath -o haproxy:haproxy -m 0755 -d $(dirname "${path}")
+	done
+}
+
+start_pre() {
+	if [ "${RC_CMD}" != "restart" ]; then
+		checkconfig || return 1
+	fi
+}
+
+stop_pre() {
+	if [ "${RC_CMD}" = "restart" ]; then
+		checkconfig || return 1
+	fi
+}
+
+stop() {
+	local _t _pid
+
+	_t="$(mktemp)"
+	for _pid in $(cat ${pidfile}) ; do
+		echo "${_pid}" > "${_t}"
+		start-stop-daemon --stop --pidfile="${_t}"
+	done
+	rm -f "${_t}"
+}
+
+reload() {
+	checkconfig || { eerror "Reloading failed, please fix your config(s) first"; return 1; }
+
+	if [ "$(command -v reload_seamless)" = "reload_seamless" ]; then
+		einfo "Calling user-defined reload_seamless()"
+		ewarn "The user-defiled reload_seamless() function is deprecated as it is no longer necessary nowadays, with recent HAProxy versions. If you think otherwise, please file a bug"
+		reload_seamless || { eerror "reload_seamless() failed!"; return 1; }
+	fi
+
+	ebegin "Reloading ${SVCNAME}"
+	start-stop-daemon --signal USR2 --pidfile "${pidfile}"
+	eend $?
+}


### PR DESCRIPTION
init.d -r10, this will look for UNIX-path bind statements and attempt to pre-create the folders.  Two problems:

1.  Permissions is assumed to be 755 for the folders (likely okay).
2.  user:group is assumed to be haproxy:haproxy - which is less likely to be generally okay.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
