### PR TITLE
app-i18n/fcitx-configtool: destabilize 5.1.12 for ~arm64

### DIFF
--- a/app-i18n/fcitx-configtool/fcitx-configtool-5.1.12.ebuild
+++ b/app-i18n/fcitx-configtool/fcitx-configtool-5.1.12.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="GPL-2+"
 SLOT="5"
-KEYWORDS="amd64 ~loong"
+KEYWORDS="amd64 ~arm64 ~loong"
 IUSE="kcm +config-qt test X"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
This keyword has been tested on an ARM64 MacBook Air M2.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
