### PR TITLE
app-office/abiword: fix USE=-goffice build with C23

### DIFF
--- a/app-office/abiword/abiword-3.0.6-r3.ebuild
+++ b/app-office/abiword/abiword-3.0.6-r3.ebuild
@@ -1,0 +1,168 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..13} )
+
+inherit autotools flag-o-matic python-single-r1 xdg
+
+DESCRIPTION="Fully featured yet light and fast cross platform word processor"
+HOMEPAGE="https://gitlab.gnome.org/World/AbiWord"
+SRC_URI="
+	https://gitlab.gnome.org/World/AbiWord/-/archive/release-${PV}/AbiWord-release-${PV}.tar.bz2
+	https://dev.gentoo.org/~soap/distfiles/${PN}-3.0.6-patches-r1.tar.xz"
+S="${WORKDIR}/AbiWord-release-${PV}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="calendar collab cups debug eds +goffice grammar +introspection latex map math +plugins readline redland spell wordperfect wmf thesaurus"
+# You need 'plugins' enabled if want to enable the extra plugins
+REQUIRED_USE="
+	collab? ( plugins )
+	grammar? ( plugins )
+	introspection? ( ${PYTHON_REQUIRED_USE} )
+	latex? ( plugins )
+	math? ( plugins )
+	readline? ( plugins )
+	thesaurus? ( plugins )
+	wmf? ( plugins )
+	wordperfect? ( plugins )"
+
+RDEPEND="
+	>=app-text/wv-1.2
+	>=dev-libs/fribidi-0.10.4
+	>=dev-libs/glib-2.16:2
+	>=dev-libs/libgcrypt-1.4.5:0=
+	>=dev-libs/libxml2-2.4:2=
+	dev-libs/libxslt
+	>=gnome-base/librsvg-2.16:2
+	>=gnome-extra/libgsf-1.14.18:=
+	media-libs/libjpeg-turbo:=
+	>=media-libs/libpng-1.2:0=
+	>=x11-libs/cairo-1.10
+	>=x11-libs/gtk+-3.0.8:3[cups?]
+	calendar? ( >=dev-libs/libical-0.46:= )
+	eds? ( >=gnome-extra/evolution-data-server-3.6.0:= )
+	goffice? ( >=x11-libs/goffice-0.10.2:0.10 )
+	introspection? (
+		${PYTHON_DEPS}
+		>=dev-libs/gobject-introspection-1.82.0-r2:=
+	)
+	map? ( >=media-libs/libchamplain-0.12:0.12[gtk] )
+	plugins? (
+		collab? (
+			>=net-libs/loudmouth-1
+			net-libs/libsoup:2.4
+			net-libs/gnutls:=
+		)
+		grammar? ( >=dev-libs/link-grammar-4.2.1 )
+		math? ( >=x11-libs/gtkmathview-0.7.5 )
+		readline? ( sys-libs/readline:0= )
+		thesaurus? ( >=app-text/aiksaurus-1.2[gtk] )
+		wordperfect? (
+			app-text/libwpd:0.10
+			app-text/libwpg:0.3
+		)
+		wmf? ( >=media-libs/libwmf-0.2.8 )
+	)
+	redland? (
+		>=dev-libs/redland-1.0.10
+		>=dev-libs/rasqal-0.9.17
+	)
+	spell? ( app-text/enchant:2 )"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+	collab? ( dev-cpp/asio )"
+BDEPEND="
+	dev-lang/perl
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${WORKDIR}"/patches
+	"${FILESDIR}/${PN}-3.0.6-goffice-pointers.patch"
+	"${FILESDIR}/${PN}-3.0.6-metarecord.patch"
+)
+
+pkg_setup() {
+	use introspection && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# -Werror=odr
+	# https://bugs.gentoo.org/940907
+	#
+	# Upstream closed as wontfix. The bug is gone due to refactoring (?) in the
+	# unreleased 4.x branch. "The stable branch (3.0.x) will not get any
+	# significant changes."
+	filter-lto
+
+	local plugins=()
+
+	if use plugins; then
+		# Plugins depending on libgsf
+		plugins+=(t602 docbook clarisworks wml kword hancom openwriter pdf
+			loadbindings mswrite garble pdb applix opendocument sdw xslfo)
+
+		# Plugins depending on librsvg
+		plugins+=(svg)
+
+		# Plugins not depending on anything
+		plugins+=(gimp bmp freetranslation iscii s5 babelfish opml eml wikipedia
+			gdict passepartout google presentation urldict hrtext mif openxml)
+
+		# inter7eps: eps.h
+		# libtidy: gsf + tidy.h
+		# paint: windows only ?
+		plugins+=(
+			$(usev collab)
+			$(usev goffice)
+			$(usev latex)
+			$(usev math mathview)
+			# psion: >=psiconv-0.9.4
+			$(usev readline command)
+			$(usev thesaurus aiksaurus)
+			$(usev wmf)
+			# wordperfect: >=wpd-0.9 >=wpg-0.2
+			$(usev wordperfect wpg)
+		)
+	fi
+
+	econf \
+		--disable-maintainer-mode \
+		--enable-plugins="${plugins[*]}" \
+		--disable-default-plugins \
+		--disable-builtin-plugins \
+		--disable-collab-backend-telepathy \
+		--enable-clipart \
+		--enable-statusbar \
+		--enable-templates \
+		--with-gio \
+		--without-gnomevfs \
+		--without-gtk2 \
+		$(use_enable debug) \
+		$(use_with goffice goffice) \
+		$(use_with calendar libical) \
+		$(use_enable cups print) \
+		$(use_enable collab collab-backend-xmpp) \
+		$(use_enable collab collab-backend-tcp) \
+		$(use_enable collab collab-backend-service) \
+		$(use_with eds evolution-data-server) \
+		$(use_enable introspection) \
+		$(use_with map champlain) \
+		$(use_with redland) \
+		$(use_enable spell)
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${D}" -name '*.la' -delete || die
+}

--- a/app-office/abiword/abiword-3.0.7-r1.ebuild
+++ b/app-office/abiword/abiword-3.0.7-r1.ebuild
@@ -1,0 +1,168 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} )
+
+inherit autotools flag-o-matic python-single-r1 xdg
+
+DESCRIPTION="Fully featured yet light and fast cross platform word processor"
+HOMEPAGE="https://gitlab.gnome.org/World/AbiWord"
+SRC_URI="
+	https://gitlab.gnome.org/World/AbiWord/-/archive/release-${PV}/AbiWord-release-${PV}.tar.bz2
+	https://dev.gentoo.org/~soap/distfiles/${PN}-3.0.6-patches-r1.tar.xz"
+S="${WORKDIR}/AbiWord-release-${PV}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="calendar collab cups debug eds +goffice grammar +introspection latex map math +plugins readline redland spell wordperfect wmf thesaurus"
+# You need 'plugins' enabled if want to enable the extra plugins
+REQUIRED_USE="
+	collab? ( plugins )
+	grammar? ( plugins )
+	introspection? ( ${PYTHON_REQUIRED_USE} )
+	latex? ( plugins )
+	math? ( plugins )
+	readline? ( plugins )
+	thesaurus? ( plugins )
+	wmf? ( plugins )
+	wordperfect? ( plugins )"
+
+RDEPEND="
+	>=app-text/wv-1.2
+	>=dev-libs/fribidi-0.10.4
+	>=dev-libs/glib-2.16:2
+	>=dev-libs/libgcrypt-1.4.5:0=
+	>=dev-libs/libxml2-2.4:2=
+	dev-libs/libxslt
+	>=gnome-base/librsvg-2.16:2
+	>=gnome-extra/libgsf-1.14.18:=
+	media-libs/libjpeg-turbo:=
+	>=media-libs/libpng-1.2:0=
+	>=x11-libs/cairo-1.10
+	>=x11-libs/gtk+-3.0.8:3[cups?]
+	calendar? ( >=dev-libs/libical-0.46:= )
+	eds? ( >=gnome-extra/evolution-data-server-3.6.0:= )
+	goffice? ( >=x11-libs/goffice-0.10.2:0.10 )
+	introspection? (
+		${PYTHON_DEPS}
+		>=dev-libs/gobject-introspection-1.82.0-r2:=
+	)
+	map? ( >=media-libs/libchamplain-0.12:0.12[gtk] )
+	plugins? (
+		collab? (
+			>=net-libs/loudmouth-1
+			net-libs/libsoup:2.4
+			net-libs/gnutls:=
+		)
+		grammar? ( >=dev-libs/link-grammar-4.2.1 )
+		math? ( >=x11-libs/gtkmathview-0.7.5 )
+		readline? ( sys-libs/readline:0= )
+		thesaurus? ( >=app-text/aiksaurus-1.2[gtk] )
+		wordperfect? (
+			app-text/libwpd:0.10
+			app-text/libwpg:0.3
+		)
+		wmf? ( >=media-libs/libwmf-0.2.8 )
+	)
+	redland? (
+		>=dev-libs/redland-1.0.10
+		>=dev-libs/rasqal-0.9.17
+	)
+	spell? ( app-text/enchant:2 )"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+	collab? ( dev-cpp/asio )"
+BDEPEND="
+	dev-lang/perl
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${WORKDIR}"/patches
+	"${FILESDIR}/${PN}-3.0.6-goffice-pointers.patch"
+	"${FILESDIR}/${PN}-3.0.6-metarecord.patch"
+)
+
+pkg_setup() {
+	use introspection && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# -Werror=odr
+	# https://bugs.gentoo.org/940907
+	#
+	# Upstream closed as wontfix. The bug is gone due to refactoring (?) in the
+	# unreleased 4.x branch. "The stable branch (3.0.x) will not get any
+	# significant changes."
+	filter-lto
+
+	local plugins=()
+
+	if use plugins; then
+		# Plugins depending on libgsf
+		plugins+=(t602 docbook clarisworks wml kword hancom openwriter pdf
+			loadbindings mswrite garble pdb applix opendocument sdw xslfo)
+
+		# Plugins depending on librsvg
+		plugins+=(svg)
+
+		# Plugins not depending on anything
+		plugins+=(gimp bmp freetranslation iscii s5 babelfish opml eml wikipedia
+			gdict passepartout google presentation urldict hrtext mif openxml)
+
+		# inter7eps: eps.h
+		# libtidy: gsf + tidy.h
+		# paint: windows only ?
+		plugins+=(
+			$(usev collab)
+			$(usev goffice)
+			$(usev latex)
+			$(usev math mathview)
+			# psion: >=psiconv-0.9.4
+			$(usev readline command)
+			$(usev thesaurus aiksaurus)
+			$(usev wmf)
+			# wordperfect: >=wpd-0.9 >=wpg-0.2
+			$(usev wordperfect wpg)
+		)
+	fi
+
+	econf \
+		--disable-maintainer-mode \
+		--enable-plugins="${plugins[*]}" \
+		--disable-default-plugins \
+		--disable-builtin-plugins \
+		--disable-collab-backend-telepathy \
+		--enable-clipart \
+		--enable-statusbar \
+		--enable-templates \
+		--with-gio \
+		--without-gnomevfs \
+		--without-gtk2 \
+		$(use_enable debug) \
+		$(use_with goffice goffice) \
+		$(use_with calendar libical) \
+		$(use_enable cups print) \
+		$(use_enable collab collab-backend-xmpp) \
+		$(use_enable collab collab-backend-tcp) \
+		$(use_enable collab collab-backend-service) \
+		$(use_with eds evolution-data-server) \
+		$(use_enable introspection) \
+		$(use_with map champlain) \
+		$(use_with redland) \
+		$(use_enable spell)
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${D}" -name '*.la' -delete || die
+}

--- a/app-office/abiword/files/abiword-3.0.6-goffice-pointers.patch
+++ b/app-office/abiword/files/abiword-3.0.6-goffice-pointers.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/965487
+Casting to GObject is valid, because GtkWidget embeds GObject.
+--- a/goffice-bits/goffice/gtk/go-combo-box.c
++++ b/goffice-bits/goffice/gtk/go-combo-box.c
+@@ -173,7 +173,7 @@
+ 	gdk_device_ungrab (gtk_get_current_event_device (),
+ 	                   GDK_CURRENT_TIME);
+ 
+-	pdc = g_object_ref (combo_box->priv->popdown_container);
++	pdc = G_OBJECT (g_object_ref (combo_box->priv->popdown_container));
+ 	g_signal_emit (combo_box,
+ 		       go_combo_box_signals [POP_DOWN_DONE], 0,
+ 		       pdc, &popup_info_destroyed);

--- a/app-office/abiword/files/abiword-3.0.6-metarecord.patch
+++ b/app-office/abiword/files/abiword-3.0.6-metarecord.patch
@@ -1,0 +1,30 @@
+https://gitlab.gnome.org/World/AbiWord/-/merge_requests/5
+https://bugs.gentoo.org/717336
+From 6579f1e6472e1c12e4aa17a85b61b8c2a1fe9390 Mon Sep 17 00:00:00 2001
+From: Chris Mayo <aklhfex@gmail.com>
+Date: Fri, 6 Mar 2020 19:31:35 +0000
+Subject: [PATCH] Install AppStream data into metainfo directory
+
+appdata directory is now deprecated [1].
+
+[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0f6ab5e1e..d9131a790 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -15,7 +15,7 @@ desktop_DATA = com.abisource.AbiWord.desktop
+ mimedir = @ABIWORD_DATADIR@/mime-info
+ mime_DATA = abiword.keys
+ 
+-appdatadir = $(datarootdir)/appdata
++appdatadir = $(datarootdir)/metainfo
+ appdata_DATA = com.abisource.AbiWord.appdata.xml
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+-- 
+GitLab
+


### PR DESCRIPTION
GtkWidget is GObject, we can use normal GTK cast.
Add upstream patch for QA issue with deprecated folder.

Closes: https://bugs.gentoo.org/965487
Closes: https://bugs.gentoo.org/717336

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
