### PR TITLE
sys-apps/xdg-desktop-portal: always use python-any-r1

### DIFF
--- a/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.20.3.ebuild
+++ b/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.20.3.ebuild
@@ -36,12 +36,12 @@ RDEPEND="
 	sys-apps/dbus
 "
 BDEPEND="
+	${PYTHON_DEPS}
 	>=dev-util/gdbus-codegen-2.80.5-r1
 	dev-python/docutils
 	sys-devel/gettext
 	virtual/pkgconfig
 	test? (
-		${PYTHON_DEPS}
 		dev-util/umockdev
 		media-libs/gstreamer
 		media-libs/gst-plugins-good
@@ -60,14 +60,12 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.20.0-sandbox-disable-failing-tests.patch"
 )
 
-pkg_setup() {
-	use test && python-any-r1_pkg_setup
-}
-
 python_check_deps() {
-	python_has_version ">=dev-python/pytest-3[${PYTHON_USEDEP}]" &&
-	python_has_version "dev-python/pytest-xdist[${PYTHON_USEDEP}]" &&
-	python_has_version "dev-python/python-dbusmock[${PYTHON_USEDEP}]"
+	if use test; then
+		python_has_version ">=dev-python/pytest-3[${PYTHON_USEDEP}]" &&
+		python_has_version "dev-python/pytest-xdist[${PYTHON_USEDEP}]" &&
+		python_has_version "dev-python/python-dbusmock[${PYTHON_USEDEP}]"
+	fi
 }
 
 src_configure() {


### PR DESCRIPTION
used by [src/generate-method-info.py](https://github.com/flatpak/xdg-desktop-portal/blob/1.20.3/src/meson.build#L59)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
