### PR TITLE
Clean up stale Postgres dependencies

### DIFF
--- a/dev-db/postgresql/postgresql-14.20.ebuild
+++ b/dev-db/postgresql/postgresql-14.20.ebuild
@@ -1,26 +1,24 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 pam python-single-r1 systemd tmpfiles
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
-
-SLOT=$(ver_cut 1)
-
-MY_PV=${PV/_/}
-S="${WORKDIR}/${PN}-${MY_PV}"
-
-SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
-
-LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
+
+MY_PV=${PV/_/}
+SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
+S="${WORKDIR}/${PN}-${MY_PV}"
+LICENSE="POSTGRESQL GPL-2"
+SLOT=$(ver_cut 1)
+
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
 
 IUSE="debug doc icu kerberos ldap llvm +lz4 nls pam perl python +readline
 	  selinux +server systemd ssl static-libs tcl uuid xml zlib"

--- a/dev-db/postgresql/postgresql-15.15.ebuild
+++ b/dev-db/postgresql/postgresql-15.15.ebuild
@@ -1,26 +1,24 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 pam python-single-r1 systemd tmpfiles
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
-
-SLOT=$(ver_cut 1)
-
-MY_PV=${PV/_/}
-S="${WORKDIR}/${PN}-${MY_PV}"
-
-SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
-
-LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
+
+MY_PV=${PV/_/}
+SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
+S="${WORKDIR}/${PN}-${MY_PV}"
+LICENSE="POSTGRESQL GPL-2"
+SLOT=$(ver_cut 1)
+
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
 
 IUSE="debug doc icu kerberos ldap llvm +lz4 nls pam perl python +readline
 	  selinux +server systemd ssl static-libs tcl uuid xml zlib +zstd"

--- a/dev-db/postgresql/postgresql-16.11.ebuild
+++ b/dev-db/postgresql/postgresql-16.11.ebuild
@@ -1,26 +1,24 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 pam python-single-r1 systemd tmpfiles
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
-
-SLOT=$(ver_cut 1)
-
-MY_PV=${PV/_/}
-S="${WORKDIR}/${PN}-${MY_PV}"
-
-SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
-
-LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
+
+MY_PV=${PV/_/}
+SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
+S="${WORKDIR}/${PN}-${MY_PV}"
+LICENSE="POSTGRESQL GPL-2"
+SLOT=$(ver_cut 1)
+
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
 
 IUSE="debug doc +icu kerberos ldap llvm +lz4 nls pam perl python
 	  +readline selinux +server systemd ssl static-libs tcl uuid xml

--- a/dev-db/postgresql/postgresql-17.7.ebuild
+++ b/dev-db/postgresql/postgresql-17.7.ebuild
@@ -4,23 +4,21 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 pam python-single-r1 systemd tmpfiles
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
-
-SLOT=$(ver_cut 1)
-
-MY_PV=${PV/_/}
-S="${WORKDIR}/${PN}-${MY_PV}"
-
-SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
-
-LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
+
+MY_PV=${PV/_/}
+SRC_URI="https://ftp.postgresql.org/pub/source/v${MY_PV}/postgresql-${MY_PV}.tar.bz2"
+S="${WORKDIR}/${PN}-${MY_PV}"
+LICENSE="POSTGRESQL GPL-2"
+SLOT=$(ver_cut 1)
+
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos ~x64-solaris"
 
 IUSE="debug doc +icu kerberos ldap llvm +lz4 nls pam perl python
 	  +readline selinux +server systemd ssl static-libs tcl uuid xml

--- a/dev-db/postgresql/postgresql-17.7.ebuild
+++ b/dev-db/postgresql/postgresql-17.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -86,10 +86,9 @@ RDEPEND="${CDEPEND}
 selinux? ( sec-policy/selinux-postgresql )
 "
 
-# Openjade, docbook, XML, and XSLT are needed to generate manpages and
+# Docbook, XML, and XSLT are needed to generate manpages and
 # any documentation that may be elected.
 BDEPEND="
-app-text/openjade
 app-text/docbook-dsssl-stylesheets
 app-text/docbook-sgml-dtd:4.5
 app-text/docbook-xml-dtd:4.5

--- a/dev-db/postgresql/postgresql-18.1.ebuild
+++ b/dev-db/postgresql/postgresql-18.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -87,10 +87,9 @@ RDEPEND="${CDEPEND}
 selinux? ( sec-policy/selinux-postgresql )
 "
 
-# Openjade, docbook, XML, and XSLT are needed to generate manpages and
+# Docbook, XML, and XSLT are needed to generate manpages and
 # any documentation that may be elected.
 BDEPEND="
-app-text/openjade
 app-text/docbook-dsssl-stylesheets
 app-text/docbook-sgml-dtd:4.5
 app-text/docbook-xml-dtd:4.5

--- a/dev-db/postgresql/postgresql-18.1.ebuild
+++ b/dev-db/postgresql/postgresql-18.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 pam python-single-r1 systemd tmpfiles

--- a/dev-db/postgresql/postgresql-9999.ebuild
+++ b/dev-db/postgresql/postgresql-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -101,10 +101,9 @@ RDEPEND="${CDEPEND}
 selinux? ( sec-policy/selinux-postgresql )
 "
 
-# Openjade, docbook, XML, and XSLT are needed to generate manpages and
+# Docbook, XML, and XSLT are needed to generate manpages and
 # any documentation that may be elected.
 BDEPEND="
-app-text/openjade
 app-text/docbook-dsssl-stylesheets
 app-text/docbook-sgml-dtd:4.5
 app-text/docbook-xml-dtd:4.5

--- a/dev-db/postgresql/postgresql-9999.ebuild
+++ b/dev-db/postgresql/postgresql-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..14} )
-LLVM_COMPAT=( {15..21} )
+LLVM_COMPAT=( {16..21} )
 LLVM_OPTIONAL=1
 
 inherit dot-a flag-o-matic linux-info llvm-r1 meson pam python-single-r1 \


### PR DESCRIPTION
First commit drops openjade from bdep as stale since postgres-11
Second drops clang from rdeps as removed from the tree, and tidies ebuilds.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
