### PR TITLE
media-sound/abcmidi: add -std=gnu17

### DIFF
--- a/media-sound/abcmidi/abcmidi-2025.02.16.ebuild
+++ b/media-sound/abcmidi/abcmidi-2025.02.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -30,6 +30,7 @@ src_configure() {
 	# https://bugs.gentoo.org/876421
 	# https://github.com/sshlien/abcmidi/issues/9
 	filter-lto
+	append-cflags -std=gnu17
 
 	default
 }


### PR DESCRIPTION
Patch to make this valid C23 is too large, see also: https://github.com/sshlien/abcmidi/pull/15 for start of the port. Unfeasible to carry in-tree.

Closes: https://bugs.gentoo.org/968775
Closes: https://bugs.gentoo.org/943863

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
