### PR TITLE
app-office/abiword: fixed patch

### DIFF
--- a/app-office/abiword/files/abiword-3.0.6-metarecord.patch
+++ b/app-office/abiword/files/abiword-3.0.6-metarecord.patch
@@ -1,5 +1,6 @@
 https://gitlab.gnome.org/World/AbiWord/-/merge_requests/5
 https://bugs.gentoo.org/717336
+corrected for actual code
 From 6579f1e6472e1c12e4aa17a85b61b8c2a1fe9390 Mon Sep 17 00:00:00 2001
 From: Chris Mayo <aklhfex@gmail.com>
 Date: Fri, 6 Mar 2020 19:31:35 +0000
@@ -16,13 +17,13 @@ diff --git a/Makefile.am b/Makefile.am
 index 0f6ab5e1e..d9131a790 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -15,7 +15,7 @@ desktop_DATA = com.abisource.AbiWord.desktop
+@@ -26,7 +26,7 @@ desktop_DATA = com.abisource.AbiWord.desktop
  mimedir = @ABIWORD_DATADIR@/mime-info
  mime_DATA = abiword.keys
  
 -appdatadir = $(datarootdir)/appdata
 +appdatadir = $(datarootdir)/metainfo
- appdata_DATA = com.abisource.AbiWord.appdata.xml
+ appdata_DATA = abiword.appdata.xml
  
  pkgconfigdir = $(libdir)/pkgconfig
 -- 


### PR DESCRIPTION
Upstream one wasn't applying to releases

Bug: https://bugs.gentoo.org/717336

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
