### PR TITLE
net-misc/astmanproxy: Port to C23

### DIFF
--- a/net-misc/astmanproxy/astmanproxy-1.30.0-r1.ebuild
+++ b/net-misc/astmanproxy/astmanproxy-1.30.0-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Proxy for the Asterisk manager interface"
+HOMEPAGE="https://github.com/davies147/astmanproxy/"
+SRC_URI="https://github.com/davies147/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.30.0-gentoo.patch
+	"${FILESDIR}"/${PN}-1.28.2-fno-common.patch
+	"${FILESDIR}"/${PN}-1.30.0-C23.patch
+)
+
+src_prepare() {
+	default
+
+	# Fix multilib
+	sed -i -e "s#/usr/lib/#/usr/$(get_libdir)/#" Makefile \
+		|| die "multilib sed failed"
+}
+
+src_configure() {
+	tc-export CC
+}
+
+src_install() {
+	dosbin astmanproxy
+
+	dodoc -r samples
+	dodoc README.md VERSIONS
+
+	insinto /etc/asterisk
+	doins configs/astmanproxy.{conf,users}
+
+	newinitd "${FILESDIR}"/astmanproxy.rc6 astmanproxy
+}

--- a/net-misc/astmanproxy/files/astmanproxy-1.30.0-C23.patch
+++ b/net-misc/astmanproxy/files/astmanproxy-1.30.0-C23.patch
@@ -1,0 +1,22 @@
+Forward-declare structs and use them in function pointer declarations.
+Fixes build with C23.
+https://bugs.gentoo.org/967014
+--- a/src/include/astmanproxy.h
++++ b/src/include/astmanproxy.h
+@@ -107,10 +107,13 @@
+ 	char forcebanner[80];			/* override banner output in 'standard' protocol */
+ };
+ 
++struct mansession;
++struct message;
++
+ struct iohandler {
+-	int (*read) ();
+-	int (*write) ();
+-	int (*onconnect) ();
++	int (*read) (struct mansession *s, struct message *m);
++	int (*write) (struct mansession *s, struct message *m);
++	int (*onconnect) (struct mansession *s, struct message *m);
+ 	char formatname[80];
+ 	void *dlhandle;
+ 	struct iohandler *next;


### PR DESCRIPTION
Forward declarations of structs and filled function pointer arguments

Bug: https://bugs.gentoo.org/967014

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
