### PR TITLE
games-arcade/bumprace: Port to C23

### DIFF
--- a/games-arcade/bumprace/bumprace-1.5.8.ebuild
+++ b/games-arcade/bumprace/bumprace-1.5.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,8 @@ DEPEND="
 	virtual/zlib:=
 "
 RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-C23.patch" )
 
 src_install() {
 	default

--- a/games-arcade/bumprace/files/bumprace-1.5.8-C23.patch
+++ b/games-arcade/bumprace/files/bumprace-1.5.8-C23.patch
@@ -1,0 +1,13 @@
+StartText doesn't take an argument
+https://bugs.gentoo.org/966631
+--- a/src/bumprace.c	2026-02-13 16:02:19.108518662 +0300
++++ b/src/bumprace.c	2026-02-13 16:05:19.152697531 +0300
+@@ -1178,7 +1178,7 @@
+   sprintf(text,"%s/font.scl",DATAPATH);
+   Font=LoadImage("font.png",3);
+   InitFont(Font);
+-  if (final) StartText(i);
++  if (final) StartText();
+ //load data
+   printf("** Loading Data **\n");
+ #ifdef SOUND


### PR DESCRIPTION
Function that takes no arguments was given an argument

Closes: https://bugs.gentoo.org/966631

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
