### PR TITLE
dev-libs/libverto: revbump to remove USE=threads

### DIFF
--- a/dev-libs/libverto/libverto-0.3.2-r1.ebuild
+++ b/dev-libs/libverto/libverto-0.3.2-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="Main event loop abstraction library"
+HOMEPAGE="https://github.com/latchset/libverto/"
+SRC_URI="https://github.com/latchset/libverto/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="glib +libev libevent"
+REQUIRED_USE="|| ( glib libev libevent )"
+
+DEPEND="glib? ( >=dev-libs/glib-2.34.3[${MULTILIB_USEDEP}] )
+	libev? ( >=dev-libs/libev-4.15[${MULTILIB_USEDEP}] )
+	libevent? ( >=dev-libs/libevent-2.0.21[${MULTILIB_USEDEP}] )"
+
+RDEPEND="${DEPEND}"
+
+DOCS=( AUTHORS ChangeLog NEWS INSTALL README )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-non-bash.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" \
+	econf \
+		$(use_with glib) \
+		$(use_with libev) \
+		$(use_with libevent) \
+		--with-pthread \
+		--disable-static
+}
+
+multilib_src_install_all() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Upstream enables threads by default, so as described in bug #868336
enable (p)thread support unconditionally and remove "threads" from IUSE.

Closes: https://bugs.gentoo.org/869728
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
