### PR TITLE
games-action/bomberclone: update EAPI 7 -> 8, port to C23

### DIFF
--- a/games-action/bomberclone/bomberclone-0.11.9-r1.ebuild
+++ b/games-action/bomberclone/bomberclone-0.11.9-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools desktop xdg-utils
+
+DESCRIPTION="Bomberman clone with network game support"
+HOMEPAGE="https://www.bomberclone.de/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc64 ~x86"
+
+DEPEND=">=media-libs/libsdl-1.1.0[video]
+	media-libs/sdl-image[png]
+	media-libs/sdl-mixer[mod]"
+
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/"${PN}"-0.11.8-gcc52.patch
+	"${FILESDIR}"/"${PN}"-0.11.9-C23.patch
+)
+
+src_prepare() {
+	default
+
+	mv -v configure.{in,ac} || die
+	sed -i 's/configure\.in/configure.ac/g' configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	LIBS="-lm" \
+	econf \
+		--disable-werror \
+		--without-x
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		bomberclonedocdir=\${prefix}/share/doc/${PF} \
+		install
+
+	doicon -s 64 data/pixmaps/${PN}.png
+	make_desktop_entry ${PN} Bomberclone
+
+	# Delete useless documentation.
+	rm -v "${ED}"/usr/share/doc/${PF}/{COPYING,INSTALL,*.nsi} || die
+}
+
+pkg_postinst() { xdg_icon_cache_update; }
+pkg_postrm() { xdg_icon_cache_update; }

--- a/games-action/bomberclone/files/bomberclone-0.11.9-C23.patch
+++ b/games-action/bomberclone/files/bomberclone-0.11.9-C23.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/966498
+Fixes compilation with C23 compilers
+--- a/include/bomberclone.h
++++ b/include/bomberclone.h
+@@ -123,8 +123,8 @@
+ extern void game_start();
+ extern void game_showresult ();
+ extern int game_check_endgame ();
+-extern void game_showresultnormal ();
+-extern void game_showresultteam ();
++extern void game_showresultnormal (int pos_x, int pos_y, int pos_w, int pos_h);
++extern void game_showresultteam (int pos_x, int pos_y, int pos_w, int pos_h);
+ extern void game_menu_create ();
+ extern void game_menu_loop (SDL_Event *event, int eventstate);
+ extern void game_resetdata ();


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/966498

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
