### PR TITLE
games-arcade/penguin-command: port to C23

### DIFF
--- a/games-arcade/penguin-command/files/penguin-command-1.6.11-C23.patch
+++ b/games-arcade/penguin-command/files/penguin-command-1.6.11-C23.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/966225
+Porting to C23, lock and unlock are implicitly work on global Screen
+Used include with function declaration instead of re-declaring it for
+missing function.
+--- a/src/gfx.c
++++ b/src/gfx.c
+@@ -260,11 +260,11 @@
+ 
+ void LinePart(Sint32 X1, Sint32 Y1, Sint32 X2, Sint32 Y2, Sint32 lower, Sint32 upper, Uint32 Color)
+ {
+-   lock(Screen);
++   lock();
+ 
+    /* Draw the line */
+    DoLinePart(Screen, X1, Y1, X2, Y2, lower, upper, Color, &PutPixel);
+-   unlock(Screen);
++   unlock();
+ }
+ 
+ void Update()
+--- a/src/joystick.c
++++ b/src/joystick.c
+@@ -1,5 +1,6 @@
+ #include <SDL.h>
+ #include "joystick.h"
++#include "gfx.h" //for ComplainAndExit()
+ 
+ static SDL_Joystick *joy=NULL;
+ 

--- a/games-arcade/penguin-command/penguin-command-1.6.11-r1.ebuild
+++ b/games-arcade/penguin-command/penguin-command-1.6.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,6 +17,8 @@ DEPEND="media-libs/libsdl[sound,joystick,video]
 	media-libs/sdl-mixer[mod]
 	media-libs/sdl-image[jpeg,png]"
 RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-C23.patch" )
 
 src_install() {
 	default


### PR DESCRIPTION
Missing function declaration, wrong function usage.

Closes: https://bugs.gentoo.org/966225

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
