### PR TITLE
sys-apps/fwupd-efi: add notice for non-shim secure boot

### DIFF
--- a/sys-apps/fwupd-efi/fwupd-efi-1.8.ebuild
+++ b/sys-apps/fwupd-efi/fwupd-efi-1.8.ebuild
@@ -63,3 +63,14 @@ src_install() {
 	meson_src_install
 	secureboot_auto_sign
 }
+
+pkg_postinst() {
+	if use secureboot; then
+		elog "By default fwupd uses shim to secureboot updater images."
+		elog "If you're using your own keys, configure fwupd to ignore shim by adding"
+		elog "  [uefi_capsule]"
+		elog "  DisableShimForSecureBoot=true"
+		elog "to /etc/fwupd/fwupd.conf."
+		elog "Otherwise fwupd will fail trying to find the shim binary."
+	fi
+}


### PR DESCRIPTION
Based on https://wiki.archlinux.org/title/Fwupd#Assisted_process_with_sbctl.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
