### PR TITLE
media-libs/libavif: enable extras by default

### DIFF
--- a/media-libs/libavif/libavif-1.3.0.ebuild
+++ b/media-libs/libavif/libavif-1.3.0.ebuild
@@ -24,7 +24,7 @@ LICENSE="
 # See bug #822336 re subslot
 SLOT="0/16.3"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ~ppc ppc64 ~riscv ~sparc x86"
-IUSE="+aom dav1d examples extras gdk-pixbuf rav1e svt-av1 libyuv test"
+IUSE="+aom dav1d examples +extras gdk-pixbuf rav1e svt-av1 libyuv test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="|| ( aom dav1d )"
 

--- a/media-libs/libavif/libavif-1.4.1.ebuild
+++ b/media-libs/libavif/libavif-1.4.1.ebuild
@@ -25,7 +25,7 @@ LICENSE="
 # See LIBRARY_VERSION_MAJOR, LIBRARY_VERSION_MINOR in CMakeLists.txt
 SLOT="0/16.4"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
-IUSE="+aom dav1d examples extras gdk-pixbuf rav1e svt-av1 libyuv test"
+IUSE="+aom dav1d examples +extras gdk-pixbuf rav1e svt-av1 libyuv test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="|| ( aom dav1d )"
 

--- a/media-libs/libavif/libavif-9999.ebuild
+++ b/media-libs/libavif/libavif-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,10 +9,13 @@ DESCRIPTION="Library for encoding and decoding .avif files"
 HOMEPAGE="https://github.com/AOMediaCodec/libavif"
 EGIT_REPO_URI="https://github.com/AOMediaCodec/libavif.git"
 
-LICENSE="BSD-2"
+# libargparse is needed for avifenc/avifdec (extras USE flag)
+EGIT_SUBMODULES=( ext/libargparse )
+
+LICENSE="BSD-2 MIT"
 # See bug #822336 re subslot
 SLOT="0/${PV}"
-IUSE="+aom dav1d examples extras gdk-pixbuf rav1e svt-av1 libyuv test"
+IUSE="+aom dav1d examples +extras gdk-pixbuf rav1e svt-av1 libyuv test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="|| ( aom dav1d )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/971500

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
