### PR TITLE
dev-util/difftastic: unbundle jemalloc

### DIFF
--- a/dev-util/difftastic/difftastic-0.68.0-r1.ebuild
+++ b/dev-util/difftastic/difftastic-0.68.0-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 2024-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CRATES="
+"
+RUST_MIN_VER="1.85.0"
+
+inherit cargo
+
+DESCRIPTION="A structural diff that understands syntax."
+HOMEPAGE="http://difftastic.wilfred.me.uk/"
+SRC_URI="
+	https://github.com/Wilfred/${PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.gh.tar.gz
+	https://github.com/gentoo-crate-dist/${PN}/releases/download/${PV}/${P}-crates.tar.xz
+"
+
+LICENSE="MIT"
+# Dependent crate licenses
+LICENSE+=" Apache-2.0 BSD MIT Unicode-DFS-2016"
+# tree-sitter-newick
+LICENSE+=" CeCILL-C"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+
+DEPEND="dev-libs/jemalloc"
+RDEPEND="${DEPEND}"
+
+QA_FLAGS_IGNORED="usr/bin/difft"
+
+DOCS=( CHANGELOG.md README.md manual/ )
+
+pkg_setup() {
+	rust_pkg_setup
+
+	export JEMALLOC_OVERRIDE="${EPREFIX}/usr/$(get_libdir)/libjemalloc.so"
+}
+
+src_prepare() {
+	rm manual/.gitignore || die
+
+	sed -e '/^lto = /d' -i Cargo.toml || die
+
+	# Enable feature required to use system jemalloc.
+	sed \
+		-e 's/^tikv-jemallocator = "\(.*\)"/tikv-jemallocator = { version = "\1", features = ["unprefixed_malloc_on_supported_platforms"] }/' \
+		-i Cargo.toml || die
+
+	default
+}
+
+src_install() {
+	cargo_src_install
+	einstalldocs
+}


### PR DESCRIPTION
Recent versions have switched to jemalloc which makes the workaround for mimalloc unnecessary.

Closes: https://bugs.gentoo.org/971757

If the workaround with `sed`-ing the new feature seems awkward I'm fine with dropping it and using the bundled jemalloc. I'm on the fence with this one.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
