### PR TITLE
app-misc/tmux: ver 9999: remove a patch

### DIFF
--- a/app-misc/tmux/tmux-9999.ebuild
+++ b/app-misc/tmux/tmux-9999.ebuild
@@ -51,10 +51,6 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 
 DOCS=( CHANGES README )
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-2.4-flags.patch
-)
-
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Without the provided change for `::gentoo` :
<details>

<summary>A part of build log</summary>

```
>>> Preparing source in /var/tmp/portage/app-misc/tmux-9999/work/tmux-9999 ...
 * Applying tmux-2.4-flags.patch ...
patching file Makefile.am
Hunk #1 FAILED at 17.
1 out of 1 hunk FAILED -- saving rejects to file Makefile.am.rej                                                                                                                                                                         [ !! ]
 * ERROR: app-misc/tmux-9999::gentoo failed (prepare phase):
 *   patch '-p1' '-f' '-g0' '--no-backup-if-mismatch' failed with '/var/tmp/portage/app-misc/tmux-9999/files/tmux-2.4-flags.patch'
```

</details>

With the change it is ok.

Why does the removal of usage of the patch there seem OK?

<details>

<summary>The patch in question</summary>

```
 Makefile.am |    3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
--- tmux-2.4/Makefile.am
+++ tmux-2.4/Makefile.am
@@ -17,9 +17,8 @@
 
 # Set flags for gcc.
 if IS_GCC
-AM_CFLAGS += -std=gnu99 -O2
+AM_CFLAGS += -std=gnu99
 if IS_DEBUG
-AM_CFLAGS += -g
 AM_CFLAGS += -Wno-long-long -Wall -W -Wformat=2
 AM_CFLAGS += -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations
 AM_CFLAGS += -Wwrite-strings -Wshadow -Wpointer-arith -Wsign-compare

```

</details>

<details>

<summary>Current <a href="https://github.com/tmux/tmux/blob/a30fc69f868fa0adf85b0957fe3f67357fe73d73/Makefile.am#L23">situation at upstream</a> </summary>

```
# Set flags for gcc.
if IS_GCC
AM_CFLAGS += -std=gnu99
if IS_OPTIMIZED
AM_CFLAGS += -O2
else
AM_CFLAGS += -O0
endif
``` 

</details>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
