### PR TITLE
gui-wm/sway: update dependencies for 9999 build

### DIFF
--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -64,15 +64,13 @@ RDEPEND="
 	x11-misc/xkeyboard-config
 "
 BDEPEND="
-	>=dev-libs/wayland-protocols-1.24
+	>=dev-libs/wayland-protocols-1.41
 	>=dev-build/meson-1.3
 	virtual/pkgconfig
+	man? ( >=app-text/scdoc-1.9.2 )
 "
-if [[ ${PV} == 9999 ]]; then
-	BDEPEND+="man? ( ~app-text/scdoc-9999 )"
-else
-	BDEPEND+="man? ( >=app-text/scdoc-1.11.3 )
-		verify-sig? ( sec-keys/openpgp-keys-emersion )"
+if [[ ${PV} != 9999 ]]; then
+	BDEPEND+="verify-sig? ( sec-keys/openpgp-keys-emersion )"
 	VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/emersion.asc"
 fi
 

--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -22,7 +22,7 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+man +swaybar +swaynag tray wallpapers X"
+IUSE="+swaybar +swaynag tray wallpapers X"
 REQUIRED_USE="tray? ( swaybar )"
 
 DEPEND="
@@ -67,7 +67,7 @@ BDEPEND="
 	>=dev-libs/wayland-protocols-1.41
 	>=dev-build/meson-1.3
 	virtual/pkgconfig
-	man? ( >=app-text/scdoc-1.9.2 )
+	>=app-text/scdoc-1.9.2
 "
 if [[ ${PV} != 9999 ]]; then
 	BDEPEND+="verify-sig? ( sec-keys/openpgp-keys-emersion )"
@@ -80,7 +80,7 @@ FILECAPS=(
 
 src_configure() {
 	local emesonargs=(
-		$(meson_feature man man-pages)
+		-Dman-pages=enabled
 		$(meson_feature tray)
 		$(meson_feature swaybar gdk-pixbuf)
 		$(meson_use swaynag)


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Basically update wayland-protocols required to version 1.41, and remove requirement for scdoc-9999 which according to sway meson.build is not necessary (and I don't find any bug reports about generating doc with that version).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
