### PR TITLE
sci-astronomy/siril: fix compilation on Musl

### DIFF
--- a/sci-astronomy/siril/files/siril-1.4.0-cdefs.patch
+++ b/sci-astronomy/siril/files/siril-1.4.0-cdefs.patch
@@ -1,0 +1,20 @@
+From 0f713a18c1db6dbd1bcd3234861bdb1a66f79809 Mon Sep 17 00:00:00 2001
+From: Adrian Knagg-Baugh <aje.baugh@gmail.com>
+Date: Fri, 13 Mar 2026 19:58:47 +0000
+Subject: [PATCH] Remove unused header that was problematic on Musl systems
+ (fixes #1930)
+
+--- a/src/io/siril_pythonmodule.h
++++ b/src/io/siril_pythonmodule.h
+@@ -1,8 +1,6 @@
+ #ifndef SRC_IO_SIRIL_PYTHONMODULE_H
+ #define SRC_IO_SIRIL_PYTHONMODULE_H
+ 
+-// Status codes for command responses
+-#include <sys/cdefs.h>
+ // siril_plot_data
+ #include "io/siril_plot.h"
+ 
+-- 
+GitLab
+

--- a/sci-astronomy/siril/siril-1.4.0-r1.ebuild
+++ b/sci-astronomy/siril/siril-1.4.0-r1.ebuild
@@ -70,6 +70,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.4.0-libgit2.patch"
 	"${FILESDIR}/${PN}-1.4.0-libjpeg.patch"
 	"${FILESDIR}/${PN}-1.4.0-libcurl.patch"
+	"${FILESDIR}/${PN}-1.4.0-cdefs.patch"
 )
 
 DOCS=( README.md ChangeLog AUTHORS )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/970934

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
