### PR TITLE
dev-ruby/hiera-eyaml-gpg: Mark compatible with Ruby 3.3

### DIFF
--- a/dev-ruby/gpgme/gpgme-2.0.24-r4.ebuild
+++ b/dev-ruby/gpgme/gpgme-2.0.24-r4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-USE_RUBY="ruby32"
+USE_RUBY="ruby32 ruby33"
 
 RUBY_FAKEGEM_EXTRADOC="NEWS README.rdoc"
 

--- a/dev-ruby/hiera-eyaml-gpg/hiera-eyaml-gpg-0.7.4-r2.ebuild
+++ b/dev-ruby/hiera-eyaml-gpg/hiera-eyaml-gpg-0.7.4-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-USE_RUBY="ruby31 ruby32"
+USE_RUBY="ruby31 ruby32 ruby33"
 
 RUBY_FAKEGEM_TASK_TEST=""
 

--- a/dev-ruby/minitest/minitest-5.15.0-r2.ebuild
+++ b/dev-ruby/minitest/minitest-5.15.0-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-USE_RUBY="ruby27 ruby30 ruby31 ruby32"
+USE_RUBY="ruby27 ruby30 ruby31 ruby32 ruby33"
 
 RUBY_FAKEGEM_DOCDIR="doc"
 RUBY_FAKEGEM_EXTRADOC="History.rdoc README.rdoc"
@@ -10,7 +10,7 @@ RUBY_FAKEGEM_EXTRADOC="History.rdoc README.rdoc"
 inherit ruby-fakegem
 
 DESCRIPTION="minitest/unit is a small and fast replacement for ruby's huge and slow test/unit"
-HOMEPAGE="https://github.com/seattlerb/minitest"
+HOMEPAGE="https://github.com/minitest/minitest"
 
 LICENSE="MIT"
 SLOT="5.15"
@@ -18,6 +18,14 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 ~spar
 IUSE="doc test"
 
 RDEPEND="!~dev-ruby/minitest-5.15.0:5"
+
+each_ruby_prepare() {
+	case ${RUBY} in
+		*ruby33)
+			sed --in-place --expression='s/nil:NilClass/nil/g' test/minitest/test_minitest_mock.rb || die
+			;;
+	esac
+}
 
 each_ruby_test() {
 	MT_NO_PLUGINS=true ${RUBY} -Ilib:test:. -e "Dir['**/test_*.rb'].each{|f| require f}" || die "Tests failed"


### PR DESCRIPTION
Hiera eYaml GPG works find with recent versions of Ruby.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
