### PR TITLE
sys-power/power-profiles-daemon: Fix OpenRC initd file

### DIFF
--- a/sys-power/power-profiles-daemon/files/power-profiles-daemon.initd-r1
+++ b/sys-power/power-profiles-daemon/files/power-profiles-daemon.initd-r1
@@ -1,0 +1,18 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="power-profiles-daemon"
+description="Makes power profiles handling available over D-Bus"
+
+pidfile="/run/power-profiles-daemon.pid"
+command="/usr/libexec/power-profiles-daemon"
+command_background=true
+
+depend() {
+	after display-manager
+}
+
+start_pre() {
+	checkpath -d /var/lib/power-profiles-daemon
+}

--- a/sys-power/power-profiles-daemon/files/power-profiles-daemon.initd-r1
+++ b/sys-power/power-profiles-daemon/files/power-profiles-daemon.initd-r1
@@ -1,0 +1,18 @@
+#!/sbin/openrc-run
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="power-profiles-daemon"
+description="Makes power profiles handling available over D-Bus"
+
+pidfile="/run/power-profiles-daemon.pid"
+command="/usr/libexec/power-profiles-daemon"
+command_background=true
+
+depend() {
+	after display-manager
+}
+
+start_pre() {
+	checkpath -d /var/lib/power-profiles-daemon
+}

--- a/sys-power/power-profiles-daemon/metadata.xml
+++ b/sys-power/power-profiles-daemon/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Pacho Ramos</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="freedesktop-gitlab">hadess/power-profiles-daemon</remote-id>
+		<remote-id type="freedesktop-gitlab">upower/power-profiles-daemon</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-power/power-profiles-daemon/power-profiles-daemon-0.30-r1.ebuild
+++ b/sys-power/power-profiles-daemon/power-profiles-daemon-0.30-r1.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit meson python-single-r1 shell-completion systemd
+
+DESCRIPTION="Makes power profiles handling available over D-Bus"
+HOMEPAGE="https://gitlab.freedesktop.org/upower/power-profiles-daemon/"
+SRC_URI="https://gitlab.freedesktop.org/upower/${PN}/-/archive/${PV}/${P}.tar.bz2"
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+
+IUSE="bash-completion gtk-doc man selinux test zsh-completion"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="${PYTHON_DEPS}
+	$(python_gen_cond_dep 'dev-python/pygobject:3[${PYTHON_USEDEP}]')
+	dev-libs/glib:2
+	>=dev-libs/libgudev-234
+	>=sys-auth/polkit-0.99
+	sys-power/upower
+	selinux? ( sec-policy/selinux-powerprofiles )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	bash-completion? (
+		>=app-shells/bash-completion-2.0
+		$(python_gen_cond_dep '>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]')
+	)
+	gtk-doc? (
+		dev-util/gi-docgen
+		dev-util/gtk-doc
+	)
+	man? (
+		$(python_gen_cond_dep 'dev-python/argparse-manpage[${PYTHON_USEDEP}]')
+	)
+	test? (
+		dev-util/umockdev
+		$(python_gen_cond_dep '
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+			dev-python/python-dbusmock[${PYTHON_USEDEP}]
+		')
+	)
+	zsh-completion? (
+		$(python_gen_cond_dep '>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]')
+	)
+"
+
+python_check_deps() {
+	if use test; then
+		python_has_version "dev-python/python-dbusmock[${PYTHON_USEDEP}]" &&
+		python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]"
+	else
+		python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]"
+	fi
+
+	if use bash-completion || use zsh-completion; then
+		python_has_version ">=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]"
+	fi
+
+	use man && python_has_version "dev-python/argparse-manpage[${PYTHON_USEDEP}]"
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dpylint=disabled
+		-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
+		$(meson_feature bash-completion bashcomp)
+		$(meson_use gtk-doc gtk_doc)
+		$(meson_feature man manpage)
+		$(meson_use test tests)
+	)
+	use zsh-completion && emesonargs+=( -Dzshcomp="$(get_zshcompdir)" )
+	meson_src_configure
+}
+
+src_test() {
+	# Dbus tests are prone to fail when run in parallel
+	MAKEOPTS="-j1" meson_src_test
+}
+
+src_install() {
+	meson_src_install
+	python_fix_shebang "${D}"/usr/bin/powerprofilesctl
+	newinitd "${FILESDIR}/power-profiles-daemon.initd-r1" power-profiles-daemon
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		elog "You need to enable the service:"
+		if systemd_is_booted; then
+			elog "# systemctl enable ${PN}"
+		else
+			elog "# rc-update add ${PN} default"
+		fi
+	fi
+}

--- a/sys-power/power-profiles-daemon/power-profiles-daemon-0.30-r1.ebuild
+++ b/sys-power/power-profiles-daemon/power-profiles-daemon-0.30-r1.ebuild
@@ -1,0 +1,107 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit meson python-single-r1 shell-completion systemd
+
+DESCRIPTION="Makes power profiles handling available over D-Bus"
+HOMEPAGE="https://gitlab.freedesktop.org/upower/power-profiles-daemon/"
+SRC_URI="https://gitlab.freedesktop.org/upower/${PN}/-/archive/${PV}/${P}.tar.bz2"
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+
+IUSE="bash-completion gtk-doc man selinux test zsh-completion"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="${PYTHON_DEPS}
+	$(python_gen_cond_dep 'dev-python/pygobject:3[${PYTHON_USEDEP}]')
+	dev-libs/glib:2
+	>=dev-libs/libgudev-234
+	>=sys-auth/polkit-0.99
+	sys-power/upower
+	selinux? ( sec-policy/selinux-powerprofiles )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	bash-completion? (
+		>=app-shells/bash-completion-2.0
+		$(python_gen_cond_dep '>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]')
+	)
+	gtk-doc? (
+		dev-util/gi-docgen
+		dev-util/gtk-doc
+	)
+	man? (
+		$(python_gen_cond_dep 'dev-python/argparse-manpage[${PYTHON_USEDEP}]')
+	)
+	test? (
+		dev-util/umockdev
+		$(python_gen_cond_dep '
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+			dev-python/python-dbusmock[${PYTHON_USEDEP}]
+		')
+	)
+	zsh-completion? (
+		$(python_gen_cond_dep '>=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]')
+	)
+"
+
+python_check_deps() {
+	if use test; then
+		python_has_version \
+			"dev-python/python-dbusmock[${PYTHON_USEDEP}]" \
+			"dev-python/pygobject:3[${PYTHON_USEDEP}]" \
+        || return 1
+	else
+		python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return 1
+	fi
+
+	if use bash-completion || use zsh-completion; then
+		python_has_version ">=dev-python/shtab-1.7.0[${PYTHON_USEDEP}]" || return 1
+	fi
+
+	if use man; then
+		python_has_version "dev-python/argparse-manpage[${PYTHON_USEDEP}]" || return 1
+	fi
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dpylint=disabled
+		-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
+		$(meson_feature bash-completion bashcomp)
+		$(meson_use gtk-doc gtk_doc)
+		$(meson_feature man manpage)
+		$(meson_use test tests)
+	)
+	use zsh-completion && emesonargs+=( -Dzshcomp="$(get_zshcompdir)" )
+	meson_src_configure
+}
+
+src_test() {
+	# Dbus tests are prone to fail when run in parallel
+	MAKEOPTS="-j1" meson_src_test
+}
+
+src_install() {
+	meson_src_install
+	python_fix_shebang "${D}"/usr/bin/powerprofilesctl
+	newinitd "${FILESDIR}/power-profiles-daemon.initd-r1" power-profiles-daemon
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		elog "You need to enable the service:"
+		if systemd_is_booted; then
+			elog "# systemctl enable ${PN}"
+		else
+			elog "# rc-update add ${PN} default"
+		fi
+	fi
+}


### PR DESCRIPTION
I noticed that power-profiles-daemon would crash for me every boot when added to the OpenRC default run level.
(I followed the guide here: https://wiki.gentoo.org/wiki/Power_management/Guide#Using_power-profiles-daemon)

I looked at the systemd sericve file and noticed that it specifies that it should be started after the display-manager.
I added the same requirement to the openrc file, and now it is not crashing anymore for me.

I also updated the metadata.xml file with the new upstream url as requested by `pkgcheck scan --commits --net`.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
