### PR TITLE
xfce-base/libxfce4windowing: Change ebuild to use meson build system and add vala support through the vala useflag

### DIFF
--- a/xfce-base/libxfce4windowing/libxfce4windowing-4.20.5-r1.ebuild
+++ b/xfce-base/libxfce4windowing/libxfce4windowing-4.20.5-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit meson vala
+
+DESCRIPTION="Unified widget and session management libs for Xfce"
+HOMEPAGE="https://gitlab.xfce.org/xfce/libxfce4windowing/"
+SRC_URI="https://archive.xfce.org/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="LGPL-2.1+"
+SLOT="0/4.19.6"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="+introspection wayland X vala"
+REQUIRED_USE="
+	|| ( wayland X )
+	vala? ( introspection )
+"
+
+RDEPEND="
+	>=dev-libs/glib-2.72.0
+	>=x11-libs/gtk+-3.24.10:3[X?,introspection?,wayland?]
+	>=x11-libs/gdk-pixbuf-2.42.8[introspection?]
+	wayland? (
+		>=dev-libs/wayland-1.20
+	)
+	X? (
+		>=media-libs/libdisplay-info-0.1.1:=
+		>=x11-libs/libX11-1.6.7
+		>=x11-libs/libXrandr-1.5.0
+		>=x11-libs/libwnck-3.14:3
+	)
+"
+DEPEND="
+	${RDEPEND}
+	wayland? (
+		>=dev-libs/wayland-protocols-1.39
+	)
+"
+BDEPEND="
+	>=dev-build/xfce4-dev-tools-4.19.2
+	dev-lang/perl
+	dev-util/glib-utils
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+	wayland? (
+		>=dev-util/wayland-scanner-1.15
+	)
+"
+
+src_prepare() {
+	default
+	use vala && vala_setup
+}
+
+src_configure() {
+	local emesonargs=(
+		$(meson_use introspection)
+		$(meson_feature vala)
+		$(meson_feature wayland)
+		$(meson_feature X x11)
+		-Dtests=false
+	)
+
+	meson_src_configure
+}


### PR DESCRIPTION
add vala support through the vala useflag

Closes: https://bugs.gentoo.org/972562

The current ebuild does not support meson as it should. This also prevents the vala useflag from being added which is missing. To support vala I changed the ebuild to use meson as intended by the source and added the vala useflag and vala support.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
