### PR TITLE
gnome-extra/cinnamon-settings-daemon: Don't install libcsd.a

### DIFF
--- a/gnome-extra/cinnamon-settings-daemon/cinnamon-settings-daemon-6.6.3-r1.ebuild
+++ b/gnome-extra/cinnamon-settings-daemon/cinnamon-settings-daemon-6.6.3-r1.ebuild
@@ -1,0 +1,119 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit meson flag-o-matic gnome2-utils python-any-r1 xdg
+
+DESCRIPTION="Cinnamon's settings daemon"
+HOMEPAGE="https://projects.linuxmint.com/cinnamon/ https://github.com/linuxmint/cinnamon-settings-daemon"
+SRC_URI="https://github.com/linuxmint/cinnamon-settings-daemon/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+ LGPL-2+ LGPL-2.1 LGPL-2.1+ MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="+colord cups input_devices_wacom smartcard systemd wayland"
+
+RDEPEND="
+	>=dev-libs/glib-2.40.0:2[dbus]
+	dev-libs/libgudev
+	>=gnome-extra/cinnamon-desktop-6.6:0=
+	media-libs/fontconfig
+	>=media-libs/lcms-2.2:2
+	|| (
+		media-libs/libcanberra-gtk3
+		media-libs/libcanberra[gtk3(-),pulseaudio]
+	)
+	>=sys-auth/polkit-0.97
+	sys-libs/timezone-data:=
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	>=x11-libs/libnotify-0.7.3
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXi
+	>=sys-power/upower-0.99.11:=
+	x11-themes/xapp-symbolic-icon-theme
+
+	colord? ( >=x11-misc/colord-0.1.27:= )
+	cups? (
+		>=net-print/cups-1.4[dbus]
+		app-admin/system-config-printer
+		net-print/cups-pk-helper )
+	input_devices_wacom? (
+		>=x11-libs/gtk+-3.24.41-r1:3[wayland?,X]
+		>=dev-libs/libwacom-0.7:=
+		>=gnome-base/librsvg-2.36.2
+		>=x11-libs/pango-1.20.0
+	)
+	!input_devices_wacom? (
+		>=x11-libs/gtk+-3.14.0:3[X]
+	)
+	smartcard? (
+		dev-libs/nspr
+		>=dev-libs/nss-3.11.2
+	)
+	systemd? (
+		sys-apps/systemd:0=
+	)
+	!systemd? (
+		sys-auth/elogind
+	)
+"
+DEPEND="
+	${RDEPEND}
+	dev-libs/libxml2:2
+	x11-base/xorg-proto
+"
+BDEPEND="
+	${PYTHON_DEPS}
+	dev-util/glib-utils
+	>=dev-util/gdbus-codegen-2.80.5-r1
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	# Don't install static csd library
+	# https://github.com/linuxmint/cinnamon-settings-daemon/pull/450
+	"${FILESDIR}/${PN}-6.6.0-no-static-install.patch"
+)
+
+src_prepare() {
+	default
+	python_fix_shebang install-scripts plugins/color
+	rm plugins/color/tz-coords.h || die "Error removing stale tz-coords.h"
+}
+
+src_configure() {
+	# The only component that uses gdk backends is the wacom plugin
+	if use input_devices_wacom; then
+		# defang automagic dependencies
+		use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+	fi
+
+	# gudev not optional on Linux platforms
+	local emesonargs=(
+		-Duse_gudev=enabled
+		-Duse_polkit=enabled
+		-Duse_logind=enabled
+		-Dgenerate_tz_coords=true
+		-Dzone_tab="${EPREFIX}/usr/share/zoneinfo/zone1970.tab"
+		$(meson_feature colord use_color)
+		$(meson_feature cups use_cups)
+		$(meson_feature smartcard use_smartcard)
+		$(meson_feature input_devices_wacom use_wacom)
+	)
+	meson_src_configure
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}

--- a/gnome-extra/cinnamon-settings-daemon/files/cinnamon-settings-daemon-6.6.0-no-static-install.patch
+++ b/gnome-extra/cinnamon-settings-daemon/files/cinnamon-settings-daemon-6.6.0-no-static-install.patch
@@ -1,0 +1,22 @@
+From 029be9afe9468ed89290ea164a5d15e0615e1091 Mon Sep 17 00:00:00 2001
+From: Sparky Bluefang <sparky@bluefang-logic.com>
+Date: Wed, 15 Apr 2026 03:10:58 -0400
+Subject: [PATCH] Don't install the static csd library.
+
+---
+ cinnamon-settings-daemon/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/cinnamon-settings-daemon/meson.build b/cinnamon-settings-daemon/meson.build
+index 7b623455..2f10d401 100644
+--- a/cinnamon-settings-daemon/meson.build
++++ b/cinnamon-settings-daemon/meson.build
+@@ -20,8 +20,6 @@ csd_lib = static_library(
+     csd_sources,
+     include_directories: include_dirs,
+     dependencies: csd_deps,
+-    install: true,
+-    install_dir: apilibdir,
+ )
+ 
+ csd_dep = declare_dependency(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/971779

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.