### PR TITLE
sys-kernel/installkernel: Add wiki link

### DIFF
--- a/sys-kernel/installkernel/files/installkernel-65-add-wiki-url.patch
+++ b/sys-kernel/installkernel/files/installkernel-65-add-wiki-url.patch
@@ -1,0 +1,46 @@
+From d4b9cd330cb362c4c82fe956968e159a5bb039c8 Mon Sep 17 00:00:00 2001
+From: Ian Jordan <immoloism@gmail.com>
+Date: Sun, 12 Apr 2026 02:42:29 +0100
+Subject: [PATCH] Add wiki link
+
+Users get confused on what do next.
+
+This simple addition links to a wiki article section
+so we can easily keep this up to date with all the
+all options a user can use.
+
+Signed-off-by: Ian Jordan <immoloism@gmail.com>
+--- a/hooks/05-check-chroot.install
++++ b/hooks/05-check-chroot.install
+@@ -76,6 +76,9 @@ if [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]; then
+ 			echo "/etc/cmdline.d/. Or set the kernel_cmdline in a dracut"
+ 			echo "configuration file."
+ 			echo ""
++			echo "For more infomation see:"
++			echo "https://wiki.gentoo.org/wiki/Installkernel#Install_chroot_check"
++			echo ""
+ 			echo "Override this check with:"
+ 			echo "    touch /etc/kernel/preinst.d/05-check-chroot.install"
+ 			echo ""
+@@ -92,6 +95,9 @@ if [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]; then
+ 			echo ""
+ 			echo "Please specify a command line to use in /etc/kernel/cmdline."
+ 			echo ""
++			echo "For more infomation see:"
++ 			echo "https://wiki.gentoo.org/wiki/Installkernel#Install_chroot_check"
++ 			echo ""
+ 			echo "Override this check with:"
+ 			echo "    touch /etc/kernel/preinst.d/05-check-chroot.install"
+ 			echo ""
+@@ -108,6 +114,9 @@ if [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]; then
+ 			echo "Please specify a command line to use in /etc/kernel/cmdline"
+ 			echo "or set the Cmdline= option in /etc/kernel/uki.conf."
+ 			echo ""
++			echo "For more infomation see:"
++ 			echo "https://wiki.gentoo.org/wiki/Installkernel#Install_chroot_check"
++			echo ""
+ 			echo "Override this check with:"
+ 			echo "    touch /etc/kernel/preinst.d/05-check-chroot.install"
+ 			echo ""
+-- 
+2.53.0

--- a/sys-kernel/installkernel/installkernel-65-r1.ebuild
+++ b/sys-kernel/installkernel/installkernel-65-r1.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://github.com/projg2/installkernel-gentoo/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${PN}-gentoo-${PV}"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 fi
 
 LICENSE="GPL-2+"
@@ -42,7 +42,7 @@ REQUIRED_USE="
 RDEPEND="
 	!<=sys-kernel/installkernel-systemd-3
 	dracut? (
-		>=sys-kernel/dracut-110
+		>=sys-kernel/dracut-108-r3
 		uki? (
 			|| (
 				sys-apps/systemd[boot(-)]
@@ -84,6 +84,8 @@ RDEPEND="
 	!~sys-apps/systemd-254.6
 	!<=sys-apps/systemd-254.5-r1
 " # Block against systemd that still installs dummy install.conf
+
+PATCHES=( "${FILESDIR}"/${PN}-65-add-wiki-url.patch )
 
 pkg_setup() {
 	use efistub && CONFIG_CHECK="~EFI_STUB" linux-info_pkg_setup

--- a/sys-kernel/installkernel/installkernel-66-r1.ebuild
+++ b/sys-kernel/installkernel/installkernel-66-r1.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://github.com/projg2/installkernel-gentoo/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${PN}-gentoo-${PV}"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2+"
@@ -42,7 +42,7 @@ REQUIRED_USE="
 RDEPEND="
 	!<=sys-kernel/installkernel-systemd-3
 	dracut? (
-		>=sys-kernel/dracut-108-r3
+		>=sys-kernel/dracut-110
 		uki? (
 			|| (
 				sys-apps/systemd[boot(-)]
@@ -84,6 +84,8 @@ RDEPEND="
 	!~sys-apps/systemd-254.6
 	!<=sys-apps/systemd-254.5-r1
 " # Block against systemd that still installs dummy install.conf
+
+PATCHES=( "${FILESDIR}"/${PN}-65-add-wiki-url.patch )
 
 pkg_setup() {
 	use efistub && CONFIG_CHECK="~EFI_STUB" linux-info_pkg_setup


### PR DESCRIPTION
Gentoo users are still struggling with the new checks in sys-kernel/installkernel.

Whilst the Handbook has been improved to help users, we still need a method to teach users what to do when they follow unofficial install guides or just miss the steps in the Handbook.

This simple patch adds a link to
https://wiki.gentoo.org/wiki/Installkernel#Install_chroot_check which shows a number of ways to satisfy the check and gives Gentoo an easy method to update the steps without making a new version of installkernel each time.

Due to the number of users hitting this and the minor change it makes I have straight to stable this as the benefits out weight the cons this time.

I haven't upstreamed to the installkernel project directly as this is a just a stopgap fix while more plans are discussed.

Bug: https://bugs.gentoo.org/971572

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
