### PR TITLE
sys-cluster/ceph: Unbundle dev-libs/apache-arrow to fix a bug

### DIFF
--- a/sys-cluster/ceph/ceph-20.2.1-r1.ebuild
+++ b/sys-cluster/ceph/ceph-20.2.1-r1.ebuild
@@ -1,0 +1,501 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Please be careful not to bump to development versions or RCs.
+# If decide to package these, please don't keyword them.
+# Stable releases are x.2.z.
+# https://docs.ceph.com/en/latest/releases/general/#understanding-the-release-cycle
+
+CMAKE_REMOVE_MODULES_LIST=( FindBoost )
+CMAKE_WARN_UNUSED_CLI=no # false positives unless all USE flags are on
+PYTHON_COMPAT=( python3_{12..13} )
+LUA_COMPAT=( lua5-{3..4} )
+
+inherit check-reqs bash-completion-r1 cmake flag-o-matic lua-single multiprocessing \
+		python-r1 udev readme.gentoo-r1 toolchain-funcs systemd tmpfiles
+
+DESCRIPTION="Ceph distributed filesystem"
+HOMEPAGE="https://ceph.com/"
+
+SRC_URI="https://download.ceph.com/tarballs/${P}.tar.gz"
+
+LICENSE="Apache-2.0 LGPL-2.1 CC-BY-SA-3.0 GPL-2 GPL-2+ LGPL-2+ LGPL-2.1 LGPL-3 GPL-3 BSD Boost-1.0 MIT public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+
+IUSE="
+	babeltrace +cephfs custom-cflags diskprediction dpdk fuse grafana jaeger
+	kafka kerberos ldap lttng +mgr nvmeof +parquet pmdk rabbitmq +radosgw
+	rbd-rwl rbd-ssd rdma rgw-lua selinux +ssl spdk +sqlite +system-boost
+	systemd +tcmalloc test +uring xfs zbd
+"
+
+CPU_FLAGS_X86=(avx2 avx512f pclmul sse{,2,3,4_1,4_2} ssse3)
+IUSE+="$(printf "cpu_flags_x86_%s\n" ${CPU_FLAGS_X86[@]})"
+
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	${LUA_REQUIRED_USE}
+	diskprediction? ( mgr )
+	kafka? ( radosgw )
+	mgr? ( cephfs )
+	rabbitmq? ( radosgw )
+	rgw-lua? ( radosgw )
+	nvmeof? ( spdk )
+"
+
+# tests need root access, and network access
+RESTRICT="test !test? ( test )"
+
+DEPEND="
+	${LUA_DEPS}
+	${PYTHON_DEPS}
+	acct-group/ceph
+	acct-user/ceph
+	virtual/libudev:=
+	app-arch/bzip2:=
+	app-arch/lz4:=
+	>=app-arch/snappy-1.1.9-r1:=
+	app-arch/zstd:=
+	app-shells/bash:0
+	app-misc/jq:=
+	dev-cpp/gflags:=
+	dev-db/lmdb:=
+	dev-lang/jsonnet:=
+	dev-libs/libaio:=
+	<dev-libs/libfmt-11.1.5:=
+	dev-libs/libnl:3=
+	dev-libs/libevent:=
+	dev-libs/libutf8proc:=
+	dev-libs/nss:=
+	dev-libs/openssl:=
+	<dev-libs/rocksdb-7.9.3:=
+	dev-libs/thrift:=
+	dev-libs/xmlsec:=[openssl]
+	dev-cpp/yaml-cpp:=
+	dev-python/natsort[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	dev-vcs/git
+	net-dns/c-ares:=
+	net-libs/gnutls:=
+	sys-auth/oath-toolkit:=
+	sys-apps/coreutils
+	sys-apps/hwloc:=
+	sys-apps/keyutils:=
+	sys-apps/util-linux:=
+	sys-libs/libcap-ng:=
+	sys-libs/libnbd
+	sys-libs/ncurses:0=
+	virtual/zlib:=
+	sys-process/numactl:=
+	virtual/libcrypt:=
+	x11-libs/libpciaccess:=
+	babeltrace? ( dev-util/babeltrace:0/1 )
+	fuse? ( sys-fs/fuse:3= )
+	jaeger? (
+		dev-cpp/nlohmann_json:=
+		<dev-cpp/opentelemetry-cpp-1.10:=[jaeger,prometheus]
+	)
+	kafka? ( dev-libs/librdkafka:= )
+	kerberos? ( virtual/krb5 )
+	ldap? ( net-nds/openldap:= )
+	lttng? ( dev-util/lttng-ust:= )
+	nvmeof? ( net-libs/grpc:= )
+	parquet? ( dev-libs/apache-arrow[parquet] )
+	pmdk? (
+		>=dev-libs/pmdk-1.10.0:=
+		sys-block/ndctl:=
+	)
+	rabbitmq? ( net-libs/rabbitmq-c:= )
+	radosgw? (
+		dev-libs/icu:=
+		dev-libs/expat:=
+		net-misc/curl:=[curl_ssl_openssl]
+	)
+	rbd-rwl? ( dev-libs/pmdk:= )
+	rdma? ( sys-cluster/rdma-core:= )
+	spdk? ( dev-util/cunit )
+	sqlite? ( dev-db/sqlite:= )
+	system-boost? ( dev-libs/boost:=[context,python,${PYTHON_USEDEP},zlib] )
+	tcmalloc? ( >=dev-util/google-perftools-2.6.1:= )
+	uring? ( sys-libs/liburing:= )
+	xfs? ( sys-fs/xfsprogs:= )
+	zbd? ( sys-block/libzbd:= )
+"
+BDEPEND="
+	amd64? ( dev-lang/nasm )
+	x86? ( dev-lang/yasm )
+	app-alternatives/cpio
+	dev-debug/valgrind
+	>=dev-build/cmake-3.5.0
+	dev-python/cython[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/sphinx
+	dev-util/gperf
+	dev-util/ragel
+	sys-apps/coreutils
+	sys-apps/grep
+	sys-apps/util-linux
+	sys-apps/which
+	app-alternatives/bc
+	sys-devel/patch
+	virtual/pkgconfig
+	jaeger? (
+		app-alternatives/yacc
+		app-alternatives/lex
+	)
+	test? (
+		dev-util/cunit
+		dev-python/coverage[${PYTHON_USEDEP}]
+		dev-python/virtualenv[${PYTHON_USEDEP}]
+		dev-python/requests-mock[${PYTHON_USEDEP}]
+		sys-apps/grep[pcre]
+		sys-fs/btrfs-progs
+	)
+"
+RDEPEND="
+	${DEPEND}
+	app-admin/sudo
+	net-misc/socat
+	sys-apps/gptfdisk
+	sys-apps/nvme-cli
+	>=sys-apps/smartmontools-7.0
+	sys-block/parted
+	sys-fs/cryptsetup
+	sys-fs/lsscsi
+	sys-fs/lvm2[lvm]
+	app-alternatives/awk
+	dev-python/bcrypt[${PYTHON_USEDEP}]
+	dev-python/cherrypy[${PYTHON_USEDEP}]
+	dev-python/python-dateutil[${PYTHON_USEDEP}]
+	dev-python/flask[${PYTHON_USEDEP}]
+	dev-python/jinja2[${PYTHON_USEDEP}]
+	dev-python/pecan[${PYTHON_USEDEP}]
+	dev-python/prettytable[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	dev-python/werkzeug[${PYTHON_USEDEP}]
+	mgr? (
+		dev-python/jsonpatch[${PYTHON_USEDEP}]
+		dev-python/more-itertools[${PYTHON_USEDEP}]
+		dev-python/numpy[${PYTHON_USEDEP}]
+		dev-python/pyjwt[${PYTHON_USEDEP}]
+		dev-python/routes[${PYTHON_USEDEP}]
+		diskprediction? (
+			>=dev-python/scipy-1.4.0[${PYTHON_USEDEP}]
+		)
+		dev-python/scikit-learn[${PYTHON_USEDEP}]
+		dev-python/six[${PYTHON_USEDEP}]
+	)
+	selinux? ( sec-policy/selinux-ceph )
+"
+
+PATCHES=(
+	"${FILESDIR}/ceph-12.2.0-use-provided-cpu-flag-values.patch"
+	"${FILESDIR}/ceph-17.2.1-no-virtualenvs.patch"
+	"${FILESDIR}/ceph-14.2.0-dpdk-cflags.patch"
+	"${FILESDIR}/ceph-16.2.0-rocksdb-cmake.patch"
+	"${FILESDIR}/ceph-16.2.0-spdk-tinfo.patch"
+	"${FILESDIR}/ceph-16.2.0-jaeger-system-boost.patch"
+	"${FILESDIR}/ceph-17.2.0-pybind-boost-1.74.patch"
+	"${FILESDIR}/ceph-17.2.0-findre2.patch"
+	"${FILESDIR}/ceph-17.2.0-osd_class_dir.patch"
+	# https://bugs.gentoo.org/866165
+	"${FILESDIR}/ceph-17.2.5-suppress-cmake-warning.patch"
+	# https://bugs.gentoo.org/868891
+	"${FILESDIR}/ceph-18.2.0-cyclic-deps.patch"
+	# https://bugs.gentoo.org/907739
+	"${FILESDIR}/ceph-18.2.0-cython3.patch"
+	# https://bugs.gentoo.org/936889
+	"${FILESDIR}/ceph-18.2.4-liburing.patch"
+	"${FILESDIR}/ceph-18.2.4-spdk.patch"
+	"${FILESDIR}/ceph-19.2.1-isa-l.patch"
+	"${FILESDIR}/ceph-19.2.2-QATAPP-Fix-clang-16-compiling-issue.patch"
+	"${FILESDIR}/ceph-19.2.2-add-option-to-build-agains-system-opentelemetry.patch"
+	"${FILESDIR}/ceph-19.2.2-common-add-dependency-on-legacy-option-headers.patch"
+	"${FILESDIR}/ceph-19.2.2-rbd-make-enums-statically-castable.patch"
+	"${FILESDIR}/ceph-19.2.2-rgw-remove-FMT_STRING-to-fix-clang-20-build-failure.patch"
+	# https://bugs.gentoo.org/960812
+	"${FILESDIR}/ceph-19.2.2-silent-unused-variable-warning.patch"
+	"${FILESDIR}/ceph-19.2.2-src-mgr-make-enum-statically-castable.patch"
+	"${FILESDIR}/ceph-20.1.0-nvmeof.patch"
+	"${FILESDIR}/ceph-20.1.1-always-lua.patch" # bug 934599
+	"${FILESDIR}/ceph-20.1.1-boost-url-linking.patch"
+	# https://bugs.gentoo.org/969039
+	"${FILESDIR}"/ceph-20.1.1-boost-1.89-{1,2,3}.patch
+	"${FILESDIR}/ceph-20.2.0-libarrow-20.0.0.patch"
+)
+
+check-reqs_export_vars() {
+	CHECKREQS_DISK_BUILD="6G"
+
+	if use system-boost; then
+		CHECKREQS_DISK_USR="350M"
+	else
+		CHECKREQS_DISK_USR="510M"
+	fi
+
+	export CHECKREQS_DISK_BUILD CHECKREQS_DISK_USR
+}
+
+pkg_pretend() {
+	check-reqs_export_vars
+	check-reqs_pkg_pretend
+}
+
+pkg_setup() {
+	python_setup
+	lua_setup
+	check-reqs_export_vars
+	check-reqs_pkg_setup
+}
+
+src_prepare() {
+	if use system-boost; then
+		rm -r src/boost || die # ensure use system boost, reduce QA spam
+	fi
+
+	# ensure system-libs, reduce QA spam (FIXME: fails w/o zstd subdir)
+	rm -r src/{arrow,c-ares,jaegertracing/opentelemetry-cpp,rocksdb,utf8proc} || die
+
+	cmake_src_prepare
+
+	if ! use systemd; then
+		find "${S}"/src/ceph-volume/ceph_volume -name '*.py' -print0 \
+			| xargs --null sed \
+			-e '/^from ceph_volume.systemd import systemctl/ d' \
+			-i || die
+	fi
+
+	sed -r -e "s:DESTINATION .+\\):DESTINATION $(get_bashcompdir)\\):" \
+		-i src/bash_completion/CMakeLists.txt || die
+
+	sed -e "s:objdump -p:$(tc-getOBJDUMP) -p:" -i CMakeLists.txt || die
+
+	# force lua version to use selected version
+	local lua_version
+	lua_version=$(ver_cut 1-2 $(lua_get_version))
+	sed "s:find_package(Lua [0-9][.][0-9] REQUIRED):find_package(Lua ${lua_version} EXACT REQUIRED):" \
+		-i src/CMakeLists.txt || die
+
+	if use spdk; then
+		# https://bugs.gentoo.org/871942
+		sed -i 's/[#]ifndef HAVE_ARC4RANDOM/#if 0/' src/spdk/lib/iscsi/iscsi.c || die
+		# unittests fail to build (??!?)
+		sed -i -e 's/CONFIG_UNIT_TESTS=y/CONFIG_UNIT_TESTS=n/' src/spdk/CONFIG || die
+	fi
+
+	# remove tests that need root access
+	rm src/test/cli/ceph-authtool/cap*.t || die
+}
+
+ceph_src_configure() {
+	local mycmakeargs=(
+		# Don't break installed bundled libraries (bug #942680)
+		-DBUILD_SHARED_LIBS=OFF
+		-DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+		-DWITH_BABELTRACE:BOOL=$(usex babeltrace)
+		-DWITH_BLUESTORE_PMEM:BOOL=$(usex pmdk)
+		-DWITH_CEPHFS:BOOL=$(usex cephfs)
+		-DWITH_CEPHFS_SHELL:BOOL=$(usex cephfs)
+		-DWITH_DPDK:BOOL=$(usex dpdk)
+		-DWITH_SPDK:BOOL=$(usex spdk)
+		-DWITH_FUSE:BOOL=$(usex fuse)
+		-DWITH_LTTNG:BOOL=$(usex lttng)
+		-DWITH_GSSAPI:BOOL=$(usex kerberos)
+		-DWITH_GRAFANA:BOOL=$(usex grafana)
+		-DWITH_MGR:BOOL=$(usex mgr)
+		-DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF
+		-DWITH_OPENLDAP:BOOL=$(usex ldap)
+		-DWITH_PYTHON3:STRING=3
+		-DWITH_RADOSGW:BOOL=$(usex radosgw)
+		-DWITH_RADOSGW_AMQP_ENDPOINT:BOOL=$(usex rabbitmq)
+		-DWITH_RADOSGW_KAFKA_ENDPOINT:BOOL=$(usex kafka)
+		-DWITH_RADOSGW_LUA_PACKAGES:BOOL=$(usex rgw-lua "$(usex radosgw)" "NO")
+		-DWITH_RBD_RWL:BOOL=$(usex rbd-rwl)
+		-DWITH_RBD_SSD_CACHE:BOOL=$(usex rbd-ssd)
+		-DWITH_SYSTEMD:BOOL=$(usex systemd)
+		-DWITH_TESTS:BOOL=$(usex test)
+		-DWITH_LIBURING:BOOL=$(usex uring)
+		-DWITH_SYSTEM_LIBURING:BOOL=$(usex uring)
+		-DWITH_LIBCEPHSQLITE:BOOL=$(usex sqlite)
+		-DWITH_XFS:BOOL=$(usex xfs)
+		-DWITH_ZBD:BOOL=$(usex zbd)
+		-DENABLE_SHARED:BOOL=ON
+		-DALLOCATOR:STRING=$(usex tcmalloc tcmalloc libc)
+		-DWITH_SYSTEM_PMDK:BOOL=$(usex pmdk 'YES' "$(usex rbd-rwl '')")
+		-DWITH_SYSTEM_BOOST:BOOL=$(usex system-boost)
+		-DWITH_SYSTEM_ROCKSDB:BOOL=ON
+		-DWITH_SYSTEM_ZSTD:BOOL=ON
+		-DWITH_RDMA:BOOL=$(usex rdma)
+		-DWITH_SYSTEM_UTF8PROC:BOOL=ON
+		-DCMAKE_INSTALL_DOCDIR:PATH="${EPREFIX}/usr/share/doc/${PN}-${PVR}"
+		-DCMAKE_INSTALL_SYSCONFDIR:PATH="${EPREFIX}/etc"
+		-DWITH_SYSTEM_FMT=ON
+		-Wno-dev
+		-DCEPHADM_BUNDLED_DEPENDENCIES=none
+		-DWITH_NVMEOF_GATEWAY_MONITOR_CLIENT:BOOL=$(usex nvmeof)
+		-DWITH_SYSTEM_ARROW:BOOL=ON
+	)
+
+	# this breaks when re-configuring for python impl
+	if [[ ${EBUILD_PHASE} == configure ]]; then
+		mycmakeargs+=(
+			-DWITH_JAEGER:BOOL=$(usex jaeger)
+			-DWITH_RADOSGW_SELECT_PARQUET:BOOL=$(usex parquet)
+		)
+		if use jaeger; then
+			mycmakeargs+=( -DWITH_SYSTEM_OPENTELEMETRY:BOOL=ON )
+		fi
+	else
+		mycmakeargs+=(
+			-DWITH_RADOSGW_SELECT_PARQUET:BOOL=OFF
+			-DWITH_JAEGER:BOOL=OFF
+			# don't want to warn about unused CLI when reconfiguring for python
+			-DCMAKE_WARN_UNUSED_CLI:BOOL=OFF
+		)
+	fi
+
+	# conditionally used cmake args
+	use test && mycmakearts+=( -DWITH_SYSTEM_GTEST:BOOL=$(usex test) )
+	use systemd && mycmakeargs+=( -DSYSTEMD_SYSTEM_UNIT_DIR:PATH=$(systemd_get_systemunitdir) )
+
+	if use amd64 || use x86; then
+		local flag
+		for flag in "${CPU_FLAGS_X86[@]}"; do
+			case "${flag}" in
+				avx*)
+					local var=${flag%f}
+					mycmakeargs+=(
+						"-DHAVE_NASM_X64_${var^^}:BOOL=$(usex cpu_flags_x86_${flag})"
+					)
+				;;
+				*) mycmakeargs+=(
+						"-DHAVE_INTEL_${flag^^}:BOOL=$(usex cpu_flags_x86_${flag})"
+					);;
+			esac
+		done
+	fi
+
+	# needed for >=glibc-2.32
+	has_version '>=sys-libs/glibc-2.32' && mycmakeargs+=( -DWITH_REENTRANT_STRSIGNAL:BOOL=ON )
+
+	rm -f "${BUILD_DIR:-${S}}/CMakeCache.txt" \
+		|| die "failed to remove cmake cache"
+
+	# https://bugs.gentoo.org/927066
+	filter-lto
+
+	cmake_src_configure
+
+	# bug #630232
+	sed -i "s:\"${T//:\\:}/${EPYTHON}/bin/python\":\"${PYTHON}\":" \
+		"${BUILD_DIR:-${S}}"/include/acconfig.h \
+		|| die "sed failed"
+}
+
+src_configure() {
+	use custom-cflags || strip-flags
+	ceph_src_configure
+}
+
+src_compile() {
+	export CMAKE_BUILD_PARALLEL_LEVEL=$(makeopts_jobs)
+	cmake_build all
+
+	# we have to do this here to prevent from building everything multiple times
+	python_copy_sources
+	python_foreach_impl python_compile
+}
+
+python_compile() {
+	local CMAKE_USE_DIR="${S}"
+	ceph_src_configure
+
+	cmake_build src/pybind/CMakeFiles/cython_modules
+	cmake_build cephadm
+}
+
+src_install() {
+	python_foreach_impl python_install
+
+	python_setup
+	cmake_src_install
+
+	python_optimize
+
+	find "${ED}" -name '*.la' -type f -delete || die
+
+	local bundled_init="${ED}/etc/init.d/ceph"
+	[[ -f "${bundled_init}" ]] && {
+		rm "${bundled_init}" || die
+	}
+
+	exeinto /usr/$(get_libdir)/ceph
+	newexe "${BUILD_DIR}/bin/init-ceph" init-ceph
+
+	insinto /etc/logrotate.d/
+	newins "${FILESDIR}"/ceph.logrotate-r2 ${PN}
+
+	keepdir /var/lib/${PN}{,/tmp} /var/log/ceph/stat /var/log/ceph/console
+
+	fowners -R ceph:ceph /var/log/ceph
+
+	newinitd "${FILESDIR}/rbdmap.initd-r1" rbdmap
+	newinitd "${FILESDIR}/${PN}.initd-r14" ${PN}
+	newconfd "${FILESDIR}/${PN}.confd-r5" ${PN}
+
+	insinto /etc/sudoers.d
+	doins sudoers.d/*
+
+	insinto /etc/sysctl.d
+	newins "${FILESDIR}"/sysctld 90-${PN}.conf
+
+	use tcmalloc && newenvd "${FILESDIR}"/envd-tcmalloc 99${PN}-tcmalloc
+
+	# units aren't installed by the build system unless systemd is enabled
+	# so no point installing these with the USE flag disabled
+	if use systemd; then
+		systemd_install_serviced "${FILESDIR}/ceph-mds_at.service.conf" "ceph-mds@.service"
+		systemd_install_serviced "${FILESDIR}/ceph-osd_at.service.conf" "ceph-osd@.service"
+	fi
+
+	udev_dorules udev/*.rules
+	newtmpfiles "${FILESDIR}"/ceph-tmpfilesd ${PN}.conf
+
+	readme.gentoo_create_doc
+
+	# bug #630232
+	sed -i -r "s:${T//:/\\:}/${EPYTHON}:/usr:" "${ED}"/usr/bin/ceph{,-crash} \
+		|| die "sed failed"
+
+	python_fix_shebang "${ED}"/usr/{,s}bin/
+
+	# python_fix_shebang apparently is not idempotent
+	local shebang_regex='(/usr/lib/python-exec/python[0-9]\.[0-9]/python)[0-9]\.[0-9]'
+	grep -r -E -l --null "${shebang_regex}" "${ED}"/usr/{s,}bin/ \
+		| xargs --null --no-run-if-empty -- sed -i -r  "s:${shebang_regex}:\1:" || die
+
+	local -a rados_classes=( "${ED}/usr/$(get_libdir)/rados-classes"/* )
+	dostrip -x "${rados_classes[@]#${ED}}"
+}
+
+python_install() {
+	local CMAKE_USE_DIR="${S}"
+	DESTDIR="${ED}" cmake_build src/pybind/install
+	DESTDIR="${ED}" cmake_build src/cephadm/install
+
+	python_optimize
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+	tmpfiles_process ${PN}.conf
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}

--- a/sys-cluster/ceph/files/ceph-20.2.0-libarrow-20.0.0.patch
+++ b/sys-cluster/ceph/files/ceph-20.2.0-libarrow-20.0.0.patch
@@ -1,0 +1,840 @@
+This patch came from Fedora: https://src.fedoraproject.org/rpms/ceph/blob/rawhide/f/0056-libarrow-20.0.0.patch
+It allows Ceph to compile against newer versions of Apache Arrow, so that the system apache-arrow can be used
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal_19.h.orig	2025-07-08 07:40:29.811814549 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal_19.h	2025-07-08 07:40:29.811739290 -0400
+@@ -0,0 +1,114 @@
++// Licensed to the Apache Software Foundation (ASF) under one
++// or more contributor license agreements.  See the NOTICE file
++// distributed with this work for additional information
++// regarding copyright ownership.  The ASF licenses this file
++// to you under the Apache License, Version 2.0 (the
++// "License"); you may not use this file except in compliance
++// with the License.  You may obtain a copy of the License at
++//
++//   http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing,
++// software distributed under the License is distributed on an
++// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++// KIND, either express or implied.  See the License for the
++// specific language governing permissions and limitations
++// under the License.
++
++#pragma once
++
++#include <memory>
++#include <string>
++#include <vector>
++
++#include "parquet/properties.h"
++#include "parquet/types.h"
++
++using parquet::ParquetCipher;
++
++namespace parquet {
++namespace encryption {
++
++constexpr int kGcmTagLength = 16;
++constexpr int kNonceLength = 12;
++
++// Module types
++constexpr int8_t kFooter = 0;
++constexpr int8_t kColumnMetaData = 1;
++constexpr int8_t kDataPage = 2;
++constexpr int8_t kDictionaryPage = 3;
++constexpr int8_t kDataPageHeader = 4;
++constexpr int8_t kDictionaryPageHeader = 5;
++constexpr int8_t kColumnIndex = 6;
++constexpr int8_t kOffsetIndex = 7;
++
++/// Performs AES encryption operations with GCM or CTR ciphers.
++class AesEncryptor {
++ public:
++  static AesEncryptor* Make(ParquetCipher::type alg_id, int key_len, bool metadata,
++                            std::vector<AesEncryptor*>* all_encryptors);
++
++  ~AesEncryptor();
++
++  /// Size difference between plaintext and ciphertext, for this cipher.
++  int CiphertextSizeDelta();
++
++  /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
++  /// If different from value in constructor, exception will be thrown.
++  int Encrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
++              int key_len, const uint8_t* aad, int aad_len, uint8_t* ciphertext);
++
++  /// Encrypts plaintext footer, in order to compute footer signature (tag).
++  int SignedFooterEncrypt(const uint8_t* footer, int footer_len, const uint8_t* key,
++                          int key_len, const uint8_t* aad, int aad_len,
++                          const uint8_t* nonce, uint8_t* encrypted_footer);
++
++  void WipeOut();
++
++ private:
++  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
++  explicit AesEncryptor(ParquetCipher::type alg_id, int key_len, bool metadata);
++  // PIMPL Idiom
++  class AesEncryptorImpl;
++  std::unique_ptr<AesEncryptorImpl> impl_;
++};
++
++/// Performs AES decryption operations with GCM or CTR ciphers.
++class AesDecryptor {
++ public:
++  static AesDecryptor* Make(ParquetCipher::type alg_id, int key_len, bool metadata,
++                            std::vector<AesDecryptor*>* all_decryptors);
++
++  ~AesDecryptor();
++  void WipeOut();
++
++  /// Size difference between plaintext and ciphertext, for this cipher.
++  int CiphertextSizeDelta();
++
++  /// Decrypts ciphertext with the key and aad. Key length is passed only for
++  /// validation. If different from value in constructor, exception will be thrown.
++  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, const uint8_t* key,
++              int key_len, const uint8_t* aad, int aad_len, uint8_t* plaintext);
++
++ private:
++  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
++  explicit AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata);
++  // PIMPL Idiom
++  class AesDecryptorImpl;
++  std::unique_ptr<AesDecryptorImpl> impl_;
++};
++
++std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
++                            int16_t row_group_ordinal, int16_t column_ordinal,
++                            int16_t page_ordinal);
++
++std::string CreateFooterAad(const std::string& aad_prefix_bytes);
++
++// Update last two bytes of page (or page header) module AAD
++void QuickUpdatePageAad(const std::string& AAD, int16_t new_page_ordinal);
++
++// Wraps OpenSSL RAND_bytes function
++void RandBytes(unsigned char* buf, int num);
++
++}  // namespace encryption
++}  // namespace parquet
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal_20.h.orig	2025-07-08 07:40:29.812759948 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal_20.h	2025-07-08 07:40:29.812687536 -0400
+@@ -0,0 +1,141 @@
++// Licensed to the Apache Software Foundation (ASF) under one
++// or more contributor license agreements.  See the NOTICE file
++// distributed with this work for additional information
++// regarding copyright ownership.  The ASF licenses this file
++// to you under the Apache License, Version 2.0 (the
++// "License"); you may not use this file except in compliance
++// with the License.  You may obtain a copy of the License at
++//
++//   http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing,
++// software distributed under the License is distributed on an
++// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++// KIND, either express or implied.  See the License for the
++// specific language governing permissions and limitations
++// under the License.
++
++#pragma once
++
++#include <memory>
++#include <string>
++#include <vector>
++
++#include "arrow/util/span.h"
++#include "parquet/properties.h"
++#include "parquet/types.h"
++
++using parquet::ParquetCipher;
++
++namespace parquet::encryption {
++
++constexpr int32_t kGcmTagLength = 16;
++constexpr int32_t kNonceLength = 12;
++
++// Module types
++constexpr int8_t kFooter = 0;
++constexpr int8_t kColumnMetaData = 1;
++constexpr int8_t kDataPage = 2;
++constexpr int8_t kDictionaryPage = 3;
++constexpr int8_t kDataPageHeader = 4;
++constexpr int8_t kDictionaryPageHeader = 5;
++constexpr int8_t kColumnIndex = 6;
++constexpr int8_t kOffsetIndex = 7;
++constexpr int8_t kBloomFilterHeader = 8;
++constexpr int8_t kBloomFilterBitset = 9;
++
++/// Performs AES encryption operations with GCM or CTR ciphers.
++class PARQUET_EXPORT AesEncryptor {
++ public:
++  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
++  /// If write_length is true, prepend ciphertext length to the ciphertext
++  explicit AesEncryptor(ParquetCipher::type alg_id, int32_t key_len, bool metadata,
++                        bool write_length = true);
++
++  static std::unique_ptr<AesEncryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
++                                            bool metadata, bool write_length = true);
++
++  ~AesEncryptor();
++
++  /// The size of the ciphertext, for this cipher and the specified plaintext length.
++  [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const;
++
++  /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
++  /// If different from value in constructor, exception will be thrown.
++  int32_t Encrypt(::arrow::util::span<const uint8_t> plaintext,
++                  ::arrow::util::span<const uint8_t> key,
++                  ::arrow::util::span<const uint8_t> aad,
++                  ::arrow::util::span<uint8_t> ciphertext);
++
++  /// Encrypts plaintext footer, in order to compute footer signature (tag).
++  int32_t SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
++                              ::arrow::util::span<const uint8_t> key,
++                              ::arrow::util::span<const uint8_t> aad,
++                              ::arrow::util::span<const uint8_t> nonce,
++                              ::arrow::util::span<uint8_t> encrypted_footer);
++
++ private:
++  // PIMPL Idiom
++  class AesEncryptorImpl;
++  std::unique_ptr<AesEncryptorImpl> impl_;
++};
++
++/// Performs AES decryption operations with GCM or CTR ciphers.
++class PARQUET_EXPORT AesDecryptor {
++ public:
++  /// \brief Construct an AesDecryptor
++  ///
++  /// \param alg_id the encryption algorithm to use
++  /// \param key_len key length. Possible values: 16, 24, 32 bytes.
++  /// \param metadata if true then this is a metadata decryptor
++  /// \param contains_length if true, expect ciphertext length prepended to the ciphertext
++  explicit AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool metadata,
++                        bool contains_length = true);
++
++  static std::unique_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
++                                            bool metadata);
++
++  ~AesDecryptor();
++
++  /// The size of the plaintext, for this cipher and the specified ciphertext length.
++  [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const;
++
++  /// The size of the ciphertext, for this cipher and the specified plaintext length.
++  [[nodiscard]] int32_t CiphertextLength(int32_t plaintext_len) const;
++
++  /// Decrypts ciphertext with the key and aad. Key length is passed only for
++  /// validation. If different from value in constructor, exception will be thrown.
++  /// The caller is responsible for ensuring that the plaintext buffer is at least as
++  /// large as PlaintextLength(ciphertext_len).
++  int32_t Decrypt(::arrow::util::span<const uint8_t> ciphertext,
++                  ::arrow::util::span<const uint8_t> key,
++                  ::arrow::util::span<const uint8_t> aad,
++                  ::arrow::util::span<uint8_t> plaintext);
++
++ private:
++  // PIMPL Idiom
++  class AesDecryptorImpl;
++  std::unique_ptr<AesDecryptorImpl> impl_;
++};
++
++std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
++                            int16_t row_group_ordinal, int16_t column_ordinal,
++                            int32_t page_ordinal);
++
++std::string CreateFooterAad(const std::string& aad_prefix_bytes);
++
++// Update last two bytes of page (or page header) module AAD
++void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD);
++
++// Wraps OpenSSL RAND_bytes function
++void RandBytes(unsigned char* buf, size_t num);
++
++// Ensure OpenSSL is initialized.
++//
++// This is only necessary in specific situations since OpenSSL otherwise
++// initializes itself automatically. For example, under Valgrind, a memory
++// leak will be reported if OpenSSL is initialized for the first time from
++// a worker thread; calling this function from the main thread prevents this.
++void EnsureBackendInitialized();
++
++}  // namespace parquet::encryption
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal.h.orig	2024-10-06 07:18:41.000000000 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/encryption_internal.h	2025-07-08 07:40:29.809908891 -0400
+@@ -17,98 +17,8 @@
+ 
+ #pragma once
+ 
+-#include <memory>
+-#include <string>
+-#include <vector>
+-
+-#include "parquet/properties.h"
+-#include "parquet/types.h"
+-
+-using parquet::ParquetCipher;
+-
+-namespace parquet {
+-namespace encryption {
+-
+-constexpr int kGcmTagLength = 16;
+-constexpr int kNonceLength = 12;
+-
+-// Module types
+-constexpr int8_t kFooter = 0;
+-constexpr int8_t kColumnMetaData = 1;
+-constexpr int8_t kDataPage = 2;
+-constexpr int8_t kDictionaryPage = 3;
+-constexpr int8_t kDataPageHeader = 4;
+-constexpr int8_t kDictionaryPageHeader = 5;
+-constexpr int8_t kColumnIndex = 6;
+-constexpr int8_t kOffsetIndex = 7;
+-
+-/// Performs AES encryption operations with GCM or CTR ciphers.
+-class AesEncryptor {
+- public:
+-  static AesEncryptor* Make(ParquetCipher::type alg_id, int key_len, bool metadata,
+-                            std::vector<AesEncryptor*>* all_encryptors);
+-
+-  ~AesEncryptor();
+-
+-  /// Size difference between plaintext and ciphertext, for this cipher.
+-  int CiphertextSizeDelta();
+-
+-  /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
+-  /// If different from value in constructor, exception will be thrown.
+-  int Encrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
+-              int key_len, const uint8_t* aad, int aad_len, uint8_t* ciphertext);
+-
+-  /// Encrypts plaintext footer, in order to compute footer signature (tag).
+-  int SignedFooterEncrypt(const uint8_t* footer, int footer_len, const uint8_t* key,
+-                          int key_len, const uint8_t* aad, int aad_len,
+-                          const uint8_t* nonce, uint8_t* encrypted_footer);
+-
+-  void WipeOut();
+-
+- private:
+-  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
+-  explicit AesEncryptor(ParquetCipher::type alg_id, int key_len, bool metadata);
+-  // PIMPL Idiom
+-  class AesEncryptorImpl;
+-  std::unique_ptr<AesEncryptorImpl> impl_;
+-};
+-
+-/// Performs AES decryption operations with GCM or CTR ciphers.
+-class AesDecryptor {
+- public:
+-  static AesDecryptor* Make(ParquetCipher::type alg_id, int key_len, bool metadata,
+-                            std::vector<AesDecryptor*>* all_decryptors);
+-
+-  ~AesDecryptor();
+-  void WipeOut();
+-
+-  /// Size difference between plaintext and ciphertext, for this cipher.
+-  int CiphertextSizeDelta();
+-
+-  /// Decrypts ciphertext with the key and aad. Key length is passed only for
+-  /// validation. If different from value in constructor, exception will be thrown.
+-  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, const uint8_t* key,
+-              int key_len, const uint8_t* aad, int aad_len, uint8_t* plaintext);
+-
+- private:
+-  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
+-  explicit AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata);
+-  // PIMPL Idiom
+-  class AesDecryptorImpl;
+-  std::unique_ptr<AesDecryptorImpl> impl_;
+-};
+-
+-std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
+-                            int16_t row_group_ordinal, int16_t column_ordinal,
+-                            int16_t page_ordinal);
+-
+-std::string CreateFooterAad(const std::string& aad_prefix_bytes);
+-
+-// Update last two bytes of page (or page header) module AAD
+-void QuickUpdatePageAad(const std::string& AAD, int16_t new_page_ordinal);
+-
+-// Wraps OpenSSL RAND_bytes function
+-void RandBytes(unsigned char* buf, int num);
+-
+-}  // namespace encryption
+-}  // namespace parquet
++#if ARROW_VERSION_MAJOR < 20
++#include "encryption_internal_19.h"
++#else
++#include "encryption_internal_20.h"
++#endif
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor_19.h.orig	2025-07-08 07:40:29.814292389 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor_19.h	2025-07-08 07:40:29.813727465 -0400
+@@ -0,0 +1,121 @@
++// Licensed to the Apache Software Foundation (ASF) under one
++// or more contributor license agreements.  See the NOTICE file
++// distributed with this work for additional information
++// regarding copyright ownership.  The ASF licenses this file
++// to you under the Apache License, Version 2.0 (the
++// "License"); you may not use this file except in compliance
++// with the License.  You may obtain a copy of the License at
++//
++//   http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing,
++// software distributed under the License is distributed on an
++// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++// KIND, either express or implied.  See the License for the
++// specific language governing permissions and limitations
++// under the License.
++
++#pragma once
++
++#include <map>
++#include <memory>
++#include <string>
++#include <vector>
++
++#include "parquet/schema.h"
++
++namespace parquet {
++
++namespace encryption {
++class AesDecryptor;
++class AesEncryptor;
++}  // namespace encryption
++
++class FileDecryptionProperties;
++
++class PARQUET_EXPORT Decryptor {
++ public:
++  Decryptor(encryption::AesDecryptor* decryptor, const std::string& key,
++            const std::string& file_aad, const std::string& aad,
++            ::arrow::MemoryPool* pool);
++
++  const std::string& file_aad() const { return file_aad_; }
++  void UpdateAad(const std::string& aad) { aad_ = aad; }
++  ::arrow::MemoryPool* pool() { return pool_; }
++
++  int CiphertextSizeDelta();
++  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, uint8_t* plaintext);
++
++ private:
++  encryption::AesDecryptor* aes_decryptor_;
++  std::string key_;
++  std::string file_aad_;
++  std::string aad_;
++  ::arrow::MemoryPool* pool_;
++};
++
++class InternalFileDecryptor {
++ public:
++  explicit InternalFileDecryptor(FileDecryptionProperties* properties,
++                                 const std::string& file_aad,
++                                 ParquetCipher::type algorithm,
++                                 const std::string& footer_key_metadata,
++                                 ::arrow::MemoryPool* pool);
++
++  std::string& file_aad() { return file_aad_; }
++
++  std::string GetFooterKey();
++
++  ParquetCipher::type algorithm() { return algorithm_; }
++
++  std::string& footer_key_metadata() { return footer_key_metadata_; }
++
++  FileDecryptionProperties* properties() { return properties_; }
++
++  void WipeOutDecryptionKeys();
++
++  ::arrow::MemoryPool* pool() { return pool_; }
++
++  std::shared_ptr<Decryptor> GetFooterDecryptor();
++  std::shared_ptr<Decryptor> GetFooterDecryptorForColumnMeta(const std::string& aad = "");
++  std::shared_ptr<Decryptor> GetFooterDecryptorForColumnData(const std::string& aad = "");
++  std::shared_ptr<Decryptor> GetColumnMetaDecryptor(
++      const std::string& column_path, const std::string& column_key_metadata,
++      const std::string& aad = "");
++  std::shared_ptr<Decryptor> GetColumnDataDecryptor(
++      const std::string& column_path, const std::string& column_key_metadata,
++      const std::string& aad = "");
++
++ private:
++  FileDecryptionProperties* properties_;
++  // Concatenation of aad_prefix (if exists) and aad_file_unique
++  std::string file_aad_;
++  std::map<std::string, std::shared_ptr<Decryptor>> column_data_map_;
++  std::map<std::string, std::shared_ptr<Decryptor>> column_metadata_map_;
++
++  std::shared_ptr<Decryptor> footer_metadata_decryptor_;
++  std::shared_ptr<Decryptor> footer_data_decryptor_;
++  ParquetCipher::type algorithm_;
++  std::string footer_key_metadata_;
++  std::vector<encryption::AesDecryptor*> all_decryptors_;
++
++  /// Key must be 16, 24 or 32 bytes in length. Thus there could be up to three
++  // types of meta_decryptors and data_decryptors.
++  std::unique_ptr<encryption::AesDecryptor> meta_decryptor_[3];
++  std::unique_ptr<encryption::AesDecryptor> data_decryptor_[3];
++
++  ::arrow::MemoryPool* pool_;
++
++  std::shared_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);
++  std::shared_ptr<Decryptor> GetColumnDecryptor(const std::string& column_path,
++                                                const std::string& column_key_metadata,
++                                                const std::string& aad,
++                                                bool metadata = false);
++
++  encryption::AesDecryptor* GetMetaAesDecryptor(size_t key_size);
++  encryption::AesDecryptor* GetDataAesDecryptor(size_t key_size);
++
++  int MapKeyLenToDecryptorArrayIndex(int key_len);
++};
++
++}  // namespace parquet
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor_20.h.orig	2025-07-08 07:40:29.815411998 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor_20.h	2025-07-08 07:40:29.815245155 -0400
+@@ -0,0 +1,148 @@
++// Licensed to the Apache Software Foundation (ASF) under one
++// or more contributor license agreements.  See the NOTICE file
++// distributed with this work for additional information
++// regarding copyright ownership.  The ASF licenses this file
++// to you under the Apache License, Version 2.0 (the
++// "License"); you may not use this file except in compliance
++// with the License.  You may obtain a copy of the License at
++//
++//   http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing,
++// software distributed under the License is distributed on an
++// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++// KIND, either express or implied.  See the License for the
++// specific language governing permissions and limitations
++// under the License.
++
++#pragma once
++
++#include <memory>
++#include <mutex>
++#include <string>
++#include <vector>
++
++#include "parquet/schema.h"
++
++namespace parquet {
++
++namespace encryption {
++class AesDecryptor;
++class AesEncryptor;
++}  // namespace encryption
++
++class ColumnCryptoMetaData;
++class FileDecryptionProperties;
++
++// An object handling decryption using well-known encryption parameters
++//
++// CAUTION: Decryptor objects are not thread-safe.
++class PARQUET_EXPORT Decryptor {
++ public:
++  Decryptor(std::unique_ptr<encryption::AesDecryptor> decryptor, const std::string& key,
++            const std::string& file_aad, const std::string& aad,
++            ::arrow::MemoryPool* pool);
++  ~Decryptor();
++
++  const std::string& file_aad() const { return file_aad_; }
++  void UpdateAad(const std::string& aad) { aad_ = aad; }
++  ::arrow::MemoryPool* pool() { return pool_; }
++
++  [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const;
++  [[nodiscard]] int32_t CiphertextLength(int32_t plaintext_len) const;
++  int32_t Decrypt(::arrow::util::span<const uint8_t> ciphertext,
++                  ::arrow::util::span<uint8_t> plaintext);
++
++ private:
++  std::unique_ptr<encryption::AesDecryptor> aes_decryptor_;
++  std::string key_;
++  std::string file_aad_;
++  std::string aad_;
++  ::arrow::MemoryPool* pool_;
++};
++
++class InternalFileDecryptor {
++ public:
++  explicit InternalFileDecryptor(std::shared_ptr<FileDecryptionProperties> properties,
++                                 const std::string& file_aad,
++                                 ParquetCipher::type algorithm,
++                                 const std::string& footer_key_metadata,
++                                 ::arrow::MemoryPool* pool);
++
++  const std::string& file_aad() const { return file_aad_; }
++
++  std::string GetFooterKey();
++
++  ParquetCipher::type algorithm() const { return algorithm_; }
++
++  const std::string& footer_key_metadata() const { return footer_key_metadata_; }
++
++  const std::shared_ptr<FileDecryptionProperties>& properties() const {
++    return properties_;
++  }
++
++  ::arrow::MemoryPool* pool() const { return pool_; }
++
++  // Get a Decryptor instance for the Parquet footer
++  std::unique_ptr<Decryptor> GetFooterDecryptor();
++
++  // Get a Decryptor instance for column chunk metadata.
++  std::unique_ptr<Decryptor> GetColumnMetaDecryptor(
++      const std::string& column_path, const std::string& column_key_metadata,
++      const std::string& aad = "") {
++    return GetColumnDecryptor(column_path, column_key_metadata, aad, /*metadata=*/true);
++  }
++
++  // Get a Decryptor instance for column chunk data.
++  std::unique_ptr<Decryptor> GetColumnDataDecryptor(
++      const std::string& column_path, const std::string& column_key_metadata,
++      const std::string& aad = "") {
++    return GetColumnDecryptor(column_path, column_key_metadata, aad, /*metadata=*/false);
++  }
++
++  // Get a Decryptor factory for column chunk metadata.
++  //
++  // This is typically useful if multi-threaded decryption is expected.
++  // This is a static function as it accepts a null `InternalFileDecryptor*`
++  // argument if the column is not encrypted.
++  static std::function<std::unique_ptr<Decryptor>()> GetColumnMetaDecryptorFactory(
++      InternalFileDecryptor*, const ColumnCryptoMetaData* crypto_metadata,
++      const std::string& aad = "");
++  // Get a Decryptor factory for column chunk data.
++  //
++  // This is typically useful if multi-threaded decryption is expected.
++  // This is a static function as it accepts a null `InternalFileDecryptor*`
++  // argument if the column is not encrypted.
++  static std::function<std::unique_ptr<Decryptor>()> GetColumnDataDecryptorFactory(
++      InternalFileDecryptor*, const ColumnCryptoMetaData* crypto_metadata,
++      const std::string& aad = "");
++
++ private:
++  std::shared_ptr<FileDecryptionProperties> properties_;
++  // Concatenation of aad_prefix (if exists) and aad_file_unique
++  std::string file_aad_;
++  ParquetCipher::type algorithm_;
++  std::string footer_key_metadata_;
++  ::arrow::MemoryPool* pool_;
++
++  // Protects footer_key_ updates
++  std::mutex mutex_;
++  std::string footer_key_;
++
++  std::string GetColumnKey(const std::string& column_path,
++                           const std::string& column_key_metadata);
++
++  std::unique_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);
++
++  std::unique_ptr<Decryptor> GetColumnDecryptor(const std::string& column_path,
++                                                const std::string& column_key_metadata,
++                                                const std::string& aad, bool metadata);
++
++  std::function<std::unique_ptr<Decryptor>()> GetColumnDecryptorFactory(
++      const ColumnCryptoMetaData* crypto_metadata, const std::string& aad, bool metadata);
++};
++
++void UpdateDecryptor(Decryptor* decryptor, int16_t row_group_ordinal,
++                     int16_t column_ordinal, int8_t module_type);
++
++}  // namespace parquet
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor.h.orig	2024-10-06 07:18:41.000000000 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/internal_file_decryptor.h	2025-07-08 07:40:29.813623143 -0400
+@@ -17,105 +17,8 @@
+ 
+ #pragma once
+ 
+-#include <map>
+-#include <memory>
+-#include <string>
+-#include <vector>
+-
+-#include "parquet/schema.h"
+-
+-namespace parquet {
+-
+-namespace encryption {
+-class AesDecryptor;
+-class AesEncryptor;
+-}  // namespace encryption
+-
+-class FileDecryptionProperties;
+-
+-class PARQUET_EXPORT Decryptor {
+- public:
+-  Decryptor(encryption::AesDecryptor* decryptor, const std::string& key,
+-            const std::string& file_aad, const std::string& aad,
+-            ::arrow::MemoryPool* pool);
+-
+-  const std::string& file_aad() const { return file_aad_; }
+-  void UpdateAad(const std::string& aad) { aad_ = aad; }
+-  ::arrow::MemoryPool* pool() { return pool_; }
+-
+-  int CiphertextSizeDelta();
+-  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, uint8_t* plaintext);
+-
+- private:
+-  encryption::AesDecryptor* aes_decryptor_;
+-  std::string key_;
+-  std::string file_aad_;
+-  std::string aad_;
+-  ::arrow::MemoryPool* pool_;
+-};
+-
+-class InternalFileDecryptor {
+- public:
+-  explicit InternalFileDecryptor(FileDecryptionProperties* properties,
+-                                 const std::string& file_aad,
+-                                 ParquetCipher::type algorithm,
+-                                 const std::string& footer_key_metadata,
+-                                 ::arrow::MemoryPool* pool);
+-
+-  std::string& file_aad() { return file_aad_; }
+-
+-  std::string GetFooterKey();
+-
+-  ParquetCipher::type algorithm() { return algorithm_; }
+-
+-  std::string& footer_key_metadata() { return footer_key_metadata_; }
+-
+-  FileDecryptionProperties* properties() { return properties_; }
+-
+-  void WipeOutDecryptionKeys();
+-
+-  ::arrow::MemoryPool* pool() { return pool_; }
+-
+-  std::shared_ptr<Decryptor> GetFooterDecryptor();
+-  std::shared_ptr<Decryptor> GetFooterDecryptorForColumnMeta(const std::string& aad = "");
+-  std::shared_ptr<Decryptor> GetFooterDecryptorForColumnData(const std::string& aad = "");
+-  std::shared_ptr<Decryptor> GetColumnMetaDecryptor(
+-      const std::string& column_path, const std::string& column_key_metadata,
+-      const std::string& aad = "");
+-  std::shared_ptr<Decryptor> GetColumnDataDecryptor(
+-      const std::string& column_path, const std::string& column_key_metadata,
+-      const std::string& aad = "");
+-
+- private:
+-  FileDecryptionProperties* properties_;
+-  // Concatenation of aad_prefix (if exists) and aad_file_unique
+-  std::string file_aad_;
+-  std::map<std::string, std::shared_ptr<Decryptor>> column_data_map_;
+-  std::map<std::string, std::shared_ptr<Decryptor>> column_metadata_map_;
+-
+-  std::shared_ptr<Decryptor> footer_metadata_decryptor_;
+-  std::shared_ptr<Decryptor> footer_data_decryptor_;
+-  ParquetCipher::type algorithm_;
+-  std::string footer_key_metadata_;
+-  std::vector<encryption::AesDecryptor*> all_decryptors_;
+-
+-  /// Key must be 16, 24 or 32 bytes in length. Thus there could be up to three
+-  // types of meta_decryptors and data_decryptors.
+-  std::unique_ptr<encryption::AesDecryptor> meta_decryptor_[3];
+-  std::unique_ptr<encryption::AesDecryptor> data_decryptor_[3];
+-
+-  ::arrow::MemoryPool* pool_;
+-
+-  std::shared_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);
+-  std::shared_ptr<Decryptor> GetColumnDecryptor(const std::string& column_path,
+-                                                const std::string& column_key_metadata,
+-                                                const std::string& aad,
+-                                                bool metadata = false);
+-
+-  encryption::AesDecryptor* GetMetaAesDecryptor(size_t key_size);
+-  encryption::AesDecryptor* GetDataAesDecryptor(size_t key_size);
+-
+-  int MapKeyLenToDecryptorArrayIndex(int key_len);
+-};
+-
+-}  // namespace parquet
++#if ARROW_VERSION_MAJOR < 20
++#include "internal_file_decryptor_19.h"
++#else
++#include "internal_file_decryptor_20.h"
++#endif
+--- ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/s3select_parquet_intrf.h.orig	2024-10-06 07:18:41.000000000 -0400
++++ ceph-20.0.0-2362-ga9d20fc0/src/s3select/include/s3select_parquet_intrf.h	2025-07-08 07:40:29.816727417 -0400
+@@ -1002,6 +1002,7 @@
+       throw ParquetException("Encrypted files cannot contain more than 32767 row groups");
+     }
+ 
++#if ARROW_VERSION_MAJOR < 20
+     // The column is encrypted
+     std::shared_ptr<::parquet::Decryptor> meta_decryptor;
+     std::shared_ptr<Decryptor> data_decryptor;
+@@ -1035,6 +1036,25 @@
+                             false,
+     #endif
+                             properties_.memory_pool(), &ctx);
++#else
++    // Arrow 20+ version uses factory functions instead of shared_ptr for decryptors
++    std::function<std::unique_ptr<Decryptor>()> meta_decryptor_factory =
++        InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(), crypto_metadata.get());
++    std::function<std::unique_ptr<Decryptor>()> data_decryptor_factory =
++        InternalFileDecryptor::GetColumnDataDecryptorFactory(file_decryptor_.get(), crypto_metadata.get());
++
++    const CryptoContext ctx {
++        col->has_dictionary_page(),
++        row_group_ordinal_,
++        static_cast<int16_t>(i),
++        meta_decryptor_factory,
++        data_decryptor_factory,
++    };
++
++    return PageReader::Open(stream, col->num_values(), col->compression(),
++                            false,
++                            properties_.memory_pool(), &ctx);
++#endif
+   }
+ 
+  private:
+@@ -1071,7 +1091,9 @@
+   }
+ 
+   void Close() override {
++#if ARROW_VERSION_MAJOR < 20
+     if (file_decryptor_) file_decryptor_->WipeOutDecryptionKeys();
++#endif
+   }
+ 
+   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
+@@ -1249,9 +1271,17 @@
+   // Handle AAD prefix
+   EncryptionAlgorithm algo = file_crypto_metadata->encryption_algorithm();
+   std::string file_aad = HandleAadPrefix(file_decryption_properties, algo);
++#if ARROW_VERSION_MAJOR < 20
+   file_decryptor_ = std::make_shared<::parquet::InternalFileDecryptor>(
+       file_decryption_properties, file_aad, algo.algorithm,
+       file_crypto_metadata->key_metadata(), properties_.memory_pool());
++#else
++  // Arrow 20+ takes a shared_ptr to FileDecryptionProperties
++  file_decryptor_ = std::make_shared<::parquet::InternalFileDecryptor>(
++      std::shared_ptr<FileDecryptionProperties>(file_decryption_properties),
++      file_aad, algo.algorithm,
++      file_crypto_metadata->key_metadata(), properties_.memory_pool());
++#endif
+ 
+   int64_t metadata_offset = source_size_ - kFooterSize - footer_len + crypto_metadata_len;
+   uint32_t metadata_len = footer_len - crypto_metadata_len;
+@@ -1282,9 +1312,18 @@
+     EncryptionAlgorithm algo = file_metadata_->encryption_algorithm();
+     // Handle AAD prefix
+     std::string file_aad = HandleAadPrefix(file_decryption_properties, algo);
++#if ARROW_VERSION_MAJOR < 20
+     file_decryptor_ = std::make_shared<::parquet::InternalFileDecryptor>(
+         file_decryption_properties, file_aad, algo.algorithm,
+         file_metadata_->footer_signing_key_metadata(), properties_.memory_pool());
++#else
++    // Arrow 20+ takes a shared_ptr to FileDecryptionProperties
++    file_decryptor_ = std::make_shared<::parquet::InternalFileDecryptor>(
++        std::shared_ptr<FileDecryptionProperties>(file_decryption_properties),
++        file_aad, algo.algorithm,
++        file_metadata_->footer_signing_key_metadata(), properties_.memory_pool());
++    // In Arrow 20+, no need to set file_decryptor in metadata
++#endif
+     // set the InternalFileDecryptor in the metadata as well, as it's used
+     // for signature verification and for ColumnChunkMetaData creation.
+ #if GAL_set_file_decryptor_declare_private


### PR DESCRIPTION
This unbundles dev-libs/apache-arrow and lets it work with the current version (23.0.1) in Portage

Closes: https://bugs.gentoo.org/972737

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
