### PR TITLE
dev-build/cmake: no longer set jobs to 1

### DIFF
--- a/dev-build/cmake/cmake-4.1.2-r1.ebuild
+++ b/dev-build/cmake/cmake-4.1.2-r1.ebuild
@@ -291,11 +291,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test

--- a/dev-build/cmake/cmake-4.1.4.ebuild
+++ b/dev-build/cmake/cmake-4.1.4.ebuild
@@ -292,11 +292,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test

--- a/dev-build/cmake/cmake-4.1.5.ebuild
+++ b/dev-build/cmake/cmake-4.1.5.ebuild
@@ -292,11 +292,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test

--- a/dev-build/cmake/cmake-4.2.4.ebuild
+++ b/dev-build/cmake/cmake-4.2.4.ebuild
@@ -291,11 +291,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test

--- a/dev-build/cmake/cmake-4.3.1.ebuild
+++ b/dev-build/cmake/cmake-4.3.1.ebuild
@@ -291,11 +291,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test

--- a/dev-build/cmake/cmake-9999.ebuild
+++ b/dev-build/cmake/cmake-9999.ebuild
@@ -291,11 +291,6 @@ src_test() {
 		"RunCMake.CMP0125"
 	)
 
-	local myctestargs=(
-		# higher number breaks tests
-		-j1
-	)
-
 	local -x QT_QPA_PLATFORM=offscreen
 
 	cmake_src_test


### PR DESCRIPTION
The intended behaviour was/is to honour the user set jobs. `ctest` calls nested `ctest` leading to higher jobs then wanted.

Using `CTEST_PARALLEL_LEVEL` would be the correct way to do this, as it only affects `ctest` calls where `-j`/`--parallel` is not set as we do in `cmake.eclass`.

Fixes: 9ca375c806a17c7d66dedbfe34b1511680e447d3

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
