### PR TITLE
dev-util/perf: allow building with no `LLVM_SLOT` if `USE="-bpf"`

### DIFF
--- a/dev-util/perf/perf-6.14.ebuild
+++ b/dev-util/perf/perf-6.14.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 LLVM_COMPAT=( {18..20} )
+LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..13} python3_13t)
 inherit bash-completion-r1 estack flag-o-matic linux-info llvm-r1 toolchain-funcs python-r1
 
@@ -39,6 +40,7 @@ IUSE="abi_mips_o32 abi_mips_n32 abi_mips_n64 babeltrace capstone big-endian bpf 
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	bpf? ( ${LLVM_REQUIRED_USE} )
 "
 
 # setuptools (and Python) are always needed even if not building Python bindings

--- a/dev-util/perf/perf-6.18.5.ebuild
+++ b/dev-util/perf/perf-6.18.5.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 LLVM_COMPAT=( {18..21} )
+LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} python3_{13,14}t)
 inherit bash-completion-r1 estack flag-o-matic linux-info llvm-r1 toolchain-funcs python-single-r1
 
@@ -39,6 +40,7 @@ IUSE="abi_mips_o32 abi_mips_n32 abi_mips_n64 babeltrace capstone big-endian bpf 
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	bpf? ( ${LLVM_REQUIRED_USE} )
 "
 
 # setuptools (and Python) are always needed even if not building Python bindings

--- a/dev-util/perf/perf-6.19.12.ebuild
+++ b/dev-util/perf/perf-6.19.12.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 LLVM_COMPAT=( {18..21} )
+LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} python3_{13,14}t)
 inherit bash-completion-r1 estack flag-o-matic linux-info llvm-r2 toolchain-funcs python-single-r1
 
@@ -39,6 +40,7 @@ IUSE="abi_mips_o32 abi_mips_n32 abi_mips_n64 babeltrace capstone big-endian bpf 
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	bpf? ( ${LLVM_REQUIRED_USE} )
 "
 
 # setuptools (and Python) are always needed even if not building Python bindings

--- a/dev-util/perf/perf-7.0.ebuild
+++ b/dev-util/perf/perf-7.0.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 LLVM_COMPAT=( {18..22} )
+LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} python3_{13,14}t)
 inherit bash-completion-r1 estack flag-o-matic linux-info llvm-r2 toolchain-funcs python-single-r1
 
@@ -39,6 +40,7 @@ IUSE="abi_mips_o32 abi_mips_n32 abi_mips_n64 babeltrace capstone big-endian bpf 
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	bpf? ( ${LLVM_REQUIRED_USE} )
 "
 
 # setuptools (and Python) are always needed even if not building Python bindings


### PR DESCRIPTION
LLVM is required only if `USE="bpf"`, so do not require selection of an `LLVM_SLOT` when `USE="-bpf"`.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` reports `pkgcheck scan: error: failed running git: fatal: not a git repository (or any parent up to mount point /var/db)` even though I am running it in a Git work tree.

Please note that all boxes must be checked for the pull request to be merged.
