### PR TITLE
media-video/obs-studio depend on VLC 3

### DIFF
--- a/media-video/obs-studio/obs-studio-32.0.4-r1.ebuild
+++ b/media-video/obs-studio/obs-studio-32.0.4-r1.ebuild
@@ -13,8 +13,8 @@ inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 
 CEF_AMD64="cef_binary_6533_linux_x86_64_v6"
 CEF_ARM64="cef_binary_6533_linux_aarch64_v6"
-OBS_BROWSER_COMMIT="ea04212e4bbadd077f9e6038758c4e4779c24fa3"
-OBS_WEBSOCKET_COMMIT="68bebc28be57a8ca371404182113e16eeac74cbf"
+OBS_BROWSER_COMMIT="a776dd6a1a0ded4a8a723f2f572f3f8a9707f5a8"
+OBS_WEBSOCKET_COMMIT="1c9306b1e200704ebe192e06c893dfc06b097c43"
 
 DESCRIPTION="Software for Recording and Streaming Live Video Content"
 HOMEPAGE="https://obsproject.com"
@@ -63,6 +63,8 @@ BDEPEND="
 	python? ( dev-lang/swig )
 "
 # media-video/ffmpeg[opus] required due to bug 909566
+# The websocket plug-in fails to build with 'dev-cpp/asio-1.34.0':
+#   https://github.com/obsproject/obs-websocket/issues/1291
 DEPEND="
 	dev-cpp/nlohmann_json
 	dev-libs/glib:2
@@ -134,13 +136,13 @@ DEPEND="
 		media-libs/libv4l
 		virtual/udev
 	)
-	vlc? ( media-video/vlc:= )
+	vlc? ( <media-video/vlc-4.0:= )
 	wayland? (
 		dev-libs/wayland
 		x11-libs/libxkbcommon
 	)
 	websocket? (
-		dev-cpp/asio
+		<dev-cpp/asio-1.34.0
 		dev-cpp/websocketpp
 		dev-libs/qr-code-generator
 	)
@@ -157,6 +159,11 @@ QA_PREBUILT="
 	usr/lib*/obs-plugins/swiftshader/libEGL.so
 	usr/lib*/obs-plugins/swiftshader/libGLESv2.so
 "
+
+PATCHES=(
+	# https://bugs.gentoo.org/966051
+	"${FILESDIR}/${PN}-32.0.2-fix-build-with-qt-6.10.patch"
+)
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup
@@ -178,9 +185,8 @@ src_unpack() {
 }
 
 src_prepare() {
-	default
-
-	sed -i 's/-Werror //' libobs/cmake/linux/libobs.pc.in || die
+	# Un-comment after all patches are gone.
+	#default
 
 	# -Werror=lto-type-mismatch
 	# https://bugs.gentoo.org/867250

--- a/media-video/obs-studio/obs-studio-32.1.0-r1.ebuild
+++ b/media-video/obs-studio/obs-studio-32.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,8 +13,8 @@ inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 
 CEF_AMD64="cef_binary_6533_linux_x86_64_v6"
 CEF_ARM64="cef_binary_6533_linux_aarch64_v6"
-OBS_BROWSER_COMMIT="a776dd6a1a0ded4a8a723f2f572f3f8a9707f5a8"
-OBS_WEBSOCKET_COMMIT="1c9306b1e200704ebe192e06c893dfc06b097c43"
+OBS_BROWSER_COMMIT="ea04212e4bbadd077f9e6038758c4e4779c24fa3"
+OBS_WEBSOCKET_COMMIT="68bebc28be57a8ca371404182113e16eeac74cbf"
 
 DESCRIPTION="Software for Recording and Streaming Live Video Content"
 HOMEPAGE="https://obsproject.com"
@@ -63,8 +63,6 @@ BDEPEND="
 	python? ( dev-lang/swig )
 "
 # media-video/ffmpeg[opus] required due to bug 909566
-# The websocket plug-in fails to build with 'dev-cpp/asio-1.34.0':
-#   https://github.com/obsproject/obs-websocket/issues/1291
 DEPEND="
 	dev-cpp/nlohmann_json
 	dev-libs/glib:2
@@ -136,13 +134,13 @@ DEPEND="
 		media-libs/libv4l
 		virtual/udev
 	)
-	vlc? ( media-video/vlc:= )
+	vlc? ( <media-video/vlc-4.0:= )
 	wayland? (
 		dev-libs/wayland
 		x11-libs/libxkbcommon
 	)
 	websocket? (
-		<dev-cpp/asio-1.34.0
+		dev-cpp/asio
 		dev-cpp/websocketpp
 		dev-libs/qr-code-generator
 	)
@@ -159,11 +157,6 @@ QA_PREBUILT="
 	usr/lib*/obs-plugins/swiftshader/libEGL.so
 	usr/lib*/obs-plugins/swiftshader/libGLESv2.so
 "
-
-PATCHES=(
-	# https://bugs.gentoo.org/966051
-	"${FILESDIR}/${PN}-32.0.2-fix-build-with-qt-6.10.patch"
-)
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup
@@ -185,8 +178,9 @@ src_unpack() {
 }
 
 src_prepare() {
-	# Un-comment after all patches are gone.
-	#default
+	default
+
+	sed -i 's/-Werror //' libobs/cmake/linux/libobs.pc.in || die
 
 	# -Werror=lto-type-mismatch
 	# https://bugs.gentoo.org/867250


### PR DESCRIPTION
This PR makes obs-studio depend on VLC 3.

VLC 4 requires patches that have not been merged upstream yet. Upstream tracking:
https://github.com/obsproject/obs-studio/pull/5882.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
