### PR TITLE
dev-libs/marisa: fix Python bindings link and install path leaking to /tmp

### DIFF
--- a/dev-libs/marisa/marisa-0.3.1-r2.ebuild
+++ b/dev-libs/marisa/marisa-0.3.1-r2.ebuild
@@ -37,8 +37,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	local cmake_build_dir="${WORKDIR}/${P}_build"
-	sed -e "s:^\([[:space:]]*\)libraries=:\1include_dirs=[\"${S}/include\"],\n\1library_dirs=[\"${cmake_build_dir}/lib/marisa\"],\n&:" \
+	sed -e "s:^\([[:space:]]*\)libraries=:\1include_dirs=[\"${S}/include\"],\n\1library_dirs=[\"${BUILD_DIR}\"],\n&:" \
 		-e "s:setup(name = \"marisa\":setup(name = \"marisa\", version = \"${PV}\":" \
 		-i bindings/python/setup.py || die
 

--- a/dev-libs/marisa/marisa-0.3.1-r2.ebuild
+++ b/dev-libs/marisa/marisa-0.3.1-r2.ebuild
@@ -50,7 +50,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIB_INSTALL_DIR="$(get_libdir)"
+		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
 		-DENABLE_TOOLS=$(usex tools)
 		-DBUILD_TESTING=OFF
 	)

--- a/dev-libs/marisa/marisa-9999.ebuild
+++ b/dev-libs/marisa/marisa-9999.ebuild
@@ -33,8 +33,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	local cmake_build_dir="${WORKDIR}/${P}_build"
-	sed -e "s:^\([[:space:]]*\)libraries=:\1include_dirs=[\"${S}/include\"],\n\1library_dirs=[\"${cmake_build_dir}/lib/marisa\"],\n&:" \
+	sed -e "s:^\([[:space:]]*\)libraries=:\1include_dirs=[\"${S}/include\"],\n\1library_dirs=[\"${BUILD_DIR}\"],\n&:" \
 		-e "s:setup(name = \"marisa\":setup(name = \"marisa\", version = \"${PV}\":" \
 		-i bindings/python/setup.py || die
 

--- a/dev-libs/marisa/marisa-9999.ebuild
+++ b/dev-libs/marisa/marisa-9999.ebuild
@@ -46,7 +46,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIB_INSTALL_DIR="$(get_libdir)"
+		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
 		-DENABLE_TOOLS=$(usex tools)
 		-DBUILD_TESTING=OFF
 	)


### PR DESCRIPTION
Two related fixes for the cmake-based ebuilds:

1. cmake.eclass sets BUILD_DIR to ${S}_build, and libmarisa.so lives at its root. Point library_dirs there instead of the nonexistent ${P}_build/lib/marisa.
2. LIB_INSTALL_DIR was passed as a relative path, so cmake_install.cmake prepended CMAKE_INSTALL_PREFIX (PORTAGE_TMPDIR) and dropped libmarisa.so into ${T}. Pin it to ${EPREFIX}/usr/$(get_libdir).

Closes: https://bugs.gentoo.org/972912
Closes: https://bugs.gentoo.org/972981

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.