### PR TITLE
net-libs/nodejs: update LICENSE with Blue Oak

### DIFF
--- a/net-libs/nodejs/nodejs-24.14.0.ebuild
+++ b/net-libs/nodejs/nodejs-24.14.0.ebuild
@@ -12,7 +12,7 @@ inherit ninja-utils pax-utils python-any-r1 toolchain-funcs xdg-utils
 
 DESCRIPTION="A JavaScript runtime built on Chrome's V8 JavaScript engine"
 HOMEPAGE="https://nodejs.org/"
-LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT npm? ( Artistic-2 )"
+LICENSE="Apache-1.1 Apache-2.0 BlueOak-1.0.0 BSD BSD-2 MIT npm? ( Artistic-2 )"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3

--- a/net-libs/nodejs/nodejs-99999999.ebuild
+++ b/net-libs/nodejs/nodejs-99999999.ebuild
@@ -12,7 +12,7 @@ inherit ninja-utils pax-utils python-any-r1 toolchain-funcs xdg-utils
 
 DESCRIPTION="A JavaScript runtime built on Chrome's V8 JavaScript engine"
 HOMEPAGE="https://nodejs.org/"
-LICENSE="Apache-1.1 Apache-2.0 BSD BSD-2 MIT npm? ( Artistic-2 )"
+LICENSE="Apache-1.1 Apache-2.0 BlueOak-1.0.0 BSD BSD-2 MIT npm? ( Artistic-2 )"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3


### PR DESCRIPTION
The license of `minimatch` which is bundled in `nodejs` was changed to `Blue Oak` (part of `OSI-APPROVED-FREE` group).
The change is included in `v20.x`, `v22.x`, `v24.x`, `v25.x`, and upcoming `v26.x` release lines. Out of the versions in gentoo tree, for now it seems to affect only `v24.14.0` and live ebuild.

Refs: https://github.com/isaacs/minimatch/commit/babaf94f74c061ba33834fa762c7b5e50279b9e1
Refs: https://github.com/nodejs/node/pull/60543
Refs: https://opensource.org/license/blueoak-1.0.0

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
