### PR TITLE
dev-libs/gmp: Replace __int128__ with __int128 for portability (clang)(#972987)

### DIFF
--- a/dev-libs/gmp/files/gmp-6.3.0-r1-__int128.patch
+++ b/dev-libs/gmp/files/gmp-6.3.0-r1-__int128.patch
@@ -1,0 +1,22 @@
+# Replace __int128__ with __int128 for portability (clang)
+# Gentoo Bug: https://bugs.gentoo.org/972987
+
+From 21cbec701d8f54d7157f8455a24b2ff4a5269496 Mon Sep 17 00:00:00 2001
+From: Marc Glisse <marc.glisse@inria.fr>
+Date: Sat, 1 Feb 2025 19:36:16 +0100
+Subject: [PATCH] Replace __int128__ with __int128 for portability (clang).
+
+---
+diff --git a/longlong.h b/longlong.h
+index be1c3cbc6..41ad4f980 100644
+--- a/longlong.h
++++ b/longlong.h
+@@ -1162,7 +1162,7 @@ extern UWtype __MPN(udiv_qrnnd) (UWtype *, UWtype, UWtype, UWtype);
+   do {									\
+     UDItype __u = (u), __v = (v);					\
+     (w0) = __u * __v;							\
+-    (w1) = (unsigned __int128__) __u * __v >> 64;			\
++    (w1) = __extension__ (unsigned __int128) __u * __v >> 64;		\
+   } while (0)
+ #endif
+ 

--- a/dev-libs/gmp/gmp-6.3.0-r1.ebuild
+++ b/dev-libs/gmp/gmp-6.3.0-r1.ebuild
@@ -43,6 +43,7 @@ MULTILIB_WRAPPED_HEADERS=( /usr/include/gmp.h )
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.1.0-noexecstack-detect.patch
 	"${FILESDIR}"/${PN}-6.2.1-no-zarch.patch
+	"${FILESDIR}"/${PN}-6.3.0-r1-__int128.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Clang rejects `unsigned __int128__` in `longlong.h` on loongarch64,
which breaks GMP while expanding `umul_ppmm`

Upstream patch: https://github.com/gmp-mirror/gmp/commit/21cbec701d8f54d7157f8455a24b2ff4a5269496

Closes: https://bugs.gentoo.org/972987

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
