### PR TITLE
dev-libs/libpcre2: fix ld.lld symbol not defined (#973026)

### DIFF
--- a/dev-libs/libpcre2/files/libpcre2-10.47-remove-local-symbols.patch
+++ b/dev-libs/libpcre2/files/libpcre2-10.47-remove-local-symbols.patch
@@ -1,0 +1,56 @@
+# Gentoo Bug: https://bugs.gentoo.org/973026
+# Upstream PR: https://github.com/PCRE2Project/pcre2/pull/884
+# Patch: https://github.com/termux/termux-packages/blob/master/packages/pcre2/0001-version-script-remove-local-symbols.patch
+#
+# Fixes:
+# ld.lld: error: version script assignment of 'local' to symbol '_fini' failed: symbol not defined
+# ld.lld: error: version script assignment of 'local' to symbol '_init' failed: symbol not defined
+
+--- a/src/libpcre2-16.sym
++++ b/src/libpcre2-16.sym
+@@ -80,9 +80,6 @@
+     pcre2_substring_list_get_16;
+     pcre2_substring_nametable_scan_16;
+     pcre2_substring_number_from_name_16;
+-  local:
+-    _fini;
+-    _init;
+ };
+ 
+ # PCRE2_10.48 {} PCRE2_10.47;
+--- a/src/libpcre2-32.sym
++++ b/src/libpcre2-32.sym
+@@ -80,9 +80,6 @@
+     pcre2_substring_list_get_32;
+     pcre2_substring_nametable_scan_32;
+     pcre2_substring_number_from_name_32;
+-  local:
+-    _fini;
+-    _init;
+ };
+ 
+ # PCRE2_10.48 {} PCRE2_10.47;
+--- a/src/libpcre2-8.sym
++++ b/src/libpcre2-8.sym
+@@ -80,9 +80,6 @@
+     pcre2_substring_list_get_8;
+     pcre2_substring_nametable_scan_8;
+     pcre2_substring_number_from_name_8;
+-  local:
+-    _fini;
+-    _init;
+ };
+ 
+ # PCRE2_10.48 {} PCRE2_10.47;
+--- a/src/libpcre2-posix.sym
++++ b/src/libpcre2-posix.sym
+@@ -5,9 +5,6 @@
+     pcre2_regerror;
+     pcre2_regexec;
+     pcre2_regfree;
+-  local:
+-    _fini;
+-    _init;
+ };
+ 
+ # PCRE2_10.48 {} PCRE2_10.47;

--- a/dev-libs/libpcre2/libpcre2-10.47.ebuild
+++ b/dev-libs/libpcre2/libpcre2-10.47.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -49,6 +49,7 @@ MULTILIB_CHOST_TOOLS=(
 PATCHES=(
 	"${FILESDIR}"/${PN}-10.10-000-Fix-multilib.patch
 	"${FILESDIR}"/${PN}-10.47-riscv.patch
+	"${FILESDIR}"/${PN}-10.47-remove-local-symbols.patch
 )
 
 src_prepare() {

--- a/dev-libs/libpcre2/libpcre2-10.47.ebuild
+++ b/dev-libs/libpcre2/libpcre2-10.47.ebuild
@@ -50,6 +50,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-10.10-000-Fix-multilib.patch
 	"${FILESDIR}"/${PN}-10.47-riscv.patch
 	"${FILESDIR}"/${PN}-10.47-constness.patch
+	"${FILESDIR}"/${PN}-10.47-remove-local-symbols.patch
 )
 
 QA_CONFIG_IMPL_DECL_SKIP=(


### PR DESCRIPTION
remove local symbols to fix ld.ldd build errors:
- ld.lld: error: version script assignment of 'local' to symbol '_fini' failed: symbol not defined
- ld.lld: error: version script assignment of 'local' to symbol '_init' failed: symbol not defined

Upstream PR: https://github.com/PCRE2Project/pcre2/pull/884
Patch: https://github.com/termux/termux-packages/blob/master/packages/pcre2/0001-version-script-remove-local-symbols.patch

Closes: https://bugs.gentoo.org/973026

---
- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
