### PR TITLE
dev-util/claude-code: require cpu_flags_x86_* for amd64 only

### DIFF
--- a/dev-util/claude-code/claude-code-2.1.111-r1.ebuild
+++ b/dev-util/claude-code/claude-code-2.1.111-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Claude Code - an agentic coding tool by Anthropic"
+HOMEPAGE="https://claude.com/product/claude-code"
+
+# NOTE(JayF): Claude code's official install method is now curl|bash
+#             the script is simple: it fetches the latest version,
+#             downloads a manifest of files for that version, and
+#             downloads a single binary claude executable matching.
+#             All this from an unbranded GCS bucket (yikes).
+# https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/bootstrap.sh
+GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+SRC_URI="
+	amd64? (
+		elibc_glibc? ( ${GCS_BUCKET}/${PV}/linux-x64/claude -> claude-amd64-glibc-${PV} )
+		elibc_musl?  ( ${GCS_BUCKET}/${PV}/linux-x64-musl/claude -> claude-amd64-musl-${PV} )
+	)
+	arm64? (
+		elibc_glibc? ( ${GCS_BUCKET}/${PV}/linux-arm64/claude -> claude-arm64-glibc-${PV} )
+		elibc_musl?  ( ${GCS_BUCKET}/${PV}/linux-arm64-musl/claude -> claude-arm64-musl-${PV} )
+	)"
+S="${WORKDIR}"
+
+# NOTE(JayF): claude-code is only usable via paid subscription and has a
+#             clickthrough EULA-type license. Please see $HOMEPAGE for
+#             full details.
+LICENSE="all-rights-reserved"
+SLOT="0"
+KEYWORDS="amd64 arm64"
+QA_PREBUILT="opt/bin/claude"
+
+RDEPEND="sys-apps/ripgrep"
+
+IUSE="cpu_flags_x86_avx cpu_flags_x86_avx2"
+REQUIRED_USE="amd64? ( cpu_flags_x86_avx cpu_flags_x86_avx2 )"
+
+RESTRICT="bindist mirror strip"
+
+src_compile() {
+	# Skip, nothing to compile here.
+	:
+}
+
+src_install() {
+	# NOTE(JayF) Literally the file we download is all there is to
+	#            install. It's just a binary. No docs. Nothing else.
+	exeinto /opt/bin
+	newexe "${DISTDIR}/${A[0]}" claude
+
+	insinto /etc/${PN}
+	newins "${FILESDIR}/managed-settings-native.json" managed-settings.json
+}
+
+pkg_postinst() {
+	if ! grep -q DISABLE_INSTALLATION_CHECKS /etc/claude-code/managed-settings.json; then
+		ewarn "Ensure you run etc-update or dispatch-conf before executing claude."
+		ewarn "Failure to properly integrate changes to /etc/claude-code/managed-settings.json"
+		ewarn "may lead to claude installing itself to your homedir without asking."
+	fi
+}


### PR DESCRIPTION
Having `cpu_flags_x86_*` in `REQUIRED_USE` prevents it from being built on AArch64.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
