### PR TITLE
media-libs/giflib: patch CVE-2026-26740

### DIFF
--- a/media-libs/giflib/files/giflib-5.2.2-CVE-2026-26740.patch
+++ b/media-libs/giflib/files/giflib-5.2.2-CVE-2026-26740.patch
@@ -1,0 +1,24 @@
+From 9f5ee9217734df524764daac6d26a250ba8fb42d Mon Sep 17 00:00:00 2001
+From: Andrew Moylan <amoylan@google.com>
+Date: Tue, 21 Apr 2026 12:43:56 +0000
+Subject: [PATCH] Prevent CVE-2026-26740
+
+---
+ egif_lib.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/egif_lib.c b/egif_lib.c
+index 1526868..4f16f88 100644
+--- a/egif_lib.c
++++ b/egif_lib.c
+@@ -678,6 +678,7 @@ int EGifGCBToSavedExtension(const GraphicsControlBlock *GCB,
+ 		ExtensionBlock *ep =
+ 		    &GifFile->SavedImages[ImageIndex].ExtensionBlocks[i];
+ 		if (ep->Function == GRAPHICS_EXT_FUNC_CODE) {
++			if (ep->ByteCount < 4) return GIF_ERROR;
+ 			EGifGCBToExtension(GCB, ep->Bytes);
+ 			return GIF_OK;
+ 		}
+-- 
+2.53.0
+

--- a/media-libs/giflib/giflib-5.2.2-r1.ebuild
+++ b/media-libs/giflib/giflib-5.2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ inherit flag-o-matic multilib-minimal toolchain-funcs
 
 DESCRIPTION="Library to handle, display and manipulate GIF images"
 HOMEPAGE="https://sourceforge.net/projects/giflib/"
-SRC_URI="https://downloads.sourceforge.net/giflib/${P}.tar.gz"
+SRC_URI="https://downloads.sourceforge.net/project/giflib/giflib-5.x/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/7"
@@ -18,6 +18,7 @@ BDEPEND="doc? ( virtual/imagemagick-tools )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.2.1-fix-missing-quantize-API-symbols.patch
+	"${FILESDIR}"/${PN}-5.2.2-CVE-2026-26740.patch
 	"${FILESDIR}"/${PN}-5.2.2-fortify.patch
 	"${FILESDIR}"/${PN}-5.2.2-verbose-tests.patch
 )


### PR DESCRIPTION
CVE:
* Fetched giflib 5.2.2 and verified the PoC from the CVE disclosure does indeed crash with ASan enabled. (6.1.2 also crashes.)
* Applied one-line fix to return error in such case.
* ASan build no longer crashes.
* The fix is added here as a .patch in files/.
* ebuild test passes

And:
* Update redirecting SRC_URI per pkgdev warning.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
  => This returns SuspiciousSrcUriChange which I assume is a false positive given the nature of the SRC_URI update.

Please note that all boxes must be checked for the pull request to be merged.
