### PR TITLE
app-emulation/libguestfs: Remove vestigial bash completion files

### DIFF
--- a/app-emulation/libguestfs/files/libguestfs-1.56.2-bash-Remove-vestigial-bash-completions.patch
+++ b/app-emulation/libguestfs/files/libguestfs-1.56.2-bash-Remove-vestigial-bash-completions.patch
@@ -1,0 +1,149 @@
+From bc0443f84259198cf51b613b9bb541758c6b0ef4 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 24 Apr 2026 18:33:29 -0500
+Subject: [PATCH 1/2] bash/*: Remove vestigial bash completions
+
+They've long since moved to other projects, and Gentoo Portage complains about them.
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ bash/guestunmount         | 108 --------------------------------------
+ bash/libguestfs-test-tool |   6 ---
+ 2 files changed, 114 deletions(-)
+
+diff --git a/bash/guestunmount b/bash/guestunmount
+index 871bf18a5..446f5d5b1 100644
+--- a/bash/guestunmount
++++ b/bash/guestunmount
+@@ -84,111 +84,3 @@ _guestunmount ()
+     _guestfs_virttools "guestunmount" 1
+ } &&
+ complete -o default -F _guestunmount guestunmount
+-
+-_virt_alignment_scan ()
+-{
+-    _guestfs_virttools "virt-alignment-scan" 1
+-} &&
+-complete -o default -F _virt_alignment_scan virt-alignment-scan
+-
+-_virt_builder ()
+-{
+-    _guestfs_virttools "virt-builder" 0
+-} &&
+-complete -o default -F _virt_builder virt-builder
+-
+-_virt_cat ()
+-{
+-    _guestfs_virttools "virt-cat" 1
+-} &&
+-complete -o default -F _virt_cat virt-cat
+-
+-_virt_customize ()
+-{
+-    _guestfs_virttools "virt-customize" 0
+-} &&
+-complete -o default -F _virt_customize virt-customize
+-
+-_virt_dib ()
+-{
+-    _guestfs_virttools "virt-dib" 0
+-} &&
+-complete -o default -F _virt_dib virt-dib
+-
+-_virt_df ()
+-{
+-    _guestfs_virttools "virt-df" 1
+-} &&
+-complete -o default -F _virt_df virt-df
+-
+-_virt_diff ()
+-{
+-    _guestfs_virttools "virt-diff" 1
+-} &&
+-complete -o default -F _virt_diff virt-diff
+-
+-_virt_edit ()
+-{
+-    _guestfs_virttools "virt-edit" 0
+-} &&
+-complete -o default -F _virt_edit virt-edit
+-
+-_virt_filesystems ()
+-{
+-    _guestfs_virttools "virt-filesystems" 1
+-} &&
+-complete -o default -F _virt_filesystems virt-filesystems
+-
+-_virt_format ()
+-{
+-    _guestfs_virttools "virt-format" 0
+-} &&
+-complete -o default -F _virt_format virt-format
+-
+-_virt_get_kernel ()
+-{
+-    _guestfs_virttools "virt-get-kernel" 1
+-} &&
+-complete -o default -F _virt_get_kernel virt-get-kernel
+-
+-_virt_inspector ()
+-{
+-    _guestfs_virttools "virt-inspector" 1
+-} &&
+-complete -o default -F _virt_inspector virt-inspector
+-
+-_virt_log ()
+-{
+-    _guestfs_virttools "virt-log" 1
+-} &&
+-complete -o default -F _virt_log virt-log
+-
+-_virt_ls ()
+-{
+-    _guestfs_virttools "virt-ls" 1
+-} &&
+-complete -o default -F _virt_ls virt-ls
+-
+-_virt_resize ()
+-{
+-    _guestfs_virttools "virt-resize" 0
+-} &&
+-complete -o default -F _virt_resize virt-resize
+-
+-_virt_sparsify ()
+-{
+-    _guestfs_virttools "virt-sparsify" 0
+-} &&
+-complete -o default -F _virt_sparsify virt-sparsify
+-
+-_virt_sysprep ()
+-{
+-    _guestfs_virttools "virt-sysprep" 0
+-} &&
+-complete -o default -F _virt_sysprep virt-sysprep
+-
+-_virt_tail ()
+-{
+-    _guestfs_virttools "virt-tail" 1
+-} &&
+-complete -o default -F _virt_tail virt-tail
+diff --git a/bash/libguestfs-test-tool b/bash/libguestfs-test-tool
+index 91cfbf821..4c467cf04 100644
+--- a/bash/libguestfs-test-tool
++++ b/bash/libguestfs-test-tool
+@@ -40,12 +40,6 @@ _guestfs_options_only ()
+     esac
+ }
+ 
+-_virt_win_reg ()
+-{
+-    _guestfs_options_only "virt-win-reg"
+-} &&
+-complete -o default -F _virt_win_reg virt-win-reg
+-
+ _libguestfs-test-tool ()
+ {
+     _guestfs_options_only "libguestfs-test-tool"
+-- 
+2.53.0
+

--- a/app-emulation/libguestfs/files/libguestfs-1.56.2-guestfs-bash-completion.m4-more-control.patch
+++ b/app-emulation/libguestfs/files/libguestfs-1.56.2-guestfs-bash-completion.m4-more-control.patch
@@ -1,0 +1,78 @@
+From 48e47e7c9f3266cf3e12e3665046ae3ba3e37166 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 24 Apr 2026 21:00:32 -0500
+Subject: [PATCH 2/2] m4/guestfs-bash-completion.m4: Allow control of
+ completions installation
+
+It can be desirable to install (or suppress) the installion of the bash
+completion files regardless on what's on the compile host. Gentoo always
+installs bash completions files, even if bash-completion is not installed.
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ configure.ac                  |  2 ++
+ m4/guestfs-bash-completion.m4 | 37 +++++++++++++++++++++++++----------
+ 2 files changed, 29 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 57c24da5e..3425c11ee 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -324,6 +324,8 @@ feature "Erlang bindings"       test "x$HAVE_ERLANG_TRUE" = "x"
+ feature "Lua bindings"          test "x$HAVE_LUA_TRUE" = "x"
+ feature "Go bindings"           test "x$HAVE_GOLANG_TRUE" = "x"
+ feature "bash completion"       test "x$HAVE_BASH_COMPLETION_TRUE" = "x"
++AS_IF([test "x$HAVE_BASH_COMPLETION_TRUE" = "x"],
++[print   "Bash completions dir"  "$BASH_COMPLETIONS_DIR"])
+ feature "Rust bindings"         test "x$HAVE_RUST_TRUE" = "x"
+ 
+ echo
+diff --git a/m4/guestfs-bash-completion.m4 b/m4/guestfs-bash-completion.m4
+index ecd9f591d..72ea2ef72 100644
+--- a/m4/guestfs-bash-completion.m4
++++ b/m4/guestfs-bash-completion.m4
+@@ -16,14 +16,31 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ 
+ dnl Bash completion.
+-PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0], [
+-    bash_completion=yes
+-    AC_MSG_CHECKING([for bash-completions directory])
+-    BASH_COMPLETIONS_DIR="`pkg-config --variable=completionsdir bash-completion`"
+-    AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
+-    AC_SUBST([BASH_COMPLETIONS_DIR])
+-],[
+-    bash_completion=no
+-    AC_MSG_WARN([bash-completion not installed])
++AC_ARG_WITH([bash-completion],
++  [AS_HELP_STRING([--with-bash-completion],[Enable bash completions @<:@default=auto@:>@])],
++  [with_bash_completion="$withval"],
++  [with_bash_completion=auto])
++
++AS_IF([test "x$with_bash_completion" = "xauto"], [
++       PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
++       [], [
++         AC_MSG_WARN([bash-completion not installed])
++       BASH_COMPLETION=no
++])],[BASH_COMPLETION=$with_bash_completion])
++AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$BASH_COMPLETION" != "xno"])
++
++AC_ARG_WITH([bash-completion-dir],
++  [AS_HELP_STRING([--with-bash-completion-dir],[Directory to install bash completions @<:@default=auto@:>@])],
++  [with_bash_completion_dir="$withval"],
++  [with_bash_completion_dir=auto])
++
++AS_IF([test "x$BASH_COMPLETION" != "xno"], [
++  AC_MSG_CHECKING([for bash-completions directory])
++  AS_IF([test "x$with_bash_completion_dir" = "xauto" || test "x$with_bash_completion_dir" = "xyes"], [
++    PKG_CHECK_VAR([BASH_COMPLETIONS_DIR], [bash-completion], [completionsdir], [], [
++      BASH_COMPLETIONS_DIR="${datadir}/bash-completion/completions"])
++  ],
++  [BASH_COMPLETIONS_DIR=$with_bash_completion_dir])
++  AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
++  AC_SUBST([BASH_COMPLETIONS_DIR])
+ ])
+-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$bash_completion" = "xyes"])
+-- 
+2.53.0
+

--- a/app-emulation/libguestfs/libguestfs-1.56.2.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.56.2.ebuild
@@ -106,17 +106,11 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-1.52.1-disable-obsolete-lvmetad-in-tests.patch"
 	"${FILESDIR}/${PN}-1.56.2-respect-LDFLAGS-in-perl-module.patch"
+	"${FILESDIR}/${PN}-1.56.2-bash-Remove-vestigial-bash-completions.patch"
+	"${FILESDIR}/${PN}-1.56.2-guestfs-bash-completion.m4-more-control.patch"
 )
 
 src_prepare() {
-	cat <<EOF > "${S}/m4/guestfs-bash-completion.m4" || die
-dnl Unconditionally install Bash completion files
-AC_MSG_CHECKING([for bash-completions directory])
-AC_SUBST([BASH_COMPLETIONS_DIR],[$(get_bashcompdir)])
-AC_MSG_RESULT([\$BASH_COMPLETIONS_DIR])
-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[/bin/true])
-EOF
-
 	default
 	eautoreconf
 }
@@ -158,6 +152,8 @@ src_configure() {
 		--disable-introspection
 		$(use_with libvirt)
 		--with-default-backend=$(usex libvirt libvirt direct)
+		--with-bash-completion
+		--with-bash-completion-dir=$(get_bashcompdir)
 		$(use_enable perl)
 		$(use_enable python)
 		$(use_enable static-libs static)


### PR DESCRIPTION
The tools references by them were moved to other packages (mostly guestfs-tools).

No revbump because they didn't do anything anyway, this quiets portage when bash-completions is installed. 

Closes: https://bugs.gentoo.org/973092

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
