### PR TITLE
app-misc/ca-certificates: create relative symlink with --sysroot

### DIFF
--- a/app-misc/ca-certificates/ca-certificates-20250419.3.112-r1.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20250419.3.112-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # The Debian ca-certificates package merely takes the CA database as it exists
@@ -120,6 +120,7 @@ src_prepare() {
 	fi
 
 	default
+	eapply -p2 "${FILESDIR}"/${PN}-20250419-root.patch
 	eapply -p2 "${FILESDIR}"/${PN}-20240203.3.98-update-ca-certificates-drop-pointless-dependency.patch
 
 	pushd "${S}/${PN}" >/dev/null || die

--- a/app-misc/ca-certificates/files/ca-certificates-20250419-root.patch
+++ b/app-misc/ca-certificates/files/ca-certificates-20250419-root.patch
@@ -1,0 +1,50 @@
+create relative symlink with --sysroot
+
+--- a/image/usr/sbin/update-ca-certificates
++++ b/image/usr/sbin/update-ca-certificates
+@@ -30,6 +30,8 @@ LOCALCERTSDIR=/usr/local/share/ca-certificates
+ CERTBUNDLE=ca-certificates.crt
+ ETCCERTSDIR=/etc/ssl/certs
+ HOOKSDIR=/etc/ca-certificates/update.d
++SYSROOT=""
++RELPATH=""
+ 
+ while [ $# -gt 0 ];
+ do
+@@ -62,11 +64,11 @@ do
+     --sysroot)
+       shift
+       SYSROOT="$1"
+-      CERTSCONF="$1/${CERTSCONF}"
+-      CERTSDIR="$1/${CERTSDIR}"
+-      LOCALCERTSDIR="$1/${LOCALCERTSDIR}"
+-      ETCCERTSDIR="$1/${ETCCERTSDIR}"
+-      HOOKSDIR="$1/${HOOKSDIR}";;
++      CERTSCONF="${SYSROOT}${CERTSCONF}"
++      CERTSDIR="${SYSROOT}${CERTSDIR}"
++      LOCALCERTSDIR="${SYSROOT}${LOCALCERTSDIR}"
++      ETCCERTSDIR="${SYSROOT}${ETCCERTSDIR}"
++      HOOKSDIR="${SYSROOT}${HOOKSDIR}";;
+     --help|-h|*)
+       echo "$0: [--verbose] [--fresh]"
+       exit;;
+@@ -74,6 +76,10 @@ do
+   shift
+ done
+ 
++if [ -n "${SYSROOT}" ] ; then
++  RELPATH="$(realpath -s --relative-to="${ETCCERTSDIR}" "${SYSROOT}")"
++fi
++
+ if [ ! -s "$CERTSCONF" ]
+ then
+   fresh=1
+@@ -102,7 +108,7 @@ add() {
+                                                   -e 's/,/_/g').pem"
+   if ! test -e "$PEM" || [ "$(readlink "$PEM")" != "$CERT" ]
+   then
+-    ln -sf "$CERT" "$PEM"
++    ln -sf "${RELPATH}${CERT#$SYSROOT}" "$PEM"
+     echo "+$PEM" >> "$ADDED"
+   fi
+   # Add trailing newline to certificate, if it is missing (#635570)

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -505,14 +505,6 @@ virtual/perl-Unicode-Normalize
 >=sys-devel/gettext-0.24
 >=dev-libs/libintl-0.24
 
-# Sam James <sam@gentoo.org> (2025-06-03)
-# Fetching from GitHub seems broken with this:
-# > Connecting to github.com|20.26.156.215|:443... connected.
-# > ERROR: cannot verify github.com's certificate, issued by 'CN=Sectigo ECC Domain Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB':
-# >  Unable to locally verify the issuer's authority.
-# See bug #963400.
-=app-misc/ca-certificates-20250419.3.112
-
 # Sam James <sam@gentoo.org> (2025-05-26)
 # Breaks some reverse dependencies and is abandoned upstream (bug #956630).
 =dev-cpp/glog-0.7.1


### PR DESCRIPTION
changes made upstream in a652c7f4158e ("sbin/update-ca-certificates: add a --sysroot option") does not create symlink relatively, leading to unresolvable files removed as part of orphan cleanup. This patch restore original behaviour implemented in 26c99295c5d5
("app-misc/ca-certificates: version bump to 20150426.3.20").

Bug: https://bugs.gentoo.org/963400

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
