### PR TITLE
app-emulation/guestfs-tools: Remove vestigial bash completions

### DIFF
--- a/app-emulation/guestfs-tools/files/guestfs-tools-1.52.3-guestfs-bash-completion.m4-more-control.patch
+++ b/app-emulation/guestfs-tools/files/guestfs-tools-1.52.3-guestfs-bash-completion.m4-more-control.patch
@@ -1,0 +1,64 @@
+From c844f09d5dcacc679569e6adf3a04b97abd13fe0 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 24 Apr 2026 21:11:37 -0500
+Subject: [PATCH] m4/guestfs-bash-completion.m4: Allow control of completions
+ installation
+
+It can be desirable to install (or suppress) the installion of the bash
+completion files regardless on what's on the compile host. Gentoo always
+installs bash completions files, even if bash-completion is not installed.
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ m4/guestfs-bash-completion.m4 | 37 +++++++++++++++++++++++++----------
+ 1 file changed, 27 insertions(+), 10 deletions(-)
+
+diff --git a/m4/guestfs-bash-completion.m4 b/m4/guestfs-bash-completion.m4
+index 4a9c2ee0..1a7bd8b3 100644
+--- a/m4/guestfs-bash-completion.m4
++++ b/m4/guestfs-bash-completion.m4
+@@ -16,14 +16,31 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ 
+ dnl Bash completion.
+-PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0], [
+-    bash_completion=yes
+-    AC_MSG_CHECKING([for bash-completions directory])
+-    BASH_COMPLETIONS_DIR="`pkg-config --variable=completionsdir bash-completion`"
+-    AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
+-    AC_SUBST([BASH_COMPLETIONS_DIR])
+-],[
+-    bash_completion=no
+-    AC_MSG_WARN([bash-completion not installed])
++AC_ARG_WITH([bash-completion],
++  [AS_HELP_STRING([--with-bash-completion],[Enable bash completions @<:@default=auto@:>@])],
++  [with_bash_completion="$withval"],
++  [with_bash_completion=auto])
++
++AS_IF([test "x$with_bash_completion" = "xauto"], [
++       PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
++       [], [
++         AC_MSG_WARN([bash-completion not installed])
++       BASH_COMPLETION=no
++])],[BASH_COMPLETION=$with_bash_completion])
++AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$BASH_COMPLETION" != "xno"])
++
++AC_ARG_WITH([bash-completion-dir],
++  [AS_HELP_STRING([--with-bash-completion-dir],[Directory to install bash completions @<:@default=auto@:>@])],
++  [with_bash_completion_dir="$withval"],
++  [with_bash_completion_dir=auto])
++
++AS_IF([test "x$BASH_COMPLETION" != "xno"], [
++  AC_MSG_CHECKING([for bash-completions directory])
++  AS_IF([test "x$with_bash_completion_dir" = "xauto" || test "x$with_bash_completion_dir" = "xyes"], [
++    PKG_CHECK_VAR([BASH_COMPLETIONS_DIR], [bash-completion], [completionsdir], [], [
++      BASH_COMPLETIONS_DIR="${datadir}/bash-completion/completions"])
++  ],
++  [BASH_COMPLETIONS_DIR=$with_bash_completion_dir])
++  AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
++  AC_SUBST([BASH_COMPLETIONS_DIR])
+ ])
+-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$bash_completion" = "xyes"])
+-- 
+2.53.0
+

--- a/app-emulation/guestfs-tools/files/guestfs-tools-1.54.0-bash-Remove-vestigial-bash-completions.patch
+++ b/app-emulation/guestfs-tools/files/guestfs-tools-1.54.0-bash-Remove-vestigial-bash-completions.patch
@@ -1,0 +1,47 @@
+From a880070ce7ede60be0cf1cb7f013f21ac46b6e7d Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 24 Apr 2026 18:47:13 -0500
+Subject: [PATCH 1/2] bash/*: Remove vestigial bash completions
+
+They've long since moved to other projects, and Gentoo Portage complains about them.
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ bash/virt-alignment-scan | 6 ------
+ bash/virt-win-reg        | 6 ------
+ 2 files changed, 12 deletions(-)
+
+diff --git a/bash/virt-alignment-scan b/bash/virt-alignment-scan
+index 36529fa8..ba299064 100644
+--- a/bash/virt-alignment-scan
++++ b/bash/virt-alignment-scan
+@@ -79,12 +79,6 @@ _guestfs_virttools ()
+     esac
+ }
+ 
+-_guestunmount ()
+-{
+-    _guestfs_virttools "guestunmount" 1
+-} &&
+-complete -o default -F _guestunmount guestunmount
+-
+ _virt_alignment_scan ()
+ {
+     _guestfs_virttools "virt-alignment-scan" 1
+diff --git a/bash/virt-win-reg b/bash/virt-win-reg
+index 91cfbf82..a430508a 100644
+--- a/bash/virt-win-reg
++++ b/bash/virt-win-reg
+@@ -45,9 +45,3 @@ _virt_win_reg ()
+     _guestfs_options_only "virt-win-reg"
+ } &&
+ complete -o default -F _virt_win_reg virt-win-reg
+-
+-_libguestfs-test-tool ()
+-{
+-    _guestfs_options_only "libguestfs-test-tool"
+-} &&
+-complete -o default -F _libguestfs-test-tool libguestfs-test-tool
+-- 
+2.53.0
+

--- a/app-emulation/guestfs-tools/files/guestfs-tools-1.54.0-guestfs-bash-completion.m4-more-control.patch
+++ b/app-emulation/guestfs-tools/files/guestfs-tools-1.54.0-guestfs-bash-completion.m4-more-control.patch
@@ -1,0 +1,78 @@
+From 8f1531ec29968e379758baac487b3e63f9bdaf55 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 24 Apr 2026 21:11:37 -0500
+Subject: [PATCH 2/2] m4/guestfs-bash-completion.m4: Allow control of
+ completions installation
+
+It can be desirable to install (or suppress) the installion of the bash
+completion files regardless on what's on the compile host. Gentoo always
+installs bash completions files, even if bash-completion is not installed.
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ configure.ac                  |  2 ++
+ m4/guestfs-bash-completion.m4 | 37 +++++++++++++++++++++++++----------
+ 2 files changed, 29 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 8a180a1d..bb1d35d7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -218,6 +218,8 @@ feature "OCaml-based virt tools" test "x$HAVE_OCAML_TRUE" = "x"
+ feature "OCaml gettext"          test "x$OCAML_PKG_gettext" != "xno"
+ feature "Perl-based virt tools"  test "x$HAVE_TOOLS_TRUE" = "x"
+ feature "Bash tab completion"    test "x$HAVE_BASH_COMPLETION_TRUE" = "x"
++AS_IF([test "x$HAVE_BASH_COMPLETION_TRUE" = "x"],
++[print   "Bash completions dir"  "$BASH_COMPLETIONS_DIR"])
+ 
+ echo
+ echo "If any optional component is configured 'no' when you expected 'yes'"
+diff --git a/m4/guestfs-bash-completion.m4 b/m4/guestfs-bash-completion.m4
+index ecd9f591..72ea2ef7 100644
+--- a/m4/guestfs-bash-completion.m4
++++ b/m4/guestfs-bash-completion.m4
+@@ -16,14 +16,31 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ 
+ dnl Bash completion.
+-PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0], [
+-    bash_completion=yes
+-    AC_MSG_CHECKING([for bash-completions directory])
+-    BASH_COMPLETIONS_DIR="`pkg-config --variable=completionsdir bash-completion`"
+-    AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
+-    AC_SUBST([BASH_COMPLETIONS_DIR])
+-],[
+-    bash_completion=no
+-    AC_MSG_WARN([bash-completion not installed])
++AC_ARG_WITH([bash-completion],
++  [AS_HELP_STRING([--with-bash-completion],[Enable bash completions @<:@default=auto@:>@])],
++  [with_bash_completion="$withval"],
++  [with_bash_completion=auto])
++
++AS_IF([test "x$with_bash_completion" = "xauto"], [
++       PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
++       [], [
++         AC_MSG_WARN([bash-completion not installed])
++       BASH_COMPLETION=no
++])],[BASH_COMPLETION=$with_bash_completion])
++AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$BASH_COMPLETION" != "xno"])
++
++AC_ARG_WITH([bash-completion-dir],
++  [AS_HELP_STRING([--with-bash-completion-dir],[Directory to install bash completions @<:@default=auto@:>@])],
++  [with_bash_completion_dir="$withval"],
++  [with_bash_completion_dir=auto])
++
++AS_IF([test "x$BASH_COMPLETION" != "xno"], [
++  AC_MSG_CHECKING([for bash-completions directory])
++  AS_IF([test "x$with_bash_completion_dir" = "xauto" || test "x$with_bash_completion_dir" = "xyes"], [
++    PKG_CHECK_VAR([BASH_COMPLETIONS_DIR], [bash-completion], [completionsdir], [], [
++      BASH_COMPLETIONS_DIR="${datadir}/bash-completion/completions"])
++  ],
++  [BASH_COMPLETIONS_DIR=$with_bash_completion_dir])
++  AC_MSG_RESULT([$BASH_COMPLETIONS_DIR])
++  AC_SUBST([BASH_COMPLETIONS_DIR])
+ ])
+-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[test "x$bash_completion" = "xyes"])
+-- 
+2.53.0
+

--- a/app-emulation/guestfs-tools/guestfs-tools-1.52.3-r1.ebuild
+++ b/app-emulation/guestfs-tools/guestfs-tools-1.52.3-r1.ebuild
@@ -83,15 +83,12 @@ BDEPEND="
 	test? ( ocaml? ( dev-ml/ounit2[ocamlopt] ) )
 "
 
-src_prepare() {
-	cat <<EOF > "${S}/m4/guestfs-bash-completion.m4" || die
-dnl Unconditionally install Bash completion files
-AC_MSG_CHECKING([for bash-completions directory])
-AC_SUBST([BASH_COMPLETIONS_DIR],[$(get_bashcompdir)])
-AC_MSG_RESULT([\$BASH_COMPLETIONS_DIR])
-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[/bin/true])
-EOF
+PATCHES=(
+	"${FILESDIR}/${PN}-1.54.0-bash-Remove-vestigial-bash-completions.patch"
+        "${FILESDIR}/${PN}-1.52.3-guestfs-bash-completion.m4-more-control.patch"
+)
 
+src_prepare() {
 	default
 	eautoreconf
 }
@@ -109,6 +106,8 @@ src_configure() {
 		$(use_enable ocaml)
 		$(use_enable perl)
 		$(use_with libvirt)
+                --with-bash-completion
+                --with-bash-completion-dir="$(get_bashcompdir)"
 	)
 
 	econf "${myconf[@]}"

--- a/app-emulation/guestfs-tools/guestfs-tools-1.54.0.ebuild
+++ b/app-emulation/guestfs-tools/guestfs-tools-1.54.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -83,15 +83,12 @@ BDEPEND="
 	test? ( ocaml? ( dev-ml/ounit2[ocamlopt] ) )
 "
 
-src_prepare() {
-	cat <<EOF > "${S}/m4/guestfs-bash-completion.m4" || die
-dnl Unconditionally install Bash completion files
-AC_MSG_CHECKING([for bash-completions directory])
-AC_SUBST([BASH_COMPLETIONS_DIR],[$(get_bashcompdir)])
-AC_MSG_RESULT([\$BASH_COMPLETIONS_DIR])
-AM_CONDITIONAL([HAVE_BASH_COMPLETION],[/bin/true])
-EOF
+PATCHES=(
+	"${FILESDIR}/${PN}-1.54.0-guestfs-bash-completion.m4-more-control.patch"
+	"${FILESDIR}/${PN}-1.54.0-guestfs-bash-completion.m4-more-control.patch"
+)
 
+src_prepare() {
 	default
 	eautoreconf
 }
@@ -109,6 +106,8 @@ src_configure() {
 		$(use_enable ocaml)
 		$(use_enable perl)
 		$(use_with libvirt)
+		--with-bash-completion
+		--with-bash-completion-dir="$(get_bashcompdir)"
 	)
 
 	econf "${myconf[@]}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/973137

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
