### PR TITLE
media-sound/spotify: add local-playback USE flag with ffmpeg-compat:7

### DIFF
--- a/media-sound/spotify/files/spotify-wrapper
+++ b/media-sound/spotify/files/spotify-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export LD_LIBRARY_PATH="/usr/lib64/apulse"
+export LD_LIBRARY_PATH="/usr/lib64/apulse:/usr/lib/ffmpeg7/lib64"
 
 if command -v spotify-dbus.py > /dev/null; then
         echo "Launching spotify with Gnome systray integration."

--- a/media-sound/spotify/spotify-1.2.86-r1.ebuild
+++ b/media-sound/spotify/spotify-1.2.86-r1.ebuild
@@ -56,7 +56,7 @@ RDEPEND="
 	!gnome-extra/gnome-integration-spotify
 	libnotify? ( x11-libs/libnotify )
 	dev-libs/libayatana-appindicator
-	local-playback? ( media-video/ffmpeg:0/56.58.58 )
+	local-playback? ( media-video/ffmpeg-compat:7 )
 	pulseaudio? ( media-libs/libpulse )
 	!pulseaudio? ( media-sound/apulse )
 "


### PR DESCRIPTION
Replaces media-sound/ffmpeg with media-sound/ffmpeg-compat:7 and adds it to the LD_LIBRARY_PATH in the spotify-wrapper script.

Closes: https://bugs.gentoo.org/971657

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
