### PR TITLE
dev-ml/libvirt-ocaml: use dot-a eclass

### DIFF
--- a/dev-ml/libvirt-ocaml/libvirt-ocaml-0.6.1.7.ebuild
+++ b/dev-ml/libvirt-ocaml/libvirt-ocaml-0.6.1.7.ebuild
@@ -1,7 +1,9 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
+inherit dot-a
 
 DESCRIPTION="OCaml language binding for libvirt native C API"
 HOMEPAGE="https://ocaml.libvirt.org/"
@@ -18,3 +20,15 @@ DEPEND="app-emulation/libvirt
 BDEPEND="dev-lang/perl
 	 dev-ml/findlib[ocamlopt]
 	 virtual/pkgconfig"
+
+
+src_configure() {
+	lto-guarantee-fat
+	default
+}
+
+src_install() {
+	# ocaml always installs a static lib even without USE=static-libs
+	strip-lto-bytecode "${ED}"
+	default
+}


### PR DESCRIPTION
... to avoid installing broken static libraries w/ LTO.

Closes: https://bugs.gentoo.org/972519

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
