### PR TITLE
media-sound/musepack-tools: Fix crash in mpcenc

### DIFF
--- a/media-sound/musepack-tools/files/musepack-tools-495-unconstify-written-variable.patch
+++ b/media-sound/musepack-tools/files/musepack-tools-495-unconstify-written-variable.patch
@@ -1,0 +1,36 @@
+diff '--color=auto' -r -u a/common/fastmath.c b/common/fastmath.c
+--- a/common/fastmath.c	2013-10-21 21:21:51.000000000 -0000
++++ b/common/fastmath.c	2026-04-29 19:23:16.853879006 -0000
+@@ -20,10 +20,10 @@
+ 
+ #ifdef FAST_MATH
+ 
+-const float  tabatan2   [ 2*TABSTEP+1] [2];
+-const float  tabcos     [26*TABSTEP+1] [2];
+-const float  tabsqrt_ex [256];
+-const float  tabsqrt_m  [   TABSTEP+1] [2];
++float  tabatan2   [ 2*TABSTEP+1] [2];
++float  tabcos     [26*TABSTEP+1] [2];
++float  tabsqrt_ex [256];
++float  tabsqrt_m  [   TABSTEP+1] [2];
+ 
+ 
+ void   Init_FastMath ( void )
+diff '--color=auto' -r -u a/include/mpc/mpcmath.h b/include/mpc/mpcmath.h
+--- a/include/mpc/mpcmath.h	2013-10-21 21:21:51.000000000 -0000
++++ b/include/mpc/mpcmath.h	2026-04-29 19:29:49.576261251 -0000
+@@ -86,10 +86,10 @@
+ # define IFLOORF(x)   my_ifloor ((float)(x))
+ 
+ void   Init_FastMath ( void );
+-extern const float  tabatan2   [] [2];
+-extern const float  tabcos     [] [2];
+-extern const float  tabsqrt_ex [];
+-extern const float  tabsqrt_m  [] [2];
++extern float  tabatan2   [] [2];
++extern float  tabcos     [] [2];
++extern float  tabsqrt_ex [];
++extern float  tabsqrt_m  [] [2];
+ 
+ static mpc_inline float my_atan2 ( float x, float y )
+ {

--- a/media-sound/musepack-tools/musepack-tools-495-r1.ebuild
+++ b/media-sound/musepack-tools/musepack-tools-495-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+# svn export http://svn.musepack.net/libmpc/trunk musepack-tools-${PV}
+# tar -cjf musepack-tools-${PV}.tar.bz2 musepack-tools-${PV}
+
+DESCRIPTION="Musepack SV8 libraries and utilities"
+HOMEPAGE="https://www.musepack.net"
+SRC_URI="https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}.tar.xz"
+
+LICENSE="BSD LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+DEPEND="
+	>=media-libs/libcuefile-477
+	>=media-libs/libreplaygain-477
+"
+RDEPEND="
+	${DEPEND}
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-respect-cflags.patch
+	"${FILESDIR}"/${P}-fixup-link-depends.patch
+	"${FILESDIR}"/${P}-incompatible-pointers.patch
+	"${FILESDIR}"/${P}-unconstify-written-variable.patch
+)
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/860882
+	#
+	# Software is dead since 2016.
+	filter-lto
+
+	# Symbols are decorated with MPC_API but visibility isn't wired up to the
+	# build system(s)
+	append-flags -fvisibility=hidden
+
+	cmake_src_configure
+}


### PR DESCRIPTION
The application wrote to a const variable which is UB in C.

Closes: https://bugs.gentoo.org/973383

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
