### PR TITLE
net-misc/chrony: use dynamic pool directive and IPv6-enabled zone

### DIFF
--- a/net-misc/chrony/chrony-4.8-r1.ebuild
+++ b/net-misc/chrony/chrony-4.8-r1.ebuild
@@ -83,7 +83,7 @@ else
 fi
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-4.7-pool-vendor-gentoo.patch
+	"${FILESDIR}"/${PN}-4.8-pool-vendor-gentoo.patch
 	"${FILESDIR}"/${PN}-4.7-systemd-gentoo.patch
 )
 

--- a/net-misc/chrony/chrony-9999.ebuild
+++ b/net-misc/chrony/chrony-9999.ebuild
@@ -83,7 +83,7 @@ else
 fi
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-4.7-pool-vendor-gentoo.patch
+	"${FILESDIR}"/${PN}-4.8-pool-vendor-gentoo.patch
 	"${FILESDIR}"/${PN}-4.7-systemd-gentoo.patch
 )
 

--- a/net-misc/chrony/files/chrony-4.8-pool-vendor-gentoo.patch
+++ b/net-misc/chrony/files/chrony-4.8-pool-vendor-gentoo.patch
@@ -1,16 +1,13 @@
 - Use the Gentoo pool
-- Use the server directive instead of the pool directive so we get four time
-  sources and not twelve.
+- Use the IPv6-enabled zone
 --- a/examples/chrony.conf.example1
 +++ b/examples/chrony.conf.example1
 @@ -1,5 +1,8 @@
 -# Use four public NTP servers from the pool.ntp.org project.
 -pool pool.ntp.org iburst
 +# Use public NTP servers from the pool.ntp.org project.
-+server 0.gentoo.pool.ntp.org iburst
-+server 1.gentoo.pool.ntp.org iburst
-+server 2.gentoo.pool.ntp.org iburst
-+server 3.gentoo.pool.ntp.org iburst
++# Only `2.` zone provides both IPv4 and IPv6, see https://bugs.gentoo.org/973543
++pool 2.gentoo.pool.ntp.org iburst
  
  # Record the rate at which the system clock gains/losses time.
  driftfile /var/lib/chrony/drift


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/973543

On all systems, `pool` is superior for both clients and servers.
On IPv6-first systems, `[0123].` approach provides only one time source (which is also resolved only once, so if the chosen server goes down, synchonization drops entirely).

Implicit `maxsources 4` will ensure that chrony uses 4 time sources and not 12 as mentioned in previous comment (i also don't see any DNS returning more than 4 addresses at once so this could be outdated).

If https://github.com/abh/ntppool/pull/237 or something similar gets merged, we probably can use `gentoo.pool.ntp.org` directly.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
