### PR TITLE
app-office/calcurse-4.8.2: bump PYTHON_COMPAT to 3.14

### DIFF
--- a/app-office/calcurse/calcurse-4.8.2-r1.ebuild
+++ b/app-office/calcurse/calcurse-4.8.2-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..14} )
+
+inherit python-single-r1
+
+DESCRIPTION="A text-based calendar and scheduling application"
+HOMEPAGE="https://calcurse.org/"
+SRC_URI="https://calcurse.org/files/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~x86"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+IUSE="caldav doc"
+
+RDEPEND="
+	sys-libs/ncurses:0=
+	sys-libs/timezone-data
+	${PYTHON_DEPS}
+	caldav? (
+		$(python_gen_cond_dep '
+			dev-python/httplib2[${PYTHON_USEDEP}]
+			dev-python/pyparsing[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+DEPEND="
+	${RDEPEND}
+"
+
+BDEPEND="virtual/pkgconfig"
+
+src_configure() {
+	local myconf=(
+		$(use_enable doc docs)
+		--without-asciidoc # do not use AsciiDoc to regenerate docs
+	)
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
+}
+
+src_compile() {
+	default
+	if use caldav; then
+		python_fix_shebang contrib/caldav/calcurse-caldav
+	fi
+}
+
+src_install() {
+	docompress -x /usr/share/doc # decompress text files
+	default
+}


### PR DESCRIPTION
As title

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
