### PR TITLE
sys-libs/openipmi: Fix existing preserved libs with net-analyzer/net-snmpd

### DIFF
--- a/sys-libs/openipmi/openipmi-2.0.36-r1.ebuild
+++ b/sys-libs/openipmi/openipmi-2.0.36-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	sys-libs/ncurses:=
 	sys-libs/readline:=
 	crypt? ( dev-libs/openssl:= )
-	snmp? ( net-analyzer/net-snmp )
+	snmp? ( net-analyzer/net-snmp:= )
 	perl? ( dev-lang/perl:= )
 	python? ( ${PYTHON_DEPS} )
 	tcl? ( dev-lang/tcl:= )

--- a/sys-libs/openipmi/openipmi-2.0.37-r1.ebuild
+++ b/sys-libs/openipmi/openipmi-2.0.37-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	sys-libs/ncurses:=
 	sys-libs/readline:=
 	crypt? ( dev-libs/openssl:= )
-	snmp? ( net-analyzer/net-snmp )
+	snmp? ( net-analyzer/net-snmp:= )
 	perl? ( dev-lang/perl:= )
 	python? ( ${PYTHON_DEPS} )
 	tcl? ( dev-lang/tcl:= )


### PR DESCRIPTION

Fix this problem:

<pre>
!!! existing preserved libs:
>>> package: net-analyzer/net-snmp-5.9.5.2
 *  - /usr/lib64/libnetsnmp.so.40
 *  - /usr/lib64/libnetsnmp.so.40.2.1
 *      used by /usr/sbin/ipmi_ui (sys-libs/openipmi-2.0.37)
</pre>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
