### PR TITLE
l10n.desc: add be-tarask

### DIFF
--- a/profiles/desc/l10n.desc
+++ b/profiles/desc/l10n.desc
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 Gentoo Authors
+# Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This file contains descriptions of L10N USE_EXPAND flags.
@@ -32,6 +32,7 @@ as - Assamese
 ast - Asturian
 az - Azerbaijani
 be - Belarusian
+be-tarask - Belarusian (traditional orthography)
 bea - Beaver
 bg - Bulgarian
 bn - Bengali


### PR DESCRIPTION
During my project that transforms Wikipedias into `man` - I found that `be-tarask` is missing.

https://gitlab.com/vitaly-zdanevich/wiki2man_on_rust

This is the Wikipedia for `be` https://be.wikipedia.org/wiki/Галоўная_старонка 

This is for `be-tarask` https://be-tarask.wikipedia.org/wiki/Галоўная_старонка

Also hunspell has `be` and `be-tarask` https://aur.archlinux.org/packages?O=0&SeB=nd&K=hunspell-be&outdated=&SB=p&SO=d&PP=50&submit=Go

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
