### PR TITLE
profiles/targets/systemd: Mask acct-user/gdm-greeter

### DIFF
--- a/profiles/targets/systemd/package.mask
+++ b/profiles/targets/systemd/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Hyland B. <me@ow.swag.toys> (2026-05-05)
+# gdm breaks on systemd if this user is provided.
+acct-user/gdm-greeter
+
 # Sam James <sam@gentoo.org> (2026-02-18)
 # Requires systemd, so specifically unmasked only in targets/systemd.
 -kde-plasma/plasma-login-manager


### PR DESCRIPTION
Users were manually installing this, and gdm was breaking as a result due to a possible userdb conflict. It should not be installed at all anyway, as it was made for elogind.

Bug: https://bugs.gentoo.org/973590

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
