### PR TITLE
dev-libs/md4c: drop myself as maintainer

### DIFF
--- a/dev-libs/md4c/metadata.xml
+++ b/dev-libs/md4c/metadata.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>nrk@disroot.org</email>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="md2html">Build the md2html cli tool</flag>
 	</use>


### PR DESCRIPTION
i only upgrade my system once or twice an year at my own pace, which means i don't always have latest python version installed to run the tests against (https://bugs.gentoo.org/973832).

according to discussion in #gentoo-proxy-maint, this is not acceptable. so drop myself from maintainer.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
