### PR TITLE
app-text/xapers: enable py3.14

### DIFF
--- a/app-text/xapers/xapers-0.9.3.ebuild
+++ b/app-text/xapers/xapers-0.9.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2016-2025 Gentoo Authors
+# Copyright 2016-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 


### PR DESCRIPTION
Update app-text/xapers to enable python 3.14 support.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
