### PR TITLE
sys-apps/systemd: fix building with gcc 17

### DIFF
--- a/sys-apps/systemd/files/systemd-260.1-gcc-17.patch
+++ b/sys-apps/systemd/files/systemd-260.1-gcc-17.patch
@@ -1,0 +1,45 @@
+From 64b1e6be83f49b9fdebc9e07cc3b7485169970c2 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Tue, 5 May 2026 21:55:30 +0100
+Subject: [PATCH] sd-boot: efi-log: fix `__stack_chk_guard` type
+
+In https://gcc.gnu.org/PR121911 `gcc` started enforcing the type of
+`__stack_chk_guard` to `uintptr_t` and broke `systemd` build as:
+
+```
+../src/boot/efi-log.c:136:17: error: conflicting types for '__stack_chk_guard'; have 'intptr_t' {aka 'long int'}
+  136 | _used_ intptr_t __stack_chk_guard = (intptr_t) 0x70f6967de78acae3;
+      |                 ^~~~~~~~~~~~~~~~~
+cc1: note: previous declaration of '__stack_chk_guard' with type 'long unsigned int'
+../src/boot/efi-log.c:136:17: error: declaration of '__stack_chk_guard' shadows a global declaration [-Werror=shadow]
+  136 | _used_ intptr_t __stack_chk_guard = (intptr_t) 0x70f6967de78acae3;
+      |                 ^~~~~~~~~~~~~~~~~
+```
+
+Let's match the declaration to unsigned type as suggested by upstream in
+https://gcc.gnu.org/PR121911#c6.
+---
+ src/boot/efi-log.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/boot/efi-log.c b/src/boot/efi-log.c
+index ed0a2746933e0..520f985389c55 100644
+--- a/src/boot/efi-log.c
++++ b/src/boot/efi-log.c
+@@ -133,7 +133,7 @@ void log_wait(void) {
+ }
+ 
+ // NOLINTNEXTLINE(misc-use-internal-linkage)
+-_used_ intptr_t __stack_chk_guard = (intptr_t) 0x70f6967de78acae3;
++_used_ uintptr_t __stack_chk_guard = (uintptr_t) 0x70f6967de78acae3;
+ 
+ /* We can only set a random stack canary if this function attribute is available,
+  * otherwise this may create a stack check fail. */
+@@ -144,7 +144,7 @@ void __stack_chk_guard_init(void) {
+                 (void) rng->GetRNG(rng, NULL, sizeof(__stack_chk_guard), (void *) &__stack_chk_guard);
+         else
+                 /* Better than no extra entropy. */
+-                __stack_chk_guard ^= (intptr_t) __executable_start;
++                __stack_chk_guard ^= (uintptr_t) __executable_start;
+ }
+ #endif

--- a/sys-apps/systemd/systemd-260.1.ebuild
+++ b/sys-apps/systemd/systemd-260.1.ebuild
@@ -258,6 +258,7 @@ src_prepare() {
 	local PATCHES=(
 		"${FILESDIR}/systemd-260.1-fuzz-journald.patch"
 		"${FILESDIR}/systemd-260.1-openssl-4.patch"
+		"${FILESDIR}/systemd-260.1-gcc-17.patch"
 	)
 
 	if ! use vanilla; then


### PR DESCRIPTION
Backport upstream commit [1] that fixes building with gcc 17.

[1] https://github.com/systemd/systemd/commit/fc68ee6

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
