### PR TITLE
app-emulation/guestfs-tools: Make compatible with libguestfs-1.56 and lower

### DIFF
--- a/app-emulation/guestfs-tools/files/guestfs-tools-1.52.3-common-libguestfs-1.58-compat.patch
+++ b/app-emulation/guestfs-tools/files/guestfs-tools-1.52.3-common-libguestfs-1.58-compat.patch
@@ -1,0 +1,13 @@
+Submodule common contains modified content
+diff --git a/common/structs/structs-print.c b/common/structs/structs-print.c
+index 6d825e1..1ed2055 100644
+--- a/common/structs/structs-print.c
++++ b/common/structs/structs-print.c
+@@ -63,7 +63,6 @@ guestfs_int_print_application2_indent (struct guestfs_application2 *application2
+   fprintf (dest, "%sapp2_source_package: %s%s", indent, application2->app2_source_package, linesep);
+   fprintf (dest, "%sapp2_summary: %s%s", indent, application2->app2_summary, linesep);
+   fprintf (dest, "%sapp2_description: %s%s", indent, application2->app2_description, linesep);
+-  fprintf (dest, "%sapp2_spare1: %s%s", indent, application2->app2_spare1, linesep);
+   fprintf (dest, "%sapp2_spare2: %s%s", indent, application2->app2_spare2, linesep);
+   fprintf (dest, "%sapp2_spare3: %s%s", indent, application2->app2_spare3, linesep);
+   fprintf (dest, "%sapp2_spare4: %s%s", indent, application2->app2_spare4, linesep);

--- a/app-emulation/guestfs-tools/guestfs-tools-1.52.3-r1.ebuild
+++ b/app-emulation/guestfs-tools/guestfs-tools-1.52.3-r1.ebuild
@@ -86,6 +86,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-1.54.0-bash-Remove-vestigial-bash-completions.patch"
 	"${FILESDIR}/${PN}-1.52.3-guestfs-bash-completion.m4-more-control.patch"
+	"${FILESDIR}/${PN}-1.52.3-common-libguestfs-1.58-compat.patch"
 )
 
 src_prepare() {

--- a/app-emulation/guestfs-tools/guestfs-tools-1.54.0.ebuild
+++ b/app-emulation/guestfs-tools/guestfs-tools-1.54.0.ebuild
@@ -85,7 +85,8 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.54.0-guestfs-bash-completion.m4-more-control.patch"
-	"${FILESDIR}/${PN}-1.54.0-guestfs-bash-completion.m4-more-control.patch"
+	"${FILESDIR}/${PN}-1.54.0-bash-Remove-vestigial-bash-completions.patch"
+	"${FILESDIR}/${PN}-1.52.3-common-libguestfs-1.58-compat.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
See https://github.com/libguestfs/guestfs-tools/issues/28. The function is only used for dubbing, so i removed the offending line. 

Unfortunately, the newest guestfs-tools (1.55.8) now requires libguestfs-1.59.7. so when then the guestfs-1.56 is is cut, it won't be compatible with the upstream libguestfs stable branch.  

Closes: https://bugs.gentoo.org/974252

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
