### PR TITLE
dev-vcs/git: rebase fsmonitor patch for -9999-r3

### DIFF
--- a/dev-vcs/git/files/git-next-0001-macos-no-fsmonitor.patch
+++ b/dev-vcs/git/files/git-next-0001-macos-no-fsmonitor.patch
@@ -1,0 +1,68 @@
+From 4c1b3deac5d80f12fc7ba3227b49ef5b1a7242c4 Mon Sep 17 00:00:00 2001
+Message-ID: <4c1b3deac5d80f12fc7ba3227b49ef5b1a7242c4.1778619463.git.ben.knoble+github@gmail.com>
+From: "D. Ben Knoble" <ben.knoble+github@gmail.com>
+Date: Tue, 12 May 2026 16:46:38 -0400
+Subject: [PATCH] meson.build: allow to disable fsmonitor backend for macOS
+
+Gentoo Prefix toolchain and setup does not enable CoreServices Framework
+by default, so simply allow to disable the fsmonitor backend
+
+Best-viewed-with: --ignore-all-space
+Signed-off-by: Fabian Groffen <grobian@gentoo.org>
+Signed-off-by: D. Ben Knoble <ben.knoble+github@gmail.com>
+---
+ meson.build       | 24 +++++++++++++-----------
+ meson_options.txt |  2 ++
+ 2 files changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 38dddd67ab..1c369c7157 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1353,17 +1353,19 @@ endif
+ 
+ fsmonitor_backend = ''
+ fsmonitor_os = ''
+-if host_machine.system() == 'windows'
+-  fsmonitor_backend = 'win32'
+-  fsmonitor_os = 'win32'
+-elif host_machine.system() == 'linux' and threads.found() and compiler.has_header('linux/magic.h')
+-  fsmonitor_backend = 'linux'
+-  fsmonitor_os = 'unix'
+-  libgit_c_args += '-DHAVE_LINUX_MAGIC_H'
+-elif host_machine.system() == 'darwin'
+-  fsmonitor_backend = 'darwin'
+-  fsmonitor_os = 'unix'
+-  libgit_dependencies += dependency('CoreServices')
++if get_option('fsmonitor')
++  if host_machine.system() == 'windows'
++    fsmonitor_backend = 'win32'
++    fsmonitor_os = 'win32'
++  elif host_machine.system() == 'linux' and threads.found() and compiler.has_header('linux/magic.h')
++    fsmonitor_backend = 'linux'
++    fsmonitor_os = 'unix'
++    libgit_c_args += '-DHAVE_LINUX_MAGIC_H'
++  elif host_machine.system() == 'darwin'
++    fsmonitor_backend = 'darwin'
++    fsmonitor_os = 'unix'
++    libgit_dependencies += dependency('CoreServices')
++  endif
+ endif
+ if fsmonitor_backend != ''
+   libgit_c_args += '-DHAVE_FSMONITOR_DAEMON_BACKEND'
+diff --git a/meson_options.txt b/meson_options.txt
+index 80a8025f20..9c0e391254 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -81,6 +81,8 @@ option('rust', type: 'feature', value: 'enabled',
+   description: 'Enable building with Rust.')
+ option('macos_use_homebrew_gettext', type: 'boolean', value: true,
+   description: 'Use gettext from Homebrew instead of the slightly-broken system-provided one.')
++option('fsmonitor', type: 'boolean', value: true,
++  description: 'Build fsmonitor backend on supported platforms.')
+ 
+ # gitweb configuration.
+ option('gitweb_config', type: 'string', value: 'gitweb_config.perl')
+-- 
+2.54.0.564.ge3ee0a11b5.dirty
+

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -144,7 +144,7 @@ REQUIRED_USE="
 RESTRICT="!test? ( test )"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-2.48.1-macos-no-fsmonitor.patch
+	"${FILESDIR}"/${PN}-next-0001-macos-no-fsmonitor.patch
 
 	# This patch isn't merged upstream but is kept in the ebuild by
 	# demand from developers. It's opt-in (needs a config option)

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -144,7 +144,7 @@ REQUIRED_USE="
 RESTRICT="!test? ( test )"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-2.48.1-macos-no-fsmonitor.patch
+	"${FILESDIR}"/${PN}-next-0001-macos-no-fsmonitor.patch
 
 	# This patch isn't merged upstream but is kept in the ebuild by
 	# demand from developers. It's opt-in (needs a config option)


### PR DESCRIPTION
As described in bug 972727, a topic in Git's seen branch that will likely stabilize in next [1] (and eventually master and a release) conflicts with a patch we've been carrying for a while. Create a rebased version of that patch (using git-format-patch(1) this time, so it can easily be applied to work on with git-am(1)) that applies to seen. As the topic stabilizes, this patch can be pushed into lower-revisioned live ebuilds and then finally the release ebuild.

[1]: https://lore.kernel.org/git/xmqqa4u5nnxq.fsf@gitster.g/

Bug: https://bugs.gentoo.org/972727

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

Hopefully I've structured this one correctly :)

PS I know we're moving away from the GitHub mirror to CodeForge; just haven't got my account setup there yet.