### PR TITLE
sys-apps/bubblewrap: add static use flag

### DIFF
--- a/sys-apps/bubblewrap/bubblewrap-0.11.0.ebuild
+++ b/sys-apps/bubblewrap/bubblewrap-0.11.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,14 +12,22 @@ SRC_URI="https://github.com/containers/${PN}/releases/download/v${PV}/${P}.tar.x
 LICENSE="LGPL-2+"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv x86"
-IUSE="selinux suid"
+IUSE="selinux suid static"
 
 RDEPEND="
-	sys-libs/libseccomp
-	sys-libs/libcap
-	selinux? ( >=sys-libs/libselinux-2.1.9 )
+	!static? (
+		sys-libs/libseccomp
+		sys-libs/libcap
+		selinux? ( >=sys-libs/libselinux-2.1.9 )
+	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	static? (
+		sys-libs/libseccomp[static-libs]
+		sys-libs/libcap[static-libs]
+		selinux? ( >=sys-libs/libselinux-2.1.9[static-libs] )
+	)
+"
 BDEPEND="
 	app-text/docbook-xml-dtd:4.3
 	app-text/docbook-xsl-stylesheets
@@ -45,6 +53,7 @@ src_configure() {
 		-Dtests=false
 		-Dzsh_completion=enabled
 		$(meson_feature selinux)
+		$(meson_use static prefer_static)
 	)
 
 	meson_src_configure

--- a/sys-apps/bubblewrap/bubblewrap-0.11.2.ebuild
+++ b/sys-apps/bubblewrap/bubblewrap-0.11.2.ebuild
@@ -12,14 +12,22 @@ SRC_URI="https://github.com/containers/${PN}/releases/download/v${PV}/${P}.tar.x
 LICENSE="LGPL-2+"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv x86"
-IUSE="selinux suid"
+IUSE="selinux suid static"
 
 RDEPEND="
-	sys-libs/libseccomp
-	sys-libs/libcap
-	selinux? ( >=sys-libs/libselinux-2.1.9 )
+	!static? (
+		sys-libs/libseccomp
+		sys-libs/libcap
+		selinux? ( >=sys-libs/libselinux-2.1.9 )
+	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	static? (
+		sys-libs/libseccomp[static-libs]
+		sys-libs/libcap[static-libs]
+		selinux? ( >=sys-libs/libselinux-2.1.9[static-libs] )
+	)
+"
 BDEPEND="
 	app-text/docbook-xml-dtd:4.3
 	app-text/docbook-xsl-stylesheets
@@ -51,6 +59,7 @@ src_configure() {
 		-Dsupport_setuid=$(usex suid true false)
 		-Dzsh_completion=enabled
 		$(meson_feature selinux)
+		$(meson_use static prefer_static)
 	)
 
 	meson_src_configure


### PR DESCRIPTION
enable static build of bwrap

Closes: https://bugs.gentoo.org/974792

---
There is an issue from pkgcheck, which I'm unsure how to handle, because technically `RDEPEND` did not change, but is now conditional.

```
  RdependChange: version 0.11.0: RDEPEND modified without revbump
  RdependChange: version 0.11.2: RDEPEND modified without revbump
```
---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
