### PR TITLE
dev-python/requests-download: enable py3.13, py3.14

### DIFF
--- a/dev-python/requests-download/requests-download-0.1.2-r2.ebuild
+++ b/dev-python/requests-download/requests-download-0.1.2-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 2019-2024 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{10..12} pypy3 )
+PYTHON_COMPAT=( python3_{10..14} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/requests-download/requests-download-0.1.2-r2.ebuild
+++ b/dev-python/requests-download/requests-download-0.1.2-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{10..14} pypy3 )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952393

Simple bump to enable the latest Python versions for this package.  Package builds fine for both versions.  This is also a requirement for `rpmdevtools` ([bug 952457](https://bugs.gentoo.org/952457))
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
