### PR TITLE
dev-util/rpmdevtools: enable py3.13, py3.14

### DIFF
--- a/dev-util/rpmdevtools/rpmdevtools-9.6-r1.ebuild
+++ b/dev-util/rpmdevtools/rpmdevtools-9.6-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{11..14} )
 inherit python-single-r1
 
 DESCRIPTION="Collection of rpm packaging related utilities"
@@ -12,7 +12,7 @@ SRC_URI="https://releases.pagure.org/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="emacs"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/dev-util/rpmdevtools/rpmdevtools-9.6.ebuild
+++ b/dev-util/rpmdevtools/rpmdevtools-9.6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..14} )
 inherit python-single-r1
 
 DESCRIPTION="Collection of rpm packaging related utilities"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/952457

Package builds fine with both 3.13 & 3.14 once [requests-download](https://github.com/gentoo/gentoo/pull/46265) is also bumped.  The package is a bunch of simple tools for working with RPM script files which it is helpful to have available on Gentoo for my RHEL & CentOS work.  I tested `rpmdev-bumpspec` and `rpmdev-spectool` with both new Python versions and they worked as expected.

`pkgcheck` recommended dropping 3.10 and bumping, which is in the second commit.
~~~
  RdependChange: version 9.6: RDEPEND modified without revbump
  OldPythonCompat: version 9.6: old PYTHON_COMPAT target listed: [ python3_10 ]
~~~

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
