### PR TITLE
games-action/prismlauncher: fix GCC 16 compilation

### DIFF
--- a/games-action/prismlauncher/prismlauncher-11.0.0.ebuild
+++ b/games-action/prismlauncher/prismlauncher-11.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 QTMIN=6.0.0
-inherit cmake java-pkg-2 optfeature toolchain-funcs xdg
+inherit cmake flag-o-matic java-pkg-2 optfeature toolchain-funcs xdg
 
 DESCRIPTION="Custom, open source Minecraft launcher"
 HOMEPAGE="https://prismlauncher.org/ https://github.com/PrismLauncher/PrismLauncher"
@@ -82,6 +82,11 @@ src_prepare() {
 }
 
 src_configure() {
+	if tc-is-gcc && [[ $(gcc-major-version) -eq 16 ]]; then
+		append-cflags -Wno-error=sfinae-incomplete
+		append-cxxflags -Wno-error=sfinae-incomplete
+	fi
+
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="/usr"
 		# Resulting binary is named prismlauncher


### PR DESCRIPTION
Append -Wno-error=sfinae-incomplete to bypass strict SFINAE-incomplete warnings introduced in GCC 16 which cause the build to halt prematurely when evaluating certain Qt6 meta-type constructs.

Closes: https://bugs.gentoo.org/973648

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
