### PR TITLE
app-text/cherrytree: removing proxy maintainer

### DIFF
--- a/app-text/cherrytree/metadata.xml
+++ b/app-text/cherrytree/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>gjoandet@gmail.com</email>
-		<name>Guillermo Joandet</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">giuspen/cherrytree</remote-id>
 	</upstream>


### PR DESCRIPTION
Removing proxy maintainer

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
