### PR TITLE
vim-doc.eclass: Support installing in alternative ROOT

### DIFF
--- a/eclass/vim-doc.eclass
+++ b/eclass/vim-doc.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-doc.eclass
@@ -61,7 +61,7 @@ update_vim_helptags() {
 		# Remove links
 		readarray -d '' files < <(find "${d}"/doc -name "*.txt" -type l -print0 || die "cannot traverse ${d}/doc" )
 		for helpfile in "${files[@]}"; do
-			if [[ $(readlink -f "${helpfile}") == "${vimfiles}"/* ]]; then
+			if [[ $(realpath "$(readlink -f "${helpfile}")") == "${vimfiles}"/* ]]; then
 				rm "${helpfile}" || die
 			fi
 		done
@@ -80,8 +80,16 @@ update_vim_helptags() {
 		# Re-create / install new links
 		if [[ -d "${vimfiles}"/doc ]]; then
 			for helpfile in "${vimfiles}"/doc/*.txt; do
-				if [[ ! -e "${d}/doc/$(basename "${helpfile}")" ]]; then
-					ln -s "${helpfile}" "${d}/doc" || die
+				helpfile="$(basename "${helpfile}")"
+				# Symlinks to packaged files should've already been removed
+				# above, but if somehow a symlink exists for this file, make
+				# sure to point it to the new file.
+				if [[ -h "${d}/doc/${helpfile}" ]]; then
+					ewarn "Updating symlink ${d}/doc/${helpfile}"
+					rm "${d}/doc/${helpfile}" || die
+				fi
+				if [[ ! -e "${d}/doc/${helpfile}" ]]; then
+					ln -s "../../vimfiles/doc/${helpfile}" "${d}/doc" || die
 				fi
 			done
 		fi


### PR DESCRIPTION
When a vim-doc package is installed into an alternative ROOT, symlinks
will be created that include a full path to this root. This prevents the
symlinks from functioning in a running system. Furthermore, when the
running system attempts to reinstall any vim-doc package, it will throw
an error when it tries to create a symlink in place of one that is
stale.

To improve this situation, a few changes are made:
- Use relative symlinks, which helps the symlinks resolve no matter
  where the ROOT system is mounted. This isn't strictly necessary, as
  the symlink target path could simply be created by stripping the
  leading ROOT component, but I think it's good practice to move to
  relative symlinks where possible.
- Using relative symlinks requires the removal of existing links (which
  aids in removing stale directories) to resolve a full path to the
  symlink. This also helps deal with existing installs which will still
  have symlinks with a full path.
- Stale symlinks pass the [[ ! -e ]] check, but cause an error when the
  "ln" command is used on them. This will basically never happen
  anymore with the above fixes, but I think it makes sense to override
  any symlinks which may exist with the packaged version, to ensure
  consistency. The occurrence is logged.

Closes: https://bugs.gentoo.org/922614
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
