### PR TITLE
media-sound/pulsemixer: enable python 3.14

### DIFF
--- a/media-sound/pulsemixer/pulsemixer-1.5.1-r2.ebuild
+++ b/media-sound/pulsemixer/pulsemixer-1.5.1-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1

--- a/media-sound/pulsemixer/pulsemixer-9999.ebuild
+++ b/media-sound/pulsemixer/pulsemixer-9999.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 PYTHON_REQ_USE="ncurses"
 
 inherit distutils-r1


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/974011

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits:
  `RdependChange: version 1.5.1-r2: RDEPEND modified without revbump` but I guess it's fine..?

Please note that all boxes must be checked for the pull request to be merged.
