### PR TITLE
sys-apps/memtest86+: fix emerge with USE secureboot

### DIFF
--- a/sys-apps/memtest86+/memtest86+-8.10.ebuild
+++ b/sys-apps/memtest86+/memtest86+-8.10.ebuild
@@ -59,19 +59,28 @@ src_compile() {
 		# a different build directory has to be selected for loong, and
 		# there's no "BIOS" support.
 		pushd build/loongarch64
-			use uefi64 && emake mt86plus
+			if use uefi64; then
+				emake mt86plus
+				secureboot_sign_efi_file mt86plus
+			fi
 			use iso64 && emake iso
 		popd
 		return
 	fi
 
 	pushd build/i586
-		use bios32 || use uefi32 && emake mt86plus
+		if use bios32 || use uefi32; then
+			emake mt86plus
+			secureboot_sign_efi_file mt86plus
+		fi
 		use iso32 && emake iso
 	popd
 
 	pushd build/x86_64
-		use bios64 || use uefi64 && emake mt86plus
+		if use bios64 || use uefi64; then
+			emake mt86plus
+			secureboot_sign_efi_file mt86plus
+		fi
 		use iso64 && emake iso
 	popd
 }
@@ -102,10 +111,6 @@ src_install() {
 	else
 		use iso32 && newins build/i586/memtest.iso memtest.i586.iso
 		use iso64 && newins build/x86_64/memtest.iso memtest.x86_64.iso
-	fi
-
-	if use uefi32 || use uefi64; then
-		secureboot_auto_sign --in-place
 	fi
 }
 


### PR DESCRIPTION
```
>>> Install sys-apps/memtest86+-8.10 into /var/tmp/portage/sys-apps/memtest86+-8.10/image
 * ERROR: sys-apps/memtest86+-8.10::gentoo failed (install phase):
 *   secureboot_auto_sign was called but no efi executables were found
 *
 * Call stack:
 *     ebuild.sh, line  143:  Called src_install
 *   environment, line 1336:  Called secureboot_auto_sign '--in-place'
 *   environment, line 1160:  Called die
 * The specific snippet of code:
 *       (( ${#efi_execs[@]} )) || die "${FUNCNAME[0]} was called but no efi executables were found";
 *
 * If you need support, post the output of `emerge --info '=sys-apps/memtest86+-8.10::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=sys-apps/memtest86+-8.10::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/sys-apps/memtest86+-8.10/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/sys-apps/memtest86+-8.10/temp/environment'.
 * Working directory: '/var/tmp/portage/sys-apps/memtest86+-8.10/work/memtest86plus-8.10'
 * S: '/var/tmp/portage/sys-apps/memtest86+-8.10/work/memtest86plus-8.10'
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
