### PR TITLE
dev-ruby/json-schema: Add missing BDEPEND on dev-ruby/webmock for USE="test"

### DIFF
--- a/dev-ruby/json-schema/json-schema-5.2.2.ebuild
+++ b/dev-ruby/json-schema/json-schema-5.2.2.ebuild
@@ -25,7 +25,10 @@ ruby_add_rdepend "
 	>=dev-ruby/bigdecimal-3.1
 "
 
-ruby_add_bdepend "test? ( dev-ruby/minitest:5 )"
+ruby_add_bdepend "test? (
+	dev-ruby/minitest:5
+	dev-ruby/webmock
+)"
 
 PATCHES=(
 	"${FILESDIR}/${P}-remove-dev-tasks.patch"


### PR DESCRIPTION
Found while testing isolated testing on a clean stage3. Currently running through tatt permutations to preemptively head off bug reports.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
