### PR TITLE
sys-libs/glibc: add explicit -E to get_kheader_version()

### DIFF
--- a/sys-libs/glibc/glibc-2.19-r3.ebuild
+++ b/sys-libs/glibc/glibc-2.19-r3.ebuild
@@ -545,7 +545,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${EPREFIX}/$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${EPREFIX}/$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.31-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.31-r7.ebuild
@@ -584,7 +584,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.32-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r8.ebuild
@@ -601,7 +601,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.33-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.33-r14.ebuild
@@ -685,7 +685,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.34-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.34-r14.ebuild
@@ -694,7 +694,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.35-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.35-r11.ebuild
@@ -713,7 +713,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.36-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r8.ebuild
@@ -744,7 +744,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.37-r10.ebuild
+++ b/sys-libs/glibc/glibc-2.37-r10.ebuild
@@ -760,7 +760,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.38-r13.ebuild
+++ b/sys-libs/glibc/glibc-2.38-r13.ebuild
@@ -771,7 +771,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.39-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.39-r11.ebuild
@@ -792,7 +792,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "$(build_eprefix)$(alt_build_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "$(build_eprefix)$(alt_build_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.40-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.40-r11.ebuild
@@ -772,7 +772,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.41-r10.ebuild
+++ b/sys-libs/glibc/glibc-2.41-r10.ebuild
@@ -776,7 +776,7 @@ eend_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.42-r5.ebuild
+++ b/sys-libs/glibc/glibc-2.42-r5.ebuild
@@ -795,7 +795,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.42-r6.ebuild
+++ b/sys-libs/glibc/glibc-2.42-r6.ebuild
@@ -795,7 +795,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.42-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.42-r7.ebuild
@@ -795,7 +795,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.43-r1.ebuild
+++ b/sys-libs/glibc/glibc-2.43-r1.ebuild
@@ -821,7 +821,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.43-r2.ebuild
+++ b/sys-libs/glibc/glibc-2.43-r2.ebuild
@@ -821,7 +821,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-2.43.ebuild
+++ b/sys-libs/glibc/glibc-2.43.ebuild
@@ -821,7 +821,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -820,7 +820,7 @@ g_int_to_KV() {
 
 get_kheader_version() {
 	printf '#include <linux/version.h>\nLINUX_VERSION_CODE\n' | \
-	$(tc-getCPP ${CTARGET}) -I "${ESYSROOT}$(alt_headers)" - | \
+	$(tc-getCPP ${CTARGET}) -E -I "${ESYSROOT}$(alt_headers)" - | \
 	tail -n 1
 }
 


### PR DESCRIPTION
I've got that log during system update. Adding explicit `-E` looks like a fair solution

<details>

```
>>> Emerging (1 of 128) sys-libs/glibc-2.42-r7::gentoo
 * glibc-2.42.tar.xz BLAKE2B SHA512 size ;-) ...                                                                       [ ok ]
 * glibc-2.42-patches-9.tar.xz BLAKE2B SHA512 size ;-) ...                                                             [ ok ]
 * glibc-systemd-20210729.tar.gz BLAKE2B SHA512 size ;-) ...                                                           [ ok ]
 * Checking whether python3_14 is suitable ...
 *   dev-lang/python:3.14 ...                                                                                          [ ok ]
 * Using python3.14 to build (via PYTHON_COMPAT iteration)
>>> Unpacking source...
 * Forcing usage of the BFD linker
 * Checking general environment sanity.
 * Performing simple compile test for ABI=amd64 ...
make -j12 glibc-test
gcc -m64  -fuse-ld=bfd  -fuse-ld=bfd  -fuse-ld=bfd    -fuse-ld=bfd  glibc-test.c   -o glibc-test                       [ ok ]
 * Checking if the system can execute 32-bit binaries ...                                                              [ ok ]
g++: error: -E or -x required when input is from standard input
 * Checking running kernel version (6.18.18-gentoo-dist >= 3.2.0) ...                                                  [ ok ]
 * Checking linux-headers version (0.0.0 >= 3.2.0) ...                                                                 [ !! ]

 * You need linux-headers of at least 3.2.0!
 * ERROR: sys-libs/glibc-2.42-r7::gentoo failed (unpack phase):
 *   linux-headers version too low!
 *
 * Call stack:
 *     ebuild.sh, line  143:  Called src_unpack
 *   environment, line 3492:  Called sanity_prechecks
 *   environment, line 3224:  Called die
 * The specific snippet of code:
 *                       die "linux-headers version too low!";
 *
 * If you need support, post the output of `emerge --info '=sys-libs/glibc-2.42-r7::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=sys-libs/glibc-2.42-r7::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/sys-libs/glibc-2.42-r7/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/sys-libs/glibc-2.42-r7/temp/environment'.
 * Working directory: '/var/tmp/portage/sys-libs/glibc-2.42-r7/work'
 * S: '/var/tmp/portage/sys-libs/glibc-2.42-r7/work/glibc-2.42'

```

</details>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
