### PR TITLE
dev-lisp/sbcl: add patch to fix musl build failure on 2.6.4

### DIFF
--- a/dev-lisp/sbcl/files/sbcl-2.6.4-musl-termios.patch
+++ b/dev-lisp/sbcl/files/sbcl-2.6.4-musl-termios.patch
@@ -1,0 +1,82 @@
+diff --git a/contrib/sb-grovel/def-to-lisp.lisp b/contrib/sb-grovel/def-to-lisp.lisp
+index afd55ac66..82f8481df 100644
+--- a/contrib/sb-grovel/def-to-lisp.lisp
++++ b/contrib/sb-grovel/def-to-lisp.lisp
+@@ -80,25 +80,39 @@ code:
+   (destructuring-bind (cname &rest elements) cstruct
+     (printf "(sb-grovel::define-c-struct ~A %ld" lispname
+             (word-cast (format nil "sizeof(~A)" cname)))
+-    (dolist (e elements)
+-      (destructuring-bind (lisp-type lisp-el-name c-type c-el-name &key distrust-length) e
+-        (printf " (~A ~A \"~A\"" lisp-el-name lisp-type c-type)
+-        ;; offset
+-        (as-c "{" cname "t;")
+-        (printf "  %lu"
+-                (format nil "((unsigned long~A)&(t.~A)) - ((unsigned long~A)&(t))"
+-                        #+(and win32 64-bit) " long" #-(and win32 64-bit) ""
+-                        c-el-name
+-                        #+(and win32 64-bit) " long" #-(and win32 64-bit) ""))
+-        (as-c "}")
+-        ;; length
+-        (if distrust-length
+-            (printf "  0)")
+-            (progn
+-              (as-c "{" cname "t;")
+-              (printf "  %ld)"
+-                      (word-cast (format nil "sizeof(t.~A)" c-el-name)))
+-              (as-c "}")))))
++    (when elements
++      (as-c "{" cname "t;")
++      (dolist (e elements)
++        (destructuring-bind (lisp-type lisp-el-name c-type c-el-name &key distrust-length) e
++          (printf " (~A ~A \"~A\"" lisp-el-name lisp-type c-type)
++          ;; offset
++          (flet ((ifdef (fun c-el-name)
++                   (cond ((typep c-el-name '(cons (eql :if)))
++                          (destructuring-bind (cond then else) (cdr c-el-name)
++                            (as-c "#if" cond)
++                            (funcall fun then)
++                            (as-c "#else")
++                            (funcall fun else)
++                            (as-c "#endif")))
++                         (t
++                          (funcall fun c-el-name)))))
++            (ifdef (lambda (c-el-name)
++                     (printf "  %lu"
++                             (format nil "((unsigned long~A)&(t.~A)) - ((unsigned long~A)&(t))"
++                                     #+(and win32 64-bit) " long" #-(and win32 64-bit) ""
++                                     c-el-name
++                                     #+(and win32 64-bit) " long" #-(and win32 64-bit) "")))
++                   c-el-name)
++
++            ;; length
++            (if distrust-length
++                (printf "  0)")
++                (ifdef (lambda (c-el-name)
++                         (printf "  %ld)"
++
++                                 (word-cast (format nil "sizeof(t.~A)" c-el-name))))
++                       c-el-name)))))
++      (as-c "}"))
+     (printf ")")))
+ 
+ (defun print-c-source (stream headers definitions package-name)
+diff --git a/contrib/sb-posix/constants.lisp b/contrib/sb-posix/constants.lisp
+index 26a16d36a..8632dcded 100644
+--- a/contrib/sb-posix/constants.lisp
++++ b/contrib/sb-posix/constants.lisp
+@@ -434,8 +434,12 @@
+               (tcflag-t cflag "tcflag_t" "c_cflag")
+               (tcflag-t lflag "tcflag_t" "c_lflag")
+               ((array cc-t) cc "cc_t" "c_cc")
+-              (speed-t ispeed "speed_t" "c_ispeed")
+-              (speed-t ospeed "speed_t" "c_ospeed")))
++              (speed-t ispeed "speed_t" (:if "defined(__linux__) && !defined(__GLIBC__)"
++                                             "__c_ispeed" ;; musl
++                                             "c_ispeed"))
++              (speed-t ospeed "speed_t" (:if "defined(__linux__) && !defined(__GLIBC__)"
++                                             "__c_ospeed" ;; musl
++                                             "c_ospeed"))))
+ 
+  ;; utime(), utimes()
+  #-win32

--- a/dev-lisp/sbcl/sbcl-2.6.4.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.6.4.ebuild
@@ -112,6 +112,9 @@ src_prepare() {
 
 	eapply "${FILESDIR}"/verbose-build-2.0.3.patch
 
+	# backport fix for https://bugs.launchpad.net/sbcl/+bug/2153432
+	eapply "${FILESDIR}"/sbcl-2.6.4-musl-termios.patch
+
 	eapply_user
 
 	# Make sure the *FLAGS variables are sane.


### PR DESCRIPTION
Upstream bug https://bugs.launchpad.net/sbcl/+bug/2153432 Backport of https://github.com/sbcl/sbcl/commit/f825ab5db65fd7d68bbd8c39e37a8725409cafce

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
