### PR TITLE
sys-kernel/gentoo-kernel: s390x LTS

### DIFF
--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.18.32_p2.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.18.32_p2.ebuild
@@ -34,7 +34,7 @@ SRC_URI+="
 "
 S=${WORKDIR}/${BASE_P}
 
-KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~s390 ~riscv ~sparc x86"
 IUSE="debug hardened"
 REQUIRED_USE="
 	arm? ( savedconfig )
@@ -109,6 +109,9 @@ src_prepare() {
 			;;
 		riscv)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-riscv64-fedora.config" .config || die
+			;;
+		riscv)
+			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-s390x-fedora.config" .config || die
 			;;
 		x86)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-i686-fedora.config" .config || die

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.18.32.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.18.32.ebuild
@@ -31,7 +31,7 @@ SRC_URI+="
 "
 S=${WORKDIR}/${BASE_P}
 
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="debug hardened"
 REQUIRED_USE="
 	arm? ( savedconfig )
@@ -96,6 +96,9 @@ src_prepare() {
 			;;
 		riscv)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-riscv64-fedora.config" .config || die
+			;;
+		s390)
+			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-s390x-fedora.config" .config || die
 			;;
 		x86)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-i686-fedora.config" .config || die

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.18.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.18.9999.ebuild
@@ -82,6 +82,9 @@ src_prepare() {
 		riscv)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-riscv64-fedora.config" .config || die
 			;;
+		s390)
+			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-s390x-fedora.config" .config || die
+			;;
 		x86)
 			cp "${WORKDIR}/kernel-${CONFIG_VER}/kernel-i686-fedora.config" .config || die
 			;;

--- a/virtual/dist-kernel/dist-kernel-6.18.32_p2.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.18.32_p2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
 SLOT="0/${PVR}"
-KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~s390 ~sparc x86"
 
 RDEPEND="
 	|| (


### PR DESCRIPTION
Previously unaware LTS support would be required as well. So adding kconfig support for 6.18 to match the current genkernel usage.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
