### PR TITLE
net-vpn/iodine: add `virtual/pkgconfig` to `BDEPEND`

### DIFF
--- a/net-vpn/iodine/iodine-0.7.0-r4.ebuild
+++ b/net-vpn/iodine/iodine-0.7.0-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,6 +20,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="virtual/zlib:="
 DEPEND="${RDEPEND}
 	test? ( dev-libs/check )"
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-TestMessage.patch


### PR DESCRIPTION
Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
