### PR TITLE
sys-cluster/hpx: Drop USE=jemalloc

### DIFF
--- a/sys-cluster/hpx/hpx-1.11.0.ebuild
+++ b/sys-cluster/hpx/hpx-1.11.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,13 +19,13 @@ HOMEPAGE="https://hpx.stellar-group.org/"
 
 LICENSE="Boost-1.0"
 SLOT="0"
-IUSE="examples jemalloc mpi papi +perftools tbb zlib"
+IUSE="examples mpi papi +perftools tbb zlib"
 # tests fail to compile
 RESTRICT="test"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
-	?? ( jemalloc perftools tbb )
+	?? ( perftools tbb )
 "
 
 BDEPEND="
@@ -42,7 +42,6 @@ RDEPEND="
 	<dev-cpp/asio-1.34
 	dev-libs/boost:=
 	sys-apps/hwloc:=
-	jemalloc? ( dev-libs/jemalloc:= )
 	mpi? ( virtual/mpi )
 	papi? ( dev-libs/papi )
 	perftools? ( dev-util/google-perftools:= )
@@ -87,9 +86,7 @@ src_configure() {
 		-DHPX_WITH_COMPRESSION_ZLIB=$(usex zlib)
 		-DHPX_WITH_TESTS=OFF
 	)
-	if use jemalloc; then
-		mycmakeargs+=( -DHPX_WITH_MALLOC=jemalloc )
-	elif use perftools; then
+	if use perftools; then
 		mycmakeargs+=( -DHPX_WITH_MALLOC=tcmalloc )
 	elif use tbb; then
 		mycmakeargs+=( -DHPX_WITH_MALLOC=tbbmalloc )

--- a/sys-cluster/hpx/hpx-9999.ebuild
+++ b/sys-cluster/hpx/hpx-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,13 +19,13 @@ HOMEPAGE="https://hpx.stellar-group.org/"
 
 LICENSE="Boost-1.0"
 SLOT="0"
-IUSE="examples jemalloc mpi papi +perftools tbb zlib"
+IUSE="examples mpi papi +perftools tbb zlib"
 # tests fail to compile
 RESTRICT="test"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
-	?? ( jemalloc perftools tbb )
+	?? ( perftools tbb )
 "
 
 BDEPEND="
@@ -42,7 +42,6 @@ RDEPEND="
 	<dev-cpp/asio-1.34
 	dev-libs/boost:=
 	sys-apps/hwloc:=
-	jemalloc? ( dev-libs/jemalloc:= )
 	mpi? ( virtual/mpi )
 	papi? ( dev-libs/papi )
 	perftools? ( dev-util/google-perftools:= )
@@ -83,9 +82,7 @@ src_configure() {
 		-DHPX_WITH_COMPRESSION_ZLIB=$(usex zlib)
 		-DHPX_WITH_TESTS=OFF
 	)
-	if use jemalloc; then
-		mycmakeargs+=( -DHPX_WITH_MALLOC=jemalloc )
-	elif use perftools; then
+	if use perftools; then
 		mycmakeargs+=( -DHPX_WITH_MALLOC=tcmalloc )
 	elif use tbb; then
 		mycmakeargs+=( -DHPX_WITH_MALLOC=tbbmalloc )


### PR DESCRIPTION
Drop USE=jemalloc. HPX uses tcmalloc by default anyway. Thanks!

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
