### PR TITLE
sci-ml/caffe2[distributed,rocm]: add dev-util/amdsmi dependency

### DIFF
--- a/sci-ml/caffe2/caffe2-2.12.0-r2.ebuild
+++ b/sci-ml/caffe2/caffe2-2.12.0-r2.ebuild
@@ -114,7 +114,10 @@ RDEPEND="
 		>=sci-libs/rocRAND-6.3:=   <sci-libs/rocRAND-7.3:=
 		>=sci-libs/rocSOLVER-6.3:= <sci-libs/rocSOLVER-7.3:=
 		memefficient? ( =sci-libs/aotriton-bin-0.11*:= )
-		distributed? ( >=dev-util/rocm-smi-6.3:= <dev-util/rocm-smi-7.3:= )
+		distributed? (
+			>=dev-util/rocm-smi-6.3:= <dev-util/rocm-smi-7.3:=
+			>=dev-util/amdsmi-6.3:= <dev-util/amdsmi-7.3:=
+		)
 		cusparselt? ( >=sci-libs/hipsparselt-6.3:= <sci-libs/hipsparselt-7.3:= )
 	)
 	distributed? (


### PR DESCRIPTION
At this moment caffe2 c10d depends both on rocm-smi and amdsmi. amdsmi is dlopen'ed, so qa-vdb could complain, but it is practically both build and runtime dependency.

Closes: https://bugs.gentoo.org/975835

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
