### PR TITLE
mate-extra/mate-tweak: correct spelling of proxy maintainer name in metadata.xml

### DIFF
--- a/mate-extra/mate-tweak/metadata.xml
+++ b/mate-extra/mate-tweak/metadata.xml
@@ -7,7 +7,7 @@
 	</maintainer>
 	<maintainer type="person" proxied="yes">
 		<email>tacokoneko@gmail.com</email>
-		<name>Robet Kirkman</name>
+		<name>Robert Kirkman</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
correct spelling of proxy maintainer name in metadata.xml

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
