### PR TITLE
dev-python/pyside: 6.11.1-r1 fix cmake files

### DIFF
--- a/dev-python/pyside/pyside-6.11.1-r1.ebuild
+++ b/dev-python/pyside/pyside-6.11.1-r1.ebuild
@@ -565,7 +565,6 @@ python_compile() {
 		-e "s~libshiboken6\.cpython.*\.so\.$(ver_cut 1-2)~libshiboken6\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
 		-e "s~libpyside6\.cpython.*\.so\.$(ver_cut 1-2)~libpyside6\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
 		-e "s~libpyside6qml\.cpython.*\.so\.$(ver_cut 1-2)~libpyside6qml\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
-		-e "s~\${PACKAGE_PREFIX_DIR}/~\${PACKAGE_PREFIX_DIR}/share/PySide6/~g" \
 		-e "s~\${_IMPORT_PREFIX}/shiboken6/include~/usr/include/shiboken6~g" \
 		-e "s~\${_IMPORT_PREFIX}/PySide6/include~/usr/include/PySide6~g" \
 		-i "${BUILD_DIR}/install/usr/lib/cmake/"*/*.cmake || die

--- a/dev-python/pyside/pyside-6.11.1-r1.ebuild
+++ b/dev-python/pyside/pyside-6.11.1-r1.ebuild
@@ -516,8 +516,8 @@ python_compile() {
 			|| die
 
 	for dir in cmake pkgconfig; do
-		find "${BUILD_DIR}"/build*/"${pyside_build_dir}"/install -type d -name "${dir}" \
-			-exec cp -r "{}" "${BUILD_DIR}/install/usr/lib/" \; \
+		find "${BUILD_DIR}"/build*/"${pyside_build_dir}"/install/lib -type d -path "*/lib/${dir}" \
+			-exec cp -nr "{}" "${BUILD_DIR}/install/usr/lib/" \; \
 				|| die
 	done
 

--- a/dev-python/pyside/pyside-6.9999.ebuild
+++ b/dev-python/pyside/pyside-6.9999.ebuild
@@ -563,7 +563,6 @@ python_compile() {
 		-e "s~libshiboken6\.cpython.*\.so\.$(ver_cut 1-2)~libshiboken6\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
 		-e "s~libpyside6\.cpython.*\.so\.$(ver_cut 1-2)~libpyside6\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
 		-e "s~libpyside6qml\.cpython.*\.so\.$(ver_cut 1-2)~libpyside6qml\${PYTHON_CONFIG_SUFFIX}\.so\.$(ver_cut 1-2)~g" \
-		-e "s~\${PACKAGE_PREFIX_DIR}/~\${PACKAGE_PREFIX_DIR}/share/PySide6/~g" \
 		-e "s~\${_IMPORT_PREFIX}/shiboken6/include~/usr/include/shiboken6~g" \
 		-e "s~\${_IMPORT_PREFIX}/PySide6/include~/usr/include/PySide6~g" \
 		-i "${BUILD_DIR}/install/usr/lib/cmake/"*/*.cmake || die

--- a/dev-python/pyside/pyside-6.9999.ebuild
+++ b/dev-python/pyside/pyside-6.9999.ebuild
@@ -514,8 +514,8 @@ python_compile() {
 			|| die
 
 	for dir in cmake pkgconfig; do
-		find "${BUILD_DIR}"/build*/"${pyside_build_dir}"/install -type d -name "${dir}" \
-			-exec cp -r "{}" "${BUILD_DIR}/install/usr/lib/" \; \
+		find "${BUILD_DIR}"/build*/"${pyside_build_dir}"/install/lib -type d -path "*/lib/${dir}" \
+			-exec cp -nr "{}" "${BUILD_DIR}/install/usr/lib/" \; \
 				|| die
 	done
 


### PR DESCRIPTION
pyside fixed the install cmake files in 69dd63f, making the `share/PySide6` we inserted wrong.

Closes: https://bugs.gentoo.org/975021

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
