### PR TITLE
sci-libs/arprec: force single thread to avoid fortran module file race

### DIFF
--- a/sci-libs/arprec/arprec-2.2.20.ebuild
+++ b/sci-libs/arprec/arprec-2.2.20.ebuild
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.19-narrowing.patch #Bug 731916
 	"${FILESDIR}"/${PN}-2.2.19-noregister.patch #Bug 926266
 	"${FILESDIR}"/${P}-automake.patch
+	"${FILESDIR}"/${P}-fortranmod.patch
 )
 
 src_prepare() {

--- a/sci-libs/arprec/files/arprec-2.2.20-fortranmod.patch
+++ b/sci-libs/arprec/files/arprec-2.2.20-fortranmod.patch
@@ -1,0 +1,22 @@
+From cea820b2257e93fea1e510d899ccca368ff36b0d Mon Sep 17 00:00:00 2001
+From: Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>
+Date: Wed, 27 May 2026 09:08:38 +0200
+Subject: [PATCH] fix fortran module dependence in automake
+
+Closes: https://github.com/BL-highprecision/ARPREC/issues/4
+---
+ toolkit/Makefile.am | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/toolkit/Makefile.am b/toolkit/Makefile.am
+index 925835b..239aa08 100644
+--- a/toolkit/Makefile.am
++++ b/toolkit/Makefile.am
+@@ -21,5 +21,7 @@ nodist_EXTRA_mathtool_SOURCES = dummy.cpp
+ mathtool_LINK = $(CXXLINK)
+ 
+ toolkit: $(TOOLKIT)
++mathinit.$(OBJEXT): globdata.$(OBJEXT) # fortran mod needed first
++mathtool.$(OBJEXT) pslqsub.$(OBJEXT) quadsub.$(OBJEXT) rootsub.$(OBJEXT) zetapz.$(OBJEXT): globdata.$(OBJEXT) # fortran mod needed first
+ 
+ endif


### PR DESCRIPTION
I encountered following error:

```
make -l16 -j16 -s toolkit 
mathinit.f:25:5:

   25 | use globdata
      |     1
Fatal Error: Cannot open module file ‘globdata.mod’ for reading at (1): No such file or directory
compilation terminated.
rootsub.f:8:5:

    8 | use globdata
      |     1
Fatal Error: Cannot open module file ‘globdata.mod’ for reading at (1): No such file or directory
compilation terminated.
zetapz.f:12:5:

   12 | use globdata
      |     1
Fatal Error: Cannot open module file ‘globdata.mod’ for reading at (1): No such file or directory
compilation terminated.
mathtool.f:16:5:

   16 | use globdata
      |     1
Fatal Error: Cannot open module file ‘globdata.mod’ for reading at (1): No such file or directory
compilation terminated.
make[1]: *** [Makefile:429: rootsub.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:429: zetapz.o] Error 1
make[1]: *** [Makefile:429: mathinit.o] Error 1
make[1]: *** [Makefile:429: mathtool.o] Error 1
quadsub.f:13:5:

   13 | use globdata
      |     1
Fatal Error: Cannot open module file ‘globdata.mod’ for reading at (1): No such file or directory
compilation terminated.
make[1]: *** [Makefile:429: quadsub.o] Error 1
make: *** [Makefile:942: toolkit] Error 2
```