### PR TITLE
x11-wm/mutter: backport patch for wake-from-suspend crash

### DIFF
--- a/x11-wm/mutter/files/mutter-49.5-update-kms-resource-lists.patch
+++ b/x11-wm/mutter/files/mutter-49.5-update-kms-resource-lists.patch
@@ -1,0 +1,43 @@
+From de07dcb15332e0cbca1cf99d14809ad1f7b6b9ce Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <mdaenzer@redhat.com>
+Date: Thu, 7 May 2026 16:25:21 +0200
+Subject: [PATCH] kms/connector: Update KMS resource lists in
+ update_connector_in_impl
+
+meta_kms_impl_device_update_states may modify the MetaKmsImplDevice
+resource lists, which may result in the corresponding MetaKmsDevice
+lists pointing to already-destroyed objects.
+
+Use meta_kms_device_update_states_in_impl instead, which updates the
+latter lists to match the former after calling
+meta_kms_impl_device_update_states.
+
+Fixes use after free if meta_kms_impl_device_update_states removes
+a resource (most likely a connector).
+
+Closes: https://gitlab.gnome.org/GNOME/mutter/-/work_items/4796
+Part-of: <https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5061>
+---
+ src/backends/native/meta-kms-connector.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/backends/native/meta-kms-connector.c b/src/backends/native/meta-kms-connector.c
+index 1a69a6319c..5bdd246f0e 100644
+--- a/src/backends/native/meta-kms-connector.c
++++ b/src/backends/native/meta-kms-connector.c
+@@ -1111,10 +1111,10 @@ update_connector_in_impl (MetaThreadImpl  *thread_impl,
+                           GError         **error)
+ {
+   MetaKmsConnector *connector = user_data;
++  MetaKmsDevice *device = meta_kms_connector_get_device (connector);
+   MetaKmsResourceChanges changes;
+ 
+-  changes = meta_kms_impl_device_update_states (connector->impl_device,
+-                                                0, connector->id);
++  changes = meta_kms_device_update_states_in_impl (device, 0, connector->id);
+ 
+   return GUINT_TO_POINTER (changes);
+ }
+-- 
+2.53.0
+

--- a/x11-wm/mutter/mutter-49.5-r1.ebuild
+++ b/x11-wm/mutter/mutter-49.5-r1.ebuild
@@ -1,0 +1,277 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{11..14} )
+inherit gnome.org gnome2-utils meson python-any-r1 udev xdg
+
+DESCRIPTION="GNOME compositing window manager based on Clutter"
+HOMEPAGE="https://mutter.gnome.org"
+LICENSE="GPL-2+"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/mutter.git"
+	SRC_URI=""
+	SLOT="0/17" # This can get easily out of date, but better than 9967
+else
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+	SLOT="0/$(($(ver_cut 1) - 32))" # 0/libmutter_api_version - ONLY gnome-shell (or anything using mutter-clutter-<api_version>.pc) should use the subslot
+fi
+
+IUSE="bash-completion debug devkit elogind gnome gtk-doc input_devices_wacom +introspection screencast selinux sysprof systemd test udev +wayland X +xwayland video_cards_nvidia"
+# native backend requires gles3 for hybrid graphics blitting support, udev and a logind provider
+REQUIRED_USE="
+	|| ( X wayland )
+	devkit? ( screencast wayland )
+	gtk-doc? ( introspection )
+	wayland? ( ^^ ( elogind systemd ) udev )
+	test? ( screencast wayland )
+	xwayland? ( wayland )"
+RESTRICT="!test? ( test )"
+
+# gnome-settings-daemon is build checked, but used at runtime only for org.gnome.settings-daemon.peripherals.keyboard gschema
+# USE=libei was first introduced in xwayland-23.2.1; we min dep on that to ensure the [libei(+)] works right, as missing USE flag with
+# previous versions meant that it's not there, while the intention seems to be to make it always enabled without USE flag in the future;
+# this ensures have_enable_ei_portal is always there in xwayland.pc, which affects how Xwayland is launched, thus if it were toggled off
+# in Xwayland after mutter is installed, Xwayland would fail to be started by mutter. mutter already hard-depends on libei, so there's
+# really no extra deps here (besides xdg-desktop-portal, but we want that too, anyhow).
+# v3.32.2 has many excessive or unused *_req variables declared, thus currently the dep order ignores those and goes via dependency() call order
+# dev-libs/wayland is always needed at build time due to https://bugs.gentoo.org/937632
+RDEPEND="
+	>=media-libs/graphene-1.10.2[introspection?]
+	>=x11-libs/pango-1.46[introspection?]
+	>=x11-libs/cairo-1.14[X]
+	>=x11-libs/pixman-0.42
+	>=gui-libs/gtk-4.14.0:4[introspection?]
+	>=dev-libs/fribidi-1.0.0
+	>=gnome-base/gsettings-desktop-schemas-47_beta[introspection?]
+	>=dev-libs/glib-2.81.1:2
+	gnome-base/gnome-settings-daemon
+	>=x11-libs/libxkbcommon-1.8.0[X?]
+	>=app-accessibility/at-spi2-core-2.46:2[introspection?]
+	sys-apps/dbus
+	>=x11-misc/colord-1.4.5:=
+	>=media-libs/lcms-2.6:2
+	>=media-libs/harfbuzz-2.6.0:=
+	>=dev-libs/libei-1.3.901
+	>=media-libs/libdisplay-info-0.2:=
+	>=media-libs/glycin-2.0_beta_p2:=
+
+	devkit? (
+		gui-libs/libadwaita
+	)
+	gnome? ( gnome-base/gnome-desktop:4= )
+
+	>=media-libs/libcanberra-0.26
+
+	media-libs/libglvnd
+
+	>=dev-libs/wayland-1.24.0
+	wayland? (
+		>=dev-libs/wayland-protocols-1.45
+
+		>=x11-libs/libdrm-2.4.118
+		media-libs/mesa[gbm(+)]
+		>=dev-libs/libinput-1.27.0:=
+
+		elogind? ( sys-auth/elogind )
+		xwayland? ( >=x11-base/xwayland-23.2.1[libei(+)] )
+		video_cards_nvidia? ( gui-libs/egl-wayland )
+	)
+	udev? (
+		>=virtual/libudev-232-r1:=
+		>=dev-libs/libgudev-238
+	)
+	systemd? ( sys-apps/systemd )
+	input_devices_wacom? ( >=dev-libs/libwacom-0.13:= )
+	screencast? ( >=media-video/pipewire-1.2.7:= )
+	introspection? ( >=dev-libs/gobject-introspection-1.82.0-r2:= )
+	test? (
+		>=x11-libs/gtk+-3.19.8:3[X,introspection?]
+		>=dev-util/umockdev-0.3.0
+	)
+	sysprof? ( >=dev-util/sysprof-capture-3.40.1:4 >=dev-util/sysprof-3.46.0 )
+"
+
+X11_CLIENT_DEPS="
+	>=gui-libs/gtk-4.14.0:4[X,introspection?]
+	media-libs/libglvnd[X]
+	>=x11-libs/libX11-1.7.0
+	>=x11-libs/libXcomposite-0.4
+	x11-libs/libXcursor
+	x11-libs/libXdamage
+	x11-libs/libXext
+	>=x11-libs/libXfixes-6
+	>=x11-libs/libXi-1.7.4
+	x11-misc/xkeyboard-config
+	>=x11-libs/libXrandr-1.5.0
+	x11-libs/libxcb:=
+	x11-libs/libXinerama
+	x11-libs/libXau
+	>=x11-libs/startup-notification-0.7
+"
+
+RDEPEND+="
+	X? (
+		${X11_CLIENT_DEPS}
+		x11-libs/libxkbfile
+		x11-libs/libXtst
+	)
+	wayland? ( xwayland? ( ${X11_CLIENT_DEPS} ) )
+"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	sysprof? ( >=dev-util/sysprof-common-3.38.0 )
+"
+RDEPEND+=" selinux? ( sec-policy/selinux-wm )"
+BDEPEND="
+	>=dev-build/meson-1.5.0
+	dev-util/wayland-scanner
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	dev-python/docutils
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	gtk-doc? ( >=dev-util/gi-docgen-2021.1 )
+	test? (
+		${PYTHON_DEPS}
+		$(python_gen_any_dep '
+			>=dev-python/python-dbusmock-0.28[${PYTHON_USEDEP}]
+		')
+		app-text/docbook-xml-dtd:4.5
+		X? (
+			gnome-extra/zenity
+			x11-misc/xvfb-run
+		)
+	)
+	wayland? (
+		>=sys-kernel/linux-headers-4.4
+		x11-libs/libxcvt
+	)
+	bash-completion? (
+		app-shells/bash-completion
+		${PYTHON_DEPS}
+		$(python_gen_any_dep '
+			dev-python/argcomplete[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-update-kms-resource-lists.patch
+)
+
+python_check_deps() {
+	if use test; then
+		python_has_version ">=dev-python/python-dbusmock-0.28[${PYTHON_USEDEP}]"
+	fi
+	if use bash-completion; then
+		python_has_version dev-python/argcomplete[${PYTHON_USEDEP}]
+	fi
+}
+
+src_configure() {
+	use debug && EMESON_BUILDTYPE=debug
+	local emesonargs=(
+		# Mutter X11 renderer only supports gles2 and GLX, thus do NOT pass
+		#
+		#   -Dopengl_libname=libOpenGL.so.0
+		#
+		# while we build the x11 renderer, as we currently enable gles2 only
+		# with USE=wayland and x11 renderer wouldn't find the needed GLX symbols
+		# in a configuration where wayland is disabled, as libOpenGL doesn't
+		# include them.
+		#
+		# See
+		# - https://bugs.gentoo.org/835786
+		# - https://forums.gentoo.org/viewtopic-p-8695669.html
+
+		-Dopengl=true
+		$(meson_use wayland gles2)
+		#gles2_libname
+		-Degl=true
+		$(meson_use X glx)
+		$(meson_use wayland)
+		-Dfonts=true
+	)
+
+	if use wayland; then
+		emesonargs+=(
+			$(meson_use xwayland)
+		)
+	else
+		emesonargs+=(
+			-Dxwayland=false
+		)
+	fi
+
+	if use elogind || use systemd; then
+		emesonargs+=(
+			-Dlogind=true
+		)
+	fi
+
+	emesonargs+=(
+		$(meson_use wayland native_backend)
+		$(meson_use screencast remote_desktop)
+		$(meson_use gnome libgnome_desktop)
+		$(meson_use udev)
+		-Dudev_dir=$(get_udevdir)
+		$(meson_use input_devices_wacom libwacom)
+		-Dsound_player=true
+		-Dstartup_notification=true
+		$(meson_use introspection)
+		$(meson_feature devkit)
+		$(meson_use gtk-doc docs)
+		$(meson_use test cogl_tests)
+		$(meson_use test clutter_tests)
+		$(meson_use test mutter_tests)
+		$(meson_feature test tests)
+		-Dkvm_tests=false
+		-Dtty_tests=false
+		$(meson_use sysprof profiler)
+		-Dinstalled_tests=false
+		$(meson_use X x11)
+		$(meson_use bash-completion bash_completion)
+
+		#verbose # Let upstream choose default for verbose mode
+		#xwayland_path
+		# TODO: relies on default settings, but in Gentoo we might have some more packages we want to give Xgrab access (mostly virtual managers and remote desktops)
+		#xwayland_grab_default_access_rules
+	)
+
+	if use wayland && use video_cards_nvidia; then
+		emesonargs+=(
+			-Degl_device=true
+			-Dwayland_eglstream=true
+		)
+	else
+		emesonargs+=(
+			-Degl_device=false
+			-Dwayland_eglstream=false
+		)
+	fi
+
+	meson_src_configure
+}
+
+src_test() {
+	# Reset variables to avoid issues from /etc/profile.d/flatpak.sh file
+	gnome2_environment_reset
+	export XDG_DATA_DIRS="${EPREFIX}"/usr/share
+	glib-compile-schemas "${BUILD_DIR}"/data
+	GSETTINGS_SCHEMA_DIR="${BUILD_DIR}"/data meson_src_test
+}
+
+pkg_postinst() {
+	use udev && udev_reload
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	use udev && udev_reload
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
Resolve wake-from-suspend crashing the session by back-porting changes from mutter 50.2.

Closes: https://bugs.gentoo.org/976156

When waking my notebook from sleep, specifically after connecting or disconnecting USB devices or chargers, my gnome-base/gnome-shell-49.6 session is consistently terminated with a variation of the following error in dmesg:

"gnome-shell[2004]: segfault at 1fffffff69 ip 00007f510cddb980 sp 00007fffcee787c0 error 4 in libmutter-17.so.0.0.0[1db980,7f510cc40000+1c6000] likely on CPU 2 (core 8, socket 0)"

This bug is documented here:
https://gitlab.gnome.org/GNOME/mutter/-/work_items/4796

And has already been fixed upstream after mutter 50.1:
https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5061

I have back-ported the two-line change locally and applied it to the x11-wm/mutter-49.5 ebuild. After test-driving the updated version for two days, I can confirm that my issue is resolved, and the session no longer crashes after resuming from suspend.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
