### PR TITLE
gnome-base/gnome-shell: Add patch for elogind's sd_notify support

### DIFF
--- a/gnome-base/gnome-shell/files/0001-shell-elogind-support-to-avoid-stubbed-sd_notify.patch
+++ b/gnome-base/gnome-shell/files/0001-shell-elogind-support-to-avoid-stubbed-sd_notify.patch
@@ -1,0 +1,79 @@
+From ee7240469583e9ab5124ba6c3df12c91050f177e Mon Sep 17 00:00:00 2001
+From: Swagtoy <me@ow.swag.toys>
+Date: Wed, 27 May 2026 17:57:33 -0400
+Subject: [PATCH] shell: elogind support to avoid stubbed sd_notify
+
+sd_notify is supported by elogind (with such an unfortunate name) and
+openrc's supervise-daemon is able to get at READY=1. Unfortunately, it
+is stubbed, so let's start using it if -Dsystemd=off and elogind is
+found.
+
+Signed-off-by: Swagtoy <me@ow.swag.toys>
+---
+ config.h.meson   | 3 +++
+ meson.build      | 6 +++++-
+ src/shell-util.c | 4 +++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/config.h.meson b/config.h.meson
+index a357e1c1f..2c4923617 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -28,6 +28,9 @@
+ /* Define if we have systemd */
+ #mesondefine HAVE_SYSTEMD
+ 
++/* Define if we have elogind */
++#mesondefine HAVE_ELOGIND
++
+ /* Define if _NL_TIME_FIRST_WEEKDATE is available */
+ #mesondefine HAVE__NL_TIME_FIRST_WEEKDAY
+ 
+diff --git a/meson.build b/meson.build
+index 14ba11953..05d0bc910 100644
+--- a/meson.build
++++ b/meson.build
+@@ -129,9 +129,12 @@ if get_option('systemd')
+   systemd_dep = dependency('systemd', version: systemd_req)
+   systemduserunitdir = systemd_dep.get_variable('systemduserunitdir',
+     pkgconfig_define: ['prefix', prefix])
++  have_elogind = false
+   have_systemd = true
+ else
+-  libsystemd_dep = []
++  # elogind isn't required either, but reap the benefits if it does exists
++  libsystemd_dep = dependency('libelogind', required: false)
++  have_elogind = libsystemd_dep.found()
+   have_systemd = false
+ endif
+ 
+@@ -154,6 +157,7 @@ cdata.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+ cdata.set_quoted('VERSION', meson.project_version())
+ cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+ 
++cdata.set('HAVE_ELOGIND', have_elogind)
+ cdata.set('HAVE_NETWORKMANAGER', have_networkmanager)
+ cdata.set('HAVE_PIPEWIRE', have_pipewire)
+ cdata.set('HAVE_SYSTEMD', have_systemd)
+diff --git a/src/shell-util.c b/src/shell-util.c
+index 21fe7a7f4..ecc3c169c 100644
+--- a/src/shell-util.c
++++ b/src/shell-util.c
+@@ -35,11 +35,13 @@
+ #ifdef HAVE_SYSTEMD
+ #include <systemd/sd-daemon.h>
+ #include <systemd/sd-login.h>
++#elif defined(HAVE_ELOGIND)
++#include <elogind/sd-daemon.h>
+ #else
+ /* So we don't need to add ifdef's everywhere */
+ #define sd_notify(u, m)            do {} while (0)
+ #define sd_notifyf(u, m, ...)      do {} while (0)
+-#endif
++#endif /* HAVE_SYSTEMD */
+ 
+ static void
+ stop_pick (ClutterActor *actor)
+-- 
+2.53.0
+

--- a/gnome-base/gnome-shell/gnome-shell-49.6-r1.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-49.6-r1.ebuild
@@ -1,0 +1,199 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{11..14} )
+
+inherit flag-o-matic gnome.org gnome2-utils meson optfeature python-single-r1 virtualx xdg
+
+DESCRIPTION="Provides core UI functions for the GNOME desktop"
+HOMEPAGE="https://gitlab.gnome.org/GNOME/gnome-shell"
+
+LICENSE="GPL-2+ LGPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+IUSE="X elogind gtk-doc +ibus +networkmanager pipewire selinux systemd test wayland"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+	?? ( elogind systemd )"
+RESTRICT="!test? ( test )"
+
+# libXfixes-5.0 needed for pointer barriers and #include <X11/extensions/Xfixes.h>
+DEPEND="
+	>=gnome-extra/evolution-data-server-3.46.0:=
+	>=app-crypt/gcr-3.90.0:4=[introspection]
+	>=dev-libs/glib-2.86.0:2
+	>=dev-libs/gobject-introspection-1.86.0:=
+	>=dev-libs/gjs-1.85.90[cairo(+)]
+	>=gui-libs/gtk-4:4[X?,introspection,wayland?]
+	>=x11-wm/mutter-49.0:0/17[introspection,test?]
+	>=sys-auth/polkit-0.120_p20220509[introspection]
+	>=gnome-base/gsettings-desktop-schemas-49_alpha[introspection]
+	X? (
+	   x11-libs/libX11
+	   x11-libs/libXext
+	   >=x11-libs/libXfixes-5.0
+	)
+	>=app-i18n/ibus-1.5.19
+	dev-python/docutils
+	>=gnome-base/gnome-desktop-40.0:4=
+	networkmanager? (
+		>=net-misc/networkmanager-1.10.4[introspection]
+		net-libs/libnma[introspection]
+		>=app-crypt/libsecret-0.18
+	)
+	pipewire? ( >=media-video/pipewire-0.3.49:= )
+	systemd? (
+		>=sys-apps/systemd-246:=
+		>=gnome-base/gnome-desktop-3.34.2:3=[systemd]
+	)
+	elogind? ( >=sys-auth/elogind-237 )
+
+	app-arch/gnome-autoar
+	dev-libs/json-glib
+	net-libs/libsoup:3.0
+
+	>=app-accessibility/at-spi2-core-2.46:2[introspection]
+	x11-libs/gdk-pixbuf:2[introspection]
+	dev-libs/libxml2:2=
+
+	>=media-libs/libpulse-2[glib]
+	dev-libs/libical:=
+
+	${PYTHON_DEPS}
+	$(python_gen_cond_dep '
+		dev-python/pygobject:3[${PYTHON_USEDEP}]
+	')
+	media-libs/libglvnd[X]
+"
+# Runtime-only deps are probably incomplete and approximate.
+# Introspection deps generated from inspection of the output of:
+#  for i in `rg -INUo 'const(?s).*imports.gi' |cut -d= -f1 |cut -c7- |sort -u`; do echo $i ;done |cut -d, -f1 |sort -u
+# or
+#  rg -INUo 'const(?s).*imports.gi' |cut -d= -f1 |cut -c7- | sed -e 's:[{}]::g' | awk '{$1=$1; print}' | awk -F',' '{$1=$1;print}' | tr ' ' '\n' | sort -u | sed -e 's/://g'
+# These will give a lot of unnecessary things due to greedy matching (TODO), and `(?s).*?` doesn't seem to work as desired.
+# Compare with `grep -rhI 'imports.gi.versions' |sort -u` for any SLOT requirements
+# Each block:
+# 1. Introspection stuff needed via imports.gi (those that build time check may be listed above already)
+# 2. gnome-session needed for shutdown/reboot/inhibitors/etc
+# 3. Control shell settings
+# 4. xdg-utils needed for xdg-open, used by extension tool
+# 5. adwaita-icon-theme needed for various icons & arrows (3.26 for new video-joined-displays-symbolic and co icons; review for 3.28+)
+# 6. mobile-broadband-provider-info, timezone-data for shell-mobile-providers.c  # TODO: Review
+# 7. IBus is needed for nls integration
+# 8. Adwaita font used in gnome-shell global CSS (if removing this for some reason, make sure it's pulled in somehow for non-meta users still too)
+# 9. xdg-desktop-portal-gtk for various integration, e.g. #764632
+# 10. TODO: semi-optional webkit-gtk[introspection] for captive portal helper
+RDEPEND="${DEPEND}
+	>=sys-apps/accountsservice-0.6.14[introspection]
+	app-accessibility/at-spi2-core:2[introspection]
+	app-misc/geoclue:2.0[introspection]
+	media-libs/graphene[introspection]
+	>=x11-libs/pango-1.46.0[introspection]
+	net-libs/libsoup:3.0[introspection]
+	>=sys-power/upower-0.99:=[introspection]
+	gnome-base/librsvg:2[introspection]
+	gui-libs/libadwaita:1[introspection]
+
+	>=gnome-base/gnome-session-49
+	>=gnome-base/gnome-settings-daemon-3.8.3
+
+	x11-misc/xdg-utils
+
+	>=x11-themes/adwaita-icon-theme-3.26
+
+	networkmanager? (
+		net-misc/mobile-broadband-provider-info
+		sys-libs/timezone-data
+	)
+	ibus? ( >=app-i18n/ibus-1.5.26[gtk3,gtk4,introspection] )
+	selinux? ( sec-policy/selinux-wm )
+	media-fonts/adwaita-fonts
+
+	sys-apps/xdg-desktop-portal-gnome
+"
+
+# avoid circular dependency, see bug #546134
+PDEPEND="
+	>=gnome-base/gdm-49[introspection(+)]
+	>=gnome-base/gnome-control-center-3.26[networkmanager(+)?]
+"
+BDEPEND="
+	>=dev-build/meson-1.3.0
+	dev-libs/libxslt
+	>=dev-util/gdbus-codegen-2.80.5-r1
+	dev-util/glib-utils
+	gtk-doc? (
+		>=dev-util/gtk-doc-1.17
+		>=dev-util/gi-docgen-2021.1
+		app-text/docbook-xml-dtd:4.5
+	)
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	test? (
+		sys-apps/dbus
+		x11-wm/mutter[test]
+	)
+"
+# These are not needed from tarballs, unless stylesheets or manpage get patched with patchset:
+# dev-lang/sassc
+# app-text/asciidoc
+
+PATCHES=(
+	"${FILESDIR}"/0001-shell-elogind-support-to-avoid-stubbed-sd_notify.patch
+)
+
+src_prepare() {
+	default
+	xdg_environment_reset
+	# Hack in correct python shebang
+	sed -e "s:python\.full_path():'/usr/bin/env ${EPYTHON}':" -i src/meson.build || die
+}
+
+src_configure() {
+	use X || append-cppflags -DGENTOO_GTK_HIDE_X11
+	use wayland || append-cppflags -DGENTOO_GTK_HIDE_WAYLAND
+
+	local emesonargs=(
+		$(meson_use pipewire camera_monitor)
+		-Dextensions_tool=true
+		-Dextensions_app=true
+		$(meson_use gtk-doc gtk_doc)
+		-Dman=true
+		$(meson_use test tests)
+		$(meson_use networkmanager)
+		$(meson_use networkmanager portal_helper)
+		$(meson_use systemd) # this controls journald integration and desktop file user services related property only as of 3.34.4
+		# (structured logging and having gnome-shell launched apps use its own identifier instead of gnome-session)
+		# suspend support is runtime optional via /run/systemd/seats presence and org.freedesktop.login1.Manager dbus interface; elogind should provide what's necessary
+	)
+	meson_src_configure
+}
+
+src_test() {
+	# Reset variables to avoid issues from /etc/profile.d/flatpak.sh file modifying XDG_DATA_DIRS
+	gnome2_environment_reset
+	export XDG_DATA_DIRS="${EPREFIX}"/usr/share
+	virtx dbus-run-session meson test -C "${BUILD_DIR}" || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+
+	if ! has_version "media-libs/mesa[llvm]"; then
+		elog "llvmpipe is used as fallback when no 3D acceleration"
+		elog "is available. You will need to enable llvm USE for"
+		elog "media-libs/mesa if you do not have hardware 3D setup."
+	fi
+
+	optfeature "Bluetooth integration" gnome-base/gnome-control-center[bluetooth] net-wireless/gnome-bluetooth:3[introspection]
+	optfeature "Browser extension integration" gnome-extra/gnome-browser-connector
+	optfeature "Screencast/capture support" media-video/pipewire media-libs/gstreamer[introspection] media-libs/gst-plugins-base[introspection] media-libs/gst-plugins-good media-plugins/gst-plugins-vpx
+	optfeature "Weather support" dev-libs/libgweather:4[introspection]
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
As the patch states, we need sd_notify exposed from gnome-shell. Unfortunately, gnome-shell stubs the sd-notify calls for non-systemd systems, which won't allow us to (properly) verify that gnome-shell is ready. It'll be mandatory for gnome-session-openrc, as I need to check for gnome-shell service readiness to fix some env var issues.

Patch also upstreamed as GNOME/gnome-shell !4233, so in the future this can hopefully be dropped.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
