### PR TITLE
media-video/vlc: fix cxx standard passing for 3.0.x

### DIFF
--- a/media-video/vlc/vlc-3.0.23-r1.ebuild
+++ b/media-video/vlc/vlc-3.0.23-r1.ebuild
@@ -260,18 +260,12 @@ src_prepare() {
 		sed -i 's/ --started-from-file//' share/vlc.desktop.in || die
 	fi
 
-	# old bundled version
-	# so we need to call AX_CXX_COMPILE_STDCXX directly
-	rm \
-		m4/ax_cxx_compile_stdcxx.m4 \
-		m4/ax_cxx_compile_stdcxx_17.m4 \
-		|| die
 	local CXXSTD="17"
 	if has_version ">=dev-cpp/abseil-cpp-20260107.0"; then
 		# needs >=c++20
 		CXXSTD="20"
 	fi
-	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_17(/(${CXXSTD}, /}" configure.ac || die
+	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_[0-9]*(/(${CXXSTD}, /}" configure.ac || die
 
 	eautoreconf
 }

--- a/media-video/vlc/vlc-3.0.23.ebuild
+++ b/media-video/vlc/vlc-3.0.23.ebuild
@@ -276,18 +276,12 @@ src_prepare() {
 		sed -i 's/ --started-from-file//' share/vlc.desktop.in || die
 	fi
 
-	# old bundled version
-	# so we need to call AX_CXX_COMPILE_STDCXX directly
-	rm \
-		m4/ax_cxx_compile_stdcxx.m4 \
-		m4/ax_cxx_compile_stdcxx_17.m4 \
-		|| die
 	local CXXSTD="17"
 	if has_version ">=dev-cpp/abseil-cpp-20260107.0"; then
 		# needs >=c++20
 		CXXSTD="20"
 	fi
-	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_17(/(${CXXSTD}, /}" configure.ac || die
+	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_[0-9]*(/(${CXXSTD}, /}" configure.ac || die
 
 	eautoreconf
 }

--- a/media-video/vlc/vlc-3.0.9999.ebuild
+++ b/media-video/vlc/vlc-3.0.9999.ebuild
@@ -260,18 +260,12 @@ src_prepare() {
 		sed -i 's/ --started-from-file//' share/vlc.desktop.in || die
 	fi
 
-	# old bundled version
-	# so we need to call AX_CXX_COMPILE_STDCXX directly
-	rm \
-		m4/ax_cxx_compile_stdcxx.m4 \
-		m4/ax_cxx_compile_stdcxx_17.m4 \
-		|| die
 	local CXXSTD="17"
 	if has_version ">=dev-cpp/abseil-cpp-20260107.0"; then
 		# needs >=c++20
 		CXXSTD="20"
 	fi
-	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_17(/(${CXXSTD}, /}" configure.ac || die
+	sed -i -e "/AX_CXX_COMPILE_STDCXX/{s/_[0-9]*(/(${CXXSTD}, /}" configure.ac || die
 
 	eautoreconf
 }


### PR DESCRIPTION
Fixes: d9c4fce156e78b321e8a05683759cee6f55f7f58
Closes: https://bugs.gentoo.org/976256

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
