### PR TITLE
dev-libs/imath: enable py3.14

### DIFF
--- a/dev-libs/imath/imath-3.1.12-r2.ebuild
+++ b/dev-libs/imath/imath-3.1.12-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit cmake python-single-r1
 


### PR DESCRIPTION
Building with USE=doc fails due to bug 973362 in dev-python/sphinx-press-theme.

Bug: https://bugs.gentoo.org/972709
Closes: https://bugs.gentoo.org/973436

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
