### PR TITLE
app-admin/clsync: fix SIGCHLD handler for GCC 16

### DIFF
--- a/app-admin/clsync/clsync-0.4.5.ebuild
+++ b/app-admin/clsync/clsync-0.4.5.ebuild
@@ -42,6 +42,10 @@ RDEPEND="${DEPEND}
 	!dev-libs/libclsync
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-gcc16.patch" # bug 943773
+)
+
 pkg_pretend() {
 	if use clsync; then
 		use inotify && CONFIG_CHECK+=" ~INOTIFY_USER"
@@ -52,7 +56,7 @@ pkg_pretend() {
 }
 
 src_prepare() {
-	eapply_user
+	default
 	eautoreconf
 }
 

--- a/app-admin/clsync/files/clsync-0.4.5-gcc16.patch
+++ b/app-admin/clsync/files/clsync-0.4.5-gcc16.patch
@@ -1,0 +1,26 @@
+Fix SIGCHLD handler prototype for GCC 15+ default C23.
+
+Bug: https://bugs.gentoo.org/943773
+
+--- a/main.c
++++ b/main.c
+@@ -427,8 +427,9 @@
+ 	return 1;
+ }
+
+-void child_sigchld()
++void child_sigchld(int sig)
+ {
++	(void)sig;
+ 	if ( getppid() != 1 )
+ 		return;
+
+@@ -437,7 +438,7 @@ void child_sigchld()
+ 	return;
+ }
+
+-int sethandler_sigchld ( void ( *handler ) () )
++int sethandler_sigchld ( void ( *handler ) (int) )
+ {
+ 	struct sigaction sa;
+ 	sa.sa_handler = handler;


### PR DESCRIPTION
## Summary
- Add patch to fix SIGCHLD handler signature incompatible with GCC 16
- Apply via PATCHES array in clsync-0.4.5.ebuild

## Bug
https://bugs.gentoo.org/943773

## Test plan
- [x] `ebuild app-admin/clsync/clsync-0.4.5.ebuild clean compile`
- [x] `pkgcheck scan app-admin/clsync`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.