### PR TITLE
app-accessibility/yasr: fix Func pointer signature for GCC 16

### DIFF
--- a/app-accessibility/yasr/files/yasr-0.6.9-gcc16.patch
+++ b/app-accessibility/yasr/files/yasr-0.6.9-gcc16.patch
@@ -1,0 +1,21 @@
+Fix Func function pointer signature for GCC 16 / Clang strict.
+
+GCC 16 treats -Wincompatible-pointer-types as an error. Clang rejects
+calls to functions without a prototype (-Wdeprecated-non-prototype).
+In C23, void (*f)() means void (*)(void), but yasr command handlers
+take int *argp.
+
+Bug: https://bugs.gentoo.org/943766
+Bug: https://bugs.gentoo.org/881865
+
+--- a/yasr/yasr.h
++++ b/yasr/yasr.h
+@@ -87,7 +87,7 @@ struct Opt
+ typedef struct Func Func;
+ struct Func
+ {
+-    void (*f) ();
++    void (*f)(int *);
+     char *desc;
+ };
+ 

--- a/app-accessibility/yasr/yasr-0.6.9-r1.ebuild
+++ b/app-accessibility/yasr/yasr-0.6.9-r1.ebuild
@@ -20,6 +20,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.6.9-automake113.patch
 	"${FILESDIR}"/${PN}-0.6.9-gettext019.patch
 	"${FILESDIR}"/${PN}-0.6.9-gcc43.patch
+	"${FILESDIR}"/${PN}-0.6.9-gcc16.patch # bug 943766, 881865
 	"${FILESDIR}"/${PN}-0.6.9-remove-m4.patch
 )
 


### PR DESCRIPTION
## Summary
- Add patch to fix `Func.f` function pointer signature in `yasr.h`
- Resolves GCC 16 `-Wincompatible-pointer-types` and Clang `-Wdeprecated-non-prototype` build failures

## Bugs
- https://bugs.gentoo.org/943766
- https://bugs.gentoo.org/881865

## Test plan
- [x] `ebuild app-accessibility/yasr/yasr-0.6.9-r1.ebuild clean compile`
- [x] `pkgcheck scan app-accessibility/yasr`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.