### PR TITLE
app-cdr/dvdisaster: fix configure with GCC 14+

### DIFF
--- a/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
+++ b/app-cdr/dvdisaster/dvdisaster-0.79.5.ebuild
@@ -31,7 +31,10 @@ BDEPEND="
 	virtual/os-headers
 	virtual/pkgconfig"
 
-PATCHES=( "${FILESDIR}"/${P}-fno-common.patch )
+PATCHES=(
+	"${FILESDIR}/${P}-fno-common.patch"
+	"${FILESDIR}/${P}-stdio.patch" # bug 874939
+)
 
 DOCS=( CHANGELOG CREDITS.en README README.MODIFYING TODO TRANSLATION.HOWTO )
 

--- a/app-cdr/dvdisaster/files/dvdisaster-0.79.5-stdio.patch
+++ b/app-cdr/dvdisaster/files/dvdisaster-0.79.5-stdio.patch
@@ -1,0 +1,48 @@
+Add stdio.h to configure conftest snippets using printf.
+
+GCC 14+ rejects implicit printf declarations in configure probes.
+
+Bug: https://bugs.gentoo.org/874939
+
+--- a/scripts/bash-based-configure
++++ b/scripts/bash-based-configure
+@@ -1170,6 +1170,7 @@ EOF
+ 
+    cat >conftest.c <<EOF
+ #include <Xm/Xm.h>
++#include <stdio.h>
+ int main()
+ {  printf("%d.%d.%d\n",XmVERSION,XmREVISION,XmUPDATE_LEVEL);
+ }
+@@ -1197,6 +1198,7 @@ EOF
+ 
+    cat >conftest.c <<EOF
+ #include <Xm/Xm.h>
++#include <stdio.h>
+ int main()
+ {  printf("%s\n",LesstifVERSION_STRING);
+ }
+@@ -1354,6 +1356,7 @@ EOF
+ 
+    cat >conftest.c <<EOF
+ #include <glib.h>
++#include <stdio.h>
+ int main(int argc, char *argv[])
+ { g_malloc(1024); 
+ 
+@@ -1856,6 +1859,7 @@ EOF
+    # Try automatic detection
+ 
+    cat > conftest.c <<EOF
++#include <stdio.h>
+ int main()
+ {  if(sizeof(int)==4)
+    {  char *c = "1234";
+@@ -1924,6 +1928,7 @@ EOF
+    # Try automatic detection
+ 
+    cat > conftest.c <<EOF
++#include <stdio.h>
+ int main()
+ {  switch(sizeof(char*))
+    {  case 4: printf("32\n"); break;


### PR DESCRIPTION
## Summary
- Add `dvdisaster-0.79.5-stdio.patch` to include `<stdio.h>` in `scripts/bash-based-configure` conftest snippets that call `printf()` without it.
- Fixes configure failure on GCC 14+ when probing GLib (and related Motif/endian/bitness probes).

## Bug
- https://bugs.gentoo.org/874939

## Test plan
- [x] `emerge -1 app-cdr/dvdisaster` on amd64 with GCC 16.1.0 (configure + full build succeeded)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.