### PR TITLE
app-crypt/bcwipe: fix upstream tarball URL and GCC 15+ build

### DIFF
--- a/app-crypt/bcwipe/bcwipe-1.9.13.ebuild
+++ b/app-crypt/bcwipe/bcwipe-1.9.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ MY_PV="$(ver_rs 2- -)"
 
 DESCRIPTION="Secure file removal utility"
 HOMEPAGE="https://www.jetico.com/"
-SRC_URI="https://www.jetico.com/linux/BCWipe-${MY_PV}.tar.gz"
+SRC_URI="https://www.jetico.com/file-downloads/linux/BCWipe-${MY_PV}.tar.gz"
 
 LICENSE="bestcrypt"
 SLOT="0"
@@ -17,6 +17,7 @@ RESTRICT="mirror bindist"
 PATCHES=(
 	"${FILESDIR}/${PN}-1.9.7-fix_warnings.patch"
 	"${FILESDIR}/${PN}-1.9.8-fix-flags.patch"
+	"${FILESDIR}/${P}-rand-prototypes.patch" # bug 943917
 )
 
 S="${WORKDIR}/${PN}-${MY_PV}"

--- a/app-crypt/bcwipe/files/bcwipe-1.9.13-rand-prototypes.patch
+++ b/app-crypt/bcwipe/files/bcwipe-1.9.13-rand-prototypes.patch
@@ -1,0 +1,44 @@
+Fix K&R rand.h prototypes for modern GCC.
+
+GCC 15+ treats comment-style prototypes as zero-argument declarations,
+breaking calls from prng.c and K&R definitions in rand.c.
+
+Bug: https://bugs.gentoo.org/943917
+
+--- a/rand.h
++++ b/rand.h
+@@ -40,9 +40,9 @@
+  If (flag==TRUE), then use the contents of randrsl[0..RANDSIZ-1] as the seed.
+ ------------------------------------------------------------------------------
+ */
+-void randinit(/*_ randctx *r, word flag _*/);
++void randinit(randctx *r, word flag);
+ 
+-void isaac(/*_ randctx *r _*/);
++void isaac(randctx *r);
+ 
+ 
+ /*
+--- a/rand.c
++++ b/rand.c
+@@ -25,8 +25,7 @@
+   *(r++) = b = ind(mm,y>>RANDSIZL) + x; \
+ }
+ 
+-void     isaac(ctx)
+-randctx *ctx;
++void isaac(randctx *ctx)
+ {
+    register ub4 a,b,x,y,*m,*mm,*m2,*r,*mend;
+    mm=ctx->randmem; r=ctx->randrsl;
+@@ -62,9 +61,7 @@
+ }
+ 
+ /* if (flag==TRUE), then use the contents of randrsl[] to initialize mm[]. */
+-void randinit(ctx, flag)
+-randctx *ctx;
+-word     flag;
++void randinit(randctx *ctx, word flag)
+ {
+    word i;
+    ub4 a,b,c,d,e,f,g,h;


### PR DESCRIPTION
## Summary
- Update `SRC_URI` from `https://www.jetico.com/linux/` to `https://www.jetico.com/file-downloads/linux/` (old path returns 404).
- Add `bcwipe-1.9.13-rand-prototypes.patch` for K&R `rand.h`/`rand.c` prototypes that fail on GCC 15+.

## Bug
- https://bugs.gentoo.org/943917

## Test plan
- [x] `emerge -1 app-crypt/bcwipe` on amd64 with GCC 16.1.0 (fetch, compile, install succeeded)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.