### PR TITLE
app-crypt/gpgstats: fix build with GCC 16

### DIFF
--- a/app-crypt/gpgstats/files/gpgstats-0.5-localtime.patch
+++ b/app-crypt/gpgstats/files/gpgstats-0.5-localtime.patch
@@ -1,0 +1,27 @@
+Fix localtime() calls for gpgme unsigned timestamps.
+
+gpgme subkey/signature timestamps are unsigned long while localtime()
+expects const time_t*; this fails to compile with GCC 16 / -std=c++14.
+
+--- a/s.cpp
++++ b/s.cpp
+@@ -265,7 +265,8 @@
+ 			/* determine subkeys per year */
+ 			if (subkeys -> timestamp > 0)
+ 			{
+-				struct tm *sts = localtime(&subkeys -> timestamp);
++				time_t ts = subkeys -> timestamp;
++				struct tm *sts = localtime(&ts);
+ 
+ 				key_per_year.addvalue(sts -> tm_year + 1900, 1);
+ 				key_per_month.addvalue(sts -> tm_mon + 1, 1);
+@@ -401,7 +402,8 @@
+ 				/* determine sigs per year/month/day */
+ 				if (sigs -> timestamp > 0)
+ 				{
+-					struct tm *sts = localtime(&sigs -> timestamp);
++					time_t ts = sigs -> timestamp;
++					struct tm *sts = localtime(&ts);
+ 
+ 					sig_per_year.addvalue(sts -> tm_year + 1900, 1);
+ 					sig_per_month.addvalue(sts -> tm_mon + 1, 1);

--- a/app-crypt/gpgstats/gpgstats-0.5-r3.ebuild
+++ b/app-crypt/gpgstats/gpgstats-0.5-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,10 @@ KEYWORDS="~amd64 ~x86"
 RDEPEND="app-crypt/gpgme:="
 DEPEND="${RDEPEND}"
 
-PATCHES=( "${FILESDIR}"/${P}-flags.patch )
+PATCHES=(
+	"${FILESDIR}/${P}-flags.patch"
+	"${FILESDIR}/${P}-localtime.patch"
+)
 
 src_compile() {
 	# Uses removed 'register' keyword, bug #894350


### PR DESCRIPTION
## Summary
- Add `gpgstats-0.5-localtime.patch` to pass gpgme timestamps through a `time_t` before calling `localtime()`.
- Bump to `0.5-r3` (fixes GCC 16 / `-std=c++14` build failure from #894350 follow-up).

## Bug
- https://bugs.gentoo.org/894350

## Keywords
- `0.5-r2` and `0.5-r3` both use `~amd64 ~x86` only; no stable keywords dropped.

## Test plan
- [x] `ebuild gpgstats-0.5-r3.ebuild clean compile` on amd64 with GCC 16.1.0

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.