### PR TITLE
app-text/sdcv: fix build with newer glib

### DIFF
--- a/app-text/sdcv/files/sdcv-0.5.5-glib-const.patch
+++ b/app-text/sdcv/files/sdcv-0.5.5-glib-const.patch
@@ -1,0 +1,21 @@
+Fix build with glib where g_utf8_next_char returns const char*.
+
+--- a/src/stardict_lib.cpp
++++ b/src/stardict_lib.cpp
+@@ -1047,12 +1047,12 @@ bool Libs::LookupSimilarWord(const gchar *sWord, std::
+         }
+         // Upper the first character and lower others.
+         if (!bFound) {
+-            gchar *nextchar = g_utf8_next_char(sWord);
++            const gchar *nextchar = g_utf8_next_char(sWord);
+             gchar *firstchar = g_utf8_strup(sWord, nextchar - sWord);
+-            nextchar = g_utf8_strdown(nextchar, -1);
+-            casestr = g_strdup_printf("%s%s", firstchar, nextchar);
++            gchar *nextDownchar = g_utf8_strdown(nextchar, -1);
++            casestr = g_strdup_printf("%s%s", firstchar, nextDownchar);
+             g_free(firstchar);
+-            g_free(nextchar);
++            g_free(nextDownchar);
+             if (strcmp(casestr, sWord)) {
+                 if (oLib[iLib]->Lookup(casestr, iWordIndices))
+                     bFound = true;

--- a/app-text/sdcv/sdcv-0.5.5.ebuild
+++ b/app-text/sdcv/sdcv-0.5.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -31,6 +31,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.5.3-t_list.patch"
 	"${FILESDIR}/${PN}-t_interactive.patch"
 	"${FILESDIR}/${P}-read-history.patch"
+	"${FILESDIR}/${P}-glib-const.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
## Summary
- Fix `g_utf8_next_char` const-correctness in `stardict_lib.cpp` for newer glib
- Unblocks all `stardict.eclass` consumers that BDEPEND on `app-text/sdcv`

## Context
Newer glib's `g_utf8_next_char` macro returns `const gchar*`, but sdcv 0.5.5 assigns it to `gchar*`. This breaks the build and causes every stardict dictionary package to be dropped from the depgraph.

Bug: https://bugs.gentoo.org/945818

## Test plan
- [x] `emerge -1 app-text/sdcv` on amd64 with GCC 16 and glib 2.x

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.