### PR TITLE
app-editors/aee: add 2.2.22-r1, fix build without termio.h

### DIFF
--- a/app-editors/aee/aee-2.2.22-r1.ebuild
+++ b/app-editors/aee/aee-2.2.22-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit prefix toolchain-funcs
+
+DESCRIPTION="An easy to use text editor"
+HOMEPAGE="https://gitlab.com/ports1/aee"
+SRC_URI="https://gitlab.com/ports1/aee/-/archive/${PV}/${P}.tar.bz2"
+
+LICENSE="Artistic"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="X"
+
+RDEPEND="X? ( x11-libs/libX11 )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-ae-location.patch
+	"${FILESDIR}"/${PN}-gcc-10.patch
+	"${FILESDIR}"/${PN}-linux-termios.patch
+)
+DOCS=( Changes README.${PN} ${PN}.i18n.guide ${PN}.msg )
+
+src_prepare() {
+	sed -i \
+		-e "s/make -/\$(MAKE) -/g" \
+		-e "/^buildaee/s/$/ localaee/" \
+		-e "/^buildxae/s/$/ localxae/" \
+		Makefile || die
+
+	sed -i \
+		-e "s/\([\t ]\)cc /\1\\\\\$(CC) /" \
+		-e "/CFLAGS =/s/\" >/ \\\\\$(LDFLAGS)\" >/" \
+		-e "/other_cflag/s/ \${strip_option}//" \
+		-e "s/-lcurses/$($(tc-getPKG_CONFIG) --libs ncurses)/" \
+		create.mk.{aee,xae} || die
+
+	hprefixify create.mk.{aee,xae}
+
+	# https://gitlab.com/ports1/aee/-/merge_requests/1
+	chmod +x create.mk.{aee,xae} || die
+
+	default
+}
+
+src_compile() {
+	local target="aee"
+	use X && target="both"
+
+	emake CC="$(tc-getCC)" ${target}
+}
+
+src_install() {
+	dobin ${PN}
+	dosym ${PN} /usr/bin/rae
+	doman ${PN}.1
+	einstalldocs
+
+	insinto /usr/share/${PN}
+	doins help.ae
+
+	if use X; then
+		dobin xae
+		dosym xae /usr/bin/rxae
+	fi
+}

--- a/app-editors/aee/files/aee-linux-termios.patch
+++ b/app-editors/aee/files/aee-linux-termios.patch
@@ -1,0 +1,47 @@
+From: Gentoo Contributors <gentoo@gentoo.org>
+Bug: https://bugs.gentoo.org/961439
+Description: Use termios on Linux when termio.h is absent
+
+--- a/create.mk.aee	2021-06-12 10:26:59.000000000 +0200
++++ b/create.mk.aee	2026-05-31 23:51:43.954116224 +0200
+@@ -50,7 +50,7 @@
+ 
+ # test for existence of termio header (on SysV systems)
+ 
+-if [ -f /usr/include/termio.h ]
++if [ -f /usr/include/termio.h -o -f /usr/include/termios.h ]
+ then
+ 	termio="-DSYS5"
+ else
+--- a/new_curse.h	2026-05-31 23:51:43.944507822 +0200
++++ b/new_curse.h	2026-05-31 23:51:44.043369833 +0200
+@@ -42,7 +42,29 @@
+ #include <stdio.h>
+ 
+ #ifdef SYS5
++#if defined(__linux__)
++#include <sys/ioctl.h>
++#include <termios.h>
++#ifndef NCC
++#define NCC 8
++#endif
++struct termio {
++	unsigned short c_iflag;
++	unsigned short c_oflag;
++	unsigned short c_cflag;
++	unsigned short c_lflag;
++	char c_line;
++	unsigned char c_cc[NCC];
++};
++#ifndef TCGETA
++#define TCGETA 0x5405
++#endif
++#ifndef TCSETA
++#define TCSETA 0x5408
++#endif
++#else
+ #include <termio.h>
++#endif
+ #else
+ #include <sgtty.h>
+ #include <fcntl.h>


### PR DESCRIPTION
## Summary
- Add `2.2.22-r1` with `aee-linux-termios.patch` to fix compile failure on modern Glibc.
- `create.mk.aee` now treats `termios.h` as SYS5; Linux gets a `struct termio` shim using `TCGETA`/`TCSETA`.
- `2.2.22.ebuild` unchanged; stable keywords preserved.

## Bug
- https://bugs.gentoo.org/961439

## Keywords
- `2.2.22` (unchanged): `amd64 ~riscv x86`
- `2.2.22-r1` (new): `~amd64 ~riscv ~x86`

## Test plan
- [x] `ebuild app-editors/aee/aee-2.2.22-r1.ebuild clean compile` on amd64 with GCC 16.1.0
- [x] `pkgcheck scan --commits --net`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.