### PR TITLE
app-editors/dhex: add 0.69-r1, fix initcolors prototype

### DIFF
--- a/app-editors/dhex/dhex-0.69-r1.ebuild
+++ b/app-editors/dhex/dhex-0.69-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P=${PN}_${PV}
+inherit toolchain-funcs
+
+DESCRIPTION="ncurses-based hex-editor with diff mode"
+HOMEPAGE="https://www.dettus.net/dhex/"
+SRC_URI="https://www.dettus.net/${PN}/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~riscv ~x86"
+
+DEPEND="sys-libs/ncurses:="
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Makefile.patch
+	"${FILESDIR}"/${P}-initcolors-prototype.patch
+)
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		LIBS="$($(tc-getPKG_CONFIG) --libs ncurses)"
+}
+
+src_install() {
+	dobin dhex
+	dodoc README.txt
+	doman dhex.1 dhex_markers.5 dhex_searchlog.5 dhexrc.5
+}

--- a/app-editors/dhex/files/dhex-0.69-initcolors-prototype.patch
+++ b/app-editors/dhex/files/dhex-0.69-initcolors-prototype.patch
@@ -1,0 +1,15 @@
+From: Gentoo Contributors <gentoo@gentoo.org>
+Bug: https://bugs.gentoo.org/944101
+Description: Fix initcolors prototype for GCC 16
+
+--- a/output.h
++++ b/output.h
+@@ -7,7 +7,7 @@
+ #include "machine_type.h"
+ #include "datatypes.h"
+ 
+-void initcolors();
++void initcolors(tOutput* output);
+ void colorpair(tOutput* output,uicolors uicol,short fg,short bg,int attr);
+ void pairsinit(tOutput* output);
+ void setcolor(tOutput* output,uicolors col);


### PR DESCRIPTION
## Summary
- Add `0.69-r1` with `initcolors-prototype.patch` fixing `void initcolors()` vs `void initcolors(tOutput*)` under GCC 16.
- Bump to EAPI 8.
- `0.69.ebuild` unchanged; stable keywords preserved.

## Bug
- https://bugs.gentoo.org/944101

## Keywords
- `0.69` (unchanged): `amd64 ~arm ~mips ~riscv x86`
- `0.69-r1` (new): `~amd64 ~arm ~mips ~riscv ~x86`

## Test plan
- [x] `ebuild app-editors/dhex/dhex-0.69-r1.ebuild clean compile` on amd64 with GCC 16.1.0
- [x] `pkgcheck scan --commits --net`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.