### PR TITLE
app-editors/ee: add 1.5.2-r2, fix build without termio.h

### DIFF
--- a/app-editors/ee/ee-1.5.2-r2.ebuild
+++ b/app-editors/ee/ee-1.5.2-r2.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="An easy to use text editor. A subset of aee"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.src.tgz"
+S="${WORKDIR}/easyedit-${PV}"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+RDEPEND="
+	!app-editors/ersatz-emacs
+	sys-libs/ncurses:=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-init-location.patch
+	"${FILESDIR}"/${PN}-signal.patch
+	"${FILESDIR}"/${PN}-Wformat-security.patch
+	"${FILESDIR}"/${PN}-gcc-10.patch
+	"${FILESDIR}"/${PN}-linux-termios.patch
+)
+DOCS=( Changes README.${PN} ${PN}.i18n.guide ${PN}.msg )
+
+src_prepare() {
+	sed -i \
+		-e "s/make -/\$(MAKE) -/g" \
+		-e "/^buildee/s/$/ localmake/" \
+		Makefile
+
+	sed -i \
+		-e "s/\tcc /\t\\\\\$(CC) /" \
+		-e "/CFLAGS =/s/\" >/ \\\\\$(LDFLAGS)\" >/" \
+		-e "/other_cflag/s/ *-s//" \
+		-e "s/-lcurses/$($(tc-getPKG_CONFIG) --libs ncurses)/" \
+		create.make
+
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin ${PN}
+	doman ${PN}.1
+	einstalldocs
+	keepdir /usr/share/${PN}
+}

--- a/app-editors/ee/files/ee-linux-termios.patch
+++ b/app-editors/ee/files/ee-linux-termios.patch
@@ -1,0 +1,47 @@
+From: Gentoo Contributors <gentoo@gentoo.org>
+Bug: https://bugs.gentoo.org/961425
+Description: Use termios on Linux when termio.h is absent
+
+--- a/create.make	2002-09-23 06:18:30.000000000 +0200
++++ b/create.make	2026-06-01 00:46:49.316906905 +0200
+@@ -40,7 +40,7 @@
+ 
+ # test for existence of termio header (on SysV systems)
+ 
+-if [ -f /usr/include/termio.h ]
++if [ -f /usr/include/termio.h -o -f /usr/include/termios.h ]
+ then
+ 	termio="-DSYS5"
+ else
+--- a/new_curse.h	2026-06-01 00:46:49.275133471 +0200
++++ b/new_curse.h	2026-06-01 00:46:49.316656855 +0200
+@@ -42,7 +42,29 @@
+ #include <stdio.h>
+ 
+ #ifdef SYS5
++#if defined(__linux__)
++#include <sys/ioctl.h>
++#include <termios.h>
++#ifndef NCC
++#define NCC 8
++#endif
++struct termio {
++	unsigned short c_iflag;
++	unsigned short c_oflag;
++	unsigned short c_cflag;
++	unsigned short c_lflag;
++	char c_line;
++	unsigned char c_cc[NCC];
++};
++#ifndef TCGETA
++#define TCGETA 0x5405
++#endif
++#ifndef TCSETA
++#define TCSETA 0x5408
++#endif
++#else
+ #include <termio.h>
++#endif
+ #else
+ #include <sgtty.h>
+ #include <fcntl.h>


### PR DESCRIPTION
## Summary
- Add `1.5.2-r2` with `linux-termios.patch` (same failure class as aee: missing `-DSYS5` on modern Glibc).
- Bump to EAPI 8.
- `1.5.2-r1.ebuild` unchanged; stable keywords preserved.

## Bug
- https://bugs.gentoo.org/961425

## Keywords
- `1.5.2-r1` (unchanged): `~alpha amd64 ~mips ppc ppc64 ~riscv ~sparc x86`
- `1.5.2-r2` (new): `~alpha ~amd64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86`

## Test plan
- [x] `ebuild app-editors/ee/ee-1.5.2-r2.ebuild clean compile` on amd64 with GCC 16.1.0
- [x] `pkgcheck scan --commits --net`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.