### PR TITLE
app-editors/hteditor: add 2.1.1_pre20161206-r1, fix aclocal and GCC build

### DIFF
--- a/app-editors/hteditor/files/hteditor-2.1.0-yylex.patch
+++ b/app-editors/hteditor/files/hteditor-2.1.0-yylex.patch
@@ -1,0 +1,11 @@
+--- a/eval/lex.h	2026-06-01 01:06:48.695581612 +0200
++++ b/eval/lex.h	2026-06-01 01:06:48.698038808 +0200
+@@ -7,6 +7,7 @@
+ void lex_delete_buffer(void *buffer);
+ void *lex_scan_string_buffer(const char *str);
+ 
+-int yylex();
++union YYSTYPE;
++int yylex(union YYSTYPE *lvalp);
+ 
+ #endif /* __LEX_H__ */

--- a/app-editors/hteditor/hteditor-2.1.1_pre20161206-r1.ebuild
+++ b/app-editors/hteditor/hteditor-2.1.1_pre20161206-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic
+
+MY_P=${P/editor}
+
+DESCRIPTION="File viewer, editor and analyzer for text, binary, and executable files"
+HOMEPAGE="https://hte.sourceforge.net/ https://github.com/sebastianbiallas/ht/"
+SRC_URI="https://dev.gentoo.org/~sam/distfiles/${MY_P}.tar.gz"
+
+S=${WORKDIR}/${MY_P/_pre*}
+
+LICENSE="GPL-2"
+
+SLOT="0"
+
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="X"
+
+RDEPEND="sys-libs/ncurses:0=
+	X? ( x11-libs/libX11 )
+	>=dev-libs/lzo-2"
+DEPEND="${RDEPEND}
+	app-alternatives/yacc
+	app-alternatives/lex"
+
+DOCS=( AUTHORS ChangeLog KNOWNBUGS README TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.1.0-gcc-6-uchar.patch
+	"${FILESDIR}"/${PN}-2.1.0-yylex.patch
+)
+
+src_configure() {
+	# stdscr lives in libtinfo; HT_LIBS must include it (replaces configure.ac patch)
+	append-libs -ltinfo
+	append-cflags -std=gnu89
+
+	econf \
+		$(use_enable X x11-textmode) \
+		--disable-maintainermode
+}
+
+src_install() {
+	chmod u+x "${S}/install-sh"
+
+	local HTML_DOCS="doc/*.html"
+	doinfo doc/*.info
+
+	default
+}


### PR DESCRIPTION
## Summary
- Add `2.1.1_pre20161206-r1` (EAPI 8, testing keywords) fixing compile failure
- Drop `--enable-maintainermode` and the `configure.ac` tinfo patch so emake no longer regenerates `aclocal.m4`; link libtinfo via `append-libs` instead
- Add `yylex` prototype patch for pure-parser flex; build C sources as gnu89 for bundled `regex.c` on modern GCC
- Stable keywords preserved on existing ebuild

## Bug
- https://bugs.gentoo.org/942116

## Test plan
- [x] `ebuild app-editors/hteditor/hteditor-2.1.1_pre20161206-r1.ebuild clean compile` on amd64 / GCC 16.1.0
- [x] `pkgcheck scan --commits --net`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.