### PR TITLE
net-libs/ngtcp2-1.22.0: openssl was requested (--with-openssl) but not found

### DIFF
--- a/net-libs/ngtcp2/ngtcp2-1.12.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.12.0.ebuild
@@ -42,8 +42,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -51,6 +49,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.20.0-r1.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.20.0-r1.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.20.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.20.0.ebuild
@@ -48,8 +48,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -57,6 +55,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.21.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.21.0.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.22.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.22.0.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.22.1.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.22.1.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-1.23.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.23.0.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 

--- a/net-libs/ngtcp2/ngtcp2-9999.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-9999.ebuild
@@ -56,8 +56,6 @@ multilib_src_configure() {
 	local myeconfargs=(
 		--disable-werror
 		--enable-lib-only
-		$(use_with openssl)
-		$(use_with gnutls)
 		--without-boringssl
 		--without-picotls
 		--without-wolfssl
@@ -65,6 +63,12 @@ multilib_src_configure() {
 		--without-libnghttp3
 		--without-jemalloc
 	)
+	if use ssl; then
+		myeconfargs+=(
+			$(use_with openssl)
+			$(use_with gnutls)
+		)
+	fi
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 


### PR DESCRIPTION
Fixes an issue where USE -ssl and either openssl || gnutls would cause configuration errors if the respective package wasn't already installed.

Closes: https://bugs.gentoo.org/976594
Signed-off-by: Alexander Barker (https://github.com/kwhat) alex@1stleg.com

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits. (github rate limited...)

Please note that all boxes must be checked for the pull request to be merged. 
