### PR TITLE
dev-util/Tensile-7.2.0-r1: Add support for python 3.14

### DIFF
--- a/dev-util/Tensile/Tensile-7.2.0-r1.ebuild
+++ b/dev-util/Tensile/Tensile-7.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 ROCM_VERSION=${PV}
 LLVM_COMPAT=( 22 )


### PR DESCRIPTION
Adds Tensile support for Python 3.14.

It builds fine on my local

https://bugs.gentoo.org/976695