### PR TITLE
net-misc/gerbera: Sync live ebuild

### DIFF
--- a/net-misc/gerbera/gerbera-9999.ebuild
+++ b/net-misc/gerbera/gerbera-9999.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 	dev-libs/libfmt:=
 	dev-libs/pugixml
 	dev-libs/spdlog:=
+	dev-libs/jsoncpp:=
 	net-libs/libupnp:=[ipv6(+),reuseaddr,-blocking-tcp]
 	sys-apps/util-linux
 	virtual/zlib:=
@@ -88,6 +89,7 @@ src_configure() {
 		-DWITH_SYSTEMD=$(usex systemd)
 		-DWITH_TAGLIB=$(usex taglib)
 		-DWITH_TESTS=$(usex test)
+		-DWITH_ZIP=0
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Fix building of the live ebuild by:
- add missing required jsoncpp dependency
- disable zip config setting (depends on package not in gentoo repo)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
