### PR TITLE
sys-fabric/opensm: Fix rpm sandbox violation

### DIFF
--- a/sys-fabric/opensm/files/opensm-3.3.23-no-rpm-check.patch
+++ b/sys-fabric/opensm/files/opensm-3.3.23-no-rpm-check.patch
@@ -1,0 +1,30 @@
+From 2644ea307db495e9c0d6f8863f5decf5d4f9ed83 Mon Sep 17 00:00:00 2001
+From: "Daniel M. Weeks" <dan@danweeks.net>
+Date: Thu, 4 Jun 2026 22:45:05 -0400
+Subject: [PATCH] Do not execute rpm during configure
+
+Signed-off-by: Daniel M. Weeks <dan@danweeks.net>
+---
+ configure.ac | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 4633fbb1..89cf0c9e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -17,11 +17,7 @@ AC_ARG_WITH([rdma_service],
+                    [name of the RDMA service: "rdma" when using /etc/init.d/rdma to start RDMA services; "openibd" when using /etc/init.d/openibd to start RDMA services [default=${default_rdma_service}]]))
+ AC_SUBST(RDMA_SERVICE, ${with_rdma_service:-${default_rdma_service}})
+ 
+-if { rpm -q sles-release || rpm -q openSUSE-release; } >/dev/null 2>&1; then
+-   default_stop="0 1 4 6"
+-else
+-   default_stop="0 1 6"
+-fi
++default_stop="0 1 6"
+ 
+ default_start="null"
+ 
+-- 
+Daniel M. Weeks
+

--- a/sys-fabric/opensm/opensm-3.3.23-r2.ebuild
+++ b/sys-fabric/opensm/opensm-3.3.23-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -22,7 +22,7 @@ RDEPEND="${DEPEND}
 		virtual/openssh
 	)"
 
-PATCHES=( "${FILESDIR}/${PN}-3.3.17-sldd.patch" )
+PATCHES=( "${FILESDIR}/${PN}-3.3.17-sldd.patch" "${FILESDIR}/${PN}-3.3.23-no-rpm-check.patch" )
 
 src_prepare() {
 	default

--- a/sys-fabric/opensm/opensm-3.3.24-r1.ebuild
+++ b/sys-fabric/opensm/opensm-3.3.24-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,7 +22,7 @@ RDEPEND="${DEPEND}
 		virtual/openssh
 	)"
 
-PATCHES=( "${FILESDIR}"/${PN}-3.3.17-sldd.patch )
+PATCHES=( "${FILESDIR}"/${PN}-3.3.17-sldd.patch "${FILESDIR}/${PN}-3.3.23-no-rpm-check.patch" )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Fixes configure phase sandbox violations when rpm is present on the system.

Closes: https://bugs.gentoo.org/777654

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
