### PR TITLE
sys-auth/ssh-ldap-pubkey: enable py3.14

### DIFF
--- a/sys-auth/ssh-ldap-pubkey/ssh-ldap-pubkey-1.4.0-r1.ebuild
+++ b/sys-auth/ssh-ldap-pubkey/ssh-ldap-pubkey-1.4.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 

--- a/sys-auth/ssh-ldap-pubkey/ssh-ldap-pubkey-1.4.0-r1.ebuild
+++ b/sys-auth/ssh-ldap-pubkey/ssh-ldap-pubkey-1.4.0-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/974143

Bump Python to allow 3.14 

---

Please check all the boxes that apply:

- [ x ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
