### PR TITLE
profiles: Unmask 'ios' USE on arm64

### DIFF
--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -94,7 +94,6 @@ wimax
 amr
 
 # No hardware to test by the team
-ios
 ipod
 
 # Stuff that doesn't make sense on this arch


### PR DESCRIPTION
The relevant packages work perfectly fine on arm64

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
