### PR TITLE
sys-fs/bcachefs-tools: fix MODULES_OPTIONAL_IUSE, MODULES_KERNEL_MIN typo

### DIFF
--- a/sys-fs/bcachefs-tools/bcachefs-tools-1.37.4-r1.ebuild
+++ b/sys-fs/bcachefs-tools/bcachefs-tools-1.37.4-r1.ebuild
@@ -147,7 +147,8 @@ CRATES="
 
 LLVM_COMPAT=( {17..21} )
 MODULES_INITRAMFS_IUSE=+initramfs
-MODDULES_KERNEL_MIN=6.16
+MODULES_KERNEL_MIN=6.16
+MODULES_OPTIONAL_IUSE=+modules
 PYTHON_COMPAT=( python3_{11..14} )
 RUST_MIN_VER="1.85.0"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kentoverstreet.asc
@@ -173,7 +174,7 @@ LICENSE="GPL-2"
 # Dependent crate licenses
 LICENSE+=" Apache-2.0 BSD ISC MIT Unicode-DFS-2016"
 SLOT="0"
-IUSE="debug verify-sig +modules"
+IUSE="debug verify-sig"
 
 # manual testing for now:
 # fallocate -l 10G /tmp/bcfs.img

--- a/sys-fs/bcachefs-tools/bcachefs-tools-1.38.2-r1.ebuild
+++ b/sys-fs/bcachefs-tools/bcachefs-tools-1.38.2-r1.ebuild
@@ -147,7 +147,8 @@ CRATES="
 
 LLVM_COMPAT=( {17..21} )
 MODULES_INITRAMFS_IUSE=+initramfs
-MODDULES_KERNEL_MIN=6.16
+MODULES_KERNEL_MIN=6.16
+MODULES_OPTIONAL_IUSE=+modules
 PYTHON_COMPAT=( python3_{11..14} )
 RUST_MIN_VER="1.85.0"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kentoverstreet.asc
@@ -173,7 +174,7 @@ LICENSE="GPL-2"
 # Dependent crate licenses
 LICENSE+=" Apache-2.0 BSD ISC MIT Unicode-DFS-2016"
 SLOT="0"
-IUSE="debug verify-sig +modules"
+IUSE="debug verify-sig"
 RESTRICT="test"
 
 DEPEND="

--- a/sys-fs/bcachefs-tools/bcachefs-tools-9999.ebuild
+++ b/sys-fs/bcachefs-tools/bcachefs-tools-9999.ebuild
@@ -147,7 +147,8 @@ CRATES="
 
 LLVM_COMPAT=( {17..21} )
 MODULES_INITRAMFS_IUSE=+initramfs
-MODDULES_KERNEL_MIN=6.16
+MODULES_KERNEL_MIN=6.16
+MODULES_OPTIONAL_IUSE=+modules
 PYTHON_COMPAT=( python3_{11..14} )
 RUST_MIN_VER="1.85.0"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kentoverstreet.asc
@@ -173,7 +174,7 @@ LICENSE="GPL-2"
 # Dependent crate licenses
 LICENSE+=" Apache-2.0 BSD ISC MIT Unicode-DFS-2016"
 SLOT="0"
-IUSE="debug verify-sig +modules"
+IUSE="debug verify-sig"
 RESTRICT="test"
 
 DEPEND="


### PR DESCRIPTION
This revisits a511907236aa2054832b67ceb3a768e71babd11b 

USE=modules was declared in IUSE directly instead of via MODULES_OPTIONAL_IUSE.  The linux-mod-r1 eclass only gates its exported phases (pkg_setup, src_compile, src_install, pkg_postinst) through _modules_check_function when MODULES_OPTIONAL_IUSE is set; without it all kernel-related code runs unconditionally regardless of USE=-modules.  This causes fatal failures in environments without a configured kernel source tree (e.g. catalyst livecd-stage1, prefix installs, chroots).

The eclass documentation notes: "The typical recommended value is +modules" and "modules being optional can be useful even if user space tools require them (e.g. installing in a chroot or prefix when the modules are loaded on the host)."

Also fix the MODDULES_KERNEL_MIN typo (double O) introduced in the same commit that added USE=modules; the eclass reads MODULES_KERNEL_MIN so the minimum kernel version check of 6.16 was silently ignored.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
