### PR TITLE
dev-lang/php: Skip forceful creation of empty 'log' and 'run' directories

### DIFF
--- a/dev-lang/php/php-8.2.31.ebuild
+++ b/dev-lang/php/php-8.2.31.ebuild
@@ -224,7 +224,7 @@ php_set_ini_dir() {
 src_prepare() {
 	default
 
-	# In php-7.x, the FPM pool configuration files have been split off
+	# In php-8.x, the FPM pool configuration files have been split off
 	# of the main config. By default the pool config files go in
 	# e.g. /etc/php-fpm.d, which isn't slotted. So here we move the
 	# include directory to a subdirectory "fpm.d" of $PHP_INI_DIR. Later
@@ -251,6 +251,12 @@ src_prepare() {
 	   ext/sockets/tests/mcast_ipv6_recv_limited.phpt \
 	   ext/sockets/tests/mcast_ipv6_send.phpt \
 	   || die
+
+	# The PHP Makefile templates for the 'fpm' and 'phpdbg'
+	# sapi forcefully create the (empty) directories '/var/log' and '/var/run',
+	# see bug #977105
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/run/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/log/d' sapi/{fpm,phpdbg}/Makefile.frag || die
 
 	# fails in a network sandbox,
 	#

--- a/dev-lang/php/php-8.3.31.ebuild
+++ b/dev-lang/php/php-8.3.31.ebuild
@@ -215,7 +215,7 @@ pkg_setup() {
 src_prepare() {
 	default
 
-	# In php-7.x, the FPM pool configuration files have been split off
+	# In php-8.x, the FPM pool configuration files have been split off
 	# of the main config. By default the pool config files go in
 	# e.g. /etc/php-fpm.d, which isn't slotted. So here we move the
 	# include directory to a subdirectory "fpm.d" of $PHP_INI_DIR. Later
@@ -224,6 +224,12 @@ src_prepare() {
 	sed -i "s~^include=.*$~include=${PHP_INI_DIR}/fpm.d/*.conf~" \
 		sapi/fpm/php-fpm.conf.in \
 		|| die 'failed to move the include directory in php-fpm.conf'
+
+	# The PHP Makefile templates for the 'fpm' and 'phpdbg'
+	# sapi forcefully create the (empty) directories '/var/log' and '/var/run',
+	# see bug #977105
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/run/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/log/d' sapi/{fpm,phpdbg}/Makefile.frag || die
 
 	# fails in a network sandbox,
 	#

--- a/dev-lang/php/php-8.4.22.ebuild
+++ b/dev-lang/php/php-8.4.22.ebuild
@@ -224,6 +224,12 @@ src_prepare() {
 		sapi/fpm/php-fpm.conf.in \
 		|| die 'failed to move the include directory in php-fpm.conf'
 
+	# The PHP Makefile templates for the 'fpm' and 'phpdbg'
+	# sapi forcefully create the (empty) directories '/var/log' and '/var/run',
+	# see bug #977105
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/run/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/log/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+
 	# fails in a network sandbox,
 	#
 	#   https://github.com/php/php-src/issues/11662

--- a/dev-lang/php/php-8.5.7-r1.ebuild
+++ b/dev-lang/php/php-8.5.7-r1.ebuild
@@ -222,6 +222,12 @@ src_prepare() {
 		sapi/fpm/php-fpm.conf.in \
 		|| die 'failed to move the include directory in php-fpm.conf'
 
+	# The PHP Makefile templates for the 'fpm' and 'phpdbg'
+	# sapi forcefully create the (empty) directories '/var/log' and '/var/run',
+	# see bug #977105
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/run/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/log/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+
 	# fails in a network sandbox,
 	#
 	#   https://github.com/php/php-src/issues/11662

--- a/dev-lang/php/php-8.5.7.ebuild
+++ b/dev-lang/php/php-8.5.7.ebuild
@@ -216,6 +216,12 @@ src_prepare() {
 		sapi/fpm/php-fpm.conf.in \
 		|| die 'failed to move the include directory in php-fpm.conf'
 
+	# The PHP Makefile templates for the 'fpm' and 'phpdbg'
+	# sapi forcefully create the (empty) directories '/var/log' and '/var/run',
+	# see bug #977105
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/run/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+	sed -i '/@$(mkinstalldirs) $(INSTALL_ROOT)$(localstatedir)\/log/d' sapi/{fpm,phpdbg}/Makefile.frag || die
+
 	# fails in a network sandbox,
 	#
 	#   https://github.com/php/php-src/issues/11662


### PR DESCRIPTION
The Makefile templates for the "fpm" and "phpdb" SAPI forcefully create emtpy "var" and "run" directories below "/var/".

By modifying the Makefile templates, we skip the empty directory creation, which is not allowed per our standards.

I decided not to revbump the ebuilds, since this fixes an QA issue and won't affect a "real" installation. The stable ebuilds are untouched, I think we should start a stabilization round soon anyways since they are pretty much outdated now.

Closes: https://bugs.gentoo.org/977105

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
