### PR TITLE
profiles/targets/desktop: No tiff for webp

### DIFF
--- a/profiles/targets/desktop/package.use
+++ b/profiles/targets/desktop/package.use
@@ -1,6 +1,11 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ian Jordan <immoloism@gmail.com> (2026-06-15)
+# Circular depend on webp and tiff #972473
+# Helps users going from a basic to desktop profile.
+media-libs/libwebp -tiff
+
 # Ian Jordan <immoloism@gmail.com> (2026-01-14)
 # Use PipeWire sound server. It also acts as PulseAudio implementation for
 # packages using media-libs/libpulse (e.g. via USE="pulseaudio").


### PR DESCRIPTION
Causes a circluar depend on arches without a desktop stage3, than have to update from a basic stage, change to a desktop profile then update.

TIFF support in webp appears so niche at this point that this is is the most reasonable fix over spliting webp's tools out into a new package or adding more desktop stages to arches with little user base.

It also leaves the door open to change at a later date if needs changes and one of the above suggestions becomes the better way forward.

Closes: https://bugs.gentoo.org/972473

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
