### PR TITLE
media-libs/libdvdread: disable changelog autogeneration from git log

### DIFF
--- a/media-libs/libdvdread/libdvdread-7.0.1.ebuild
+++ b/media-libs/libdvdread/libdvdread-7.0.1.ebuild
@@ -25,7 +25,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	sed -i -e "s/'COPYING', //" -e "s/doc\/${PN}/doc\/${P}/" meson.build || die
+	sed -i -e "s/'COPYING', //" -e "s/doc\/${PN}/doc\/${P}/" -e "s/HEAD/DISABLE/" meson.build || die
 
 	default
 }

--- a/media-libs/libdvdread/libdvdread-9999.ebuild
+++ b/media-libs/libdvdread/libdvdread-9999.ebuild
@@ -25,7 +25,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	sed -i -e "s/'COPYING', //" -e "s/doc\/${PN}/doc\/${P}/" meson.build || die
+	sed -i -e "s/'COPYING', //" -e "s/doc\/${PN}/doc\/${P}/" -e "s/HEAD/DISABLE/" meson.build || die
 
 	default
 }


### PR DESCRIPTION
The libdvdread switch from autotools to meson added an annoying ChangeLog autogeneration from git log which fails in the 9999 ebuild. Simplest solution is just to disable via the ebuilds sed of meson.build.

Closes: https://bugs.gentoo.org/972716

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
