### PR TITLE
x11-base/xorg-server: fix --sysconfdir value in new revision

### DIFF
--- a/x11-base/xorg-server/xorg-server-21.1.22-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.22-r1.ebuild
@@ -114,7 +114,7 @@ src_configure() {
 	# sysconfdir is used for the xorg.conf location; same applies
 	local XORG_CONFIGURE_OPTIONS=(
 		--localstatedir "${EPREFIX}/var"
-		--sysconfdir "${EPREFIX}/etc/X11"
+		--sysconfdir "${EPREFIX}/etc"
 		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)

--- a/x11-base/xorg-server/xorg-server-21.1.23-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.23-r1.ebuild
@@ -114,7 +114,7 @@ src_configure() {
 	# sysconfdir is used for the xorg.conf location; same applies
 	local XORG_CONFIGURE_OPTIONS=(
 		--localstatedir "${EPREFIX}/var"
-		--sysconfdir "${EPREFIX}/etc/X11"
+		--sysconfdir "${EPREFIX}/etc"
 		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -109,7 +109,7 @@ src_configure() {
 	# sysconfdir is used for the xorg.conf location; same applies
 	local XORG_CONFIGURE_OPTIONS=(
 		--localstatedir "${EPREFIX}/var"
-		--sysconfdir "${EPREFIX}/etc/X11"
+		--sysconfdir "${EPREFIX}/etc"
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)
 		$(meson_use !minimal dri2)


### PR DESCRIPTION
Bugfix: Replaced wrong old value of --sysconfdir "${EPREFIX}/etc/X11" with new good value "${EPREFIX}/etc".

Reason: As the name suggests, the sysconfdir is the confdir of operating system and not X11's, so /etc is the correct path. It is easy to verify that /etc/X11 is incorrect by running the command "man xorg.wrap", which shows that CONFIG FILE section mentions /etc/X11/X11/Xwrapper.config, meaning that X11 is duplicated, which is an error.

Addition: The bug fix will affect systems where files were placed in the /etc/X11/X11 folder to circumvent the bug (e.g. Xwrapper.config), as these files will no longer be used by xorg-server. Therefore, I recommend that we also give users a NEWS entry about the change.

This change should be applied in future versions of xorg-server ebuilds as well.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
