### PR TITLE
media-sound/picard: Add USE flag dependency dev-python/pyqt6[ssl]

### DIFF
--- a/media-sound/picard/picard-3.0.0_alpha4-r2.ebuild
+++ b/media-sound/picard/picard-3.0.0_alpha4-r2.ebuild
@@ -43,7 +43,7 @@ RDEPEND="
 		dev-python/charset-normalizer[${PYTHON_USEDEP}]
 		dev-python/fasteners[${PYTHON_USEDEP}]
 		dev-python/pyjwt[${PYTHON_USEDEP}]
-		dev-python/pyqt6[gui,multimedia?,network,qml,widgets,${PYTHON_USEDEP}]
+		dev-python/pyqt6[gui,multimedia?,network,qml,ssl,widgets,${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		media-libs/mutagen[${PYTHON_USEDEP}]
 		discid? ( dev-python/discid[${PYTHON_USEDEP}] )

--- a/media-sound/picard/picard-3.0.0_beta4.ebuild
+++ b/media-sound/picard/picard-3.0.0_beta4.ebuild
@@ -43,7 +43,7 @@ RDEPEND="
 		dev-python/charset-normalizer[${PYTHON_USEDEP}]
 		dev-python/fasteners[${PYTHON_USEDEP}]
 		dev-python/pyjwt[${PYTHON_USEDEP}]
-		dev-python/pyqt6[gui,multimedia?,network,qml,widgets,${PYTHON_USEDEP}]
+		dev-python/pyqt6[gui,multimedia?,network,qml,ssl,widgets,${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		media-libs/mutagen[${PYTHON_USEDEP}]
 		discid? ( dev-python/discid[${PYTHON_USEDEP}] )

--- a/media-sound/picard/picard-9999.ebuild
+++ b/media-sound/picard/picard-9999.ebuild
@@ -40,7 +40,7 @@ RDEPEND="
 		dev-python/charset-normalizer[${PYTHON_USEDEP}]
 		dev-python/fasteners[${PYTHON_USEDEP}]
 		>=dev-python/pyjwt-2.12[${PYTHON_USEDEP}]
-		dev-python/pyqt6[gui,multimedia?,network,qml,widgets,${PYTHON_USEDEP}]
+		dev-python/pyqt6[gui,multimedia?,network,qml,ssl,widgets,${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		media-libs/mutagen[${PYTHON_USEDEP}]
 		discid? ( dev-python/discid[${PYTHON_USEDEP}] )


### PR DESCRIPTION
If `pyqt6` is compiled without USE flag `ssl`,
picard will immediately terminate with

```
File "/usr/lib/python3.14/site-packages/picard/webservice/__init__.py",
    from PyQt6.QtNetwork import (
    ...<3 lines>...
    )
ImportError: cannot import name 'QSslError' from 'PyQt6.QtNetwork'
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
