### PR TITLE
app-admin/keepassxc: Add USE flag dependencies dev-qt/qtbase[concurrent,dbus,network]

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	dev-libs/botan:3=
 	dev-libs/libusb:1
 	dev-libs/zxcvbn-c
-	dev-qt/qtbase:6[network]
+	dev-qt/qtbase:6[concurrent,network]
 	dev-qt/qtsvg:6
 	media-gfx/qrencode:=
 	sys-apps/pcsc-lite

--- a/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	dev-libs/botan:3=
 	dev-libs/libusb:1
 	dev-libs/zxcvbn-c
-	dev-qt/qtbase:6[concurrent,network]
+	dev-qt/qtbase:6[concurrent,dbus,network]
 	dev-qt/qtsvg:6
 	media-gfx/qrencode:=
 	sys-apps/pcsc-lite

--- a/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.8.0_pre20260504-r1.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	dev-libs/botan:3=
 	dev-libs/libusb:1
 	dev-libs/zxcvbn-c
-	dev-qt/qtbase:6
+	dev-qt/qtbase:6[network]
 	dev-qt/qtsvg:6
 	media-gfx/qrencode:=
 	sys-apps/pcsc-lite


### PR DESCRIPTION
If `qtbase` is compiled without the USE flags `dbus`,`concurrent` or `network`
the configure phase will fail with

```
-- Could NOT find Qt6Concurrent (missing: Qt6Concurrent_DIR)
-- Could NOT find Qt6DBus (missing: Qt6DBus_DIR)
-- Could NOT find Qt6Network (missing: Qt6Network_DIR)
```

If multiple USE flags are missing, only one error will be shown, before the configure phase is aborted.
The priority of the error messages is:
1. `network`
2. `concurrent`
3. `dbus`

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
