### PR TITLE
profiles: Flip savedconfig

### DIFF
--- a/profiles/arch/amd64/package.use.force
+++ b/profiles/arch/amd64/package.use.force
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Eric Joldasov <bratishkaerik@landless-city.net> (2025-03-11)
@@ -15,11 +15,6 @@ sys-devel/binutils cet
 # sys-devel/gcc[multilib] (which is forced) will fail late in build.
 dev-libs/libatomic_ops abi_x86_32
 dev-libs/boehm-gc abi_x86_32
-
-# Michał Górny <mgorny@gentoo.org> (2017-12-30)
-# We have ready-to-use configs here.
-sys-kernel/gentoo-kernel -savedconfig
-sys-kernel/vanilla-kernel -savedconfig
 
 # Luke Dashjr <luke-jr+gentoobugs@utopios.org> (2019-09-21)
 # iasl is stable on amd64

--- a/profiles/arch/arm/package.mask
+++ b/profiles/arch/arm/package.mask
@@ -1,5 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com>  (2026-06-19)
+# Debian kernel configs aren't tested below 6.18
+# users should unmask this package and use savedconfig
+<sys-kernel/gentoo-kernel-6.18
+<sys-kernel/vanilla-kernel-6.18
 
 # Sam James <sam@gentoo.org> (2020-06-24)
 # Valgrind lacks support for < ARMv7

--- a/profiles/arch/arm64/package.use.force
+++ b/profiles/arch/arm64/package.use.force
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Paul Zander <negril.nx+gentoo@gmail.com> (2024-04-12)
@@ -9,11 +9,6 @@ media-libs/opencv cpu_flags_arm_neon
 # GHC does not gain native codegen for arm64 until 9.2.
 # We don't want an unregisterised build, so force LLVM codegen.
 dev-lang/ghc:0/9.0.2 llvm
-
-# Michał Górny <mgorny@gentoo.org> (2021-02-19)
-# We have ready-to-use configs here.
-sys-kernel/gentoo-kernel -savedconfig
-sys-kernel/vanilla-kernel -savedconfig
 
 # Aaron Bauman <bman@gentoo.org> (2019-12-27)
 # ffmpeg does support 64 bit neon

--- a/profiles/arch/hppa/package.mask
+++ b/profiles/arch/hppa/package.mask
@@ -1,5 +1,11 @@
-# Copyright 2019-2025 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com>  (2026-06-19)
+# Debian kernel configs aren't tested below 6.18
+# users should unmask this package and use savedconfig
+<sys-kernel/gentoo-kernel-6.18
+<sys-kernel/vanilla-kernel-6.18
 
 # Sam James <sam@gentoo.org> (2023-03-28)
 # Needs explicit porting to each platform (bug 894078#c6)

--- a/profiles/arch/hppa/package.use.force
+++ b/profiles/arch/hppa/package.use.force
@@ -1,5 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com (2026-06-17}
+# No premade kernel configs for HPPA.
+# Force the use of savedconfig
+sys-kernel/gentoo-kernel savedconfig
+sys-kernel/vanilla-kernel savedconfig
 
 # Sam James <sam@gentoo.org> (2023-04-30)
 # Stacks on HPPA grow upwards and GCC doesn't support SSP or SCP there.

--- a/profiles/arch/mips/package.use.force
+++ b/profiles/arch/mips/package.use.force
@@ -1,2 +1,8 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com (2026-06-17}
+# No premade kernel configs for MIPS.
+# Force the use of savedconfig
+sys-kernel/gentoo-kernel savedconfig
+sys-kernel/vanilla-kernel savedconfig

--- a/profiles/arch/powerpc/ppc64/64le/package.use.force
+++ b/profiles/arch/powerpc/ppc64/64le/package.use.force
@@ -1,5 +1,10 @@
-# Copyright 2021-2024 Gentoo Authors
+# Copyright 2021-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com (2026-06-17}
+# Premade kernel configs for PPC64le here.
+sys-kernel/gentoo-kernel -savedconfig
+sys-kernel/vanilla-kernel -savedconfig
 
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2022-01-20)
 # force users to use system versions
@@ -9,8 +14,3 @@ dev-java/openjdk:11 system-bootstrap
 dev-java/openjdk:17 system-bootstrap
 dev-java/openjdk:21 system-bootstrap
 dev-java/openjdk:25 system-bootstrap
-
-# Michał Górny <mgorny@gentoo.org> (2021-02-19)
-# We have ready-to-use configs here.
-sys-kernel/gentoo-kernel -savedconfig
-sys-kernel/vanilla-kernel -savedconfig

--- a/profiles/arch/powerpc/ppc64/package.use.force
+++ b/profiles/arch/powerpc/ppc64/package.use.force
@@ -1,5 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com (2026-06-17}
+# No premade kernel configs for PPC64.
+# Force the use of savedconfig
+sys-kernel/gentoo-kernel savedconfig 
+sys-kernel/vanilla-kernel savedconfig
 
 # Alexey Sokolov <alexey+gentoo@asokolov.org> (2023-08-14)
 # OpenMW is only playtested with LuaJIT, and in fact unit tests fail with Lua-5.

--- a/profiles/arch/riscv/package.mask
+++ b/profiles/arch/riscv/package.mask
@@ -1,5 +1,11 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Ian Jordan <immoloism@gmail.com>  (2026-06-19)
+# Debian kernel configs aren't tested below 6.18
+# users should unmask this package and use savedconfig
+<sys-kernel/gentoo-kernel-6.18
+<sys-kernel/vanilla-kernel-6.18
 
 # Yixun Lan <dlan@gentoo.org> (2022-08-27)
 # mask it due to depend on virtual/jre

--- a/profiles/arch/sparc/package.mask
+++ b/profiles/arch/sparc/package.mask
@@ -1,6 +1,12 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ian Jordan <immoloism@gmail.com>  (2026-06-19)
+# Debian kernel configs aren't tested below 6.18
+# users should unmask this package and use savedconfig
+<sys-kernel/gentoo-kernel-6.18
+<sys-kernel/vanilla-kernel-6.18
+
 # matoro <matoro_gentoo@matoro.tk> (2024-06-11)
 # Extensive use of unaligned access, no plans to fix, #636552
 # https://github.com/memcached/memcached/issues/902

--- a/profiles/arch/x86/package.use.force
+++ b/profiles/arch/x86/package.use.force
@@ -34,11 +34,6 @@ dev-java/openjdk:11 -system-bootstrap
 dev-java/openjdk:17 -system-bootstrap
 dev-java/openjdk:21 -system-bootstrap
 
-# Michał Górny <mgorny@gentoo.org> (2017-12-30)
-# We have ready-to-use configs here.
-sys-kernel/gentoo-kernel -savedconfig
-sys-kernel/vanilla-kernel -savedconfig
-
 # Luke Dashjr <luke-jr+gentoobugs@utopios.org> (2019-11-21)
 # iasl is stable on x86
 sys-firmware/seabios -binary

--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -368,11 +368,6 @@ sys-devel/binutils-config native-symlinks
 sys-devel/gcc-config      native-symlinks
 sys-devel/gcc-config      cc-wrappers
 
-# Michał Górny <mgorny@gentoo.org> (2017-12-30)
-# Require user configs unless we supply our own .config.
-sys-kernel/gentoo-kernel savedconfig
-sys-kernel/vanilla-kernel savedconfig
-
 # Matt Turner <mattst88@gentoo.org> (2020-03-28)
 # wget is the default FETCHCOMMAND, and most distfiles are distributed via
 # HTTPS. Bug #611072


### PR DESCRIPTION
Now gentoo-kernel has nearly support for every arch it makes more sense to flip the savedconfig behaviour.

Previously we disabled on all arches and unmasked on arches with support.

Now we enable on all arches and disable on those with no support.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
