### PR TITLE
media-gfx/cropgui: Add USE flag dependencies x11-libs/gtk+[introspection] and dev-python/pillow[jpeg]

### DIFF
--- a/media-gfx/cropgui/cropgui-0.9-r1.ebuild
+++ b/media-gfx/cropgui/cropgui-0.9-r1.ebuild
@@ -21,7 +21,8 @@ RDEPEND="${PYTHON_DEPS}
 	dev-python/pillow[${PYTHON_USEDEP}]
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
 	media-libs/exiftool
-	media-gfx/imagemagick"
+	media-gfx/imagemagick
+	x11-libs/gtk+[introspection]"
 
 install_cropgui_wrapper() {
 	python_domodule cropgtk.py cropgui_common.py filechooser.py cropgui.glade

--- a/media-gfx/cropgui/cropgui-0.9-r1.ebuild
+++ b/media-gfx/cropgui/cropgui-0.9-r1.ebuild
@@ -18,7 +18,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}"
 RDEPEND="${PYTHON_DEPS}
-	dev-python/pillow[${PYTHON_USEDEP}]
+	dev-python/pillow[${PYTHON_USEDEP},jpeg]
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
 	media-libs/exiftool
 	media-gfx/imagemagick


### PR DESCRIPTION
If `gtk+` is compiled without USE flag `introspection`,
`cropgui` immediately terminates with
```
File "/usr/lib/python3.14/site-packages/cropgui/cropgtk.py",
    gi.require_version('Gtk', '3.0')
ValueError: Namespace Gtk not available
```

If `pillow` is compiled without USE flag `jpeg`,
`cropgui` will fail to open jpg files with
```
decoder jpeg not available
```
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
