### PR TITLE
dev-perl/WebService-MusicBrainz: Fix dependencies

### DIFF
--- a/dev-perl/WebService-MusicBrainz/WebService-MusicBrainz-1.0.7-r1.ebuild
+++ b/dev-perl/WebService-MusicBrainz/WebService-MusicBrainz-1.0.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,9 +12,10 @@ SLOT="0"
 KEYWORDS="amd64 ppc ppc64 ~riscv x86"
 
 RDEPEND="
+	dev-perl/IO-Socket-SSL
 	>=dev-perl/Mojolicious-7.130.0
 "
-BDEPEND="${RDEPEND}
+BDEPEND="
 	>=dev-perl/Module-Build-0.420.0
 "
 


### PR DESCRIPTION
Add `dev-perl/IO-Socket-SSL` to `RDEPEND`, this fixes bug 966767.
Remove `dev-perl/Mojolicious` from `BDEPEND`, it is only required at runtime.

Closes: https://bugs.gentoo.org/966767

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
