### PR TITLE
media-sound/alsa-utils: add missing RDEPEND on app-text/tree

### DIFF
--- a/media-sound/alsa-utils/alsa-utils-1.2.16.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.2.16.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 "
 RDEPEND="
 	${DEPEND}
+	app-text/tree
 	selinux? ( sec-policy/selinux-alsa )
 "
 BDEPEND="


### PR DESCRIPTION
alsa-info.sh uses the tree command at line 679 without checking availability.

Bug: https://bugs.gentoo.org/963903

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
