### PR TITLE
app-eselect/eselect-pinentry: add 3rd-party pinentry implementations

### DIFF
--- a/app-eselect/eselect-pinentry/eselect-pinentry-0.7.5.ebuild
+++ b/app-eselect/eselect-pinentry/eselect-pinentry-0.7.5.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Manage /usr/bin/pinentry symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Eselect"
+S="${WORKDIR}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos ~x64-solaris"
+
+RDEPEND=">=app-eselect/eselect-lib-bin-symlink-0.1.1"
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins "${FILESDIR}"/pinentry.eselect-${PV} pinentry.eselect
+}

--- a/app-eselect/eselect-pinentry/files/pinentry.eselect-0.7.5
+++ b/app-eselect/eselect-pinentry/files/pinentry.eselect-0.7.5
@@ -1,0 +1,23 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /usr/bin/pinentry implementation"
+MAINTAINER="maintainer-needed@gentoo.org"
+VERSION="0.7.5"
+
+SYMLINK_PATH=/usr/bin/pinentry
+SYMLINK_TARGETS=(
+	pinentry-efl
+	pinentry-gnome3
+	pinentry-qt5
+	pinentry-qt6
+	pinentry-curses
+	pinentry-tty
+	pinentry-emacs
+	pinentry-tqt
+	pinentry-bemenu
+	pinentry-fuzzel
+)
+SYMLINK_DESCRIPTION='pinentry binary'
+
+inherit bin-symlink


### PR DESCRIPTION
Add pinentry-bemenu, pinentry-tqt, and pinentry-fuzzel to SYMLINK_TARGETS so they are selectable via eselect pinentry.

pinentry-bemenu and pinentry-tqt were mentioned in the original bug report. pinentry-fuzzel was additionally found in the guru overlay (app-crypt/pinentry-fuzzel, added 2026-06-14) and is included here as well.

As noted by ulm in bug #920771, adding a couple of these implementations is a less intrusive change and carries no harm, ensuring a cleaner integration while maintaining system stability.

Bug: https://bugs.gentoo.org/920771

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
