### PR TITLE
net-libs/nghttp2: inherit autotools for 9999 only

### DIFF
--- a/net-libs/nghttp2/nghttp2-1.68.0.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.68.0.ebuild
@@ -12,10 +12,10 @@ HOMEPAGE="https://nghttp2.org/"
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/nghttp2/nghttp2.git"
-	inherit git-r3
+	inherit git-r3 autotools
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/nghttp2.asc
-	inherit autotools verify-sig
+	inherit verify-sig
 	SRC_URI="
 		https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz
 		verify-sig? ( https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz.asc )

--- a/net-libs/nghttp2/nghttp2-1.68.1.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.68.1.ebuild
@@ -12,10 +12,10 @@ HOMEPAGE="https://nghttp2.org/"
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/nghttp2/nghttp2.git"
-	inherit git-r3
+	inherit git-r3 autotools
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/nghttp2.asc
-	inherit autotools verify-sig
+	inherit verify-sig
 	SRC_URI="
 		https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz
 		verify-sig? ( https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz.asc )

--- a/net-libs/nghttp2/nghttp2-1.69.0.ebuild
+++ b/net-libs/nghttp2/nghttp2-1.69.0.ebuild
@@ -12,10 +12,10 @@ HOMEPAGE="https://nghttp2.org/"
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/nghttp2/nghttp2.git"
-	inherit git-r3
+	inherit git-r3 autotools
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/nghttp2.asc
-	inherit autotools verify-sig
+	inherit verify-sig
 	SRC_URI="
 		https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz
 		verify-sig? ( https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz.asc )

--- a/net-libs/nghttp2/nghttp2-9999.ebuild
+++ b/net-libs/nghttp2/nghttp2-9999.ebuild
@@ -12,10 +12,10 @@ HOMEPAGE="https://nghttp2.org/"
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/nghttp2/nghttp2.git"
-	inherit git-r3
+	inherit git-r3 autotools
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/nghttp2.asc
-	inherit autotools verify-sig
+	inherit verify-sig
 	SRC_URI="
 		https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz
 		verify-sig? ( https://github.com/nghttp2/nghttp2/releases/download/v${PV}/${P}.tar.xz.asc )


### PR DESCRIPTION
The live ebuild fails due to autotools wrongly being inherited in the normal package instead of the live ebuild

i have also adjusted all other ebuild files since theres no need for a revbump doing so and its cleaner that way IMO
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
