### PR TITLE
dev-python/python-caja & mate-extra/caja-admin: Add py3.14

### DIFF
--- a/dev-python/python-caja/metadata.xml
+++ b/dev-python/python-caja/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>immoloism@gmail.com</email>
+		<name>Ian Jordan</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">mate-desktop/python-caja</remote-id>
 	</upstream>

--- a/dev-python/python-caja/python-caja-1.28.0.ebuild
+++ b/dev-python/python-caja/python-caja-1.28.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 MATE_LA_PUNT="yes"
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit mate python-single-r1
 

--- a/mate-extra/caja-admin/caja-admin-0.0.5.ebuild
+++ b/mate-extra/caja-admin/caja-admin-0.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit meson python-single-r1
 

--- a/mate-extra/caja-admin/metadata.xml
+++ b/mate-extra/caja-admin/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+			<email>immoloism@gmail.com</email>
+			<name>Ian Jordan</name>
+		</maintainer>
+		<maintainer type="project" proxied="proxy">
+			<email>proxy-maint@gentoo.org</email>
+			<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription lang="en">
 			An extension for Caja that allows administrator access, 
 			including spawning a Caja instance with administrator privileges,


### PR DESCRIPTION
<!-- Please put the pull request description above -->
Bump to py3.14 after testing as best I can.

These packages aren't needed for MATE, but I'll try my best
to keep them alive in Gentoo all the time the work is free.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
