### PR TITLE
dev-util/gitlab-cli: fix shell completion generation

### DIFF
--- a/dev-util/gitlab-cli/gitlab-cli-1.100.0.ebuild
+++ b/dev-util/gitlab-cli/gitlab-cli-1.100.0.ebuild
@@ -43,9 +43,9 @@ src_compile() {
 		build manpage
 
 	einfo "generating shell completion files"
-	sysroot_try_run_prefixed bin/glab completion bash > "${T}"/glab.bash || die
-	sysroot_try_run_prefixed bin/glab completion zsh > "${T}"/glab.zsh || die
-	sysroot_try_run_prefixed bin/glab completion fish > "${T}"/glab.fish || die
+	sysroot_try_run_prefixed bin/glab completion -s bash > "${T}"/glab.bash || die
+	sysroot_try_run_prefixed bin/glab completion -s zsh > "${T}"/glab.zsh || die
+	sysroot_try_run_prefixed bin/glab completion -s fish > "${T}"/glab.fish || die
 }
 
 src_install() {


### PR DESCRIPTION
### Description
The `gitlab-cli` ebuild currently generates identical Bash completion files for all shells because it calls `glab completion` without the `-s` (or `--shell`) option. 

This PR fixes the issue by explicitly passing the correct shell argument (e.g., `glab completion -s zsh`, `glab completion -s fish`) during the build/installation phase, ensuring that proper, shell-specific completion scripts are generated and installed.

### References
* Fixes the shell completion output issue.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
