### PR TITLE
sys-apps/earlyoom: call git-r3_src_unpack in unpack() to fix live ebuilds

### DIFF
--- a/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
@@ -35,8 +35,8 @@ BDEPEND="
 src_unpack() {
 	default
 	if [[ ${PV} == 9999 ]] ; then
-                git-r3_src_unpack
-        fi
+		git-r3_src_unpack
+	fi
 	use test && go-module_src_unpack
 }
 

--- a/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
@@ -34,7 +34,9 @@ BDEPEND="
 
 src_unpack() {
 	default
-
+	if [[ ${PV} == 9999 ]] ; then
+                git-r3_src_unpack
+        fi
 	use test && go-module_src_unpack
 }
 

--- a/sys-apps/earlyoom/earlyoom-9999.ebuild
+++ b/sys-apps/earlyoom/earlyoom-9999.ebuild
@@ -35,8 +35,8 @@ BDEPEND="
 src_unpack() {
 	default
 	if [[ ${PV} == 9999 ]] ; then
-                git-r3_src_unpack
-        fi
+		git-r3_src_unpack
+	fi
 	use test && go-module_src_unpack
 }
 

--- a/sys-apps/earlyoom/earlyoom-9999.ebuild
+++ b/sys-apps/earlyoom/earlyoom-9999.ebuild
@@ -34,7 +34,9 @@ BDEPEND="
 
 src_unpack() {
 	default
-
+	if [[ ${PV} == 9999 ]] ; then
+                git-r3_src_unpack
+        fi
 	use test && go-module_src_unpack
 }
 


### PR DESCRIPTION


The live ebuild fails to unpack if `git-r3_src_unpack` is not called. This commit adds said call to the unpack() function.
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
