### PR TITLE
sys-devel/rust-std: fix cross_llvm build

### DIFF
--- a/sys-devel/rust-std/rust-std-1.74.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.74.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..12} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.74.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.74.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.74.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.74.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{12..12} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.74.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.74.1.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.75.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.75.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..12} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -41,26 +41,12 @@ PATCHES=(
 	"${FILESDIR}"/1.75.0-handle-vendored-sources.patch  # remove for >=1.77.0
 )
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.75.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.75.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -118,6 +118,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.75.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.75.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{12..12} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.75.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.75.0.ebuild
@@ -118,8 +118,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.77.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.77.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..12} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.77.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.77.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.77.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.77.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{12..12} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.77.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.77.1.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.79.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.79.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..12} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.79.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.79.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.79.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.79.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..12} )
+PYTHON_COMPAT=( python3_{12..12} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.79.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.79.0.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.80.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.80.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.80.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.80.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.80.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.80.1.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.80.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.80.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.81.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.81.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.81.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.81.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.81.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.81.0.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.81.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.81.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.82.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.82.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.82.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.82.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.82.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.82.0.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.82.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.82.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.83.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.83.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.83.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.83.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.83.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.83.0.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.83.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.83.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.84.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.84.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -37,26 +37,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.84.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.84.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -114,6 +114,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.84.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.84.1.ebuild
@@ -114,8 +114,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.84.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.84.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.85.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -35,26 +35,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.85.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -112,6 +112,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.85.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.0.ebuild
@@ -112,8 +112,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.85.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.85.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -35,26 +35,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.85.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -112,6 +112,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.85.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.1.ebuild
@@ -112,8 +112,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.85.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.85.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.86.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.86.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -35,26 +35,12 @@ RESTRICT="test"
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.86.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.86.0.ebuild
@@ -16,7 +16,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -112,6 +112,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.86.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.86.0.ebuild
@@ -112,8 +112,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.86.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.86.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs crossdev
 

--- a/sys-devel/rust-std/rust-std-1.87.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.87.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.87.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.87.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -139,6 +139,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.87.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.87.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.87.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.87.0.ebuild
@@ -139,8 +139,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/config.toml || die

--- a/sys-devel/rust-std/rust-std-1.88.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.88.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.88.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.88.0.ebuild
@@ -139,8 +139,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.88.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.88.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -139,6 +139,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.88.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.88.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.89.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.89.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.89.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.89.0.ebuild
@@ -143,8 +143,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.89.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.89.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -65,26 +65,13 @@ QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 PATCHES=(
 	"${FILESDIR}"/1.89.0-enable-stage-0-build.patch  # remove for >=1.90.0
 )
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
 
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.89.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.89.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -143,6 +143,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.90.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.90.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.90.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.90.0.ebuild
@@ -143,8 +143,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.90.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.90.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -143,6 +143,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.90.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.90.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2020-2025 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -65,26 +65,13 @@ QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 PATCHES=(
 	"${FILESDIR}"/1.90.0-enable-stage-0-build.patch  # remove for >=1.91.0
 )
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
 
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.91.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.91.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.91.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.91.0.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.91.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.91.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.91.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.91.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.92.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.92.0.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.92.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.92.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.92.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.92.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.92.0_p1-r1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.92.0_p1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.92.0_p1-r1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.92.0_p1-r1.ebuild
@@ -10,6 +10,8 @@ inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
 
+RUST_PV=${PV%%_p*}
+
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/rust-lang/rust.git"
@@ -29,7 +31,7 @@ elif [[ ${PV} == *beta* ]]; then
 	"
 	S="${WORKDIR}/${MY_P}-src"
 else
-	MY_P="rustc-${PV}"
+	MY_P="rustc-${RUST_PV}"
 	SRC_URI="https://static.rust-lang.org/dist/${MY_P}-src.tar.xz
 			verify-sig? ( https://static.rust-lang.org/dist/${MY_P}-src.tar.xz.asc )
 	"

--- a/sys-devel/rust-std/rust-std-1.93.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.93.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.0.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.93.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.93.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.93.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.93.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.1.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.93.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.93.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.93.1.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.94.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.94.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.0.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.94.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.94.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml

--- a/sys-devel/rust-std/rust-std-1.94.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 

--- a/sys-devel/rust-std/rust-std-1.94.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.1.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.94.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.1.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml
@@ -147,7 +148,6 @@ src_configure() {
 			musl-root = "/usr/${CTARGET}/usr"
 		_EOF_
 	fi
-
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die
 }

--- a/sys-devel/rust-std/rust-std-1.94.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.94.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.95.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.95.0.ebuild
@@ -140,8 +140,13 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
-		$(usev elibc_musl 'crt-static = false')
 	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
 
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die

--- a/sys-devel/rust-std/rust-std-1.95.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.95.0.ebuild
@@ -40,7 +40,7 @@ LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
 SLOT="stable/$(ver_cut 1-2)"
 # please do not keyword
 #KEYWORDS="" #nowarn
-IUSE="debug"
+IUSE="debug llvm-libunwind"
 
 BDEPEND="
 	${PYTHON_DEPS}
@@ -140,6 +140,7 @@ src_configure() {
 		cxx = "$(tc-getCXX ${CTARGET})"
 		linker = "$(tc-getCC ${CTARGET})"
 		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
 	EOF
 	if use elibc_musl; then
 		cat <<- _EOF_ >> "${S}"/bootstrap.toml
@@ -147,7 +148,6 @@ src_configure() {
 			musl-root = "/usr/${CTARGET}/usr"
 		_EOF_
 	fi
-
 	einfo "${PN^} configured with the following settings:"
 	cat "${S}"/bootstrap.toml || die
 }

--- a/sys-devel/rust-std/rust-std-1.95.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.95.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
 HOMEPAGE="https://www.rust-lang.org"
@@ -62,26 +62,12 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 
-#
-# The cross magic
-#
-export CTARGET=${CTARGET:-${CHOST}}
-if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
-	fi
-fi
-
-is_cross() {
-	[[ ${CHOST} != ${CTARGET} ]]
-}
-
 toml_usex() {
 	usex "$1" true false
 }
 
 pkg_pretend() {
-	is_cross || die "${PN} should only be used for cross"
+	is_crosspkg || die "${PN} should only be used for cross"
 }
 
 pkg_setup() {

--- a/sys-devel/rust-std/rust-std-1.95.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.95.0.ebuild
@@ -3,12 +3,12 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
-HOMEPAGE="https://www.rust-lang.org"
+HOMEPAGE="https://rust-lang.org/"
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3

--- a/sys-devel/rust-std/rust-std-9999.ebuild
+++ b/sys-devel/rust-std/rust-std-9999.ebuild
@@ -3,12 +3,12 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..15} )
 
 inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
 
 DESCRIPTION="Rust standard library, standalone (for crossdev)"
-HOMEPAGE="https://www.rust-lang.org"
+HOMEPAGE="https://rust-lang.org/"
 
 RUST_PV=${PV%%_p*}
 

--- a/sys-devel/rust-std/rust-std-9999.ebuild
+++ b/sys-devel/rust-std/rust-std-9999.ebuild
@@ -1,0 +1,174 @@
+# Copyright 2020-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..13} )
+
+inherit edo flag-o-matic multiprocessing python-any-r1 rust-toolchain toolchain-funcs verify-sig crossdev
+
+DESCRIPTION="Rust standard library, standalone (for crossdev)"
+HOMEPAGE="https://www.rust-lang.org"
+
+RUST_PV=${PV%%_p*}
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/rust-lang/rust.git"
+	EGIT_SUBMODULES=(
+			"*"
+			"-src/gcc"
+	)
+elif [[ ${PV} == *beta* ]]; then
+	# Identify the snapshot date of the beta release:
+	# curl -Ls static.rust-lang.org/dist/channel-rust-beta.toml | grep beta-src.tar.xz
+	betaver=${PV//*beta}
+	BETA_SNAPSHOT="${betaver:0:4}-${betaver:4:2}-${betaver:6:2}"
+	MY_P="rustc-beta"
+	SRC_URI="https://static.rust-lang.org/dist/${BETA_SNAPSHOT}/rustc-beta-src.tar.xz -> rustc-${PV}-src.tar.xz
+			verify-sig? ( https://static.rust-lang.org/dist/${BETA_SNAPSHOT}/rustc-beta-src.tar.xz.asc
+					-> rustc-${PV}-src.tar.xz.asc )
+	"
+	S="${WORKDIR}/${MY_P}-src"
+else
+	MY_P="rustc-${RUST_PV}"
+	SRC_URI="https://static.rust-lang.org/dist/${MY_P}-src.tar.xz
+			verify-sig? ( https://static.rust-lang.org/dist/${MY_P}-src.tar.xz.asc )
+	"
+	S="${WORKDIR}/${MY_P}-src"
+fi
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD-1 BSD-2 BSD-4"
+SLOT="stable/$(ver_cut 1-2)"
+# please do not keyword
+#KEYWORDS="" #nowarn
+IUSE="debug llvm-libunwind"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	~dev-lang/rust-${PV}:=
+	verify-sig? ( sec-keys/openpgp-keys-rust )
+"
+DEPEND="||
+	(
+		>="${CATEGORY}"/gcc-4.7:*
+		>="${CATEGORY/sys-devel/llvm-core}"/clang-3.5:*
+	)
+"
+RDEPEND="${DEPEND}"
+
+# need full compiler to run tests
+RESTRICT="test"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
+
+QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
+
+toml_usex() {
+	usex "$1" true false
+}
+
+pkg_pretend() {
+	is_crosspkg || die "${PN} should only be used for cross"
+}
+
+pkg_setup() {
+	python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+}
+
+src_configure() {
+	# do the great cleanup
+	strip-flags
+	filter-flags '-mcpu=*' '-march=*' '-mtune=*' '-m32' '-m64'
+	strip-unsupported-flags
+
+	local rust_root x
+	rust_root="$(rustc --print sysroot)"
+	rtarget="$(rust_abi ${CTARGET})"
+	rtarget="${ERUST_STD_RTARGET:-${rtarget}}" # some targets need to be custom.
+	rbuild="$(rust_abi ${CBUILD})"
+	rhost="$(rust_abi ${CHOST})"
+
+	echo
+	for x in CATEGORY rust_root rbuild rhost rtarget RUSTFLAGS CFLAGS CXXFLAGS LDFLAGS; do
+		einfo "$(printf '%10s' ${x^^}:) ${!x}"
+	done
+
+	cat <<- EOF > "${S}"/bootstrap.toml
+		[build]
+		build = "${rbuild}"
+		host = ["${rhost}"]
+		target = ["${rtarget}"]
+		cargo = "${rust_root}/bin/cargo"
+		rustc = "${rust_root}/bin/rustc"
+		submodules = false
+		local-rebuild = true
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = true
+		verbose = 2
+		cargo-native-static = false
+		[install]
+		prefix = "${EPREFIX}/usr/lib/${PN}/${PV}"
+		sysconfdir = "etc"
+		docdir = "share/doc/rust"
+		bindir = "bin"
+		libdir = "lib"
+		mandir = "share/man"
+		[rust]
+		# https://github.com/rust-lang/rust/issues/54872
+		codegen-units-std = 1
+		optimize = true
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		debuginfo-level-rustc = 0
+		backtrace = true
+		incremental = false
+		default-linker = "$(tc-getCC)"
+		rpath = false
+		dist-src = false
+		remap-debuginfo = true
+		jemalloc = false
+		[dist]
+		src-tarball = false
+		[target.${rtarget}]
+		ar = "$(tc-getAR ${CTARGET})"
+		cc = "$(tc-getCC ${CTARGET})"
+		cxx = "$(tc-getCXX ${CTARGET})"
+		linker = "$(tc-getCC ${CTARGET})"
+		ranlib = "$(tc-getRANLIB ${CTARGET})"
+		llvm-libunwind = "$(usex llvm-libunwind in-tree no)"
+	EOF
+	if use elibc_musl; then
+		cat <<- _EOF_ >> "${S}"/bootstrap.toml
+			crt-static = false
+			musl-root = "/usr/${CTARGET}/usr"
+		_EOF_
+	fi
+
+	einfo "${PN^} configured with the following settings:"
+	cat "${S}"/bootstrap.toml || die
+}
+
+src_compile() {
+	edo env RUST_BACKTRACE=1 \
+		"${EPYTHON}" ./x.py build -vv --config="${S}"/bootstrap.toml -j$(makeopts_jobs) \
+		library/std --stage 0
+}
+
+src_test() {
+	ewarn "${PN} can't run tests"
+}
+
+src_install() {
+	local rustlib="lib/rust/${PV}/lib/rustlib"
+	dodir "/usr/${rustlib}"
+	pushd "build/${rhost}/stage0-sysroot/lib/rustlib" > /dev/null || die
+	cp -pPRv "${rtarget}" "${ED}/usr/${rustlib}" || die
+	popd > /dev/null || die
+}


### PR DESCRIPTION
emerging `cross_llvm-${target}/rust-std` fails with:

**Patch 1**
```
 * ERROR: cross_llvm-${target}/rust-std-1.95.0::cross-${target} failed (pretend phase):
 *   rust-std should only be used for cross
```
extend ebuilds to check for `cross-` and `cross_llvm-` prefix.

**Patch 2**
```
thread 'main' (251728) panicked at src/bootstrap/src/core/sanity.rs:385:25:
when targeting MUSL either the rust.musl-root option or the target.$TARGET.musl-root option must be specified in bootstrap.toml
```
set musl-root for musl targets

**Patch 3**
```
  = note: ld.lld: error: unable to find library -lgcc_s
```
use in-tree llvm-libunwind when building with cross_llvm.


Closes: https://bugs.gentoo.org/977956

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
