### PR TITLE
acct-user.eclass: Automatically add deps based on ACCT_USER_HOME_OWNER

### DIFF
--- a/acct-user/alias/alias-0-r3.ebuild
+++ b/acct-user/alias/alias-0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,6 +13,3 @@ ACCT_USER_HOME_PERMS=02755
 ACCT_USER_GROUPS=( nofiles )
 
 acct-user_add_deps
-
-DEPEND+=" acct-group/qmail "
-RDEPEND+=" acct-group/qmail "

--- a/acct-user/duende/duende-0-r3.ebuild
+++ b/acct-user/duende/duende-0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,6 +9,3 @@ ACCT_USER_ID=66
 ACCT_USER_GROUPS=( "maradns" )
 
 acct-user_add_deps
-
-DEPEND+=" acct-group/maradns "
-RDEPEND+=" acct-group/maradns "

--- a/acct-user/kismet/kismet-0-r3.ebuild
+++ b/acct-user/kismet/kismet-0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,6 +10,3 @@ ACCT_USER_ID="388"
 ACCT_USER_GROUPS=( kismet )
 
 acct-user_add_deps
-
-DEPEND+=" acct-group/kismet "
-RDEPEND+=" acct-group/kismet "

--- a/acct-user/nobody/nobody-0-r2.ebuild
+++ b/acct-user/nobody/nobody-0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,5 +13,3 @@ ACCT_USER_HOME_PERMS=0755
 ACCT_USER_GROUPS=( nobody )
 
 acct-user_add_deps
-
-RDEPEND+=" acct-user/root"

--- a/acct-user/vdradmin/vdradmin-0-r3.ebuild
+++ b/acct-user/vdradmin/vdradmin-0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 Gentoo Authors
+# Copyright 2020-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,6 +11,3 @@ ACCT_USER_ID=453
 ACCT_USER_GROUPS=( vdradmin )
 
 acct-user_add_deps
-
-DEPEND+=" acct-group/vdradmin "
-RDEPEND+=" acct-group/vdradmin "

--- a/eclass/acct-user.eclass
+++ b/eclass/acct-user.eclass
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: acct-user.eclass
@@ -19,7 +19,7 @@
 # on the package providing it.
 #
 # The ebuild needs to call acct-user_add_deps after specifying
-# ACCT_USER_GROUPS.
+# ACCT_USER_GROUPS or ACCT_USER_HOME_OWNER.
 #
 # Example:
 # If your package needs user 'foo' belonging to same-named group, you
@@ -152,8 +152,8 @@ S=${WORKDIR}
 
 # @FUNCTION: acct-user_add_deps
 # @DESCRIPTION:
-# Generate appropriate RDEPEND from ACCT_USER_GROUPS.  This must be
-# called if ACCT_USER_GROUPS are set.
+# Generate appropriate RDEPEND from ACCT_USER_GROUPS and
+# ACCT_USER_HOME_OWNER.  This must be called if one of these are set.
 acct-user_add_deps() {
 	debug-print-function ${FUNCNAME} "$@"
 
@@ -165,6 +165,23 @@ acct-user_add_deps() {
 	fi
 
 	RDEPEND+=${ACCT_USER_GROUPS[*]/#/ acct-group/}
+
+	local user group
+	case ${ACCT_USER_HOME_OWNER} in
+		*:*)
+			user=${ACCT_USER_HOME_OWNER%:*}
+			group=${ACCT_USER_HOME_OWNER#*:} ;;
+		*)
+			user=${ACCT_USER_HOME_OWNER}
+			group= ;;
+	esac
+
+	# Add ACCT_USER_HOME_OWNER dependencies if necessary.
+	[[ -n ${user} && ${user} != "${ACCT_USER_NAME}" ]] &&
+		RDEPEND+=" acct-user/${user}"
+	[[ -n ${group} ]] && ! has "${group}" "${ACCT_USER_GROUPS[@]}" &&
+		RDEPEND+=" acct-group/${group}"
+
 	_ACCT_USER_ADD_DEPS_CALLED=1
 }
 


### PR DESCRIPTION
Some acct-user packages were manually adding these dependencies but most were not, sometimes causing failures at installation time.

I'm just doing CI testing here, please ignore.