### PR TITLE
sys-apps/systemd: Depend on libucontext for fiber bootstrap on musl

### DIFF
--- a/sys-apps/systemd/systemd-261-r1.ebuild
+++ b/sys-apps/systemd/systemd-261-r1.ebuild
@@ -72,6 +72,7 @@ COMMON_DEPEND="
 	)
 	elibc_musl? (
 		>=sys-libs/musl-1.2.6
+		sys-libs/libucontext
 		virtual/libcrypt
 	)
 	fido2? (

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -72,6 +72,7 @@ COMMON_DEPEND="
 	)
 	elibc_musl? (
 		>=sys-libs/musl-1.2.6
+		sys-libs/libucontext
 		virtual/libcrypt
 	)
 	fido2? (


### PR DESCRIPTION
<!-- Please put the pull request description above -->

New dependency introduced by upstream for musl systems. Refer to: https://github.com/systemd/systemd/commit/8533513aff3cc5bdb03b82ef503489ee8683478e.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
