### PR TITLE
sci-libs/pdal: fix false positive cmake warning

### DIFF
--- a/sci-libs/pdal/pdal-2.10.0.ebuild
+++ b/sci-libs/pdal/pdal-2.10.0.ebuild
@@ -36,6 +36,9 @@ DEPEND="
 	test? ( sci-libs/gdal[geos,jpeg(+),png,sqlite] )
 "
 
+# avoid false positive warning on deprecated CMake version in unused example files
+CMAKE_QA_COMPAT_SKIP=1
+
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_PLUGIN_PGPOINTCLOUD="$(usex postgres)"


### PR DESCRIPTION
fix false positive cmake warning

Closes: https://bugs.gentoo.org/976077

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
