### PR TITLE
app-containers/incus: fix RDEPEND, require nftables[json]

### DIFF
--- a/app-containers/incus/incus-7.0.0-r1.ebuild
+++ b/app-containers/incus/incus-7.0.0-r1.ebuild
@@ -28,12 +28,9 @@ DEPEND="acct-group/incus
 	sys-libs/libcap
 	virtual/udev"
 RDEPEND="${DEPEND}
-	|| (
-		net-firewall/iptables
-		net-firewall/nftables[json]
-	)
 	fuidshift? ( !app-containers/lxd )
 	net-firewall/ebtables
+	net-firewall/nftables[json]
 	sys-apps/iproute2
 	sys-fs/fuse:*
 	>=sys-fs/lxcfs-6.0.0

--- a/app-containers/incus/incus-9999.ebuild
+++ b/app-containers/incus/incus-9999.ebuild
@@ -34,12 +34,9 @@ DEPEND="acct-group/incus
 	sys-libs/libcap
 	virtual/udev"
 RDEPEND="${DEPEND}
-	|| (
-		net-firewall/iptables
-		net-firewall/nftables[json]
-	)
 	fuidshift? ( !app-containers/lxd )
 	net-firewall/ebtables
+	net-firewall/nftables[json]
 	sys-apps/iproute2
 	sys-fs/fuse:*
 	>=sys-fs/lxcfs-5.0.0


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/978032