### PR TITLE
dev-python/insipid-sphinx-theme: Upgrade to python-3.14

### DIFF
--- a/dev-python/insipid-sphinx-theme/insipid-sphinx-theme-0.4.4.ebuild
+++ b/dev-python/insipid-sphinx-theme/insipid-sphinx-theme-0.4.4.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2022-2025 Gentoo Authors
+# Copyright 2022-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_VERIFY_REPO=https://github.com/mgeier/insipid-sphinx-theme
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/973855

I checked the package files and did not see reason why python 3.14 would be a problem. There is just a small __init__.py

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
