### PR TITLE
Mongodb py314

### DIFF
--- a/dev-db/mongodb/files/mongodb-8.0.12-gcc15.patch
+++ b/dev-db/mongodb/files/mongodb-8.0.12-gcc15.patch
@@ -1,0 +1,32 @@
+--- a/src/third_party/abseil-cpp/dist/absl/container/internal/container_memory.h	2025-05-25 15:02:02.029582436 +0200
++++ b/src/third_party/abseil-cpp/dist/absl/container/internal/container_memory.h	2025-05-25 15:02:09.676522672 +0200
+@@ -18,6 +18,7 @@
+ #include <cassert>
+ #include <cstddef>
+ #include <cstring>
++#include <cstdint>
+ #include <memory>
+ #include <new>
+ #include <tuple>
+--- a/src/mongo/db/timeseries/bucket_catalog/bucket_catalog.h	2026-01-19 23:39:11.014100847 +0100
++++ b/src/mongo/db/timeseries/bucket_catalog/bucket_catalog.h	2026-01-19 23:39:42.968583829 +0100
+@@ -175,7 +175,7 @@
+     // many buckets it exist in 'archivedBuckets' for this UUID.
+     // TODO SERVER-70605: Remove this mapping, only needed when usingAlwaysCompressedBuckets is
+     // disabled.
+-    tracked_unordered_map<UUID, std::tuple<tracked_string, int64_t>> collectionTimeFields;
++    tracked_unordered_map<UUID, std::pair<tracked_string, int64_t>> collectionTimeFields;
+ 
+     // All series currently with outstanding reopening operations. Used to coordinate disk access
+     // between reopenings and regular writes to prevent stale reads and corrupted updates.
+--- a/src/mongo/db/timeseries/bucket_catalog/bucket_catalog.cpp	2026-01-19 23:39:18.027284201 +0100
++++ b/src/mongo/db/timeseries/bucket_catalog/bucket_catalog.cpp	2026-01-19 23:40:01.928810659 +0100
+@@ -177,7 +177,7 @@
+       archivedBuckets(
+           make_tracked_btree_map<ArchivedKey, ArchivedBucket, std::greater<ArchivedKey>>(
+               getTrackingContext(trackingContexts, TrackingScope::kArchivedBuckets))),
+-      collectionTimeFields(make_tracked_unordered_map<UUID, std::tuple<tracked_string, int64_t>>(
++      collectionTimeFields(make_tracked_unordered_map<UUID, std::pair<tracked_string, int64_t>>(
+           getTrackingContext(trackingContexts, TrackingScope::kArchivedBuckets))),
+       outstandingReopeningRequests(
+           make_tracked_unordered_map<

--- a/dev-db/mongodb/mongodb-8.0.12.ebuild
+++ b/dev-db/mongodb/mongodb-8.0.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 SCONS_MIN_VERSION="3.3.1"
 CHECKREQS_DISK_BUILD="2400M"
@@ -25,7 +25,7 @@ LICENSE="Apache-2.0 SSPL-1"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 -riscv"
 CPU_FLAGS="cpu_flags_x86_avx"
-IUSE="debug kerberos mongosh selinux ssl +tools ${CPU_FLAGS}"
+IUSE="debug kerberos mongosh ssl +tools ${CPU_FLAGS}"
 
 # https://github.com/mongodb/mongo/wiki/Test-The-Mongodb-Server
 # resmoke needs python packages not yet present in Gentoo
@@ -58,7 +58,6 @@ BDEPEND="
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 		dev-python/distro[${PYTHON_USEDEP}]
 		dev-python/gitpython[${PYTHON_USEDEP}]
-		dev-python/pkg-resources[${PYTHON_USEDEP}]
 		dev-python/poetry[${PYTHON_USEDEP}]
 		dev-python/pymongo[${PYTHON_USEDEP}]
 		dev-python/tenacity[${PYTHON_USEDEP}]
@@ -68,7 +67,6 @@ PDEPEND="
 	mongosh? ( app-admin/mongosh-bin )
 	tools? ( >=app-admin/mongo-tools-100 )
 "
-RDEPEND+=" selinux? ( sec-policy/selinux-mongodb )"
 
 PATCHES=(
 	"${WORKDIR}/mongodb-8.0.8-patches/mongodb-4.4.29-no-enterprise.patch"
@@ -92,7 +90,6 @@ python_check_deps() {
 	python_has_version -b "dev-python/pyyaml[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/distro[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/gitpython[${PYTHON_USEDEP}]" &&
-	python_has_version -b "dev-python/pkg-resources[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/poetry[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/pymongo[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/tenacity[${PYTHON_USEDEP}]"


### PR DESCRIPTION
This pull request add python 3.14 support to mongodb-8.0.12 and fix compilation with gcc-15 using the patch from Zappel from https://bugs.gentoo.org/955578
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
