### PR TITLE
<llvm-runtimes/compiler-rt-sanitizers-19: disable clang use flag

### DIFF
--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -1,6 +1,12 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Conrad Kostecki <conikost@gentoo.org> (2026-06-27)
+# We need to force GCC for older releases, which is needed
+# for dev-util/intel-graphics-compiler in the end, as long
+# they do not support newer clang versions (bug #974434).
+<llvm-runtimes/compiler-rt-sanitizers-19 -clang
+
 # Michael Orlitzky <mjo@gentoo.org> (2026-04-15)
 # The non-jumbo build failures are back in 2.52.x.
 =net-libs/webkit-gtk-2.52.3-r410 jumbo-build

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,13 @@
 
 # New entries go on top.
 
+# Conrad Kostecki <conikost@gentoo.org> (2026-06-27)
+# We need to force GCC for older releases, which is needed
+# for dev-util/intel-graphics-compiler in the end, as long
+# they do not support newer clang versions (bug #974434).
+# See bug #974434
+<llvm-runtimes/compiler-rt-sanitizers-19 clang
+
 # Christian Ruppert <idl0r@gentoo.org> (2026-06-08)
 # dev-libs/openssl-4.0.0/0.4 is currently masked
 net-misc/curl ech


### PR DESCRIPTION
Looks like, that GCC16 introduced a new attribute order on __normal_iterator friends, which has been fixed by >=clang-19 but not for older releases, so we need to disable clang here.

Our package dev-util/intel-graphics-compiler is the only one known to use older <clang-19 for now.

See for more information:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120949 https://github.com/llvm/llvm-project/pull/133107

Closes: https://bugs.gentoo.org/974434

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
