### PR TITLE
gui-apps/waybar: add fmt12 compatibility patch

### DIFF
--- a/gui-apps/waybar/files/fmt12.patch
+++ b/gui-apps/waybar/files/fmt12.patch
@@ -1,0 +1,15 @@
+diff --git a/src/modules/simpleclock.cpp b/src/modules/simpleclock.cpp
+index b6a96ecc..e528fcab 100644
+--- a/src/modules/simpleclock.cpp
++++ b/src/modules/simpleclock.cpp
+@@ -17,7 +17,9 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
+ auto waybar::modules::Clock::update() -> void {
+   tzset();  // Update timezone information
+   auto now = std::chrono::system_clock::now();
+-  auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
++  auto t = std::chrono::system_clock::to_time_t(now);
++  std::tm localtime{};
++  localtime_r(&t, &localtime);
+   auto text = fmt::format(fmt::runtime(format_), localtime);
+   label_.set_markup(text);
+ 

--- a/gui-apps/waybar/waybar-0.15.0.ebuild
+++ b/gui-apps/waybar/waybar-0.15.0.ebuild
@@ -5,6 +5,10 @@ EAPI=8
 
 inherit meson optfeature
 
+PATCHES=(
+	"${FILESDIR}"/fmt12.patch
+)
+
 DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
 HOMEPAGE="https://github.com/Alexays/Waybar"
 


### PR DESCRIPTION
gui-apps/waybar: add patch for libfmt-12 compatibility

The current ebuild fails to build against >=dev-libs/libfmt-12.
This PR adds a backported patch from upstream that fixes the
build issue. The patch is applied unconditionally and has been
tested with waybar-0.15.0.

Signed-off-by: RealFCC <theron.york@cloudnuke.org>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
