### PR TITLE
sci-libs/rocFFT, dev-util/amdsmi: compilation fixes

### DIFF
--- a/dev-util/amdsmi/amdsmi-7.1.1.ebuild
+++ b/dev-util/amdsmi/amdsmi-7.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-7.0.2-no-git.patch
 	"${FILESDIR}"/${PN}-7.0.2-unbundle-gtest.patch
 	"${FILESDIR}"/${PN}-7.1.1-libdrm-compat.patch
+	"${FILESDIR}"/${PN}-7.1.1-fix-includes.patch
 )
 
 CONFIG_CHECK="~HSA_AMD ~DRM_AMDGPU"

--- a/dev-util/amdsmi/amdsmi-7.2.0.ebuild
+++ b/dev-util/amdsmi/amdsmi-7.2.0.ebuild
@@ -80,7 +80,7 @@ src_configure() {
 		-DBUILD_TESTS=$(usex test)
 		-Wno-dev
 	)
-	use test && mycmakeargs+=( -CMAKE_REQUIRE_FIND_PACKAGE_GTest=ON )
+	use test && mycmakeargs+=( -DCMAKE_REQUIRE_FIND_PACKAGE_GTest=ON )
 	cmake_src_configure
 }
 

--- a/dev-util/amdsmi/files/amdsmi-7.1.1-fix-includes.patch
+++ b/dev-util/amdsmi/files/amdsmi-7.1.1-fix-includes.patch
@@ -1,0 +1,32 @@
+Fix missing includes for >=libstdc++-15.
+Upstream bug: https://github.com/ROCm/amdsmi/issues/124
+--- a/tests/amd_smi_test/functional/frequencies_read.cc
++++ b/tests/amd_smi_test/functional/frequencies_read.cc
+@@ -21,6 +21,7 @@
+  */
+ 
+ #include <cstdint>
++#include <iomanip>
+ #include <iostream>
+ #include <string>
+ 
+--- a/tests/amd_smi_test/functional/hw_topology_read.cc
++++ b/tests/amd_smi_test/functional/hw_topology_read.cc
+@@ -23,6 +23,7 @@
+ #include <cinttypes>
+ #include <cstdint>
+ 
++#include <iomanip>
+ #include <iostream>
+ #include <string>
+ #include <vector>
+--- a/tests/amd_smi_test/functional/sys_info_read.cc
++++ b/tests/amd_smi_test/functional/sys_info_read.cc
+@@ -24,6 +24,7 @@
+ #include <stddef.h>
+ #include <gtest/gtest.h>
+ 
++#include <iomanip>
+ #include <iostream>
+ #include <string>
+ #include <limits>

--- a/sci-libs/rocFFT/rocFFT-7.2.0.ebuild
+++ b/sci-libs/rocFFT/rocFFT-7.2.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_COMPAT=( python3_{12..14} )
 ROCM_VERSION=${PV}
 
-inherit cmake check-reqs edo multiprocessing python-r1 rocm
+inherit cmake check-reqs edo flag-o-matic multiprocessing python-r1 rocm
 
 DESCRIPTION="Next generation FFT implementation for ROCm"
 HOMEPAGE="https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocfft"
@@ -105,6 +105,10 @@ src_prepare() {
 
 src_configure() {
 	rocm_use_clang
+
+	# #977921: LTO is not compatible with -fgpu-rtc
+	# See also: https://github.com/ROCm/hip/issues/3879
+	filter-lto
 
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON


### PR DESCRIPTION
- sci-libs/rocFFT: filter out LTO flags 
- dev-util/amdsmi: fix typo that breaks build with FEATURES=test 
- dev-util/amdsmi: Fix 7.1.1 builds with >=libstdc++-16 

Closes: https://bugs.gentoo.org/977921
Closes: https://bugs.gentoo.org/973681
Closes: https://bugs.gentoo.org/968629

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
