### PR TITLE
app-admin/keepassxc: auto rebuild on keyutils upgrade

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.8.0_pre20260629-r1.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.8.0_pre20260629-r1.ebuild
@@ -60,7 +60,7 @@ RDEPEND="
 	dev-qt/qtsvg:6
 	media-gfx/qrencode:=
 	sys-apps/pcsc-lite
-	sys-apps/keyutils
+	sys-apps/keyutils:=
 	sys-libs/readline:0=
 	virtual/minizip:=
 	virtual/zlib:=


### PR DESCRIPTION
it is there in 1st level of lddtree and thus it should rebuild automatically

@tamiko could you please add this small change to the latest ebuild?

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
