### PR TITLE
dev-lang/python: fix leaking env vars

### DIFF
--- a/dev-lang/python/python-0.3.13.14.ebuild
+++ b/dev-lang/python/python-0.3.13.14.ebuild
@@ -448,7 +448,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -456,7 +456,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.13.9999.ebuild
+++ b/dev-lang/python/python-0.3.13.9999.ebuild
@@ -435,7 +435,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -443,7 +443,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.14.6.ebuild
+++ b/dev-lang/python/python-0.3.14.6.ebuild
@@ -467,7 +467,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -475,7 +475,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.14.6_p1.ebuild
+++ b/dev-lang/python/python-0.3.14.6_p1.ebuild
@@ -467,7 +467,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -475,7 +475,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.14.9999.ebuild
+++ b/dev-lang/python/python-0.3.14.9999.ebuild
@@ -456,7 +456,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -464,7 +464,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.15.0_beta2.ebuild
+++ b/dev-lang/python/python-0.3.15.0_beta2.ebuild
@@ -470,7 +470,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -478,7 +478,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.15.0_beta3.ebuild
+++ b/dev-lang/python/python-0.3.15.0_beta3.ebuild
@@ -470,7 +470,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -478,7 +478,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-0.3.15.9999.ebuild
+++ b/dev-lang/python/python-0.3.15.9999.ebuild
@@ -456,7 +456,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -464,7 +464,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.10.20.ebuild
+++ b/dev-lang/python/python-3.10.20.ebuild
@@ -456,7 +456,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.10.9999.ebuild
+++ b/dev-lang/python/python-3.10.9999.ebuild
@@ -445,7 +445,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.11.15-r1.ebuild
+++ b/dev-lang/python/python-3.11.15-r1.ebuild
@@ -459,7 +459,7 @@ src_compile() {
 	# Prevent using distutils bundled by setuptools.
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -467,7 +467,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.11.9999.ebuild
+++ b/dev-lang/python/python-3.11.9999.ebuild
@@ -450,7 +450,7 @@ src_compile() {
 	# Prevent using distutils bundled by setuptools.
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -458,7 +458,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.12.13_p1.ebuild
+++ b/dev-lang/python/python-3.12.13_p1.ebuild
@@ -446,7 +446,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -454,7 +454,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.12.9999.ebuild
+++ b/dev-lang/python/python-3.12.9999.ebuild
@@ -435,7 +435,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -443,7 +443,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.13.14.ebuild
+++ b/dev-lang/python/python-3.13.14.ebuild
@@ -465,7 +465,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -473,7 +473,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.13.9999.ebuild
+++ b/dev-lang/python/python-3.13.9999.ebuild
@@ -453,7 +453,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -461,7 +461,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.14.6.ebuild
+++ b/dev-lang/python/python-3.14.6.ebuild
@@ -485,7 +485,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -493,7 +493,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.14.6_p1.ebuild
+++ b/dev-lang/python/python-3.14.6_p1.ebuild
@@ -485,7 +485,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -493,7 +493,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.14.9999.ebuild
+++ b/dev-lang/python/python-3.14.9999.ebuild
@@ -469,7 +469,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -477,7 +477,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.15.0_beta2.ebuild
+++ b/dev-lang/python/python-3.15.0_beta2.ebuild
@@ -482,7 +482,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -490,7 +490,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.15.0_beta3.ebuild
+++ b/dev-lang/python/python-3.15.0_beta3.ebuild
@@ -482,7 +482,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -490,7 +490,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.15.9999.ebuild
+++ b/dev-lang/python/python-3.15.9999.ebuild
@@ -469,7 +469,7 @@ src_compile() {
 	# Ensure sed works as expected
 	# https://bugs.gentoo.org/594768
 	local -x LC_ALL=C
-	export PYTHONSTRICTEXTENSIONBUILD=1
+	local -x PYTHONSTRICTEXTENSIONBUILD=1
 
 	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
 	# end up writing bytecode & violating sandbox.
@@ -477,7 +477,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358

--- a/dev-lang/python/python-3.8.20_p7-r1.ebuild
+++ b/dev-lang/python/python-3.8.20_p7-r1.ebuild
@@ -364,7 +364,7 @@ src_compile() {
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	# also need to clear the flags explicitly here or they end up
 	# in _sysconfigdata*

--- a/dev-lang/python/python-3.9.25.ebuild
+++ b/dev-lang/python/python-3.9.25.ebuild
@@ -447,7 +447,7 @@ src_compile() {
 	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
 
 	# Gentoo hack to disable accessing system site-packages
-	export GENTOO_CPYTHON_BUILD=1
+	local -x GENTOO_CPYTHON_BUILD=1
 
 	if use pgo ; then
 		# bug 660358


### PR DESCRIPTION
GENTOO_CPYTHON_BUILD=1 is leaking from the compile step into the environment,
causing the install step failing to find gpep517 which is in site-packges.

change `export` to `local -x`

Closes: https://bugs.gentoo.org/945864

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
