### PR TITLE
app-shells/bash: fix clang cross-compile

### DIFF
--- a/app-shells/bash/bash-2.05b_p13.ebuild
+++ b/app-shells/bash/bash-2.05b_p13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -103,6 +103,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-3.0_p22.ebuild
+++ b/app-shells/bash/bash-3.0_p22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -108,6 +108,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-3.1_p23.ebuild
+++ b/app-shells/bash/bash-3.1_p23.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -103,6 +103,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-3.2_p57.ebuild
+++ b/app-shells/bash/bash-3.2_p57.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -105,6 +105,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-4.0_p44.ebuild
+++ b/app-shells/bash/bash-4.0_p44.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -99,6 +99,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-4.1_p17.ebuild
+++ b/app-shells/bash/bash-4.1_p17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -94,6 +94,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-4.2_p53.ebuild
+++ b/app-shells/bash/bash-4.2_p53.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -106,6 +106,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-4.3_p48-r2.ebuild
+++ b/app-shells/bash/bash-4.3_p48-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -114,6 +114,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-4.4_p23-r2.ebuild
+++ b/app-shells/bash/bash-4.4_p23-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -124,6 +124,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-5.0_p18-r3.ebuild
+++ b/app-shells/bash/bash-5.0_p18-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -128,6 +128,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu89)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-5.1_p16-r14.ebuild
+++ b/app-shells/bash/bash-5.1_p16-r14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -178,6 +178,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-5.2_p37-r5.ebuild
+++ b/app-shells/bash/bash-5.2_p37-r5.ebuild
@@ -195,6 +195,7 @@ src_configure() {
 	append-cflags $(test-flags-CC -std=gnu17)
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 	fi
 

--- a/app-shells/bash/bash-5.3_p12.ebuild
+++ b/app-shells/bash/bash-5.3_p12.ebuild
@@ -181,6 +181,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-5.3_p15.ebuild
+++ b/app-shells/bash/bash-5.3_p15.ebuild
@@ -181,6 +181,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-5.3_p9-r1.ebuild
+++ b/app-shells/bash/bash-5.3_p9-r1.ebuild
@@ -178,6 +178,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-5.3_p9-r2.ebuild
+++ b/app-shells/bash/bash-5.3_p9-r2.ebuild
@@ -181,6 +181,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-5.3_p9.ebuild
+++ b/app-shells/bash/bash-5.3_p9.ebuild
@@ -175,6 +175,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-5.4_alpha_pre20251202-r1.ebuild
+++ b/app-shells/bash/bash-5.4_alpha_pre20251202-r1.ebuild
@@ -181,6 +181,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 

--- a/app-shells/bash/bash-9999.ebuild
+++ b/app-shells/bash/bash-9999.ebuild
@@ -181,6 +181,7 @@ src_configure() {
 	unset -v YACC
 
 	if tc-is-cross-compiler; then
+		export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 		# https://lists.gnu.org/archive/html/bug-bash/2025-05/msg00029.html
 		export CFLAGS_FOR_BUILD="${BUILD_CFLAGS} -std=gnu17"
 


### PR DESCRIPTION
cross compiling with clang fails with:
`make[1]: gcc: No such file or directory`

export `CC_FOR_BUILD` when cross compiling

Closes: https://bugs.gentoo.org/977885

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
