### PR TITLE
dev-perl/Locale-gettext: fix cross-compile issue

### DIFF
--- a/dev-perl/Locale-gettext/Locale-gettext-1.70.0_p20181130.ebuild
+++ b/dev-perl/Locale-gettext/Locale-gettext-1.70.0_p20181130.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -31,6 +31,10 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.70.0-tests.patch"
 	"${FILESDIR}/${PN}-1.70.0_p20181130-config-log.patch"
 )
+
+src_configure() {
+	export CCFLAGS="$CFLAGS"
+}
 
 src_compile() {
 	# Makefile.PL cannot know we use libintl over system


### PR DESCRIPTION
cross compiling fails with:
`Checking for cc... error: unknown target CPU 'neoverse-n1'` due to wrong cflags being used.

set `CCFLAGS`

Closes: https://bugs.gentoo.org/978555

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
