### PR TITLE
font.eclass: Support EAPI 9

### DIFF
--- a/eclass/font.eclass
+++ b/eclass/font.eclass
@@ -4,11 +4,11 @@
 # @ECLASS: font.eclass
 # @MAINTAINER:
 # fonts@gentoo.org
-# @SUPPORTED_EAPIS: 7 8
+# @SUPPORTED_EAPIS: 7 8 9
 # @BLURB: Eclass to make font installation uniform
 
 case ${EAPI} in
-	7|8) ;;
+	7|8|9) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 


### PR DESCRIPTION
EAPI 9 is additive for this eclass — no phase-function changes needed, only the supported-EAPI guard.

With this PR I want to add, EAPI 9 support, I don't expect any breaking change.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
I get:
_gentoo -- updating eclass cache: zig-utils_


Please note that all boxes must be checked for the pull request to be merged.
