### PR TITLE
gtk: use optfeature for showing the default print-preview-command

### DIFF
--- a/gui-libs/gtk/gtk-4.20.4.ebuild
+++ b/gui-libs/gtk/gtk-4.20.4.ebuild
@@ -282,11 +282,7 @@ pkg_postinst() {
 	xdg_pkg_postinst
 	gnome2_schemas_update
 
-	if ! has_version "app-text/evince"; then
-		elog "Please install app-text/evince for print preview functionality."
-		elog "Alternatively, check \"gtk-print-preview-command\" documentation and"
-		elog "add it to your settings.ini file."
-	fi
+	optfeature "default gtk-print-preview-command" app-text/evince
 
 	if use examples ; then
 		optfeature "syntax highlighting in gtk4-demo" app-text/highlight

--- a/x11-libs/gtk+/gtk+-2.24.33-r3.ebuild
+++ b/x11-libs/gtk+/gtk+-2.24.33-r3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 GNOME2_EAUTORECONF="yes"
 
-inherit flag-o-matic gnome2 multilib multilib-minimal readme.gentoo-r1 virtualx
+inherit flag-o-matic gnome2 multilib multilib-minimal optfeature readme.gentoo-r1 virtualx
 
 DESCRIPTION="Gimp ToolKit +"
 HOMEPAGE="https://www.gtk.org/"
@@ -290,11 +290,7 @@ pkg_postinst() {
 		elog "emerge -va1 \$(qfile -qC ${EPREFIX}/usr/lib/gtk-2.0/2.[^1]*)"
 	fi
 
-	if ! has_version "app-text/evince"; then
-		elog "Please install app-text/evince for print preview functionality."
-		elog "Alternatively, check \"gtk-print-preview-command\" documentation and"
-		elog "add it to your gtkrc."
-	fi
+	optfeature "default gtk-print-preview-command" app-text/evince
 
 	readme.gentoo_print_elog
 }

--- a/x11-libs/gtk+/gtk+-3.24.52.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.52.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 GNOME_ORG_MODULE=gtk
-inherit gnome2 meson-multilib multilib toolchain-funcs virtualx
+inherit gnome2 meson-multilib multilib optfeature toolchain-funcs virtualx
 
 DESCRIPTION="Gimp ToolKit +"
 HOMEPAGE="https://www.gtk.org/"
@@ -198,11 +198,7 @@ pkg_postinst() {
 	}
 	multilib_parallel_foreach_abi multilib_pkg_postinst
 
-	if ! has_version "app-text/evince"; then
-		elog "Please install app-text/evince for print preview functionality."
-		elog "Alternatively, check \"gtk-print-preview-command\" documentation and"
-		elog "add it to your settings.ini file."
-	fi
+	optfeature "default gtk-print-preview-command" app-text/evince
 }
 
 pkg_postrm() {


### PR DESCRIPTION
looking up `gtk-print-preview-command` explains it all. I think using the optfeature here is more idiomatic. Moreover it makes the ebuild shorter and easier to understand.

If you think that more text is needed in the optfeature description I'll change it.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
