### PR TITLE
gui-wm/sway: download signature only of USE=verify-sig

### DIFF
--- a/gui-wm/sway/sway-1.12.ebuild
+++ b/gui-wm/sway/sway-1.12.ebuild
@@ -15,7 +15,7 @@ else
 	MY_PV=${PV/_rc/-rc}
 	inherit verify-sig
 	SRC_URI="https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz.sig -> ${P}.gh.tar.gz.sig"
+		verify-sig? ( https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz.sig -> ${P}.gh.tar.gz.sig )"
 	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
 	S="${WORKDIR}/${PN}-${MY_PV}"
 fi

--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -15,7 +15,7 @@ else
 	MY_PV=${PV/_rc/-rc}
 	inherit verify-sig
 	SRC_URI="https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz.sig -> ${P}.gh.tar.gz.sig"
+		verify-sig? ( https://github.com/swaywm/${PN}/releases/download/${PV}/${P}.tar.gz.sig -> ${P}.gh.tar.gz.sig )"
 	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
 	S="${WORKDIR}/${PN}-${MY_PV}"
 fi
@@ -72,7 +72,7 @@ if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" ~app-text/scdoc-9999"
 else
 	BDEPEND+=" >=app-text/scdoc-1.11.3
-		verify-sig? ( sec-keys/openpgp-keys-emersion )"
+		verify-sig? ( >=sec-keys/openpgp-keys-emersion-20260503 )"
 	VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/emersion.asc"
 fi
 


### PR DESCRIPTION
If the file never gets used then there is no need to download it

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
