### PR TITLE
dev-libs/cJSON: support static-libs

### DIFF
--- a/dev-libs/cJSON/cJSON-1.7.19-r1.ebuild
+++ b/dev-libs/cJSON/cJSON-1.7.19-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 Gentoo Authors
+# Copyright 2021-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/DaveGamble/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.g
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
-IUSE="test"
+IUSE="static-libs test"
 RESTRICT="!test? ( test )"
 
 PATCHES=(
@@ -27,6 +27,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
+		-DBUILD_SHARED_AND_STATIC_LIBS=$(usex static-libs)
 		-DENABLE_CJSON_TEST=$(usex test)
 	)
 


### PR DESCRIPTION
enables static-libs use for cJSON.

```
mischief@beast.home.arpa:/var/db/repos/gentoo/dev-libs/cJSON $ equery f dev-libs/cJSON | grep 'lib.*libcjson.[a|s]'
/usr/lib/debug/usr/lib64/libcjson.so.1.7.19.debug
/usr/lib64/libcjson.a
/usr/lib64/libcjson.so
/usr/lib64/libcjson.so.1
/usr/lib64/libcjson.so.1.7.19
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
