### PR TITLE
qmake-utils.eclass revdeps w/o eqmake6 usage: switch to qt-utils.eclass and use new "qt_"-prefixed query functions

### DIFF
--- a/dev-libs/uriparser/uriparser-1.0.2.ebuild
+++ b/dev-libs/uriparser/uriparser-1.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake qmake-utils
+inherit cmake qt-utils
 
 DESCRIPTION="Strictly RFC 3986 compliant URI parsing library in C"
 HOMEPAGE="https://uriparser.github.io/"
@@ -42,7 +42,7 @@ src_configure() {
 		# The usev wrapper is here to address this warning:
 		#   One or more CMake variables were not used by the project:
 		#   CMAKE_DISABLE_FIND_PACKAGE_Qt5Help
-		$(usev doc $(usex qt6 -DQHG_LOCATION=$(qt6_get_libexecdir)/qhelpgenerator -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Help=ON))
+		$(usev doc $(usex qt6 -DQHG_LOCATION=$(qt_get_broot_binary 6 qhelpgenerator) -DCMAKE_DISABLE_FIND_PACKAGE_Qt5Help=ON))
 	)
 	cmake_src_configure
 }

--- a/media-gfx/freecad/freecad-1.0.2-r2.ebuild
+++ b/media-gfx/freecad/freecad-1.0.2-r2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 # The added asserts break on mem leaks, so tests fail.
 # PYTHON_REQ_USE="-debug"
 
-inherit check-reqs cmake cuda edo flag-o-matic optfeature python-single-r1 qmake-utils toolchain-funcs xdg virtualx
+inherit check-reqs cmake cuda edo flag-o-matic optfeature python-single-r1 qt-utils toolchain-funcs xdg virtualx
 
 DESCRIPTION="Qt based Computer Aided Design application"
 HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
@@ -419,8 +419,8 @@ src_configure() {
 			-DFREECAD_QT_MAJOR_VERSION=6
 			-DFREECAD_QT_VERSION=6
 			-DQT_DEFAULT_MAJOR_VERSION=6
-			-DQt6Core_MOC_EXECUTABLE="$(qt6_get_bindir)/moc"
-			-DQt6Core_RCC_EXECUTABLE="$(qt6_get_bindir)/rcc"
+			-DQt6Core_MOC_EXECUTABLE="$(qt_get_broot_binary 6 moc)"
+			-DQt6Core_RCC_EXECUTABLE="$(qt_get_broot_binary 6 rcc)"
 			-DBUILD_QT5=OFF
 			# Drawing module unmaintained and not ported to qt6
 			-DBUILD_DRAWING=OFF

--- a/media-gfx/freecad/freecad-1.1.1.ebuild
+++ b/media-gfx/freecad/freecad-1.1.1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 # The added asserts break on mem leaks, so tests fail.
 # PYTHON_REQ_USE="-debug"
 
-inherit check-reqs cmake cuda edo flag-o-matic optfeature python-single-r1 qmake-utils toolchain-funcs xdg virtualx branding
+inherit check-reqs cmake cuda edo flag-o-matic optfeature python-single-r1 qt-utils toolchain-funcs xdg virtualx branding
 
 DESCRIPTION="Qt based Computer Aided Design application"
 HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
@@ -411,8 +411,8 @@ src_configure() {
 			-DFREECAD_QT_MAJOR_VERSION=6
 			-DFREECAD_QT_VERSION=6
 			-DQT_DEFAULT_MAJOR_VERSION=6
-			-DQt6Core_MOC_EXECUTABLE="$(qt6_get_bindir)/moc"
-			-DQt6Core_RCC_EXECUTABLE="$(qt6_get_bindir)/rcc"
+			-DQt6Core_MOC_EXECUTABLE="$(qt_get_broot_binary 6 moc)"
+			-DQt6Core_RCC_EXECUTABLE="$(qt_get_broot_binary 6 rcc)"
 			-DBUILD_QT5=OFF
 			# Drawing module unmaintained and not ported to qt6
 			-DBUILD_DRAWING=OFF

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -410,8 +410,8 @@ src_configure() {
 			-DFREECAD_QT_MAJOR_VERSION=6
 			-DFREECAD_QT_VERSION=6
 			-DQT_DEFAULT_MAJOR_VERSION=6
-			-DQt6Core_MOC_EXECUTABLE="$(qt6_get_bindir)/moc"
-			-DQt6Core_RCC_EXECUTABLE="$(qt6_get_bindir)/rcc"
+			-DQt6Core_MOC_EXECUTABLE="$(qt_get_broot_binary 6 moc)"
+			-DQt6Core_RCC_EXECUTABLE="$(qt_get_broot_binary 6 rcc)"
 			-DBUILD_QT5=OFF
 			# Drawing module unmaintained and not ported to qt6
 			-DBUILD_DRAWING=OFF


### PR DESCRIPTION
- [x] Consistently *don't* prepend EPREFIX or similar to paths in these functions
- [x] New function qt_get_archdatadir, which echoes /usr/$(get_libdir)/qt<qt_maj_ver>
- [x] Deprecate all legacy qt6_* functions
- [x] In deprecated qt6_get_bindir(), EPREFIX remains hardcoded
- [x] For EAPI-9, ban qt6_get_libdir w/o direct replacement; it is too basic
- [x] Introduce qt_get_broot_binary()

@negril: maybe https://bugs.gentoo.org/969111 related here?