### PR TITLE
app-crypt/tpm2-openssl: Remove forced -Werror

### DIFF
--- a/app-crypt/tpm2-openssl/files/tpm2-openssl-1.3.0-no-Werror.patch
+++ b/app-crypt/tpm2-openssl/files/tpm2-openssl-1.3.0-no-Werror.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index c531141..786ee22 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -42,7 +42,7 @@ else
+ @CODE_COVERAGE_RULES@
+ endif
+ 
+-COMMON_CFLAGS = -Werror -Wall $(CRYPTO_CFLAGS)
++COMMON_CFLAGS = -Wall $(CRYPTO_CFLAGS)
+ COMMON_LDFLAGS =
+ if WITH_ASAN
+ COMMON_CFLAGS += -O1 -g -fsanitize=address -fno-omit-frame-pointer

--- a/app-crypt/tpm2-openssl/tpm2-openssl-1.3.0.ebuild
+++ b/app-crypt/tpm2-openssl/tpm2-openssl-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -31,6 +31,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-1.1.1-build-Fix-undefined-references-when-using-slibtool.patch"
 	"${FILESDIR}/${PN}-1.3.0-tests-remove-systemd-ism.patch"
+	"${FILESDIR}/${PN}-1.3.0-no-Werror.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/976265

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
