### PR TITLE
app-emulation/libguestfs: Apply patch for Perl module to respect LDFLAGS

### DIFF
--- a/app-emulation/libguestfs/libguestfs-1.58.1.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.58.1.ebuild
@@ -108,6 +108,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.52.1-disable-obsolete-lvmetad-in-tests.patch"
 	"${FILESDIR}/${PN}-1.56.2-bash-Remove-vestigial-bash-completions.patch"
 	"${FILESDIR}/${PN}-1.56.2-guestfs-bash-completion.m4-more-control.patch"
+	"${FILESDIR}/${PN}-1.56.2-respect-LDFLAGS-in-perl-module.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
The patch already existed for prior version, but Iforgot to add it to the PATCHES array for 1.58.1

Closes: https://bugs.gentoo.org/978320

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
