### PR TITLE
sys-kernel/linux-firmware: 99999999, fix license file typo

### DIFF
--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -300,7 +300,7 @@ src_install() {
 
 	dodoc README.md
 	# some licenses require copyright and permission notice to be included
-	use bindist && dodoc -r WHENCE LICENCES
+	use bindist && dodoc -r WHENCE LICENSES
 }
 
 pkg_preinst() {


### PR DESCRIPTION
Fixes typo from f96c060220bb94c22f417d42bc9933843af18b45

Bug: https://bugs.gentoo.org/978064

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
