### PR TITLE
dev-python/tpm2-pytss: Re-add dropped BDEPEND to dev-python/pytest

### DIFF
--- a/dev-python/tpm2-pytss/tpm2-pytss-2.3.0-r3.ebuild
+++ b/dev-python/tpm2-pytss/tpm2-pytss-2.3.0-r3.ebuild
@@ -48,6 +48,10 @@ RESTRICT="!test? ( test )"
 
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
 
+EPYTEST_PLUGINS=()
+EPYTEST_XDIST=1
+distutils_enable_tests pytest
+
 python_test() {
 	local EPYTEST_DESELECT=(
 		# Current tpm2-tss specified a newer revision that the one tested for


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/979004

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
