### PR TITLE
gnome-base/gdm: add xhost to RDEPEND only with USE=X

### DIFF
--- a/gnome-base/gdm/gdm-49.3-r1.ebuild
+++ b/gnome-base/gdm/gdm-49.3-r1.ebuild
@@ -1,0 +1,231 @@
+# Copyright 2023-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop gnome.org gnome2-utils meson pam readme.gentoo-r1 systemd udev xdg
+
+DESCRIPTION="GNOME Display Manager for managing graphical display servers and user logins"
+HOMEPAGE="https://gitlab.gnome.org/GNOME/gdm"
+
+SRC_URI="${SRC_URI}
+	branding? ( https://www.mail-archive.com/tango-artists@lists.freedesktop.org/msg00043/tango-gentoo-v1.1.tar.gz )
+"
+
+LICENSE="
+	GPL-2+
+	branding? ( CC-BY-SA-4.0 )
+"
+
+SLOT="0"
+
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+IUSE="audit debug bluetooth-sound branding elogind fprint plymouth selinux systemd tcpd test video_cards_nvidia +X"
+
+RESTRICT="!test? ( test )"
+REQUIRED_USE="^^ ( elogind systemd )"
+
+# dconf, dbus and g-s-d are needed at install time for dconf update
+# keyutils is automagic dep that makes autologin unlock login keyring
+# when all the passwords match (disk encryption, user pw and login keyring)
+# dbus-run-session used at runtime.
+COMMON_DEPEND="
+	virtual/udev
+	>=dev-libs/libgudev-232:=
+	>=dev-libs/glib-2.68:2
+	>=dev-libs/json-glib-1.2.0
+	>=sys-apps/accountsservice-0.6.35
+	sys-apps/keyutils:=
+	selinux? ( sys-libs/libselinux )
+
+	X? (
+		x11-libs/libxcb
+		x11-libs/libX11
+		x11-libs/libXau
+		x11-base/xorg-server[-minimal]
+		x11-libs/libXdmcp
+		>=x11-libs/gtk+-2.91.1:3[X]
+	)
+	tcpd? ( >=sys-apps/tcp-wrappers-7.6 )
+
+	systemd? ( >=sys-apps/systemd-257:0=[pam] )
+	elogind? ( >=sys-auth/elogind-239.3[pam] )
+
+	plymouth? ( sys-boot/plymouth )
+	audit? ( sys-process/audit )
+
+	sys-libs/pam
+	sys-auth/pambase[elogind?,systemd?]
+
+	>=gnome-base/dconf-0.20
+	>=gnome-base/gnome-settings-daemon-3.1.4
+	gnome-base/gsettings-desktop-schemas
+	sys-apps/dbus
+
+	>=x11-misc/xdg-utils-1.0.2-r3
+
+	>=dev-libs/gobject-introspection-1.82.0-r2:=
+"
+# XXX: These deps are from session and desktop files in data/ directory
+# fprintd is used via dbus by gdm-fingerprint-extension
+RDEPEND="${COMMON_DEPEND}
+	acct-group/gdm
+	acct-user/gdm
+	>=gnome-base/gnome-shell-49
+
+	fprint? ( sys-auth/fprintd[pam] )
+	systemd? (
+		video_cards_nvidia? (
+			x11-drivers/nvidia-drivers
+			sys-apps/acl
+		)
+	)
+	X? ( x11-apps/xhost )
+"
+# This is a 'workaround' built into gdm 49, as elogind does not yet have
+# 'working' userdb support in stable or testing.
+# https://github.com/elogind/elogind/issues/323
+RDEPEND+="elogind? ( acct-user/gdm-greeter )"
+DEPEND="${COMMON_DEPEND}
+	x11-base/xorg-proto
+"
+BDEPEND="
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	dev-util/itstool
+	>=gnome-base/dconf-0.20
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	test? ( >=dev-libs/check-0.9.4 )
+"
+
+DOC_CONTENTS="
+	To start GDM at boot with systemd, run:\n
+	# systemctl enable gdm.service\n
+	\n
+	To start GDM at boot with OpenRC, set DISPLAYMANAGER=\"gdm\"\n
+	in /etc/conf.d/display-manager and enable the display-manager service:\n
+	# rc-update add display-manager\n
+	\n
+	For passwordless login to unlock your keyring, you need to install
+	sys-auth/pambase with USE=gnome-keyring and set an empty password
+	on your keyring. Use app-crypt/seahorse for that.\n
+	\n
+	You may need to install app-crypt/coolkey and sys-auth/pam_pkcs11
+	for smartcard support
+"
+
+PATCHES=(
+	# Multiple upstream fixes from 49.x and 50.x branches
+	"${FILESDIR}"/gdm-49.2-display-reference.patch
+	"${FILESDIR}"/gdm-49.2-boot_display-sysfs.patch
+	"${FILESDIR}"/gdm-49.2-XDG_SESSION_EXTRA_DEVICE_ACCESS.patch
+)
+
+src_prepare() {
+	default
+
+	# Show logo when branding is enabled
+	use branding && eapply "${FILESDIR}/${PN}-3.30.3-logo.patch"
+	eapply "${FILESDIR}/gdm-pam-openrc.patch"
+}
+
+src_configure() {
+	# --with-initial-vt=7 conflicts with plymouth, bug #453392
+	# gdm-3.30 now reaps (stops) the login screen when the login VT isn't active, which
+	# saves on memory. However this means if we don't start on VT1, gdm doesn't start up
+	# before user manually goes to VT7. Thus as-is we can not keep gdm away from VT1,
+	# so lets try always having it in VT1 and see if that is an issue for people before
+	# hacking up workarounds for the initial start case.
+	local emesonargs=(
+		--localstatedir /var
+
+		-Ddefault-pam-config=exherbo
+		-Dgdm-xsession=true
+		-Dgroup=gdm
+		-Dipv6=true
+		$(meson_feature audit libaudit)
+		-Dlogind-provider=$(usex systemd systemd elogind)
+		-Dpam-mod-dir=$(getpam_mod_dir)
+		$(meson_feature plymouth)
+		-Drun-dir=/run/gdm
+		$(meson_feature selinux)
+		$(meson_use systemd systemd-journal)
+		$(meson_use tcpd tcp-wrappers)
+		-Dudev-dir=$(get_udevdir)/rules.d
+		-Duser=gdm
+		-Duser-display-server=true
+		$(meson_use X x11-support)
+		$(meson_feature X xdmcp)
+	)
+
+	if use elogind; then
+		emesonargs+=(
+			-Dinitial-vt=7 # TODO: Revisit together with startDM.sh and other xinit talks; also ignores plymouth possibility
+			-Dsystemdsystemunitdir=no
+			-Dsystemduserunitdir=no
+		)
+	else
+		emesonargs+=(
+			-Dinitial-vt=1
+			-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
+			-Dsystemduserunitdir="$(systemd_get_userunitdir)"
+		)
+	fi
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if ! use bluetooth-sound ; then
+		# Workaround https://gitlab.freedesktop.org/pulseaudio/pulseaudio/merge_requests/10
+		# bug #679526
+		insinto /var/lib/gdm/.config/pulse
+		doins "${FILESDIR}"/default.pa
+	fi
+
+	# Ensure that gdm-greeter-XXX dynamic users have the needed
+	# permissions on nvidia systems, bug #973590
+	if use systemd && use video_cards_nvidia; then
+		insinto /usr/lib/systemd/system/gdm.service.d
+		doins "${FILESDIR}/90-nvidia-acl.conf"
+	fi
+
+	# install XDG_DATA_DIRS gdm changes
+	echo 'XDG_DATA_DIRS="/usr/share/gdm"' > 99xdg-gdm
+	doenvd 99xdg-gdm
+
+	use branding && newicon "${WORKDIR}/tango-gentoo-v1.1/scalable/gentoo.svg" gentoo-gdm.svg
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+
+	local d ret
+
+	# bug #669146; gdm may crash if /var/lib/gdm subdirs are not owned by gdm:gdm
+	ret=0
+	ebegin "Fixing ${EROOT}/var/lib/gdm ownership"
+	chown --no-dereference gdm:gdm "${EROOT}/var/lib/gdm" || ret=1
+	for d in "${EROOT}/var/lib/gdm/"{.cache,.color,.config,.dbus,.local}; do
+		[[ ! -e "${d}" ]] || chown --no-dereference -R gdm:gdm "${d}" || ret=1
+	done
+	eend ${ret}
+
+	systemd_reenable gdm.service
+	readme.gentoo_print_elog
+
+	udev_reload
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+	udev_reload
+}


### PR DESCRIPTION
xhost is needed only by Xsession.
Xsession is installed only when X11 support is enabled.

Location of the code that installs `Xsession.in`:
https://gitlab.gnome.org/GNOME/gdm/-/blob/49.2/data/meson.build?ref_type=tags#L164

Update 1: bump to version 49.3-r1

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
