### PR TITLE
media-gfx/brscan5: QA improvements

### DIFF
--- a/media-gfx/brscan5/brscan5-1.6.2.0-r1.ebuild
+++ b/media-gfx/brscan5/brscan5-1.6.2.0-r1.ebuild
@@ -12,15 +12,14 @@ S="${WORKDIR}/opt/brother/scanner/brscan5"
 
 LICENSE="Brother"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="-* ~amd64"
 RESTRICT="bindist mirror strip"
 
 RDEPEND="
 	dev-libs/libusb:1
 	media-gfx/sane-backends
 	net-dns/avahi[dbus]
-	sys-apps/dbus
-	virtual/libudev
+	virtual/udev
 "
 
 QA_PREBUILT="opt/brother/*"
@@ -28,12 +27,15 @@ QA_PREBUILT="opt/brother/*"
 src_install() {
 	local brscan=/opt/brother/scanner/brscan5
 
+	# Drop GTK2 GUI, in favour of cli brscan_cnetconfig
+	rm brscan_gnetconfig || die
+
 	# Install the full Brother scanner tree to /opt
 	insinto ${brscan}
 	doins -r *
 
 	# Mark executables
-	fperms 0755 ${brscan}/{brsaneconfig5,brscan_cnetconfig,brscan_gnetconfig,setupSaneScan5}
+	fperms 0755 ${brscan}/{brsaneconfig5,brscan_cnetconfig,setupSaneScan5}
 
 	# Mark libraries executable
 	find "${ED}"${brscan} -name '*.so*' -exec chmod 0755 {} + || die
@@ -70,8 +72,8 @@ src_install() {
 pkg_postinst() {
 	udev_reload
 
-	# HOSTNAME is "BRW" followed by MAC for wi-fi
-	# HOSTNAME is "BRN" followed by MAC for etherent
+	# HOSTNAME is "BRW" followed by MAC for Wi-Fi
+	# HOSTNAME is "BRN" followed by MAC for Ethernet
 	elog "Your scanner's HOSTNAME can be discovered via avahi:"
 	elog "  avahi-browse -rt _scanner._tcp"
 	elog "To connect a network scanner using network discovery:"


### PR DESCRIPTION
I ate some humble pie on the previous commit and got a tinderbox failure. So I spent a solid hour tonight reading Gentoo developer  PR reviews to learn some new things and write better ebuilds.

-----

In commit e02ab37ecf4e64fa8446b9f9a34b56f120a332bd we promptly fixed the upstream host deleting files for the only installable version.

In that commit, I observed that brscan_gnetconfig was a binary installed but missing +x and resolved that by adding +x, despite the fact that it was a deliberate omission, to avoid a GTK2 dependency.

That removal is now an explicit removal for clarity.

Deps are refined: libudev to udev (because udev rules don't require linking) Also removing the dbus dependency (not linked, but used via avahi[dbus]).

Keywords are now explicitly -* to match tree best practices.

Closes: https://bugs.gentoo.org/979201

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.