### PR TITLE
toolchain.eclass: support hard/soft float bare metal targets

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1416,7 +1416,7 @@ toolchain_src_configure() {
 			*-dietlibc)
 				needed_libc=dietlibc
 				;;
-			*-elf|*-eabi)
+			*-elf|*-eabi|*-eabihf)
 				needed_libc=newlib
 				confgcc+=(
 					# Bare-metal targets don't have access to clock_gettime()
@@ -1543,7 +1543,7 @@ toolchain_src_configure() {
 	# __cxa_atexit is "essential for fully standards-compliant handling of
 	# destructors", but apparently requires glibc.
 	case ${CTARGET#accel-} in
-		nvptx*|*-elf|*-eabi)
+		nvptx*|*-elf|*-eabi|*-eabihf)
 			confgcc+=( --with-newlib )
 			;;
 		*-musl*)
@@ -1581,12 +1581,13 @@ toolchain_src_configure() {
 			confgcc+=( --with-float=softfp )
 			;;
 		*)
-			# If they've explicitly opt-ed in, do hardfloat,
-			# otherwise let the gcc default kick in.
+			# Check the target for hardfloat again because softfloat no
+			# does not mean hardfloat yes. The check is required for
+			# arm and ppc triples.
 			case ${CTARGET//_/-} in
 				*-hardfloat-*|*eabihf*)
 					confgcc+=( --with-float=hard )
-				;;
+					;;
 			esac
 	esac
 
@@ -1603,8 +1604,30 @@ toolchain_src_configure() {
 				fi
 			done
 
-			# Convert armv7{a,r,m} to armv7-{a,r,m}
-			[[ ${arm_arch} == armv7? ]] && arm_arch=${arm_arch/7/7-}
+			# Handle converting targets that require a dash
+			case ${arm_arch} in
+				armv*[0-9]a)
+					# armv{7,8,9}a to armv{7,8,9}-a
+					arm_arch="${arm_arch%a}-a"
+					;;
+				armv*[0-9]r)
+					# armv{7,8}r to armv{7,8}-r
+					arm_arch="${arm_arch%r}-r"
+					;;
+				armv6m)
+					# armv6-m does not support SVC but it's now mandatory
+					arm_arch="armv6s-m"
+					;;
+				armv*m)
+					# armv{6,6s,7,7e}m to armv{6,6s,7,7e}-m
+					arm_arch="${arm_arch%m}-m"
+					;;
+				armv*m.*)
+					# armv{8,8.1}m.{base,main} to armv{8,8.1}-m.{base,main}
+					arm_arch="${arm_arch%%m.*}-m.${arm_arch#*m.}"
+					;;
+			esac
+
 			# See if this is a valid --with-arch flag
 			if (srcdir=${S}/gcc target=${CTARGET} with_arch=${arm_arch};
 				. "${srcdir}"/config.gcc) &>/dev/null
@@ -1612,16 +1635,63 @@ toolchain_src_configure() {
 				confgcc+=( --with-arch=${arm_arch} )
 			fi
 
-			# Make default mode thumb for microcontroller classes, bug #418209
-			[[ ${arm_arch} == *-m ]] && confgcc+=( --with-mode=thumb )
+			# Make thumb the default with exceptions
+			case ${arm_arch} in
+				arm|armv[45]*)
+					# Generic arm, version 4 and 5 should
+					# use the gcc default
+					;;
+				armv6*-m*|armv6t2*)
+					# The m and t2 variant fully support thumb
+					confgcc+=( --with-mode=thumb )
+					;;
+				armv6*)
+					# All other v6 variants only support thumb
+					# for softfloat targets
+					[[ $(tc-is-softfloat) == "yes" ]] \
+						&& confgcc+=( --with-mode=thumb )
+					;;
+				*)
+					# Version 7 and 8 or m variants, #418209
+					confgcc+=( --with-mode=thumb )
+					;;
+			esac
 
-			# Enable hardvfp
-			if [[ $(tc-is-softfloat) == "no" ]] && [[ ${CTARGET} == armv[67]* ]] ; then
-				# Follow the new arm hardfp distro standard by default
-				confgcc+=( --with-float=hard )
+			# Set default FPU for hard and softfp targets
+			if [[ $(tc-is-softfloat) == "no" ]] || [[ $(tc-is-softfloat) == "softfp" ]] ; then
 				case ${CTARGET} in
-					armv6*) confgcc+=( --with-fpu=vfp ) ;;
-					armv7*) confgcc+=( --with-fpu=vfpv3-d16 ) ;;
+					armv6m*|armv6s-m*)
+						# the 6m variants have no fpu
+						;;
+					armv5te*|armv6*)
+						confgcc+=( --with-fpu=vfp )
+						;;
+					armv7ve*)
+						confgcc+=( --with-fpu=neon-vfpv4 )
+						;;
+					armv7r*)
+						confgcc+=( --with-fpu=vfpv3xd )
+						;;
+					armv7em*)
+						# also supports fpv4-sp-d16 for single-precision
+						# targets, use EXTRA_ECONF to override
+						confgcc+=( --with-fpu=fpv5-d16 )
+						;;
+					armv7*)
+						confgcc+=( --with-fpu=vfpv3-d16 )
+						;;
+					armv8m.main*)
+						# also supports fpv5-sp-d16 for single-precision
+						# targets, use EXTRA_ECONF to override
+						confgcc+=( --with-fpu=fpv5-d16 )
+						;;
+					armv8.[0-9]m*)
+						# ARMv8.1-M and later doesn't support --with-fpu,
+						# instead it is derived from the tripple
+						;;
+					armv8*)
+						confgcc+=( --with-fpu=neon-fp-armv8 )
+						;;
 				esac
 			fi
 
@@ -2175,7 +2245,7 @@ gcc_do_filter_flags() {
 		GDCFLAGS=${CFLAGS}
 
 		# "hppa2.0-unknown-linux-gnu" -> hppa2_0_unknown_linux_gnu
-		local VAR="CFLAGS_"${CTARGET//[-.]/_}
+		local VAR="CFLAGS_"${CTARGET//[-+.]/_}
 		CXXFLAGS=${!VAR-${CFLAGS}}
 	fi
 }
@@ -2298,6 +2368,13 @@ gcc_do_make() {
 		# some reason for putting it in here... --eradicator
 		BOOT_CFLAGS=${BOOT_CFLAGS-"-O2"}
 		emakeargs+=( BOOT_CFLAGS="${BOOT_CFLAGS}" )
+
+		# ARMv8.1-M PACBTI requires branch protection when building target
+		# libraries to emit pointer authentication instructions in libgcc.
+		if [[ ${CTARGET} == *+pacbti* ]]; then
+			CFLAGS_FOR_TARGET+=" -mbranch-protection=standard"
+			emakeargs+=( CFLAGS_FOR_TARGET="${CFLAGS_FOR_TARGET}" )
+		fi
 	else
 		# XXX: Hack for bug #914881, clean this up when fixed and go back
 		# to just calling get_abi_LDFLAGS as before.


### PR DESCRIPTION
The purpose of this change is to add support for non-multilib arm targets in the toolchain eclass.

First two hunks of this patch simply add `*-eabihf` to each `*-eabi` check that currently exist. This is the conventional suffix for specifying bare metal gcc hardfloat targets and is required by hardfloat checks that currently exist in this eclass.

The third hunk was the most confusing portion of this change. Back in 2012, there were two functions called `tc-is-softfloat` and `tc-is-hardfloat` that were pretty straightforward. Then the special vendor string softfp was added for arm's softfloat ABI calling convention supported by some FPUs while also dropping support for `tc-is-hardfloat` and moving that hardfloat check to this block [1]. Later the `tc-is-softfloat` method was expanded into `tc-detect-is-softfloat || tc-tuple-is-softfloat` and the new `tc-tuple-is-softfloat` inherited and expanded upon the triple checks for softfloat and softfp [2]. This expansion included the `arm*-hardfloat-*|arm*eabihf)` case to return "no" which is what confused me because it is nearly identical to the tc-is-hardfloat check. I erroneously thought that if `tc-is-softfloat` was "no" then that must mean `tc-is-hardfloat` is "yes." The legacy comment on this block didn't do a whole lot to explain why we were doing the check again so I initially thought this case could be simplified by dropping the nested case and adding `no) confgcc+=" --with-float=hard" ;;` and gating it with a multilib check but that only works for arm cases. I still think this block is a bit clunky but its improvement is beyond the scope of this change so I've opted to try and improve the comment but I'm not sure it's better.

[1] https://gitweb.gentoo.org/archive/repo/gentoo-2.git/commit/?id=c54aeddb5a763bb36fb6061adc609013ed56f34f
[2] https://github.com/gentoo/gentoo/commit/921cb9c10de4d237924a61a1c27f914dfb479a64

The fourth block expands upon the gcc target to --with-arch conversion to support all of the various 32-bit arm arch blocks. The only thing that's strange is the armv6m to armv6s-m conversion. This was added because using armv6m is broken due to some ambiguity around if the SuperVisor Call (SVC) is required or not. I am not exactly sure on the history of this and could not verify one way or another. The reason I am converting to armv6s-m is because GCC will accept armv6m, but then GAS will fail to assemble it complaining about SVC not being supported. The only difference between 6m and 6s-m is this call and I suspect everything is going to support SVC at this point.

Fifth block expands the thumb detection mostly for the arm 4, 5 and 6 exclusions. It's a little verbose to accommodate the comments.

Sixth block is the --with-fpu support which I expanded out for the FPU's I am aware of. It's worth noting that the armv7em and armv8m.main targets support both a single and double precision FPUs. I've defaulted to the double as it is more accurate but EXTRA_ECONF should be able to override that if desired. There maybe a way to add support for this though a custom vendor field similar to whats going on with the -softfloat- and -softfp- special vendors. Alternatively we could try and use a slightly unorthodox triple like armv7em+fp.sp-none-eabi which would match how I've supported v8.1 in the following block.

Seventh block adds a '+' to the list for characters removed from the target for the CFLAG_${TARGET} variable name because '+' is not allowed in variable names and armv8.1 uses a lot of '+' characters in the --with-arch string. The only way I can think of to get them through without rewriting a lot more of this eclass is to use some unorthodox TARGET arch strings like armv8.1m.main+pacbti+mve-none-eabihf. This works as long as they get stripped from the variable name along with the dashes so I just adjusted the substitution. I don't think this will cause any side effects, but please pay a little extra attention to it as it's outside of the `arm)` case that is my primary focus.

Eighth block adds a CTARGET check for "+pacbti" because the GCC documentation seems to suggest that it is required for armv8.1m with pacbti [3]. I don't really have anyway of testing this and welcome any suggestions.

> If support for the ‘+pacbti’ architecture extension is not enabled (e.g. via -march=), then all branch protection and return address signing operations are constrained to use only the instructions defined in the architectural-NOP space. The generated code remains backwards-compatible with earlier versions of the architecture, but the additional security can be enabled at run time on processors that support the ‘PACBTI’ extension.

[3] https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html

Signed-off-by: Alexander Barker (https://github.com/kwhat) [alex@1stleg.com](mailto:alex@1stleg.com)
Bug: https://bugs.gentoo.org/868636
Closes: https://bugs.gentoo.org/976081

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
