### PR TITLE
media-libs/libfpx: fix libcxx build

### DIFF
--- a/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
+++ b/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -46,7 +46,7 @@ src_configure() {
 	append-ldflags -Wl,--no-undefined
 	econf \
 		$(use_enable static-libs static) \
-		LIBS="-lstdc++ -lm"
+		LIBS="-lm"
 }
 
 src_install() {


### PR DESCRIPTION
compiling on a libcxx profile fails with error:
`ld.lld: error: unable to find library -lstdc++`

remove `-stdc++` and let CXX decide which cxx library to use

Closes: https://bugs.gentoo.org/963816

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
