### PR TITLE
dev-db/sqlite: fix clang cross-compile

### DIFF
--- a/dev-db/sqlite/sqlite-3.53.1.ebuild
+++ b/dev-db/sqlite/sqlite-3.53.1.ebuild
@@ -44,6 +44,9 @@ DEPEND="
 	${RDEPEND}
 	test? ( >=dev-lang/tcl-8.6:0[${MULTILIB_USEDEP}] )
 "
+BDEPEND="
+	icu? ( virtual/pkgconfig )
+"
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" dev-vcs/fossil"
 else
@@ -149,6 +152,9 @@ multilib_src_configure() {
 		--enable-load-extension
 		--enable-threadsafe
 	)
+	if tc-is-cross-compiler; then
+		options+=( --sysroot="${ESYSROOT}" )
+	fi
 
 	# Support detection of misuse of SQLite API.
 	# https://sqlite.org/compile.html#enable_api_armor
@@ -274,9 +280,10 @@ multilib_src_configure() {
 	options+=( $(use_enable debug) )
 
 	if use icu; then
+		tc-export PKG_CONFIG
 		# Support ICU extension.
 		# https://sqlite.org/compile.html#enable_icu
-		options+=( --with-icu-config )
+		options+=( --with-icu-config=pkg-config )
 	fi
 
 	options+=(

--- a/dev-db/sqlite/sqlite-3.53.2-r1.ebuild
+++ b/dev-db/sqlite/sqlite-3.53.2-r1.ebuild
@@ -44,6 +44,9 @@ DEPEND="
 	${RDEPEND}
 	test? ( >=dev-lang/tcl-8.6:0[${MULTILIB_USEDEP}] )
 "
+BDEPEND="
+	icu? ( virtual/pkgconfig )
+"
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" dev-vcs/fossil"
 else
@@ -153,6 +156,9 @@ multilib_src_configure() {
 		--enable-load-extension
 		--enable-threadsafe
 	)
+	if tc-is-cross-compiler; then
+		options+=( --sysroot="${ESYSROOT}" )
+	fi
 
 	# Support detection of misuse of SQLite API.
 	# https://sqlite.org/compile.html#enable_api_armor
@@ -278,9 +284,10 @@ multilib_src_configure() {
 	options+=( $(use_enable debug) )
 
 	if use icu; then
+		tc-export PKG_CONFIG
 		# Support ICU extension.
 		# https://sqlite.org/compile.html#enable_icu
-		options+=( --with-icu-config )
+		options+=( --with-icu-config=pkg-config )
 	fi
 
 	options+=(

--- a/dev-db/sqlite/sqlite-3.53.3.ebuild
+++ b/dev-db/sqlite/sqlite-3.53.3.ebuild
@@ -44,6 +44,9 @@ DEPEND="
 	${RDEPEND}
 	test? ( >=dev-lang/tcl-8.6:0[${MULTILIB_USEDEP}] )
 "
+BDEPEND="
+	icu? ( virtual/pkgconfig )
+"
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" dev-vcs/fossil"
 else
@@ -153,6 +156,9 @@ multilib_src_configure() {
 		--enable-load-extension
 		--enable-threadsafe
 	)
+	if tc-is-cross-compiler; then
+		options+=( --sysroot="${ESYSROOT}" )
+	fi
 
 	# Support detection of misuse of SQLite API.
 	# https://sqlite.org/compile.html#enable_api_armor
@@ -278,9 +284,10 @@ multilib_src_configure() {
 	options+=( $(use_enable debug) )
 
 	if use icu; then
+		tc-export PKG_CONFIG
 		# Support ICU extension.
 		# https://sqlite.org/compile.html#enable_icu
-		options+=( --with-icu-config )
+		options+=( --with-icu-config=pkg-config )
 	fi
 
 	options+=(

--- a/dev-db/sqlite/sqlite-9999.ebuild
+++ b/dev-db/sqlite/sqlite-9999.ebuild
@@ -44,6 +44,9 @@ DEPEND="
 	${RDEPEND}
 	test? ( >=dev-lang/tcl-8.6:0[${MULTILIB_USEDEP}] )
 "
+BDEPEND="
+	icu? ( virtual/pkgconfig )
+"
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" dev-vcs/fossil"
 else
@@ -153,6 +156,9 @@ multilib_src_configure() {
 		--enable-load-extension
 		--enable-threadsafe
 	)
+	if tc-is-cross-compiler; then
+		options+=( --sysroot="${ESYSROOT}" )
+	fi
 
 	# Support detection of misuse of SQLite API.
 	# https://sqlite.org/compile.html#enable_api_armor
@@ -278,9 +284,10 @@ multilib_src_configure() {
 	options+=( $(use_enable debug) )
 
 	if use icu; then
+		tc-export PKG_CONFIG
 		# Support ICU extension.
 		# https://sqlite.org/compile.html#enable_icu
-		options+=( --with-icu-config )
+		options+=( --with-icu-config=pkg-config )
 	fi
 
 	options+=(


### PR DESCRIPTION
cross compiling using clang with USE="icu" fails with errors 
`ld.lld: error: /usr/lib/*.so is incompatible with $targetelf`

get icu path via pkg-config and provide cross sysroot

Closes: https://bugs.gentoo.org/979255

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
