### PR TITLE
dev-util/claude-code: use Claude's own URL instead of GCS

### DIFF
--- a/dev-util/claude-code/claude-code-2.1.209.ebuild
+++ b/dev-util/claude-code/claude-code-2.1.209.ebuild
@@ -10,17 +10,16 @@ HOMEPAGE="https://claude.com/product/claude-code"
 #             the script is simple: it fetches the latest version,
 #             downloads a manifest of files for that version, and
 #             downloads a single binary claude executable matching.
-#             All this from an unbranded GCS bucket (yikes).
-# https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/bootstrap.sh
-GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+# https://downloads.claude.ai/claude-code-releases/bootstrap.sh
+DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"
 SRC_URI="
 	amd64? (
-		elibc_glibc? ( ${GCS_BUCKET}/${PV}/linux-x64/claude -> claude-amd64-glibc-${PV} )
-		elibc_musl?  ( ${GCS_BUCKET}/${PV}/linux-x64-musl/claude -> claude-amd64-musl-${PV} )
+		elibc_glibc? ( ${DOWNLOAD_BASE_URL}/${PV}/linux-x64/claude -> claude-amd64-glibc-${PV} )
+		elibc_musl?  ( ${DOWNLOAD_BASE_URL}/${PV}/linux-x64-musl/claude -> claude-amd64-musl-${PV} )
 	)
 	arm64? (
-		elibc_glibc? ( ${GCS_BUCKET}/${PV}/linux-arm64/claude -> claude-arm64-glibc-${PV} )
-		elibc_musl?  ( ${GCS_BUCKET}/${PV}/linux-arm64-musl/claude -> claude-arm64-musl-${PV} )
+		elibc_glibc? ( ${DOWNLOAD_BASE_URL}/${PV}/linux-arm64/claude -> claude-arm64-glibc-${PV} )
+		elibc_musl?  ( ${DOWNLOAD_BASE_URL}/${PV}/linux-arm64-musl/claude -> claude-arm64-musl-${PV} )
 	)"
 S="${WORKDIR}"
 


### PR DESCRIPTION
Use the official download URL base instead of the unbranded GCS bucket.

Note that version 2.1.210 has been released, feel free to absorb this change into the new ebuild.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.