### PR TITLE
net-libs/ngtcp2: fix cross-compile issue

### DIFF
--- a/net-libs/ngtcp2/ngtcp2-1.24.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.24.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 # Built with autotools rather than cmake to avoid circular dep (bug #951524
 
-inherit multilib-minimal
+inherit libtool multilib-minimal
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/ngtcp2/ngtcp2.git"
@@ -49,6 +49,7 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 
 src_prepare() {
 	default
+	elibtoolize # bug #978993
 	[[ ${PV} == 9999 ]] && eautoreconf
 }
 


### PR DESCRIPTION

v1.24.0 was missing in my previous PR https://github.com/gentoo/gentoo/pull/46538

---

cross compiling from llvm to llvm fails with errors: 
`ld.lld: error: /usr/lib/*.so is incompatible with elf_${ARCH}` due to libtool relinking to -rpath /usr/lib

add libtool and run elibtoolize to patch the path

Closes: https://bugs.gentoo.org/978993

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
