### PR TITLE
dev-lang/php: Apply fix for #977105 in 'phpdbg' SAPI

### DIFF
--- a/dev-lang/php/php-8.4.23.ebuild
+++ b/dev-lang/php/php-8.4.23.ebuild
@@ -716,7 +716,7 @@ src_install() {
 
 	# Delete empty /var/run and /var/log directories.
 	# See bug #977105
-	if use fpm ; then
+	if use fpm || use phpdbg ; then
 		rmdir "${D}/var/log" "${D}/var/run" || die
 	fi
 }

--- a/dev-lang/php/php-8.5.8.ebuild
+++ b/dev-lang/php/php-8.5.8.ebuild
@@ -715,7 +715,7 @@ src_install() {
 
 	# Delete empty /var/run and /var/log directories.
 	# See bug #977105
-	if use fpm ; then
+	if use fpm || use phpdbg ; then
 		rmdir "${D}/var/log" "${D}/var/run" || die
 	fi
 }


### PR DESCRIPTION
This patch updates 08e740a6a57521b8a8217fc7e0b8a40216988f08 to remove the empty directory when using the `phpdbg` SAPI - both `fpm` and `phpdbg` include the empty `/run` and `/log` directories.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
