### PR TITLE
app-i18n/fcitx: add plasma-wayland-protocols build dependency

### DIFF
--- a/app-i18n/fcitx/fcitx-5.1.21.ebuild
+++ b/app-i18n/fcitx/fcitx-5.1.21.ebuild
@@ -70,7 +70,11 @@ RDEPEND="
 		x11-libs/xcb-util-wm
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	wayland? (
+		dev-libs/plasma-wayland-protocols
+	)
+"
 BDEPEND="
 	virtual/pkgconfig
 	kde-frameworks/extra-cmake-modules:0

--- a/profiles/arch/ppc/package.use.mask
+++ b/profiles/arch/ppc/package.use.mask
@@ -41,6 +41,10 @@ net-wireless/kismet mqtt
 # Needs gui-apps/grim, which is not keyworded here
 x11-misc/xscreensaver wayland
 
+# Dawid Rogowicz <rogowiczdawid@naoha.org> (2026-07-16)
+# Needs dev-libs/plasma-wayland-protocols, which is not keyworded here
+app-i18n/fcitx wayland
+
 # NRK <nrk@disroot.org> (2025-05-18)
 # app-arch/plzip is not keyworded
 app-alternatives/lzip plzip


### PR DESCRIPTION
`plasma-wayland-protocols` [has been added](https://github.com/fcitx/fcitx5/pull/1585) as build dependency of fcitx. 
This PR reflect this in the ebuild, emerge will otherwise fail without the package 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
