### PR TITLE
media-libs/libvorbis: fix ppc clang build

### DIFF
--- a/media-libs/libvorbis/libvorbis-1.3.7-r1.ebuild
+++ b/media-libs/libvorbis/libvorbis-1.3.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -30,6 +30,7 @@ src_prepare() {
 	sed -i \
 		-e '/CFLAGS/s:-O20::' \
 		-e '/CFLAGS/s:-mcpu=750::' \
+		-e '/CFLAGS/s:-mfused-madd::' \
 		-e '/CFLAGS/s:-mno-ieee-fp::' \
 		configure.ac || die
 

--- a/media-libs/libvorbis/libvorbis-1.3.7-r1.ebuild
+++ b/media-libs/libvorbis/libvorbis-1.3.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,8 +28,8 @@ src_prepare() {
 	default
 
 	sed -i \
-		-e '/CFLAGS/s:-O20::' \
 		-e '/CFLAGS/s:-mcpu=750::' \
+		-e '/CFLAGS/s:-mfused-madd::' \
 		-e '/CFLAGS/s:-mno-ieee-fp::' \
 		configure.ac || die
 

--- a/media-libs/libvorbis/libvorbis-1.3.7-r2.ebuild
+++ b/media-libs/libvorbis/libvorbis-1.3.7-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -32,6 +32,7 @@ src_prepare() {
 	sed -i \
 		-e '/CFLAGS/s:-O20::' \
 		-e '/CFLAGS/s:-mcpu=750::' \
+		-e '/CFLAGS/s:-mfused-madd::' \
 		-e '/CFLAGS/s:-mno-ieee-fp::' \
 		configure.ac || die
 

--- a/media-libs/libvorbis/libvorbis-1.3.7-r2.ebuild
+++ b/media-libs/libvorbis/libvorbis-1.3.7-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -30,8 +30,8 @@ src_prepare() {
 	default
 
 	sed -i \
-		-e '/CFLAGS/s:-O20::' \
 		-e '/CFLAGS/s:-mcpu=750::' \
+		-e '/CFLAGS/s:-mfused-madd::' \
 		-e '/CFLAGS/s:-mno-ieee-fp::' \
 		configure.ac || die
 


### PR DESCRIPTION
compiling fails with error:
`powerpc-unknown-linux-musl-clang: error: unknown argument: '-mfused-madd'`

filter out `-mfused-madd`, which is not supported by clang and deprecated by gcc

Closes: https://bugs.gentoo.org/979414

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
