### PR TITLE
sys-apps/smartmontools: update SRC_URI

### DIFF
--- a/sys-apps/smartmontools/smartmontools-7.5-r1.ebuild
+++ b/sys-apps/smartmontools/smartmontools-7.5-r1.ebuild
@@ -6,16 +6,17 @@ EAPI=8
 inherit flag-o-matic systemd
 
 if [[ ${PV} == 9999 ]] ; then
-	ESVN_REPO_URI="https://svn.code.sf.net/p/smartmontools/code/trunk/smartmontools"
-	ESVN_PROJECT="smartmontools"
-	inherit autotools subversion
+	EGIT_REPO_URI="https://github.com/smartmontools/smartmontools.git"
+	inherit autotools git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/smartmontools.asc
 	inherit verify-sig
 
 	SRC_URI="
-		https://downloads.sourceforge.net/${PN}/${P}.tar.gz
-		verify-sig? ( https://downloads.sourceforge.net/${PN}/${P}.tar.gz.asc )
+		https://github.com/smartmontools/${PN}/releases/download/RELEASE_${PV//./_}/${P}.tar.gz
+		verify-sig? (
+				https://github.com/smartmontools/${PN}/releases/download/RELEASE_${PV//./_}/${P}.tar.gz.asc
+		)
 	"
 
 	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~x64-macos"


### PR DESCRIPTION
A warning on both https://www.smartmontools.org/ and https://sourceforge.net/p/smartmontools/code/HEAD/tree/trunk/ indicates the project has moved to github under https://github.com/smartmontools/smartmontools.

This PR updates SRC_URI following the release pattern in github e.g. https://github.com/smartmontools/smartmontools/releases/download/RELEASE_7_5/smartmontools-7.5.tar.gz

OBS: `pkgcheck scan --commits --net` warns about SRC_URI change, but that is kind of the point... This is my first change, I hope everything checks out... I've read [the wiki](https://wiki.gentoo.org/wiki/Creating_GitHub_Pull_Requests) and tested locally with ebuild clean, fetch, unpack, compile, install, merge...

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
