### PR TITLE
add USE=static-libs for testing Smithay

### DIFF
--- a/dev-libs/libinput/libinput-1.31.3.ebuild
+++ b/dev-libs/libinput/libinput-1.31.3.ebuild
@@ -16,7 +16,7 @@ SLOT="0/10"
 if [[ $(ver_cut 3) -lt 900 ]] ; then
 	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 fi
-IUSE="doc input_devices_wacom lua test"
+IUSE="doc input_devices_wacom lua static-libs test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
 
@@ -84,6 +84,7 @@ src_configure() {
 	# gui can be built but will not be installed
 	local emesonargs=(
 		-Ddebug-gui=false
+		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_use doc documentation)
 		$(meson_use input_devices_wacom libwacom)
 		$(meson_use test tests)

--- a/media-libs/mesa/mesa-26.0.8.ebuild
+++ b/media-libs/mesa/mesa-26.0.8.ebuild
@@ -63,7 +63,7 @@ done
 IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 debug +llvm
 	lm-sensors opencl +opengl +proprietary-codecs
-	sysprof test unwind vaapi valgrind vulkan
+	sysprof static-libs test unwind vaapi valgrind vulkan
 	wayland +X +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
@@ -404,6 +404,7 @@ multilib_src_configure() {
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
 		-Db_ndebug=$(usex debug false true)
+		-Ddefault_library=$(usex static-libs both shared)
 	)
 	meson_src_configure
 }

--- a/media-libs/mesa/mesa-26.1.4.ebuild
+++ b/media-libs/mesa/mesa-26.1.4.ebuild
@@ -63,7 +63,7 @@ done
 IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 debug +llvm
 	lm-sensors opencl +opengl +proprietary-codecs
-	sysprof test unwind vaapi valgrind vulkan
+	sysprof static-libs test unwind vaapi valgrind vulkan
 	wayland +X +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
@@ -405,6 +405,7 @@ multilib_src_configure() {
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
 		-Db_ndebug=$(usex debug false true)
 		-Dallow-broken-lto=true
+		-Ddefault_library=$(usex static-libs both shared)
 	)
 	meson_src_configure
 }

--- a/media-libs/mesa/mesa-26.1.5.ebuild
+++ b/media-libs/mesa/mesa-26.1.5.ebuild
@@ -63,7 +63,7 @@ done
 IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 debug +llvm
 	lm-sensors opencl +opengl +proprietary-codecs
-	sysprof test unwind vaapi valgrind vulkan
+	sysprof static-libs test unwind vaapi valgrind vulkan
 	wayland +X +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
@@ -405,6 +405,7 @@ multilib_src_configure() {
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
 		-Db_ndebug=$(usex debug false true)
 		-Dallow-broken-lto=true
+		-Ddefault_library=$(usex static-libs both shared)
 	)
 	meson_src_configure
 }

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -63,7 +63,7 @@ done
 IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 debug +llvm
 	lm-sensors opencl +opengl +proprietary-codecs
-	sysprof test unwind vaapi valgrind vulkan
+	sysprof static-libs test unwind vaapi valgrind vulkan
 	wayland +X +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
@@ -405,6 +405,7 @@ multilib_src_configure() {
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
 		-Db_ndebug=$(usex debug false true)
 		-Dallow-broken-lto=true
+		-Ddefault_library=$(usex static-libs both shared)
 	)
 	meson_src_configure
 }

--- a/sys-apps/systemd-utils/systemd-utils-255.18.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-255.18.ebuild
@@ -28,7 +28,7 @@ SRC_URI+=" elibc_musl? ( https://dev.gentoo.org/~floppym/dist/${MUSL_PATCHSET}.t
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles test +udev ukify"
+IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles static-libs test +udev ukify"
 REQUIRED_USE="
 	|| ( kernel-install tmpfiles sysusers udev )
 	boot? ( kernel-install )
@@ -154,6 +154,7 @@ multilib_src_configure() {
 		# default is developer, bug 918671
 		-Dmode=release
 		-Dsysvinit-path=
+		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_native_use_feature boot bootloader)
 		$(meson_native_use_bool kernel-install)
 		$(meson_native_use_feature selinux)

--- a/sys-apps/systemd-utils/systemd-utils-259.3.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-259.3.ebuild
@@ -22,7 +22,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles test +udev ukify"
+IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles static-libs test +udev ukify"
 REQUIRED_USE="
 	|| ( kernel-install tmpfiles sysusers udev )
 	boot? ( kernel-install )
@@ -129,6 +129,7 @@ multilib_src_configure() {
 		-Dmode=release
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsysvinit-path=
+		-Ddefault_library=$(usex static-libs both shared)
 
 		$(meson_native_use_feature boot bootloader)
 		$(meson_native_use_bool kernel-install)

--- a/sys-apps/systemd-utils/systemd-utils-259.4.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-259.4.ebuild
@@ -22,7 +22,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles test +udev ukify"
+IUSE="+acl boot +kmod kernel-install selinux split-usr sysusers +tmpfiles static-libs test +udev ukify"
 REQUIRED_USE="
 	|| ( kernel-install tmpfiles sysusers udev )
 	boot? ( kernel-install )
@@ -148,6 +148,7 @@ multilib_src_configure() {
 		-Dmode=release
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsysvinit-path=
+		-Ddefault_library=$(usex static-libs both shared)
 
 		$(meson_native_use_feature boot bootloader)
 		$(meson_native_use_bool kernel-install)

--- a/sys-apps/systemd-utils/systemd-utils-260.1-r1.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-260.1-r1.ebuild
@@ -22,7 +22,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="+acl boot +kmod kernel-install selinux split-usr +sysctl sysusers +tmpfiles test +udev ukify"
+IUSE="+acl boot +kmod kernel-install selinux split-usr +sysctl sysusers +tmpfiles static-libs test +udev ukify"
 REQUIRED_USE="
 	|| ( kernel-install tmpfiles sysctl sysusers udev )
 	boot? ( kernel-install )
@@ -141,6 +141,7 @@ multilib_src_configure() {
 		--auto-features=disabled
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 
 		# default is developer, bug 918671
 		-Dmode=release

--- a/sys-apps/systemd/systemd-259.4-r2.ebuild
+++ b/sys-apps/systemd/systemd-259.4-r2.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
 	fido2 +gcrypt gnutls homed http idn importd +kernel-install +kmod +libarchive
 	+lz4 lzma +openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode
-	+resolvconf +seccomp selinux split-usr sysv-utils test tpm ukify vanilla xkb +zstd
+	+resolvconf +seccomp selinux split-usr sysv-utils static-libs test tpm ukify vanilla xkb +zstd
 "
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -319,6 +319,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		# default is developer, bug 918671
 		-Dmode=release
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-apps/systemd/systemd-260.1-r2.ebuild
+++ b/sys-apps/systemd/systemd-260.1-r2.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils
 	fido2 +gcrypt gnutls homed idn importd +kernel-install +kmod +libarchive +lz4 lzma
 	+openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode remote
-	+resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb +zstd
+	+resolvconf +seccomp selinux sysv-utils static-libs test tpm ukify vanilla xkb +zstd
 "
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -298,6 +298,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		-Dmode=release # default is developer, bug 918671
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-apps/systemd/systemd-260.2-r1.ebuild
+++ b/sys-apps/systemd/systemd-260.2-r1.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils
 	fido2 +gcrypt gnutls homed idn importd +kernel-install +kmod +libarchive +lz4 lzma
 	+openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode remote
-	+resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb +zstd
+	+resolvconf +seccomp selinux sysv-utils static-libs test tpm ukify vanilla xkb +zstd
 "
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -295,6 +295,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		-Dmode=release # default is developer, bug 918671
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-apps/systemd/systemd-261-r1.ebuild
+++ b/sys-apps/systemd/systemd-261-r1.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils fido2
 	+gcrypt gnutls homed idn imds importd +kernel-install +kmod +libarchive
 	+lz4 lzma +openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode
-	remote +resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb
+	remote +resolvconf +seccomp selinux sysv-utils static-libs test tpm ukify vanilla xkb
 	+zstd
 "
 REQUIRED_USE="
@@ -299,6 +299,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		-Dmode=release # default is developer, bug 918671
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-apps/systemd/systemd-261.1.ebuild
+++ b/sys-apps/systemd/systemd-261.1.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils fido2
 	+gcrypt gnutls homed idn imds importd +kernel-install +kmod +libarchive
 	+lz4 lzma +openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode
-	remote +resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb
+	remote +resolvconf +seccomp selinux sysv-utils static-libs test tpm ukify vanilla xkb
 	+zstd
 "
 REQUIRED_USE="
@@ -299,6 +299,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		-Dmode=release # default is developer, bug 918671
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -36,7 +36,7 @@ IUSE="
 	acl apparmor audit boot bpf cryptsetup curl +dns-over-tls elfutils fido2
 	+gcrypt gnutls homed idn imds importd +kernel-install +kmod +libarchive
 	+lz4 lzma +openssl pam passwdqc pcre pkcs11 policykit pwquality qrcode
-	remote +resolvconf +seccomp selinux sysv-utils test tpm ukify vanilla xkb
+	remote +resolvconf +seccomp selinux sysv-utils static-libs test tpm ukify vanilla xkb
 	+zstd
 "
 REQUIRED_USE="
@@ -298,6 +298,7 @@ multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
 		-Ddocdir="share/doc/${PF}"
+		-Ddefault_library=$(usex static-libs both shared)
 		-Dmode=release # default is developer, bug 918671
 		-Dlibc=$(usex elibc_musl musl glibc)
 		-Dsupport-url="${BRANDING_OS_SUPPORT_URL}"

--- a/sys-auth/seatd/seatd-0.9.2.ebuild
+++ b/sys-auth/seatd/seatd-0.9.2.ebuild
@@ -16,7 +16,7 @@ else
 fi
 LICENSE="MIT"
 SLOT="0/1"
-IUSE="builtin elogind selinux server systemd"
+IUSE="builtin elogind selinux server systemd static-libs"
 REQUIRED_USE="?? ( elogind systemd )"
 
 DEPEND="
@@ -32,6 +32,7 @@ BDEPEND=">=app-text/scdoc-1.9.7"
 src_configure() {
 	local emesonargs=(
 		-Dman-pages=enabled
+		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_feature builtin libseat-builtin)
 		$(meson_feature server)
 	)

--- a/sys-auth/seatd/seatd-0.9.3.ebuild
+++ b/sys-auth/seatd/seatd-0.9.3.ebuild
@@ -16,7 +16,7 @@ else
 fi
 LICENSE="MIT"
 SLOT="0/1"
-IUSE="builtin elogind selinux server systemd"
+IUSE="builtin elogind selinux server systemd static-libs"
 REQUIRED_USE="?? ( elogind systemd )"
 
 DEPEND="
@@ -41,6 +41,7 @@ src_prepare() {
 src_configure() {
 	local emesonargs=(
 		-Dman-pages=enabled
+		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_feature builtin libseat-builtin)
 		$(meson_feature server)
 	)

--- a/sys-auth/seatd/seatd-9999.ebuild
+++ b/sys-auth/seatd/seatd-9999.ebuild
@@ -16,7 +16,7 @@ else
 fi
 LICENSE="MIT"
 SLOT="0/1"
-IUSE="builtin elogind selinux server systemd"
+IUSE="builtin elogind selinux server systemd static-libs"
 REQUIRED_USE="?? ( elogind systemd )"
 
 DEPEND="
@@ -41,6 +41,7 @@ src_prepare() {
 src_configure() {
 	local emesonargs=(
 		-Dman-pages=enabled
+		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_feature builtin libseat-builtin)
 		$(meson_feature server)
 	)

--- a/virtual/libudev/libudev-251-r2.ebuild
+++ b/virtual/libudev/libudev-251-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,9 +9,9 @@ DESCRIPTION="Virtual for libudev providers"
 
 SLOT="0/1"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="systemd"
+IUSE="systemd static-libs"
 
 RDEPEND="
-	!systemd? ( >=sys-apps/systemd-utils-251[udev,${MULTILIB_USEDEP}] )
-	systemd? ( >=sys-apps/systemd-251:0/2[${MULTILIB_USEDEP}] )
+	!systemd? ( >=sys-apps/systemd-utils-251[static-libs,udev,${MULTILIB_USEDEP}] )
+	systemd? ( >=sys-apps/systemd-251:0/2[static-libs,${MULTILIB_USEDEP}] )
 "

--- a/virtual/libudev/libudev-257.ebuild
+++ b/virtual/libudev/libudev-257.ebuild
@@ -9,9 +9,9 @@ DESCRIPTION="Virtual for libudev providers"
 
 SLOT="0/1"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
-IUSE="systemd"
+IUSE="systemd static-libs"
 
 RDEPEND="
-	!systemd? ( >=sys-apps/systemd-utils-${PV}[udev,${MULTILIB_USEDEP}] )
-	systemd? ( >=sys-apps/systemd-${PV}:0/2[${MULTILIB_USEDEP}] )
+	!systemd? ( >=sys-apps/systemd-utils-${PV}[static-libs,udev,${MULTILIB_USEDEP}] )
+	systemd? ( >=sys-apps/systemd-${PV}:0/2[static-libs,${MULTILIB_USEDEP}] )
 "


### PR DESCRIPTION
Testing [Smithay](https://github.com/Smithay/smithay) fails due to missing static libraries. Enable `USE=static-libs` for them:
- lgbm: media-libs/mesa
- lseat: sys-auth/seatd
- ludev: virtual/libudev
- linput: dev-libs/libinput

I tested `USE=static-libs emerge ...` on `arm64/musl/llvm` and `ppc/musl/llvm`

Closes: https://bugs.gentoo.org/979498

--
Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
