### PR TITLE
sci-ml/ollama: use chmod instead of fperms

### DIFF
--- a/sci-ml/ollama/ollama-0.31.2-r2.ebuild
+++ b/sci-ml/ollama/ollama-0.31.2-r2.ebuild
@@ -116,9 +116,11 @@ src_install() {
 	dobin "${BUILD_DIR}"/llama-server-local/ollama
 	insinto usr
 	doins -r "${BUILD_DIR}"/lib
-	fperms 0755 /usr/lib/ollama/libllama-*-impl.so
-	fperms 0755 /usr/lib/ollama/lib*.so.0.0.0
-	fperms 0755 /usr/lib/ollama/llama-*
+	pushd "${ED}" || die
+		chmod 0755 usr/lib/ollama/libllama-*-impl.so || die
+		chmod 0755 usr/lib/ollama/lib*.so.0.0.0 || die
+		chmod 0755 usr/lib/ollama/llama-* || die
+	popd || die
 
 	einstalldocs
 

--- a/sci-ml/ollama/ollama-0.32.1.ebuild
+++ b/sci-ml/ollama/ollama-0.32.1.ebuild
@@ -116,9 +116,11 @@ src_install() {
 	dobin "${BUILD_DIR}"/llama-server-local/ollama
 	insinto usr
 	doins -r "${BUILD_DIR}"/lib
-	fperms 0755 /usr/lib/ollama/libllama-*-impl.so
-	fperms 0755 /usr/lib/ollama/lib*.so.0.0.0
-	fperms 0755 /usr/lib/ollama/llama-*
+	pushd "${ED}" || die
+		chmod 0755 usr/lib/ollama/libllama-*-impl.so || die
+		chmod 0755 usr/lib/ollama/lib*.so.0.0.0	|| die
+		chmod 0755 usr/lib/ollama/llama-* || die
+	popd || die
 
 	einstalldocs
 


### PR DESCRIPTION
For the files below `usr`, the `fperms` fails due to issues with globbing, so I replaced it with `chmod` which is a suitable replacement.

See https://bugs.gentoo.org/714082 for reference.

Closes: https://bugs.gentoo.org/979328

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
