### PR TITLE
profiles/arch/amd64/x32: charset-normalizer -native-extensions

### DIFF
--- a/profiles/arch/amd64/x32/package.use.mask
+++ b/profiles/arch/amd64/x32/package.use.mask
@@ -1,6 +1,12 @@
 # Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# ian Jordan <immoloism@gmail.com> (2026-07-21)
+# dev-python/mypy now started requiring NIH Rust packages
+# Bit of dirty fix to get stages rebuilt on x32 until
+# bug #760405 is resolved.
+dev-python/charset-normalizer native-extensions
+
 # Paul Zander <negril.nx+gentoo@gmail.com> (2025-09-11)
 # no llvm-runtimes/offload here
 dev-cpp/eigen clang-cuda


### PR DESCRIPTION
With rust now getting pulled in as a depend for
@System we need to take action to allow stages
to carry on being built for RelEng and to help
users not trip up while the lack of rust support
as reasonable possible on x32 on Gentoo is being
resolved.

Originally I thought using wd40 on x32 would be the
best solution, but overlooked (read: got a harsh
lesson on how profile depgraphs actually work :) )

So while slightly dirty, the best way forward is
to use the p.u.mask that mgorny set in wd40 that
buys us some time for a real solution at a later
date.

Commit:
https://github.com/gentoo/gentoo/commit/4c21b6159beb059cc3f0bb4166952c18ee77c401

I've not masked the packages as it will cause
QA issues and my goals are more aimed at
RelEng being able to keep building stages
while not causing problems to the efforts
of adding x32 rust support to Gentoo.

Bug: https://bugs.gentoo.org/760405

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
