### PR TITLE
sys-kernel/dracut: add dinit to RDEPEND

### DIFF
--- a/sys-kernel/dracut/dracut-111-r2.ebuild
+++ b/sys-kernel/dracut/dracut-111-r2.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/dracut-ng/dracut"
 else
 	if [[ "${PV}" != *_rc* ]]; then
-		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+		KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 	fi
 	SRC_URI="https://github.com/dracut-ng/dracut/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 fi
@@ -104,6 +104,7 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 
 PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
+	"${FILESDIR}"/${PN}-111-dash-printf.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Previously we added sys-apps/dinit to virtual/service-manager now having dinit installed with sysv-utils will soft-block dracut
This PR stops dracut from being soft-blocked by dinit
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
