### PR TITLE
app-i18n/fcitx-qt: fix broken Qt5 deps after Qt5 removal

### DIFF
--- a/app-i18n/fcitx-qt/fcitx-qt-5.1.14.ebuild
+++ b/app-i18n/fcitx-qt/fcitx-qt-5.1.14.ebuild
@@ -15,29 +15,15 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 LICENSE="BSD LGPL-2.1+"
 SLOT="5"
 KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
-IUSE="qt5 onlyplugin staticplugin +qt6 +X wayland"
+IUSE="onlyplugin staticplugin +X wayland"
 REQUIRED_USE="
-	|| ( qt5 qt6 )
-	qt5? ( X )
 	staticplugin? ( onlyplugin )
 "
 
 RDEPEND="
-	!onlyplugin? (
-		>=app-i18n/fcitx-5.1.13:5
-		qt5? ( dev-qt/qtconcurrent:5 )
-	)
-	qt5? (
-		dev-qt/qtcore:5
-		dev-qt/qtdbus:5
-		dev-qt/qtgui:5=
-		dev-qt/qtwidgets:5
-		wayland? ( dev-qt/qtwayland:5 )
-	)
-	qt6? (
-		dev-qt/qtbase:6=[dbus,gui,widgets,wayland?]
-		wayland? ( dev-qt/qtwayland:6 )
-	)
+	!onlyplugin? ( >=app-i18n/fcitx-5.1.13:5 )
+	dev-qt/qtbase:6=[dbus,gui,widgets,wayland?]
+	wayland? ( dev-qt/qtwayland:6 )
 	X? (
 		x11-libs/libX11
 		x11-libs/libxcb
@@ -55,9 +41,9 @@ src_configure() {
 	use staticplugin && lto-guarantee-fat
 	local mycmakeargs=(
 		-DENABLE_QT4=no
-		-DENABLE_QT5=$(usex qt5)
-		-DENABLE_QT6=$(usex qt6)
-		-DENABLE_QT6_WAYLAND_WORKAROUND=$(usex qt6 $(usex wayland))
+		-DENABLE_QT5=no
+		-DENABLE_QT6=yes
+		-DENABLE_QT6_WAYLAND_WORKAROUND=$(usex wayland)
 		-DENABLE_X11=$(usex X)
 		-DBUILD_ONLY_PLUGIN=$(usex onlyplugin)
 		-DBUILD_STATIC_PLUGIN=$(usex staticplugin)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/948836

Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
