### PR TITLE
llvm-core/clang-22.1.6: keyword ~s390

### DIFF
--- a/dev-python/lit/lit-22.1.8.ebuild
+++ b/dev-python/lit/lit-22.1.8.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/llvm-core/clang-common/clang-common-22.1.8.ebuild
+++ b/llvm-core/clang-common/clang-common-22.1.8.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="
 	default-compiler-rt default-libcxx default-lld
 	bootstrap-prefix cet emacs hardened llvm-libunwind

--- a/llvm-core/clang-linker-config/clang-linker-config-22.ebuild
+++ b/llvm-core/clang-linker-config/clang-linker-config-22.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="default-lld"
 
 RDEPEND="

--- a/llvm-core/clang-toolchain-symlinks/clang-toolchain-symlinks-22.ebuild
+++ b/llvm-core/clang-toolchain-symlinks/clang-toolchain-symlinks-22.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="gcc-symlinks multilib-symlinks native-symlinks"
 
 # Blocker for bug #872416

--- a/llvm-core/clang/clang-22.1.8.ebuild
+++ b/llvm-core/clang/clang-22.1.8.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA MIT"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="debug doc +extra ieee-long-double +pie +static-analyzer test xml"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RESTRICT="!test? ( test )"

--- a/llvm-core/lld-toolchain-symlinks/lld-toolchain-symlinks-22.ebuild
+++ b/llvm-core/lld-toolchain-symlinks/lld-toolchain-symlinks-22.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="multilib-symlinks native-symlinks"
 
 RDEPEND="

--- a/llvm-core/lld/lld-22.1.8-r1.ebuild
+++ b/llvm-core/lld/lld-22.1.8-r1.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="debug test zstd"
 RESTRICT="!test? ( test )"
 

--- a/llvm-core/llvm-common/llvm-common-22.1.8.ebuild
+++ b/llvm-core/llvm-common/llvm-common-22.1.8.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="emacs"
 
 RDEPEND="

--- a/llvm-core/llvm-toolchain-symlinks/llvm-toolchain-symlinks-22.ebuild
+++ b/llvm-core/llvm-toolchain-symlinks/llvm-toolchain-symlinks-22.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="multilib-symlinks native-symlinks"
 
 RDEPEND="

--- a/llvm-core/llvm/llvm-22.1.8.ebuild
+++ b/llvm-core/llvm/llvm-22.1.8.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA BSD public-domain rc"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="
 	+binutils-plugin debug debuginfod doc exegesis libedit +libffi
 	test xml z3 zstd

--- a/llvm-core/llvmgold/llvmgold-22.ebuild
+++ b/llvm-core/llvmgold/llvmgold-22.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ~ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86"
 
 RDEPEND="
 	llvm-core/llvm:${PV}[binutils-plugin]

--- a/llvm-core/polly/polly-22.1.8.ebuild
+++ b/llvm-core/polly/polly-22.1.8.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 # vendored isl (fork?)
 LICENSE+=" MIT"
 SLOT="${LLVM_MAJOR}/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 IUSE="debug test"
 RESTRICT="!test? ( test )"
 

--- a/llvm-runtimes/clang-rtlib-config/clang-rtlib-config-22.ebuild
+++ b/llvm-runtimes/clang-rtlib-config/clang-rtlib-config-22.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="default-compiler-rt +abi_x86_32 abi_x86_64"
 
 RDEPEND="

--- a/llvm-runtimes/clang-runtime/clang-runtime-22.ebuild
+++ b/llvm-runtimes/clang-runtime/clang-runtime-22.ebuild
@@ -11,7 +11,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="
 	+compiler-rt libcxx offload openmp +sanitize
 	default-compiler-rt default-libcxx default-lld llvm-libunwind polly

--- a/llvm-runtimes/clang-stdlib-config/clang-stdlib-config-22.ebuild
+++ b/llvm-runtimes/clang-stdlib-config/clang-stdlib-config-22.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="default-libcxx"
 
 RDEPEND="

--- a/llvm-runtimes/clang-unwindlib-config/clang-unwindlib-config-22.ebuild
+++ b/llvm-runtimes/clang-unwindlib-config/clang-unwindlib-config-22.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="default-compiler-rt llvm-libunwind"
 
 RDEPEND="

--- a/llvm-runtimes/compiler-rt-sanitizers/compiler-rt-sanitizers-22.1.8.ebuild
+++ b/llvm-runtimes/compiler-rt-sanitizers/compiler-rt-sanitizers-22.1.8.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv x86 ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv ~s390 x86 ~x64-macos"
 IUSE="+abi_x86_32 abi_x86_64 +clang debug test"
 # base targets
 IUSE+=" +ctx-profile +libfuzzer +memprof +orc +profile +xray"

--- a/llvm-runtimes/compiler-rt/compiler-rt-22.1.8.ebuild
+++ b/llvm-runtimes/compiler-rt/compiler-rt-22.1.8.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv ~s390 x86 ~arm64-macos ~x64-macos"
 IUSE="+abi_x86_32 abi_x86_64 +atomic-builtins +clang debug test"
 REQUIRED_USE="atomic-builtins? ( clang )"
 RESTRICT="!test? ( test ) !clang? ( test )"

--- a/llvm-runtimes/libcxx/libcxx-22.1.8.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-22.1.8.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libcxx.llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~riscv ~sparc x86 ~arm64-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~riscv ~s390 ~sparc x86 ~arm64-macos ~x64-macos"
 IUSE="+clang +libcxxabi +static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"

--- a/llvm-runtimes/openmp/openmp-22.1.8.ebuild
+++ b/llvm-runtimes/openmp/openmp-22.1.8.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://openmp.llvm.org"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv x86 ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ~mips ppc64 ~riscv ~s390 x86 ~x64-macos"
 IUSE="debug gdb-plugin hwloc ompt test"
 REQUIRED_USE="
 	gdb-plugin? ( ${PYTHON_REQUIRED_USE} )

--- a/profiles/arch/s390/s390x/make.defaults
+++ b/profiles/arch/s390/s390x/make.defaults
@@ -6,6 +6,7 @@ DEFAULT_ABI="s390x"
 ABI="${DEFAULT_ABI}"
 
 CHOST="s390x-ibm-linux-gnu"
+CHOST_s390x="s390x-ibm-linux-gnu"
 
 # Michał Górny <mgorny@gentoo.org> (2014-07-01)
 # Make the native ABI implicit so that MULTILIB_USEDEP can be satisfied

--- a/sci-mathematics/z3/z3-5.0.0.ebuild
+++ b/sci-mathematics/z3/z3-5.0.0.ebuild
@@ -14,7 +14,7 @@ S=${WORKDIR}/z3-${P}
 
 LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="doc examples gmp isabelle java python"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 

--- a/sys-apps/hwloc/hwloc-2.12.2.ebuild
+++ b/sys-apps/hwloc/hwloc-2.12.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="
 
 LICENSE="BSD"
 SLOT="0/15"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 IUSE="cairo +cpuid cuda debug doc l0 nvml +pci rocm selinux static-libs svg udev valgrind xml X video_cards_nvidia"
 
 # opencl: opencl support dropped with x11-drivers/ati-drivers being removed (bug #582406).


### PR DESCRIPTION
Following @akhuettel request to look into
keywording clang amd friends for s390x

### Keyword/testing 

No testing issues with lllvm

clang has one test fail, but doesn't seem 
overly important as I managed to build quite
packages using CC="clang"

```
Failed Tests (1):
  Clang :: Driver/no-canonical-prefixes.c


Testing Time: 5193.74s

Total Discovered Tests: 49758
  Skipped          :    10 (0.02%)
  Unsupported      :   644 (1.29%)
  Passed           : 49076 (98.63%)
  Expectedly Failed:    27 (0.05%)
  Failed           :     1 (0.00%)
FAILED: [code=1] test/CMakeFiles/check-clang /var/tmp/portage/llvm-core/clang-22.1.8/work/x/y/clang-abi_s390_64.s390x/test/CMakeFiles/check-clang
cd /var/tmp/portage/llvm-core/clang-22.1.8/work/x/y/clang-abi_s390_64.s390x/test && /usr/bin/python3.14 /var/tmp/portage/llvm-core/clang-22.1.8/work/x/y/clang-abi_s390_64.s390x/./bin/llvm-lit -vv -j 32 /var/tmp/portage/llvm-core/clang-22.1.8/work/x/y/clang-abi_s390_64.s390x/test
```

### profiles/arch/s390/s390x: Add CHOST_s390x

While trying to keyword clang for s390x I was
running into a mangled ln command.

This fix was found by pure dumb luck, so let
me explain how I got here to help with the
review.

I noticed the eclass log
for clang-common was hitting the multilib
eclass which led me to bug #515694
(What a jolly read that was...)

In the last comment I could see it was fixed
in 23.0 profiles. rather than the fix I found
https://github.com/gentoo/gentoo/commit/57fcb893661f1baf5e785acd862d7d6b19ea41cb

This made me notice every arch has a CHOST_arch
set expect s390x.

I then used the same same layout we are using
for amd64 in 23.0 and configured it for s390x.

Tried emerging clang-common again and this time
was successful.

(I wish I was this lucky playing the lotto.)

Closes: https://bugs.gentoo.org/979718
Closes: https://bugs.gentoo.org/979778

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
