### PR TITLE
www-client/opera-developer: fix CHROMIUM_VERSION

### DIFF
--- a/www-client/opera-developer/opera-developer-135.0.5960.0.ebuild
+++ b/www-client/opera-developer/opera-developer-135.0.5960.0.ebuild
@@ -31,7 +31,7 @@ fi
 # Commit ref from `strings libffmpeg.so | grep -F "FFmpeg version"` matches this Chromium version
 # or use Chromicler to handle bumps.
 # Does not _need_ to be updated for every new version of Opera, only when it breaks.
-CHROMIUM_VERSION="148"
+CHROMIUM_VERSION="150"
 SRC_URI="${SRC_URI_BASE[*]/%//${PV}/linux/${MY_PN}_${PV}_amd64.deb}"
 S=${WORKDIR}
 

--- a/www-client/opera-developer/opera-developer-135.0.5966.0.ebuild
+++ b/www-client/opera-developer/opera-developer-135.0.5966.0.ebuild
@@ -31,7 +31,7 @@ fi
 # Commit ref from `strings libffmpeg.so | grep -F "FFmpeg version"` matches this Chromium version
 # or use Chromicler to handle bumps.
 # Does not _need_ to be updated for every new version of Opera, only when it breaks.
-CHROMIUM_VERSION="148"
+CHROMIUM_VERSION="150"
 SRC_URI="${SRC_URI_BASE[*]/%//${PV}/linux/${MY_PN}_${PV}_amd64.deb}"
 S=${WORKDIR}
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/979714

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
