### PR TITLE
net-misc/openrsync: added missing ncompress dependency

### DIFF
--- a/net-misc/openrsync/openrsync-0.5.0_p20260706.ebuild
+++ b/net-misc/openrsync/openrsync-0.5.0_p20260706.ebuild
@@ -29,6 +29,7 @@ RESTRICT="!test? ( test )"
 
 # https://github.com/kristapsdz/openrsync/issues/46
 BDEPEND="
+	app-arch/ncompress
 	dev-build/bmake
 	test? (
 		app-misc/jot


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/979573

Adds missing ncompress dependency.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
