### PR TITLE
sys-auth/pambase: 9999* add USE for turnstile

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 
 # New entries go on top.
 
+# Emi <reedy.sailors.8t@icloud.com> (2026-07-30)
+# Turnstile is currently in ::guru
+sys-auth/pambase turnstile
+
 # Michael Orlitzky <mjo@gentoo.org> (2026-07-17)
 # Broke upstream, not an easy fix, bug 978718.
 >=net-analyzer/monitoring-plugins-3.0.1 snmp

--- a/profiles/default/hurd/package.use.mask
+++ b/profiles/default/hurd/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Emi <reedy.sailors.8t@icloud.com> (2026-07-30)
+# Turnstile is only being tested on Linux
+# running it on different kernels is likely to cause issues
+sys-auth/pambase turnstile
+
 # Sam James <sam@gentoo.org> (2026-03-10)
 # Fails to link
 net-libs/gnutls post-quantum

--- a/sys-auth/pambase/metadata.xml
+++ b/sys-auth/pambase/metadata.xml
@@ -100,6 +100,9 @@
 			relevant anymore as the login stack only refers to local logins
 			and local terminals imply secure access in the first place.
 		</flag>
+		<flag name="turnstile">
+			Use pam_turnstile module to register user sessions with turnstile.
+		</flag>
 	</use>
 	<upstream>
 		<remote-id type="gentoo">proj/pambase</remote-id>

--- a/sys-auth/pambase/pambase-999999999.ebuild
+++ b/sys-auth/pambase/pambase-999999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -24,7 +24,7 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="caps debug elogind gnome-keyring homed minimal mktemp +nullok pam_krb5 pam_ssh +passwdqc pwhistory pwquality securetty selinux sha512 sssd systemd +yescrypt"
+IUSE="caps debug elogind gnome-keyring homed minimal mktemp +nullok pam_krb5 pam_ssh +passwdqc pwhistory pwquality securetty selinux sha512 sssd systemd +yescrypt turnstile"
 
 RESTRICT="binchecks"
 
@@ -58,6 +58,7 @@ RDEPEND="
 	systemd? ( sys-apps/systemd[pam] )
 	yescrypt? ( sys-libs/libxcrypt[system] )
 	sssd? ( sys-auth/sssd )
+	turnstile? ( sys-apps/turnstile )
 "
 BDEPEND="
 	$(python_gen_any_dep '
@@ -97,6 +98,7 @@ src_configure() {
 		$(usev selinux '--selinux')
 		$(usex systemd '--systemd' '--openrc')
 		$(usev sssd '--sssd')
+		$(usev turnstile '--turnstile')
 
 		--encrypt=${crypt}
 	)


### PR DESCRIPTION
Since turnstile is currently in ::guru and unsupported on hurd it also masks the USEflag on both hurd and linux default profiles

Closes: https://bugs.gentoo.org/979600

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
