### PR TITLE
media-libs/gd: update HOMEPAGE

### DIFF
--- a/media-libs/gd/gd-2.3.3-r4.ebuild
+++ b/media-libs/gd/gd-2.3.3-r4.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit autotools flag-o-matic multilib-minimal
 
 DESCRIPTION="Graphics library for fast image creation"
-HOMEPAGE="https://libgd.org/ https://www.boutell.com/gd/"
+HOMEPAGE="https://libgd.github.io/ https://www.boutell.com/gd/"
 SRC_URI="https://github.com/libgd/libgd/releases/download/${P}/lib${P}.tar.xz"
 S="${WORKDIR}/lib${P}"
 


### PR DESCRIPTION
It looks like the libgd project lost control over their domain somewhere in March 2025 according to archive.org.

The domain now redirects to a gambling website.

Originally, the domain redirected to their GitHub.io page, so using the target now directly.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
