### PR TITLE
acct-user.eclass adjustments for shadow-4.20.0

### DIFF
--- a/eclass/acct-group.eclass
+++ b/eclass/acct-group.eclass
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 Gentoo Authors
+# Copyright 2019-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: acct-group.eclass
@@ -42,6 +42,10 @@ case ${EAPI} in
 esac
 
 inherit user-info
+
+case ${EAPI} in
+	7|8) inherit edo ;;
+esac
 
 [[ ${CATEGORY} == acct-group ]] ||
 	die "Ebuild error: this eclass can be used only in acct-group category!"
@@ -181,7 +185,7 @@ acct-group_pkg_preinst() {
 	fi
 
 	elog "Adding group ${ACCT_GROUP_NAME}"
-	groupadd "${opts[@]}" "${ACCT_GROUP_NAME}" || die "groupadd failed with status $?"
+	nonfatal edo groupadd "${opts[@]}" "${ACCT_GROUP_NAME}" || die "groupadd failed with status $?"
 }
 
 fi

--- a/eclass/acct-user.eclass
+++ b/eclass/acct-user.eclass
@@ -186,48 +186,6 @@ acct-user_add_deps() {
 }
 
 
-# << Helper functions >>
-
-# @FUNCTION: eislocked
-# @USAGE: <user>
-# @INTERNAL
-# @DESCRIPTION:
-# Check whether the specified user account is currently locked.
-# Returns 0 if it is locked, 1 if it is not, 2 if the platform
-# does not support determining it.
-eislocked() {
-	[[ $# -eq 1 ]] || die "usage: ${FUNCNAME} <user>"
-
-	if [[ ${EUID} -ne 0 || -n ${EPREFIX} ]]; then
-		einfo "Insufficient privileges to execute ${FUNCNAME[0]}"
-		return 0
-	fi
-
-	case ${CHOST} in
-	*-freebsd*|*-dragonfly*|*-netbsd*)
-		[[ $(egetent "$1" | cut -d: -f2) == '*LOCKED*'* ]]
-		;;
-
-	*-openbsd*)
-		return 2
-		;;
-
-	*)
-		# NB: 'no password' and 'locked' are indistinguishable
-		# but we also expire the account which is more clear
-		local shadow
-		if [[ -n "${ROOT}" ]]; then
-			shadow=$(grep "^$1:" "${ROOT}/etc/shadow")
-		else
-			shadow=$(getent shadow "$1")
-		fi
-
-		[[ $( echo ${shadow} | cut -d: -f2) == '!'* ]] &&
-			[[ $(echo ${shadow} | cut -d: -f8) == 1 ]]
-		;;
-	esac
-}
-
 # << Phase functions >>
 
 # @FUNCTION: acct-user_pkg_pretend
@@ -457,10 +415,13 @@ acct-user_pkg_postinst() {
 		--shell "${_ACCT_USER_SHELL}"
 		--gid "${groups[0]}"
 		--groups "${aux_groups// /,}"
+		--expiredate ""
 	)
 
-	if eislocked "${ACCT_USER_NAME}"; then
-		opts+=( --expiredate "" --unlock )
+	local pwhash=$(egetent shadow "${ACCT_USER_NAME}" | cut -d: -f2)
+	if [[ ${pwhash} != '!' && ${pwhash} = '!'* ]]; then
+		# Unlock the account if a password hash exists.
+		opts+=( --unlock )
 	fi
 
 	if [[ -n ${ROOT} ]]; then

--- a/eclass/acct-user.eclass
+++ b/eclass/acct-user.eclass
@@ -51,6 +51,10 @@ esac
 
 inherit user-info
 
+case ${EAPI} in
+	7|8) inherit edo ;;
+esac
+
 [[ ${CATEGORY} == acct-user ]] ||
 	die "Ebuild error: this eclass can be used only in acct-user category!"
 
@@ -340,7 +344,7 @@ acct-user_pkg_preinst() {
 		fi
 
 		elog "Adding user ${ACCT_USER_NAME}"
-		useradd "${opts[@]}" "${ACCT_USER_NAME}" || die "useradd failed with status $?"
+		nonfatal edo useradd "${opts[@]}" "${ACCT_USER_NAME}" || die "useradd failed with status $?"
 		_ACCT_USER_ADDED=1
 	fi
 
@@ -445,7 +449,7 @@ acct-user_pkg_postinst() {
 	fi
 
 	elog "Updating user ${ACCT_USER_NAME}"
-	usermod "${opts[@]}" "${ACCT_USER_NAME}"
+	nonfatal edo usermod "${opts[@]}" "${ACCT_USER_NAME}"
 	local status=$?
 	if [[ ${status} -eq 8 ]]; then
 		# usermod refused to update the home directory
@@ -509,7 +513,7 @@ acct-user_pkg_prerm() {
 	fi
 
 	elog "Locking user ${ACCT_USER_NAME}"
-	usermod "${opts[@]}" "${ACCT_USER_NAME}" || die "usermod failed with status $?"
+	nonfatal edo usermod "${opts[@]}" "${ACCT_USER_NAME}" || die "usermod failed with status $?"
 }
 
 fi

--- a/eclass/acct-user.eclass
+++ b/eclass/acct-user.eclass
@@ -445,30 +445,24 @@ acct-user_pkg_postinst() {
 	fi
 
 	elog "Updating user ${ACCT_USER_NAME}"
-	# usermod outputs a warning if unlocking the account would result in an
-	# empty password. Hide stderr in a text file and display it if usermod fails.
-	usermod "${opts[@]}" "${ACCT_USER_NAME}" 2>"${T}/usermod-error.log"
+	usermod "${opts[@]}" "${ACCT_USER_NAME}"
 	local status=$?
-	if [[ ${status} -ne 0 ]]; then
-		cat "${T}/usermod-error.log" >&2
-		if [[ ${status} -eq 8 ]]; then
-			# usermod refused to update the home directory
-			# for a uid with active processes.
-			eerror "Failed to update user ${ACCT_USER_NAME}"
-			eerror "This user currently has one or more running processes."
-			eerror "Please update this user manually with the following command:"
+	if [[ ${status} -eq 8 ]]; then
+		# usermod refused to update the home directory
+		# for a uid with active processes.
+		eerror "Failed to update user ${ACCT_USER_NAME}"
+		eerror "This user currently has one or more running processes."
+		eerror "Please update this user manually with the following command:"
 
-			# Surround opts with quotes.
-			# With bash-5 (EAPI 8), we can use "${opts[@]@Q}" instead.
-			local q="'"
-			local optsq=( "${opts[@]/#/${q}}" )
-			optsq=( "${optsq[@]/%/${q}}" )
+		# Surround opts with quotes.
+		# With bash-5 (EAPI 8), we can use "${opts[@]@Q}" instead.
+		local q="'"
+		local optsq=( "${opts[@]/#/${q}}" )
+		optsq=( "${optsq[@]/%/${q}}" )
 
-			eerror "  usermod ${optsq[*]} ${ACCT_USER_NAME}"
-		else
-			eerror "$(<"${T}/usermod-error.log")"
-			die "usermod failed with status ${status}"
-		fi
+		eerror "  usermod ${optsq[*]} ${ACCT_USER_NAME}"
+	elif [[ ${status} -ne 0 ]]; then
+		die "usermod failed with status ${status}"
 	fi
 }
 

--- a/eclass/user-info.eclass
+++ b/eclass/user-info.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: user-info.eclass
@@ -22,7 +22,7 @@ esac
 # Small wrapper for getent (Linux), nidump (< Mac OS X 10.5),
 # dscl (Mac OS X 10.5), and pw (FreeBSD) used in enewuser()/enewgroup().
 #
-# Supported databases: group passwd
+# Supported databases: group passwd shadow
 # Warning: This function can be used only in pkg_* phases when ROOT is valid.
 egetent() {
 	local db=$1 key=$2
@@ -30,7 +30,7 @@ egetent() {
 	[[ $# -ge 3 ]] && die "usage: egetent <database> <key>"
 
 	case ${db} in
-	passwd|group) ;;
+	group|passwd|shadow) ;;
 	*) die "sorry, database '${db}' not yet supported; file a bug" ;;
 	esac
 
@@ -63,7 +63,7 @@ egetent() {
 			type -p nscd >/dev/null && nscd -i "${db}" 2>/dev/null
 			getent "${db}" "${key}"
 		else
-			if [[ ${key} =~ ^[[:digit:]]+$ ]]; then
+			if [[ ${db} != shadow && ${key} =~ ^[[:digit:]]+$ ]]; then
 				grep -E "^([^:]*:){2}${key}:" "${ROOT}/etc/${db}"
 			else
 				grep "^${key}:" "${ROOT}/etc/${db}"


### PR DESCRIPTION
This PR is mainly to make acct-user.eclass compatible with shadow-4.20.0. I made some other improvements while I was touching the code.

Bug: https://bugs.gentoo.org/980084