### PR TITLE
dev-lang/php: fix TEST_PHP_* related issues

### DIFF
--- a/dev-lang/php/files/php-set-fpm-test-executable.patch
+++ b/dev-lang/php/files/php-set-fpm-test-executable.patch
@@ -1,5 +1,18 @@
+commit 37b570017659468c3b450067b0c4224b7849b395
+Author: Lothar Serra Mari <mail@serra.me>
+Date:   Thu Aug 6 14:07:33 2026 +0200
+
+    tests: Allow overriding TEST_PHP_EXECUTABLE for FPM SAPI
+    
+    The test suite derives the path to php-fpm from TEST_PHP_EXECUTABLE.
+    This fails on custom build directory layouts, leading to skipping all
+    php-fpm related tests.
+    
+    Users can provide TEST_PHP_FPM_EXECUTABLE for a custom binary path; if
+    this is unset, we'll fall back to TEST_PHP_EXECUTABLE instead.
+
 diff --git a/sapi/fpm/tests/tester.inc b/sapi/fpm/tests/tester.inc
-index 90798865433..91ba564edf8 100644
+index 9079886543..557f8c25e1 100644
 --- a/sapi/fpm/tests/tester.inc
 +++ b/sapi/fpm/tests/tester.inc
 @@ -225,7 +225,7 @@ class Tester
@@ -7,7 +20,7 @@ index 90798865433..91ba564edf8 100644
      static public function findExecutable(): bool|string
      {
 -        $phpPath = getenv("TEST_PHP_EXECUTABLE");
-+        $phpPath = getenv("TEST_PHP_FPM_EXECUTABLE");
++        $phpPath = getenv("TEST_PHP_FPM_EXECUTABLE") ?: getenv("TEST_PHP_EXECUTABLE");
          for ($i = 0; $i < 2; $i++) {
              $slashPosition = strrpos($phpPath, "/");
              if ($slashPosition) {

--- a/dev-lang/php/files/php-set-fpm-test-executable.patch
+++ b/dev-lang/php/files/php-set-fpm-test-executable.patch
@@ -1,0 +1,13 @@
+diff --git a/sapi/fpm/tests/tester.inc b/sapi/fpm/tests/tester.inc
+index 90798865433..91ba564edf8 100644
+--- a/sapi/fpm/tests/tester.inc
++++ b/sapi/fpm/tests/tester.inc
+@@ -225,7 +225,7 @@ class Tester
+      */
+     static public function findExecutable(): bool|string
+     {
+-        $phpPath = getenv("TEST_PHP_EXECUTABLE");
++        $phpPath = getenv("TEST_PHP_FPM_EXECUTABLE");
+         for ($i = 0; $i < 2; $i++) {
+             $slashPosition = strrpos($phpPath, "/");
+             if ($slashPosition) {

--- a/dev-lang/php/php-8.2.33.ebuild
+++ b/dev-lang/php/php-8.2.33.ebuild
@@ -147,6 +147,7 @@ PHP_MV="$(ver_cut 1)"
 PATCHES=(
 	"${FILESDIR}/php-iodbc-header-location.patch"
 	"${FILESDIR}/php-capstone-optional.patch"
+	"${FILESDIR}/php-set-fpm-test-executable.patch"
 	"${FILESDIR}/php-8.2.8-openssl-tests.patch"
 	"${FILESDIR}/php-8.2.20-implicit-printf.patch"
 	"${FILESDIR}/php-8.2.23-fix-ub.patch"
@@ -809,6 +810,10 @@ src_test() {
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
 		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+	fi
+
+	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
+		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then

--- a/dev-lang/php/php-8.3.33.ebuild
+++ b/dev-lang/php/php-8.3.33.ebuild
@@ -134,6 +134,7 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
+	"${FILESDIR}/php-set-fpm-test-executable.patch"
 	"${FILESDIR}/php-8.3.9-gd-cachevars.patch"
 	"${FILESDIR}/php-8.3.31-libgd-test-fixes.patch"
 	"${FILESDIR}/php-8.3.31-ipv6-printing-test-fix.patch"
@@ -729,6 +730,10 @@ src_test() {
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
 		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+	fi
+
+	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
+		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then

--- a/dev-lang/php/php-8.4.24.ebuild
+++ b/dev-lang/php/php-8.4.24.ebuild
@@ -135,6 +135,7 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
+	"${FILESDIR}/php-set-fpm-test-executable.patch"
 	"${FILESDIR}/php-8.3.31-ipv6-printing-test-fix.patch"
 )
 
@@ -727,6 +728,10 @@ src_test() {
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
 		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+	fi
+
+	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
+		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then

--- a/dev-lang/php/php-8.4.24.ebuild
+++ b/dev-lang/php/php-8.4.24.ebuild
@@ -747,6 +747,14 @@ src_test() {
 		$(usex test-full "--set-timeout 300" "") \
 		-d "session.save_path=${T}" \
 		|| die "tests failed"
+
+	# The variable TEST_PHP_EXECUTABLE is used by PHP's own
+	# install script, e.g. ext/phar/Makefile.frag.
+	#
+	# We have to unset it to guarantee a sane environment,
+	# otherwise we'll see spurious error messages during
+	# src_install().
+	unset TEST_PHP_EXECUTABLE
 }
 
 pkg_postinst() {

--- a/dev-lang/php/php-8.4.24.ebuild
+++ b/dev-lang/php/php-8.4.24.ebuild
@@ -718,7 +718,7 @@ src_install() {
 }
 
 src_test() {
-	export TEST_PHP_EXECUTABLE="${WORKDIR}/sapis-build/cli/sapi/cli/php"
+	local TEST_PHP_EXECUTABLE="${WORKDIR}/sapis-build/cli/sapi/cli/php"
 
 	# Sometimes when the sub-php launches a sub-sub-php, it uses these.
 	# Without an "-n" in all instances, the *live* php.ini can be loaded,
@@ -727,15 +727,18 @@ src_test() {
 	export TEST_PHP_EXTRA_ARGS="-n"
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
-		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+		local TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+		export TEST_PHP_CGI_EXECUTABLE
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
-		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
+		local TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
+		export TEST_PHP_FPM_EXECUTABLE
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then
-		export TEST_PHPDBG_EXECUTABLE="${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg"
+		local TEST_PHPDBG_EXECUTABLE="${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg"
+		export TEST_PHPDBG_EXECUTABLE
 	fi
 
 	# The IO capture tests need to be disabled because they fail when
@@ -752,14 +755,6 @@ src_test() {
 		$(usex test-full "--set-timeout 300" "") \
 		-d "session.save_path=${T}" \
 		|| die "tests failed"
-
-	# The variable TEST_PHP_EXECUTABLE is used by PHP's own
-	# install script, e.g. ext/phar/Makefile.frag.
-	#
-	# We have to unset it to guarantee a sane environment,
-	# otherwise we'll see spurious error messages during
-	# src_install().
-	unset TEST_PHP_EXECUTABLE
 }
 
 pkg_postinst() {

--- a/dev-lang/php/php-8.5.9.ebuild
+++ b/dev-lang/php/php-8.5.9.ebuild
@@ -717,7 +717,7 @@ src_install() {
 }
 
 src_test() {
-	export TEST_PHP_EXECUTABLE="${WORKDIR}/sapis-build/cli/sapi/cli/php"
+	local TEST_PHP_EXECUTABLE="${WORKDIR}/sapis-build/cli/sapi/cli/php"
 
 	# Sometimes when the sub-php launches a sub-sub-php, it uses these.
 	# Without an "-n" in all instances, the *live* php.ini can be loaded,
@@ -726,15 +726,18 @@ src_test() {
 	export TEST_PHP_EXTRA_ARGS="-n"
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
-		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+		local TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+		export TEST_PHP_CGI_EXECUTABLE
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
-		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
+		local TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
+		export TEST_PHP_FPM_EXECUTABLE
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then
-		export TEST_PHPDBG_EXECUTABLE="${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg"
+		local TEST_PHPDBG_EXECUTABLE="${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg"
+		export TEST_PHPDBG_EXECUTABLE
 	fi
 
 	# The IO capture tests need to be disabled because they fail when
@@ -751,14 +754,6 @@ src_test() {
 		$(usex test-full "--set-timeout 300" "") \
 		-d "session.save_path=${T}" \
 		|| die "tests failed"
-
-	# The variable TEST_PHP_EXECUTABLE is used by PHP's own
-	# install script, e.g. ext/phar/Makefile.frag.
-	#
-	# We have to unset it to guarantee a sane environment,
-	# otherwise we'll see spurious error messages during
-	# src_install().
-	unset TEST_PHP_EXECUTABLE
 }
 
 pkg_postinst() {

--- a/dev-lang/php/php-8.5.9.ebuild
+++ b/dev-lang/php/php-8.5.9.ebuild
@@ -136,6 +136,7 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
+	"${FILESDIR}/php-set-fpm-test-executable.patch"
 	"${FILESDIR}/php-8.3.31-ipv6-printing-test-fix.patch"
 )
 
@@ -726,6 +727,10 @@ src_test() {
 
 	if [[ -x "${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi" ]] ; then
 		export TEST_PHP_CGI_EXECUTABLE="${WORKDIR}/sapis-build/cgi/sapi/cgi/php-cgi"
+	fi
+
+	if [[ -x "${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm" ]] ; then
+		export TEST_PHP_FPM_EXECUTABLE="${WORKDIR}/sapis-build/fpm/sapi/fpm/php-fpm"
 	fi
 
 	if [[ -x "${WORKDIR}/sapis-build/phpdbg/sapi/phpdbg/phpdbg" ]] ; then

--- a/dev-lang/php/php-8.5.9.ebuild
+++ b/dev-lang/php/php-8.5.9.ebuild
@@ -746,6 +746,14 @@ src_test() {
 		$(usex test-full "--set-timeout 300" "") \
 		-d "session.save_path=${T}" \
 		|| die "tests failed"
+
+	# The variable TEST_PHP_EXECUTABLE is used by PHP's own
+	# install script, e.g. ext/phar/Makefile.frag.
+	#
+	# We have to unset it to guarantee a sane environment,
+	# otherwise we'll see spurious error messages during
+	# src_install().
+	unset TEST_PHP_EXECUTABLE
 }
 
 pkg_postinst() {


### PR DESCRIPTION
For src_test() to work, we need to export TEST_PHP_EXECUTABLE since this variable is used by PHP itself when running the test suite.

However, this variable is _also_ used in the Makefile fragments, e.g. ext/phar/Makefile.frag. This fragment uses the TEST_PHP_EXECUTABLE variable locally without unsetting/cleaning it first.

We need to unset this variable to prevent spurious error messages regarding shell invocation during src_install() when using "FEATURES=test":

```
make -j12 INSTALL_ROOT=/var/tmp/portage/dev-lang/php-8.5.9/image install-pharcmd
 * Installing SAPI: fpm
 * Installing php.ini for fpm into /etc/php/fpm-php8.5
 *
 * Installing FPM config files php-fpm.conf and www.conf
make -j12 INSTALL_ROOT=/var/tmp/portage/dev-lang/php-8.5.9/image install-headers
/bin/sh: - : invalid option
Usage:  /bin/sh [GNU long option] [option] ...
        /bin/sh [GNU long option] [option] script-file ...
```
```
Installing header files:          /var/tmp/portage/dev-lang/php-8.5.9/image/usr/lib64/php8.5/include/php/
make -j12 INSTALL_ROOT=/var/tmp/portage/dev-lang/php-8.5.9/image install-fpm
/bin/sh: - : invalid option
Usage:  /bin/sh [GNU long option] [option] ...
        /bin/sh [GNU long option] [option] script-file ...
```

I usually only check if the test suite itself passes and emerge runs without error messages, so I did not catch this earlier. However, I did not notice stuff breaking (phar was still installed) without this patch, but we really should fix this anyway.

After applying this patch, `php8:4` and `php8:5` install cleanly even after running the test suite.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
