### PR TITLE
net-misc/passt: workaround missing close_range for musl

### DIFF
--- a/net-misc/passt/files/passt-2026.07.28-musl.patch
+++ b/net-misc/passt/files/passt-2026.07.28-musl.patch
@@ -1,0 +1,22 @@
+--- a/isolation.c	2026-07-29 00:10:08.000000000 +0800
++++ b/isolation.c	2026-08-04 19:06:17.639471000 +0800
+@@ -98,6 +98,19 @@
+ #define CAP_VERSION	_LINUX_CAPABILITY_VERSION_3
+ #define CAP_WORDS	_LINUX_CAPABILITY_U32S_3
+ 
++#if defined(__linux__) && defined(__NR_close_range)
++
++#ifndef CLOSE_RANGE_UNSHARE
++#define CLOSE_RANGE_UNSHARE	(1U << 1)
++#endif
++
++static inline int close_range(unsigned int first, unsigned int last, int flags)
++{
++	return syscall(__NR_close_range, first, last, flags);
++}
++
++#endif
++
+ /**
+  * drop_caps_ep_except() - Drop capabilities from effective & permitted sets
+  * @keep:	Capabilities to keep

--- a/net-misc/passt/files/passt-2026.07.28-musl.patch
+++ b/net-misc/passt/files/passt-2026.07.28-musl.patch
@@ -1,22 +1,24 @@
---- a/isolation.c	2026-07-29 00:10:08.000000000 +0800
-+++ b/isolation.c	2026-08-04 19:06:17.639471000 +0800
-@@ -98,6 +98,19 @@
- #define CAP_VERSION	_LINUX_CAPABILITY_VERSION_3
- #define CAP_WORDS	_LINUX_CAPABILITY_U32S_3
+--- a/Makefile
++++ b/Makefile
+@@ -48,8 +48,8 @@
  
-+#if defined(__linux__) && defined(__NR_close_range)
-+
-+#ifndef CLOSE_RANGE_UNSHARE
-+#define CLOSE_RANGE_UNSHARE	(1U << 1)
-+#endif
-+
-+static inline int close_range(unsigned int first, unsigned int last, int flags)
-+{
-+	return syscall(__NR_close_range, first, last, flags);
-+}
-+
-+#endif
-+
- /**
-  * drop_caps_ep_except() - Drop capabilities from effective & permitted sets
-  * @keep:	Capabilities to keep
+ PASST_HEADERS = arch.h arp.h bitmap.h checksum.h conf.h dhcp.h dhcpv6.h \
+ 	epoll_ctl.h flow.h fwd.h fwd_rule.h flow_table.h icmp.h icmp_flow.h \
+-	inany.h iov.h ip.h isolation.h lineread.h log.h migrate.h ndp.h \
+-	netlink.h packet.h parse.h passt.h pasta.h pcap.h pif.h repair.h \
++	inany.h iov.h ip.h isolation.h lineread.h linux_dep.h log.h migrate.h \
++	ndp.h netlink.h packet.h parse.h passt.h pasta.h pcap.h pif.h repair.h \
+ 	serialise.h siphash.h tap.h tcp.h tcp_buf.h tcp_conn.h tcp_internal.h \
+ 	tcp_splice.h tcp_vu.h udp.h udp_flow.h udp_internal.h udp_vu.h util.h \
+ 	vhost_user.h virtio.h vu_common.h
+
+--- a/isolation.c
++++ b/isolation.c
+@@ -89,6 +89,7 @@
+ #include <linux/seccomp.h>
+ 
+ #include "util.h"
++#include "linux_dep.h"
+ #include "seccomp.h"
+ #include "passt.h"
+ #include "log.h"

--- a/net-misc/passt/passt-2026.07.28.ebuild
+++ b/net-misc/passt/passt-2026.07.28.ebuild
@@ -23,6 +23,8 @@ LICENSE="BSD GPL-2+"
 SLOT="0"
 IUSE="static"
 
+PATCHES=( "${FILESDIR}/${PN}-2026.07.28-musl.patch" )
+
 src_prepare() {
 	default
 	tc-export CC

--- a/net-misc/passt/passt-9999.ebuild
+++ b/net-misc/passt/passt-9999.ebuild
@@ -23,6 +23,8 @@ LICENSE="BSD GPL-2+"
 SLOT="0"
 IUSE="static"
 
+PATCHES=( "${FILESDIR}/${PN}-2026.07.28-musl.patch" )
+
 src_prepare() {
 	default
 	tc-export CC


### PR DESCRIPTION
This implements the missing `close_range()` for musl, and defines `CLOSE_RANGE_UNSHARE`.

n.b., I haven't filed a bug to the upstream (https://passt.top/passt/bugs) since I failed to create an account on their Bugzilla. Wish someone could help contacting the upstream about this, as well as the suspicious `__attribute__((optimize("-fno-strict-aliasing")))` which is not supported by clang as well.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
