### PR TITLE
dev-lisp/sbcl: add pkg_postinst note about SBCL_HOME

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.5.11.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.5.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -271,4 +271,14 @@ src_install() {
 	echo "SBCL_HOME=${EPREFIX}/usr/$(get_libdir)/${PN}" > "${ENVD}"
 	echo "SBCL_SOURCE_ROOT=${EPREFIX}/usr/$(get_libdir)/${PN}/src" >> "${ENVD}"
 	doenvd "${ENVD}"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "SBCL_HOME is set through /etc/env.d/50sbcl. On a first"
+		elog "installation, shells that are already running still have a"
+		elog "stale environment, so sbcl cannot locate its core file."
+		elog "Run 'source /etc/profile' in each affected shell, or start"
+		elog "a new login session."
+	fi
 }

--- a/dev-lisp/sbcl/sbcl-2.5.4.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.5.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -267,4 +267,14 @@ src_install() {
 	echo "SBCL_HOME=${EPREFIX}/usr/$(get_libdir)/${PN}" > "${ENVD}"
 	echo "SBCL_SOURCE_ROOT=${EPREFIX}/usr/$(get_libdir)/${PN}/src" >> "${ENVD}"
 	doenvd "${ENVD}"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "SBCL_HOME is set through /etc/env.d/50sbcl. On a first"
+		elog "installation, shells that are already running still have a"
+		elog "stale environment, so sbcl cannot locate its core file."
+		elog "Run 'source /etc/profile' in each affected shell, or start"
+		elog "a new login session."
+	fi
 }

--- a/dev-lisp/sbcl/sbcl-2.6.5.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.6.5.ebuild
@@ -269,3 +269,13 @@ src_install() {
 	echo "SBCL_SOURCE_ROOT=${EPREFIX}/usr/$(get_libdir)/${PN}/src" >> "${ENVD}"
 	doenvd "${ENVD}"
 }
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "SBCL_HOME is set through /etc/env.d/50sbcl. On a first"
+		elog "installation, shells that are already running still have a"
+		elog "stale environment, so sbcl cannot locate its core file."
+		elog "Run 'source /etc/profile' in each affected shell, or start"
+		elog "a new login session."
+	fi
+}

--- a/dev-lisp/sbcl/sbcl-2.6.6.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.6.6.ebuild
@@ -269,3 +269,13 @@ src_install() {
 	echo "SBCL_SOURCE_ROOT=${EPREFIX}/usr/$(get_libdir)/${PN}/src" >> "${ENVD}"
 	doenvd "${ENVD}"
 }
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "SBCL_HOME is set through /etc/env.d/50sbcl. On a first"
+		elog "installation, shells that are already running still have a"
+		elog "stale environment, so sbcl cannot locate its core file."
+		elog "Run 'source /etc/profile' in each affected shell, or start"
+		elog "a new login session."
+	fi
+}

--- a/dev-lisp/sbcl/sbcl-2.6.7.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.6.7.ebuild
@@ -269,3 +269,13 @@ src_install() {
 	echo "SBCL_SOURCE_ROOT=${EPREFIX}/usr/$(get_libdir)/${PN}/src" >> "${ENVD}"
 	doenvd "${ENVD}"
 }
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog "SBCL_HOME is set through /etc/env.d/50sbcl. On a first"
+		elog "installation, shells that are already running still have a"
+		elog "stale environment, so sbcl cannot locate its core file."
+		elog "Run 'source /etc/profile' in each affected shell, or start"
+		elog "a new login session."
+	fi
+}


### PR DESCRIPTION
On a first installation, /etc/env.d/50sbcl is not yet reflected in already-running shells, so sbcl fails to locate sbcl.core. Point users at re-sourcing /etc/profile or starting a new session.

Closes: https://bugs.gentoo.org/979792

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
