### PR TITLE
sci-ml/pytorch: unbundle dev-cpp/cpp-httplib for distributed build

### DIFF
--- a/sci-ml/pytorch/files/pytorch-2.13.0-unbundle_httplib.patch
+++ b/sci-ml/pytorch/files/pytorch-2.13.0-unbundle_httplib.patch
@@ -1,0 +1,32 @@
+Link to system shared httplib instead of using bundled header-only version
+
+Bug: https://bugs.gentoo.org/980398
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -1338,8 +1338,9 @@ if(USE_KINETO)
+     ${TORCH_ROOT}/third_party/kineto/libkineto/src)
+ endif()
+ 
+-target_include_directories(torch_cpu PRIVATE
+-  ${TORCH_ROOT}/third_party/cpp-httplib)
++if(USE_DISTRIBUTED)
++  target_link_libraries(torch_cpu PRIVATE httplib)
++endif()
+ 
+ target_include_directories(torch_cpu PRIVATE
+   ${TORCH_ROOT}/third_party/nlohmann/include)
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -1732,8 +1732,10 @@ include(${CMAKE_CURRENT_LIST_DIR}/FlatBuffers.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/FlatBuffers.cmake)
+ 
+ # Include cpp-httplib
+-add_library(httplib INTERFACE IMPORTED)
+-target_include_directories(httplib SYSTEM INTERFACE ${PROJECT_SOURCE_DIR}/third_party/cpp-httplib)
++if(USE_DISTRIBUTED)
++  find_package(httplib REQUIRED)
++  add_library(httplib ALIAS httplib::httplib)
++endif()
+ 
+ # Include nlohmann-json
+ add_library(nlohmann INTERFACE IMPORTED)

--- a/sci-ml/pytorch/pytorch-2.13.0-r3.ebuild
+++ b/sci-ml/pytorch/pytorch-2.13.0-r3.ebuild
@@ -85,6 +85,7 @@ RDEPEND="
 	)
 	distributed? (
 		!rocm? ( sci-ml/tensorpipe[cuda?] )
+		dev-cpp/cpp-httplib:=
 	)
 	fbgemm? ( >=sci-ml/FBGEMM-1.4 )
 	gloo? ( >=sci-ml/gloo-2025.06.04[cuda?,rocm?] )
@@ -148,7 +149,6 @@ DEPEND="
 		dev-python/typing-extensions[${PYTHON_USEDEP}]
 	')
 	cuda? ( ~dev-libs/cutlass-4.4.2[tools(+)] )
-	distributed? ( dev-cpp/cpp-httplib:= )
 	onednn? ( sci-ml/ideep )
 	rocm? (
 		>=sci-libs/hipCUB-6.3:=    <sci-libs/hipCUB-7.3:=
@@ -169,6 +169,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-unbundle_flatbuffers.patch
 	"${FILESDIR}"/${P}-unbundle_fmt.patch
 	"${FILESDIR}"/${P}-unbundle_fxdiv.patch
+	"${FILESDIR}"/${P}-unbundle_httplib.patch
 	"${FILESDIR}"/${P}-unbundle_kineto.patch
 	"${FILESDIR}"/${P}-unbundle_mkldnn.patch
 	"${FILESDIR}"/${P}-unbundle_nnpack.patch


### PR DESCRIPTION
Link to system shared httplib instead of using bundled header-only version

Closes: https://bugs.gentoo.org/980398

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
