### PR TITLE
sys-devel/gcc: fix typo in `metadata.xml`

### DIFF
--- a/sys-devel/gcc/metadata.xml
+++ b/sys-devel/gcc/metadata.xml
@@ -131,7 +131,7 @@
 		<flag name="vtv">
 			Build support for virtual table verification (a C++ hardening feature).
 
-			This does not control whether GCC defaults to using VTV>
+			This does not control whether GCC defaults to using VTV.
 
 			Note that actually using VTV breaks ABI and hence the whole
 			system must be built with -fvtable-verify.


### PR DESCRIPTION
it had a `>` instead of a `.`

Signed-off-by: ruby-R53 <enkiferreiracosta867@gmail.com>

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
