### PR TITLE
app-i18n/fcitx: add plasma USE flag for plasma-wayland-protocols

### DIFF
--- a/app-i18n/fcitx/fcitx-5.1.21.ebuild
+++ b/app-i18n/fcitx/fcitx-5.1.21.ebuild
@@ -15,11 +15,12 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 LICENSE="LGPL-2+ Unicode-DFS-2016"
 SLOT="5"
 KEYWORDS="amd64 arm64 ~ppc ~ppc64 ~riscv x86"
-IUSE="+autostart doc +emoji +enchant +keyboard presage +server systemd system-yoga test wayland +X"
+IUSE="+autostart doc +emoji +enchant +keyboard +plasma presage +server systemd system-yoga test wayland +X"
 REQUIRED_USE="
 	|| ( wayland X )
 	X? ( keyboard )
 	wayland? ( keyboard )
+	plasma? ( wayland )
 "
 
 RESTRICT="!test? ( test )"
@@ -71,7 +72,7 @@ RDEPEND="
 	)
 "
 DEPEND="${RDEPEND}
-	wayland? (
+	plasma? (
 		dev-libs/plasma-wayland-protocols
 	)
 "
@@ -100,6 +101,7 @@ src_configure() {
 		-DENABLE_DOC=$(usex doc)
 		-DUSE_SYSTEMD=$(usex systemd)
 		-DUSE_SYSTEM_YOGA=$(usex system-yoga)
+		-DUSE_SYSTEM_PLASMA_WAYLAND_PROTOCOLS=$(usex plasma)
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Since 5.1.21 `plasma-wayland-protocols` is unconditionally pulled in, which brings Qt/Plasma dependencies that non-Plasma users don't need.
This change introduces `plasma` USE flag to gate it.
See also https://github.com/fcitx/fcitx5/pull/1634
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
