### PR TITLE
app-containers/docker-buildx: sync live

### DIFF
--- a/app-containers/docker-buildx/docker-buildx-9999.ebuild
+++ b/app-containers/docker-buildx/docker-buildx-9999.ebuild
@@ -19,11 +19,11 @@ fi
 
 LICENSE="Apache-2.0"
 # Dependent licenses
-LICENSE+=" Apache-2.0 BSD BSD-2 ISC MIT MPL-2.0"
+LICENSE+=" Apache-2.0 BSD BSD-2 ISC MIT MPL-2.0 Unicode-DFS-2016"
 SLOT="0"
 
 RDEPEND="app-containers/docker-cli"
-BDEPEND=">=dev-lang/go-1.25.5"
+BDEPEND=">=dev-lang/go-1.26.3"
 
 src_compile() {
 	local _buildx_r='github.com/docker/buildx'


### PR DESCRIPTION
Update app-containers/docker-buildx live ebuild from 0.36.1. Prior to this live builds were failing with the following error:

```
>>> Failed to emerge app-containers/docker-buildx-9999, Log file:

>>>  '/var/tmp/portage/app-containers/docker-buildx-9999/temp/build.log'

 * Messages for package app-containers/docker-buildx-9999:

 * ERROR: app-containers/docker-buildx-9999::gentoo failed:
 *   Update BDEPEND with >=dev-lang/go-1.26.3:=
 * Call stack:
 *    misc-functions.sh, line 740:  Called install_qa_check
 *    misc-functions.sh, line 129:  Called source 'install_symlink_html_docs'
 *   60go-module-eclass, line  37:  Called go_ver_check
 *   60go-module-eclass, line  33:  Called die
 * The specific snippet of code:
 *              [[ ${EAPI} != 8 ]] && die "Update BDEPEND with >=dev-lang/go-${go_mod_version}:="
 * If you need support, post the output of `emerge --info '=app-containers/docker-buildx-9999::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=app-containers/docker-buildx-9999::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/app-containers/docker-buildx-9999/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/app-containers/docker-buildx-9999/temp/environment'.
 * Working directory: '/var/tmp/portage/app-containers/docker-buildx-9999/image'
 * S: '/var/tmp/portage/app-containers/docker-buildx-9999/work/docker-buildx-9999'
 * 
 * The following package has failed to build, install, or execute postinst:
 * 
 *  (app-containers/docker-buildx-9999:0/0::gentoo, ebuild scheduled for merge), Log file:
 *   '/var/tmp/portage/app-containers/docker-buildx-9999/temp/build.log'
 * 
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
