### PR TITLE
wine.eclass: Symlink fex-xtajit unixlib if present

### DIFF
--- a/eclass/wine.eclass
+++ b/eclass/wine.eclass
@@ -57,8 +57,8 @@ REQUIRED_USE="
 "
 
 RDEPEND="
-	arm64? ( wow64? ( app-emulation/fex-xtajit[wow64(+)] ) )
-	arm64ec? ( app-emulation/fex-xtajit[arm64ec(-)] )
+	arm64? ( wow64? ( >=app-emulation/fex-xtajit-2608[wow64(+)] ) )
+	arm64ec? ( >=app-emulation/fex-xtajit-2608[arm64ec(-)] )
 "
 BDEPEND="
 	|| (
@@ -408,13 +408,23 @@ wine_src_install() {
 		fi
 	fi
 
-	use arm64 && use wow64 &&
-		dosym -r /usr/lib/fex-xtajit/libwow64fex.dll \
-			${WINE_PREFIX}/wine/aarch64-windows/xtajit.dll
+	if use arm64; then
+		if use wow64; then
+			dosym -r /usr/lib/fex-xtajit/libwow64fex.dll \
+				${WINE_PREFIX}/wine/aarch64-windows/xtajit.dll
 
-	use arm64ec &&
-		dosym -r /usr/lib/fex-xtajit/libarm64ecfex.dll \
-			${WINE_PREFIX}/wine/aarch64-windows/xtajit64.dll
+			dosym -r /usr/lib/fex-xtajit/libwow64fex.so \
+				${WINE_PREFIX}/wine/aarch64-unix/libwow64fex.so
+		fi
+
+		if use arm64ec; then
+			dosym -r /usr/lib/fex-xtajit/libarm64ecfex.dll \
+				${WINE_PREFIX}/wine/aarch64-windows/xtajit64.dll
+
+			dosym -r /usr/lib/fex-xtajit/libarm64ecfex.so \
+				${WINE_PREFIX}/wine/aarch64-unix/libarm64ecfex.so
+		fi
+	fi
 
 	# delete unwanted files if requested, not done directly in ebuilds
 	# given must be done after install and before wrappers


### PR DESCRIPTION
FEX will soon require a *nix-side library for its xtajit implementation. Check to see if it has been built by the user's fex-xtajit ebuild and automatically symlink it into `aarch64-unix` like we do with the Windows-side libraries.

The current fex-xtajit version in ::gentoo does not yet build the unixlib as it is two versions behind, however it is present in the Asahi overlay as of https://github.com/chadmed/asahi-overlay/commit/c456c7e60a305bbb4c6494d14bc602a4193ba6e5.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
