### PR TITLE
dev-lang/perl: Add missing sys-libs/timezone-data dependency

### DIFF
--- a/dev-lang/perl/perl-5.44.0.ebuild
+++ b/dev-lang/perl/perl-5.44.0.ebuild
@@ -65,6 +65,7 @@ RDEPEND="
 	app-arch/bzip2
 	>=virtual/zlib-1.2.12:=
 	virtual/libcrypt:=
+	sys-libs/timezone-data
 "
 DEPEND="${RDEPEND}"
 BDEPEND="${RDEPEND}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/980411

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
