### PR TITLE
dev-perl/Config-AutoConf: Fix flex is executable test failure

### DIFF
--- a/dev-perl/Config-AutoConf/Config-AutoConf-0.320.0.ebuild
+++ b/dev-perl/Config-AutoConf/Config-AutoConf-0.320.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,3 +28,7 @@ BDEPEND="${RDEPEND}
 	virtual/perl-ExtUtils-MakeMaker
 	test? ( >=virtual/perl-Test-Simple-0.900.0 )
 "
+
+PATCHES=(
+	"${FILESDIR}"/Config-AutoConf-0.320.0-flex.patch
+)

--- a/dev-perl/Config-AutoConf/files/Config-AutoConf-0.320.0-flex.patch
+++ b/dev-perl/Config-AutoConf/files/Config-AutoConf-0.320.0-flex.patch
@@ -1,0 +1,44 @@
+From ced7abc24ed75ceb2d89afd22a914bdc0d35b498 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alberto=20Sim=C3=B5es?= <alberto.simoes@tiobe.com>
+Date: Thu, 23 Jul 2026 14:54:14 +0100
+Subject: [PATCH] t/01.checkprog.t: resolve bare command names via PATH before
+ -x check
+
+check_prog_{lex,yacc,awk,sed} honor $ENV{LEX}/$ENV{YACC}/... verbatim,
+which is correct autoconf-style override behavior (also allows
+multi-word values like "bison -y"). But the executable-bit test ran
+-x directly on the raw value, which only works for absolute paths.
+On Gentoo, LEX/YACC etc are exported as bare command names (e.g.
+LEX=flex), so the test failed even though the program was installed
+and on PATH. Resolve bare names the same way the shell would before
+checking -x.
+
+Fixes #18
+---
+ t/01.checkprog.t | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/t/01.checkprog.t b/t/01.checkprog.t
+index e46b114907a82a2005d902fd80f423697321635f..c960c0c2d59a309eec21514475f9a6de5e995d1e 100644
+--- a/t/01.checkprog.t
++++ b/t/01.checkprog.t
+@@ -60,8 +60,17 @@ diag("Check for some progs to get an overview about world outside");
+ 
+ sub _is_x
+ {
+-    $^O =~ m/MSWin32/i and return $_[0] =~ m/\.(?:exe|com|bat|cmd)$/;
+-    return -x $_[0];
++    my ($bin) = @_;
++    $^O =~ m/MSWin32/i and return $bin =~ m/\.(?:exe|com|bat|cmd)$/;
++
++    # A bare command name (no directory component) is only resolvable via
++    # $PATH at exec time, not with -x on the literal string; e.g. Gentoo
++    # exports LEX=flex, YACC=bison etc without an absolute path. Resolve it
++    # the same way the shell would before checking for executability.
++    File::Spec->file_name_is_absolute($bin)
++      or $bin = Config::AutoConf->check_prog($bin) || $bin;
++
++    return -x $bin;
+ }
+ 
+ SKIP:


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/887345
Closes: https://bugs.gentoo.org/911747

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
