### PR TITLE
media-video/vlc: Add qt6 dependencies for 3.0.9999

### DIFF
--- a/media-video/vlc/vlc-3.0.9999.ebuild
+++ b/media-video/vlc/vlc-3.0.9999.ebuild
@@ -29,7 +29,7 @@ else
 	fi
 	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv -sparc ~x86"
 fi
-inherit autotools flag-o-matic lua-single toolchain-funcs virtualx xdg-utils
+inherit autotools flag-o-matic lua-single toolchain-funcs virtualx xdg
 
 DESCRIPTION="Media player and framework with support for most multimedia files and streaming"
 HOMEPAGE="https://www.videolan.org/vlc/"
@@ -39,12 +39,12 @@ SLOT="0/5-9" # vlc - vlccore
 
 IUSE="alsa aom archive aribsub bidi bluray chromaprint chromecast dav1d dbus
 	dc1394 debug directx +dvbpsi dvd +encode faad fdk +ffmpeg flac fluidsynth
-	fontconfig +gcrypt gme keyring gstreamer ieee1394 jack jpeg kate libass
-	libcaca libnotify +libsamplerate libtiger linsys lirc live lua mad matroska
-	modplug mp3 mtp musepack ncurses nfs ogg omxil optimisememory opus png
-	projectm pulseaudio run-as-root samba selinux sftp shout sid soxr speex srt ssl svg
-	taglib theora tremor truetype twolame udev upnp vaapi v4l vdpau vnc vpx
-	wayland +X x264 x265 xml zeroconf zvbi
+	fontconfig +gcrypt gme keyring gstreamer +gui ieee1394 jack jpeg kate
+	libass libcaca libnotify +libsamplerate libtiger linsys lirc live lua
+	mad matroska modplug mp3 mtp musepack ncurses nfs ogg
+	omxil optimisememory opus png projectm pulseaudio run-as-root samba selinux
+	sftp shout sid skins soxr speex srt ssl svg taglib theora tremor truetype twolame
+	udev upnp vaapi v4l vdpau vnc vpx wayland +X x264 x265 xml zeroconf zvbi
 	cpu_flags_arm_neon cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse
 "
 REQUIRED_USE="
@@ -54,6 +54,7 @@ REQUIRED_USE="
 	libcaca? ( X )
 	libtiger? ( kate )
 	lua? ( ${LUA_REQUIRED_USE} )
+	skins? ( archive gui truetype X xml )
 	ssl? ( gcrypt )
 	vaapi? ( ffmpeg X )
 	vdpau? ( ffmpeg X )
@@ -121,6 +122,16 @@ RDEPEND="
 	gme? ( media-libs/game-music-emu )
 	keyring? ( app-crypt/libsecret )
 	gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
+	gui? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtsvg:5
+		dev-qt/qtwidgets:5
+		X? (
+			dev-qt/qtx11extras:5
+			x11-libs/libX11
+		)
+	)
 	ieee1394? (
 		sys-libs/libavc1394
 		sys-libs/libraw1394
@@ -168,6 +179,11 @@ RDEPEND="
 	sftp? ( net-libs/libssh2 )
 	shout? ( media-libs/libshout )
 	sid? ( media-libs/libsidplay:2 )
+	skins? (
+		x11-libs/libXext
+		x11-libs/libXinerama
+		x11-libs/libXpm
+	)
 	soxr? ( >=media-libs/soxr-0.1.2 )
 	speex? (
 		>=media-libs/speex-1.2.0
@@ -230,11 +246,6 @@ PATCHES=(
 pkg_setup() {
 	if use lua; then
 		lua-single_pkg_setup
-	fi
-
-	if has_version "<=media-video/vlc-3.0.9999[gui]"; then
-		ewarn "Warning: User interface no longer available in VLC 3.x (Qt5 is dead)."
-		ewarn "media-video/vlc-4 is available in ~arch with Qt6-based GUI instead."
 	fi
 }
 
@@ -328,6 +339,7 @@ src_configure() {
 		$(use_enable gme)
 		$(use_enable keyring secret)
 		$(use_enable gstreamer gst-decode)
+		$(use_enable gui qt)
 		$(use_enable ieee1394 dv1394)
 		$(use_enable jack)
 		$(use_enable jpeg)
@@ -362,6 +374,7 @@ src_configure() {
 		$(use_enable sftp)
 		$(use_enable shout)
 		$(use_enable sid)
+		$(use_enable skins skins2)
 		$(use_enable soxr)
 		$(use_enable speex)
 		$(use_enable srt)
@@ -413,19 +426,17 @@ src_configure() {
 		--disable-opensles
 		--disable-oss
 		--disable-osx-notifications # MacOS only
-		--disable-qt # Qt5-based; bug #954006
 		--disable-rpi-omxil
 		--disable-schroedinger
 		--disable-sdl-image # not officially supported anymore
 		--disable-shine
-		--disable-skins2 # requires Qt5-based IUSE gui
 		--disable-sndio
 		--disable-spatialaudio
 		--disable-vsxu
 		--disable-wasapi
 		--disable-wma-fixed
 	)
-	# ^ We don't have these disabled libraries in the Portage tree yet/anymore.
+	# ^ We don't have these disabled libraries in the Portage tree yet.
 
 	# https://code.videolan.org/videolan/vlc/-/issues/17626 (bug #861143)
 	append-flags -fno-strict-aliasing
@@ -480,7 +491,10 @@ src_test() {
 src_install() {
 	default
 	find "${ED}" -name '*.la' -delete || die
-	rm "${ED}"/usr/share/applications/*desktop || die
+
+	if ! use gui; then
+		rm "${ED}"/usr/share/applications/*desktop || die
+	fi
 }
 
 pkg_postinst() {
@@ -492,10 +506,14 @@ pkg_postinst() {
 		ewarn "Please run ${EPREFIX}/usr/$(get_libdir)/vlc/vlc-cache-gen manually"
 		ewarn "If you do not do it, vlc will take a long time to load."
 	fi
+
+	use gui && xdg_pkg_postinst
 }
 
 pkg_postrm() {
 	if [[ -e "${EROOT}"/usr/$(get_libdir)/vlc/plugins/plugins.dat ]]; then
 		rm "${EROOT}"/usr/$(get_libdir)/vlc/plugins/plugins.dat || die "Failed to rm plugins.dat"
 	fi
+
+	use gui && xdg_pkg_postrm
 }

--- a/media-video/vlc/vlc-3.0.9999.ebuild
+++ b/media-video/vlc/vlc-3.0.9999.ebuild
@@ -123,12 +123,11 @@ RDEPEND="
 	keyring? ( app-crypt/libsecret )
 	gstreamer? ( >=media-libs/gst-plugins-base-1.4.5:1.0 )
 	gui? (
-		dev-qt/qtcore:5
-		dev-qt/qtgui:5
-		dev-qt/qtsvg:5
-		dev-qt/qtwidgets:5
+		dev-qt/qtbase:6=[gui,opengl,widgets]
+		dev-qt/qtdeclarative:6
+		dev-qt/qtsvg:6
 		X? (
-			dev-qt/qtx11extras:5
+			dev-qt/qtbase:6[X]
 			x11-libs/libX11
 		)
 	)
@@ -259,6 +258,9 @@ src_prepare() {
 	if [[ ${PV} == *9999* || ${PV} == *_p[0-9]* ]] ; then
 		./bootstrap
 	fi
+
+	# Disable qt5
+	sed -i 's/Qt5Svg/Qt5Svg Qt5DisableDetection/' configure.ac
 
 	# Make it build with libtool 1.5
 	rm m4/lt* m4/libtool.m4 || die


### PR DESCRIPTION
Revert "media-video/vlc: 3.0.9999 Qt5 cleanup: Drop IUSE gui, skins"
media-video/vlc: Add qt6 dependencies for 3.0.9999

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
