### PR TITLE
app-containers/aardvark-dns: fix musl close_range

### DIFF
--- a/app-containers/aardvark-dns/aardvark-dns-2.1.0.ebuild
+++ b/app-containers/aardvark-dns/aardvark-dns-2.1.0.ebuild
@@ -29,6 +29,10 @@ QA_FLAGS_IGNORED="usr/libexec/podman/${PN}"
 QA_PRESTRIPPED="usr/libexec/podman/${PN}"
 ECARGO_VENDOR="${WORKDIR}/vendor"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.1.0-musl-close_range.patch #bug #980641, fixed in >2.1.0
+)
+
 src_unpack() {
 	if [[ ${PV} == 9999* ]]; then
 		git-r3_src_unpack

--- a/app-containers/aardvark-dns/files/aardvark-dns-2.1.0-musl-close_range.patch
+++ b/app-containers/aardvark-dns/files/aardvark-dns-2.1.0-musl-close_range.patch
@@ -1,0 +1,43 @@
+From 9e73fd8ddde844d755f3f992ca9cd7bb0502d87e Mon Sep 17 00:00:00 2001
+From: Pepper Gray <hello@peppergray.xyz>
+Date: Tue, 11 Aug 2026 00:03:34 +0200
+Subject: [PATCH] add syscall for close_range for non-glibc targets
+
+compiling on musl fails with error:
+```
+error[E0425]: cannot find function `close_range` in crate `libc`
+```
+
+use syscall for targets which do not provide a `close-range`-wrapper
+
+Closes: #730
+Signed-off-by: Pepper Gray <hello@peppergray.xyz>
+---
+ src/main.rs | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index f3af0d6a..c20761e1 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -32,9 +32,19 @@ enum SubCommand {
+     Version(version::Version),
+ }
+ 
++#[cfg(any(all(target_os = "linux", target_env = "gnu"), target_os = "freebsd",))]
++unsafe fn close_range(first: libc::c_uint, last: libc::c_uint, flags: libc::c_int) -> libc::c_int {
++    unsafe { libc::close_range(first, last, flags) }
++}
++
++#[cfg(all(target_os = "linux", not(target_env = "gnu"),))]
++unsafe fn close_range(first: libc::c_uint, last: libc::c_uint, flags: libc::c_int) -> libc::c_int {
++    unsafe { libc::syscall(libc::SYS_close_range, first, last, flags) as libc::c_int }
++}
++
+ fn main() {
+     // Close all fds we inherited from our parent process, we only need stdio.
+-    let _ = unsafe { libc::close_range(3, libc::c_uint::MAX, 0) };
++    let _ = unsafe { close_range(3, libc::c_uint::MAX, 0) };
+ 
+     let formatter = Formatter3164 {
+         facility: Facility::LOG_USER,


### PR DESCRIPTION
backport upstream musl fix #730:
- add syscall for close_range for non-glibc targets which do not provide a `close-range`-wrapper

Closes: https://bugs.gentoo.org/980641

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
