### PR TITLE
dev-libs/libdivsufsort: Fix various issues with CMakeLists

### DIFF
--- a/dev-libs/libdivsufsort/files/libdivsufsort-2.0.1-cmake.patch
+++ b/dev-libs/libdivsufsort/files/libdivsufsort-2.0.1-cmake.patch
@@ -1,0 +1,75 @@
+Fix various issues with the CMakeLists
+
+- Update to cmake 4
+- Unhardcoded destination locations for libraries
+- Fixed libdir in pkgconfig files
+
+--- libdivsufsort-2.0.1.orig/CMakeLists.txt
++++ libdivsufsort-2.0.1/CMakeLists.txt
+@@ -1,7 +1,8 @@
+ ### cmake file for building libdivsufsort Package ###
+-cmake_minimum_required(VERSION 2.4)
++cmake_minimum_required(VERSION 4.0)
+ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+ include(AppendCompilerFlags)
++include(GNUInstallDirs)
+ 
+ ## SVN revision ##
+ set(SVN_REVISION "")
+--- libdivsufsort-2.0.1.orig/lib/CMakeLists.txt
++++ libdivsufsort-2.0.1/lib/CMakeLists.txt
+@@ -5,10 +5,7 @@
+ 
+ ## libdivsufsort ##
+ add_library(divsufsort ${divsufsort_SRCS})
+-install(TARGETS divsufsort
+-  RUNTIME DESTINATION bin
+-  LIBRARY DESTINATION lib
+-  ARCHIVE DESTINATION lib)
++install(TARGETS divsufsort)
+ set_target_properties(divsufsort PROPERTIES
+   VERSION   "${LIBRARY_VERSION_FULL}"
+   SOVERSION "${LIBRARY_VERSION_MAJOR}"
+@@ -18,10 +15,7 @@
+ ## libdivsufsort64 ##
+ if(BUILD_DIVSUFSORT64)
+   add_library(divsufsort64 ${divsufsort_SRCS})
+-  install(TARGETS divsufsort64
+-    RUNTIME DESTINATION bin
+-    LIBRARY DESTINATION lib
+-    ARCHIVE DESTINATION lib)
++  install(TARGETS divsufsort64)
+   set_target_properties(divsufsort64 PROPERTIES
+     VERSION   "${LIBRARY_VERSION_FULL}"
+     SOVERSION "${LIBRARY_VERSION_MAJOR}"
+--- libdivsufsort-2.0.1.orig/pkgconfig/CMakeLists.txt
++++ libdivsufsort-2.0.1/pkgconfig/CMakeLists.txt
+@@ -1,10 +1,13 @@
+ ## generate libdivsufsort.pc ##
+ set(prefix "${CMAKE_INSTALL_PREFIX}")
++set(exec_prefix "\${prefix}")
++set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
++set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+ set(W64BIT "")
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libdivsufsort.pc.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort.pc" @ONLY)
+-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort.pc" DESTINATION lib/pkgconfig)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ if(BUILD_DIVSUFSORT64)
+   set(W64BIT "64")
+   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libdivsufsort.pc.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort64.pc" @ONLY)
+-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort64.pc" DESTINATION lib/pkgconfig)
++  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdivsufsort64.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+ endif(BUILD_DIVSUFSORT64)
+--- libdivsufsort-2.0.1.orig/pkgconfig/libdivsufsort.pc.cmake
++++ libdivsufsort-2.0.1/pkgconfig/libdivsufsort.pc.cmake
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=${exec_prefix}/lib
+-includedir=${prefix}/include
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
+ 
+ Name: @PROJECT_NAME@@W64BIT@
+ Description: @PROJECT_DESCRIPTION@

--- a/dev-libs/libdivsufsort/libdivsufsort-2.0.1-r3.ebuild
+++ b/dev-libs/libdivsufsort/libdivsufsort-2.0.1-r3.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake toolchain-funcs
+
+DESCRIPTION="Suffix-sorting library (for BWT)"
+HOMEPAGE="https://github.com/y-256/libdivsufsort/"
+SRC_URI="https://github.com/y-256/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="openmp"
+
+PATCHES=(
+	"${FILESDIR}/libdivsufsort-2.0.1-cmake.patch"
+)
+
+pkg_pretend() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_DIVSUFSORT64=ON
+		-DUSE_OPENMP=$(usex openmp)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
- Update to cmake 4
- Unhardcoded destination locations for libraries
- Fixed libdir in pkgconfig files

Closes: https://bugs.gentoo.org/979794
Closes: https://bugs.gentoo.org/953994
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
