### PR TITLE
x11-libs/libdrm: remove freedreno for the live ebuild

### DIFF
--- a/x11-libs/libdrm/libdrm-9999.ebuild
+++ b/x11-libs/libdrm/libdrm-9999.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} != 9999* ]]; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
-VIDEO_CARDS="amdgpu exynos freedreno intel nouveau omap radeon tegra vc4 vivante vmware"
+VIDEO_CARDS="amdgpu exynos intel nouveau omap radeon tegra vc4 vivante vmware"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -55,7 +55,6 @@ multilib_src_configure() {
 		-Dcairo-tests=disabled
 		$(meson_feature video_cards_amdgpu amdgpu)
 		$(meson_feature video_cards_exynos exynos)
-		$(meson_feature video_cards_freedreno freedreno)
 		$(meson_feature video_cards_intel intel)
 		$(meson_feature video_cards_nouveau nouveau)
 		$(meson_feature video_cards_omap omap)


### PR DESCRIPTION
This was removed in libdrm and now is in the mesa source tree instead.

Upstream-Commit: https://gitlab.freedesktop.org/mesa/libdrm/-/commit/d7a6f5fc6ef97f129b0d422a3c2c92ec7264eea0

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
