### PR TITLE
dev-libs/libgpiod-2.3.1 dependency issues and static-libs

### DIFF
--- a/dev-libs/libgpiod/libgpiod-2.3.1-r1.ebuild
+++ b/dev-libs/libgpiod/libgpiod-2.3.1-r1.ebuild
@@ -13,7 +13,7 @@ LICENSE="LGPL-2.1"
 # Reflects the ABI of libgpiod.so
 SLOT="0/3"
 KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
-IUSE="cxx dbus introspection glib python +tools test"
+IUSE="cxx dbus introspection glib python static-libs +tools test"
 REQUIRED_USE="introspection? ( glib )"
 RESTRICT="!test? ( test )"
 
@@ -85,4 +85,13 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# -Ddefault_library=shared is ignored
+	if ! use static-libs; then
+		find "${ED}" -name '*.a' -delete || die
+	fi
 }

--- a/dev-libs/libgpiod/libgpiod-2.3.1-r1.ebuild
+++ b/dev-libs/libgpiod/libgpiod-2.3.1-r1.ebuild
@@ -13,25 +13,54 @@ LICENSE="LGPL-2.1"
 # Reflects the ABI of libgpiod.so
 SLOT="0/3"
 KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
-IUSE="+tools cxx dbus introspection glib python test"
+IUSE="cxx dbus introspection glib python +tools test"
+REQUIRED_USE="introspection? ( glib )"
 RESTRICT="!test? ( test )"
 
-DEPEND="
-	dev-libs/libedit
-	dbus? ( sys-apps/dbus )
-	glib? (
-		dev-libs/libgudev
+COMMON_DEPEND="
+	dbus? (
 		>=dev-libs/glib-2.80
-		>=dev-util/glib-utils-2.80
-		>=dev-util/gdbus-codegen-2.80
+		dev-libs/libgudev
 	)
-	introspection? ( dev-libs/gobject-introspection )
+	glib? (
+		>=dev-libs/glib-2.80
+	)
+	tools? (
+		dev-libs/libedit
+	)
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	dbus? (
+		sys-apps/dbus
+	)
+"
+DEPEND="
+	${COMMON_DEPEND}
+	introspection? (
+		dev-libs/gobject-introspection
+	)
 	test? (
 		>=dev-libs/glib-2.80
 		>=sys-apps/kmod-18
 		>=sys-apps/util-linux-2.33.1
 		>=virtual/libudev-215
-		cxx? ( <dev-cpp/catch-3.5:0 )
+		cxx? (
+			<dev-cpp/catch-3.5:0
+		)
+	)
+"
+BDEPEND="
+	sys-apps/help2man
+	dbus? (
+		>=dev-util/glib-utils-2.80
+		>=dev-util/gdbus-codegen-2.80
+	)
+	glib? (
+		>=dev-util/glib-utils-2.80
+	)
+	introspection? (
+		dev-libs/gobject-introspection
 	)
 "
 
@@ -44,13 +73,13 @@ src_configure() {
 	local emesonargs=(
 		$(meson_feature test tests)
 		$(meson_feature tools)
+		$(meson_feature tools gpioset-interactive)
 		$(meson_feature cxx bindings-cxx)
 		$(meson_feature python bindings-python)
 		$(meson_feature dbus)
 		$(meson_feature glib bindings-glib)
 		$(meson_feature introspection)
 		-Dexamples=enabled
-		-Dgpioset-interactive=enabled
 		-Dbindings-rust=disabled
 		-Dprofiling=false
 	)


### PR DESCRIPTION
REQUIRED_USE added because meson.build requires it: https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L72-L76

dev-libs/libedit added to both DEPEND and RDEPEND, gpioset is gated by the tools USE but opt_gpioset_interactive requires it: https://bugs.gentoo.org/980751 https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L227
**I've gone back and forth on this and I think rolling opt_gpioset_interactive into the tools use instead of enabled by default to better control the libedit depened is the better option. Input welcome**
plutonium244 /tmp/rootfs # readelf -d usr/bin/gpioset | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libgpiod.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libgpiotools.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libedit.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

dev-libs/glib-2.80 usr/bin/gpio-manager added to both DEPEND and RDEPEND because /usr/bin/gpio-manager requires it at runtime
plutonium244 /tmp/rootfs # readelf -d usr/bin/gpio-manager | grep NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libgpiod-glib.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libglib-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgio-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgobject-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libgudev-1.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

dev-libs/glib-2.80 added to both DEPEND and RDEPEND because /usr/lib64/libgpiod-glib.so requires it at runtime
plutonium244 /tmp/rootfs # ldd usr/lib64/libgpiod-glib.so
 linux-vdso.so.1 (0x00007f73993c9000)
 libgpiod.so.3 => /usr/lib64/libgpiod.so.3 (0x00007f739936b000)
 libglib-2.0.so.0 => /usr/lib64/libglib-2.0.so.0 (0x00007f73991de000)
 libgobject-2.0.so.0 => /usr/lib64/libgobject-2.0.so.0 (0x00007f7399176000)
 libgio-2.0.so.0 => /usr/lib64/libgio-2.0.so.0 (0x00007f7398f88000)
 libc.so.6 => /lib64/libc.so.6 (0x00007f7398daa000)
 libpcre2-8.so.0 => /usr/lib64/libpcre2-8.so.0 (0x00007f7398cf9000)
 libffi.so.8 => /usr/lib64/libffi.so.8 (0x00007f7398ce5000)
 libgmodule-2.0.so.0 => /usr/lib64/libgmodule-2.0.so.0 (0x00007f7398cde000)
 libz.so.1 => /usr/lib64/libz.so.1 (0x00007f7398cc3000)
 libmount.so.1 => /usr/lib64/libmount.so.1 (0x00007f7398c65000)
 /lib64/ld-linux-x86-64.so.2 (0x00007f73993cb000)
 libblkid.so.1 => /usr/lib64/libblkid.so.1 (0x00007f7398c25000)

BDEPEND >=dev-util/glib-utils-2.80 is required for both USE dbus and glib on the build target.

BDEPEND >=dev-util/glib-utils-2.80 needed by find_program(): https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L127

BDEPEND >=dev-util/gdbus-codegen-2.80 needed by find_program(): https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L137

BDEPEND dev-libs/gobject-introspection needed by find_program(): https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L147-L148

BDEPEND sys-apps/help2man controls if man pages are created/installed, to make it deterministic I am always adding it: https://github.com/brgl/libgpiod/blob/v2.3.1/meson.build#L179

USE static-libs added to control the removal of static libs if not provided. Passing -Ddefault_library=shared should do this but appears to be ignored by all but 1 library.


---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
