### PR TITLE
net-irc/atheme-services: Bump to 7.2.12-r7

### DIFF
--- a/net-irc/atheme-services/atheme-services-7.2.12-r7.ebuild
+++ b/net-irc/atheme-services/atheme-services-7.2.12-r7.ebuild
@@ -34,7 +34,8 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-configure-logdir.patch
 	"${FILESDIR}"/${P}-libathemecore-account-fix-assertion-macro-return-type.patch
-	"${FILESDIR}"/${P}-fix-compilation-with-recent-ExtUtils-ParseXS.patch)
+	"${FILESDIR}"/${P}-fix-compilation-with-recent-ExtUtils-ParseXS.patch
+	"${FILESDIR}"/${P}-Fix-implicit-function-declaration-on-Perl-5.44.patch)
 
 src_configure() {
 	# perl scriping module support is also broken in 7.0.0. Yay for QA failures.

--- a/net-irc/atheme-services/files/atheme-services-7.2.12-Fix-implicit-function-declaration-on-Perl-5.44.patch
+++ b/net-irc/atheme-services/files/atheme-services-7.2.12-Fix-implicit-function-declaration-on-Perl-5.44.patch
@@ -1,0 +1,24 @@
+From 23d60185ebeda03c31a82d9c90f837f80b210bf0 Mon Sep 17 00:00:00 2001
+From: Attila Toth <unknown@unknown.com>
+Date: Sun, 9 Aug 2026 15:34:59 -0700
+Subject: [PATCH] Fix implicit function declaration on Perl 5.44
+
+---
+ modules/scripting/perl/api/channel.xs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/modules/scripting/perl/api/channel.xs b/modules/scripting/perl/api/channel.xs
+index ec289c03c..9fba442ae 100644
+--- a/modules/scripting/perl/api/channel.xs
++++ b/modules/scripting/perl/api/channel.xs
+@@ -1,5 +1,7 @@
+ MODULE = Atheme			PACKAGE = Atheme::Channel
+ 
++#include "../../../chanserv/chanserv.h"
++
+ Atheme_Channel
+ find(SV * package, const char * name)
+ CODE:
+-- 
+2.54.0
+


### PR DESCRIPTION
Fix compilation failure with Perl 5.44.

Closes: https://bugs.gentoo.org/980329

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
