### PR TITLE
net-vpn/tor: systemd use cache dir, run as user, add template

### DIFF
--- a/net-vpn/tor/files/tor.service-r1
+++ b/net-vpn/tor/files/tor.service-r1
@@ -1,0 +1,43 @@
+# tor.service -- this systemd configuration file for Tor sets up a
+# relatively conservative, hardened Tor service.  You may need to
+# edit it if you are making changes to your Tor configuration that it
+# does not allow.  Package maintainers: this should be a starting point
+# for your tor.service; it is not the last point.
+
+[Unit]
+Description=Anonymizing overlay network for TCP
+After=syslog.target network.target nss-lookup.target
+
+[Service]
+User=tor
+Type=notify
+NotifyAccess=all
+ExecStartPre=/usr/bin/tor --DataDirectory "$STATE_DIRECTORY" --CacheDirectory "$CACHE_DIRECTORY" -f /etc/tor/torrc --verify-config
+ExecStart=/usr/bin/tor --DataDirectory "$STATE_DIRECTORY" --CacheDirectory "$CACHE_DIRECTORY"  -f /etc/tor/torrc
+ExecReload=/bin/kill -HUP ${MAINPID}
+KillSignal=SIGINT
+TimeoutSec=60
+Restart=on-failure
+WatchdogSec=1m
+LimitNOFILE=32768
+
+# Hardening
+Group=tor
+CacheDirectory=tor
+CacheDirectoryMode=0770
+StateDirectory=tor
+StateDirectoryMode=0770
+LogsDirectory=tor
+LogsDirectoryMode=0770
+RuntimeDirectory=tor
+RuntimeDirectoryMode=0770
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectSystem=full
+ReadOnlyDirectories=/
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/net-vpn/tor/files/tor_at.service
+++ b/net-vpn/tor/files/tor_at.service
@@ -1,5 +1,4 @@
-# /lib/systemd/system/tor.service
-# tor.service -- this systemd configuration file for Tor sets up a
+# tor@.service -- this systemd configuration file for Tor sets up a
 # relatively conservative, hardened Tor service.  You may need to
 # edit it if you are making changes to your Tor configuration that it
 # does not allow.  Package maintainers: this should be a starting point

--- a/net-vpn/tor/files/tor_at.service
+++ b/net-vpn/tor/files/tor_at.service
@@ -1,0 +1,45 @@
+# /lib/systemd/system/tor.service
+# tor.service -- this systemd configuration file for Tor sets up a
+# relatively conservative, hardened Tor service.  You may need to
+# edit it if you are making changes to your Tor configuration that it
+# does not allow.  Package maintainers: this should be a starting point
+# for your tor.service; it is not the last point.
+
+[Unit]
+Description=Anonymizing overlay network for TCP
+After=syslog.target network.target nss-lookup.target
+
+[Service]
+User=tor
+Type=notify
+NotifyAccess=all
+ExecStartPre=/usr/bin/tor --DataDirectory "$STATE_DIRECTORY" --CacheDirectory "$CACHE_DIRECTORY" -f "/etc/tor/torrc-%i" --verify-config
+ExecStart=/usr/bin/tor --DataDirectory "$STATE_DIRECTORY" --CacheDirectory "$CACHE_DIRECTORY" -f "/etc/tor/torrc-%i"
+ExecReload=/bin/kill -HUP ${MAINPID}
+KillSignal=SIGINT
+TimeoutSec=60
+Restart=on-failure
+WatchdogSec=1m
+LimitNOFILE=32768
+
+# Hardening
+Group=tor
+CacheDirectory=tor-%i
+CacheDirectoryMode=0770
+StateDirectory=tor-%i
+StateDirectoryMode=0770
+LogsDirectory=tor-%i
+LogsDirectoryMode=0770
+RuntimeDirectory=tor-%i
+RuntimeDirectoryMode=0770
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectHome=yes
+ProtectSystem=full
+ReadOnlyDirectories=/
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+

--- a/net-vpn/tor/tor-0.4.9.11-r1.ebuild
+++ b/net-vpn/tor/tor-0.4.9.11-r1.ebuild
@@ -28,7 +28,7 @@ else
 	S="${WORKDIR}/${MY_PF}"
 
 	if [[ ${PV} != *_alpha* && ${PV} != *_beta* && ${PV} != *_rc* ]]; then
-		KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+		KEYWORDS="amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv ~sparc x86"
 	fi
 
 	BDEPEND="verify-sig? ( >=sec-keys/openpgp-keys-tor-20250713 )"

--- a/net-vpn/tor/tor-0.4.9.11-r1.ebuild
+++ b/net-vpn/tor/tor-0.4.9.11-r1.ebuild
@@ -28,7 +28,7 @@ else
 	S="${WORKDIR}/${MY_PF}"
 
 	if [[ ${PV} != *_alpha* && ${PV} != *_beta* && ${PV} != *_rc* ]]; then
-		KEYWORDS="amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv ~sparc x86"
+		KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 	fi
 
 	BDEPEND="verify-sig? ( >=sec-keys/openpgp-keys-tor-20250713 )"


### PR DESCRIPTION
Improve systemd service:
* Use the cache directory for cache data, instead of the default which to use the data directory
* Run as the tor user by default instead of root
* Add a systemd service template

Bug: https://bugs.gentoo.org/706430
Bug: https://bugs.gentoo.org/547068
Bug: https://bugs.gentoo.org/694986

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
