### PR TITLE
games-emulation/melonds: Add X dependency on dev-qt/qtbase

### DIFF
--- a/games-emulation/melonds/melonds-1.1-r1.ebuild
+++ b/games-emulation/melonds/melonds-1.1-r1.ebuild
@@ -31,7 +31,7 @@ IUSE="+jit +opengl wayland"
 
 RDEPEND="
 	app-arch/libarchive[zstd]
-	dev-qt/qtbase:6[network,opengl,widgets]
+	dev-qt/qtbase:6[network,opengl,widgets,X]
 	dev-qt/qtmultimedia:6
 	dev-qt/qtsvg:6
 	media-libs/faad2


### PR DESCRIPTION
Without the X USE flag being enabled on dev-qt/qtbase, the package fails to build due to the symbol `QX11Application` being undefined. This commit adds that dependency to the ebuild

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
