### PR TITLE
gui-app/waybar: Fix libcxx unwinding over glibc

### DIFF
--- a/gui-apps/waybar/files/meson-fix-build.patch
+++ b/gui-apps/waybar/files/meson-fix-build.patch
@@ -1,0 +1,38 @@
+From 69c61c3d9ae8f7397d64570412655007ea086c56 Mon Sep 17 00:00:00 2001
+From: ShengYi Hung <aokblast@FreeBSD.org>
+Date: Sun, 23 Aug 2026 12:45:10 +0800
+Subject: [PATCH] meson: Fix unwinding error in libunwind over glibc
+
+glibc's pthread_cancel dlopens libgcc_s.so.1 and uses its unwinder,
+while libc++abi's personality routine resolves the Unwind* accessors
+from the global scope, where LLVM libunwind wins. This causes the two
+unwinders to interpret each other's unwind context incorrectly, and
+cancelling a thread segfaults. Pull libgcc_s into DT_NEEDED before
+libc++abi/libunwind so all Unwind* symbols resolve to the same unwinder.
+---
+ meson.build | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 5dc7338d5f..88be32e27b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -17,7 +17,17 @@ cpp_link_args = []
+ 
+ if get_option('libcxx')
+     cpp_args += ['-stdlib=libc++']
+-    cpp_link_args += ['-stdlib=libc++', '-lc++abi']
++    cpp_link_args += ['-stdlib=libc++']
++    # glibc's pthread_cancel dlopens libgcc_s.so.1 and forces the unwind through
++    # that unwinder, while libc++abi's personality routine resolves the _Unwind_*
++    # accessors through the global scope, where LLVM libunwind wins. The two read
++    # each other's unwind context as their own, so cancelling a thread
++    # (SleeperThread::stop) segfaults. Pull libgcc_s into DT_NEEDED ahead of
++    # libc++abi/libunwind so every _Unwind_* symbol resolves to one unwinder.
++    if compiler.has_link_argument('-lgcc_s')
++        cpp_link_args += ['-Wl,--push-state,--no-as-needed', '-lgcc_s', '-Wl,--pop-state']
++    endif
++    cpp_link_args += ['-lc++abi']
+ endif
+ 
+ if compiler.has_link_argument('-lc++fs')

--- a/gui-apps/waybar/waybar-0.14.0.ebuild
+++ b/gui-apps/waybar/waybar-0.14.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson optfeature
+inherit meson optfeature toolchain-funcs
 
 DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
 HOMEPAGE="https://github.com/Alexays/Waybar"
@@ -75,9 +75,20 @@ DEPEND="${RDEPEND}
 	dev-libs/wayland-protocols
 	test? ( dev-cpp/catch:0 )
 "
+PATCHES=(
+	"${FILESDIR}"/meson-fix-build.patch
+)
 
 src_configure() {
+	local cxx_stdlib=$(tc-get-cxx-stdlib)
+	einfo "C++ standard library: ${cxx_stdlib:-unknown}"
+	local libcxx=false
+	if [[ ${cxx_stdlib} == libc++ ]]; then
+		libcxx=true
+	fi
+
 	local emesonargs=(
+		-Dlibcxx=${libcxx}
 		-Dman-pages=enabled
 		-Dcava=disabled # depends on LukashonakV/cava fork, but media-sound/cava is karlstav/cava
 		$(meson_feature evdev libevdev)

--- a/gui-apps/waybar/waybar-0.15.0.ebuild
+++ b/gui-apps/waybar/waybar-0.15.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson optfeature
+inherit meson optfeature toolchain-funcs
 
 DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
 HOMEPAGE="https://github.com/Alexays/Waybar"
@@ -78,8 +78,20 @@ DEPEND="${RDEPEND}
 	test? ( dev-cpp/catch:0 )
 "
 
+PATCHES=(
+	"${FILESDIR}"/meson-fix-build.patch
+)
+
 src_configure() {
+	local cxx_stdlib=$(tc-get-cxx-stdlib)
+	einfo "C++ standard library: ${cxx_stdlib:-unknown}"
+	local libcxx=false
+	if [[ ${cxx_stdlib} == libc++ ]]; then
+		libcxx=true
+	fi
+
 	local emesonargs=(
+		-Dlibcxx=${libcxx}
 		-Dman-pages=enabled
 		-Dcava=disabled # depends on LukashonakV/cava fork, but media-sound/cava is karlstav/cava
 		$(meson_feature evdev libevdev)


### PR DESCRIPTION
Gentoo's clang can default to libc++ (llvm-core/clang-common) writes --stdlib=libc++ into /etc/clang/gentoo-runtimes.cfg when llvm-runtimes/clang-runtime[libcxx] is set), which upstream's -Dlibcxx option cannot see. Ask the toolchain instead, so the libc++-specific link handling in meson.build is enabled whenever it is actually needed.

Also, backport libcxx unwinding fix over glibc patch from upstream.