### PR TITLE
Fix "PYTHON_EXECUTABLE" in Jupyter kernel.

### DIFF
--- a/sci-mathematics/cadabra/cadabra-2.5.14_p1-r2.ebuild
+++ b/sci-mathematics/cadabra/cadabra-2.5.14_p1-r2.ebuild
@@ -83,10 +83,6 @@ src_prepare() {
 	cp -r -l "${WORKDIR}/MicroTeX-${BUNDLED_MICROTEX_SUBMODULE_SHA}"/* \
 	   ./submodules/microtex/ || die
 
-	# Fix "PYTHON_EXECUTABLE" in Jupyter kernel
-	sed -i "s|@PYTHON_EXECUTABLE@|${EPYTHON}|"  \
-		./jupyterkernel/kernelspec/kernel.json.in || die
-
 	# Clean postinst script which calls libtool and icon-cache update
 	echo '#!/bin/sh' > ./config/postinst.in || die
 
@@ -102,14 +98,13 @@ src_prepare() {
 
 src_configure() {
 	local -a mycmakeargs=(
+		-DPython_EXECUTABLE="${PYTHON}"
 		-DENABLE_SYSTEM_JSONCPP="ON"
 		-DPACKAGING_MODE="ON"
-
 		-DBUILD_AS_CPP_LIBRARY="OFF"
 		-DENABLE_JUPYTER="OFF"  # For a special Xeus Jupyter kernel (uses xtl).
 		-DENABLE_MATHEMATICA="OFF"
 		-DINSTALL_TARGETS_ONLY="OFF"
-
 		-DBUILD_TESTS="$(usex test)"
 		-DENABLE_FRONTEND="$(usex gui)"
 		-DENABLE_PY_JUPYTER="$(usex jupyter)"


### PR DESCRIPTION
The sed in src_prepare was not working, it was getting the path in /var/tmp/... and passing to the installed files.

This drop sed in src_prepare and uses -DPython_EXECUTABLE="${PYTHON}" in mycmakeargs.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
