### PR TITLE
Fix Clang bootstarpping in macOS/Darwin Prefix

### DIFF
--- a/dev-libs/libassuan/files/libassuan-3.0.0-remove-putc.patch
+++ b/dev-libs/libassuan/files/libassuan-3.0.0-remove-putc.patch
@@ -1,0 +1,28 @@
+From 69069bc63e6b1152e34e39bc322132fd4fd7284d Mon Sep 17 00:00:00 2001
+From: Werner Koch <wk@gnupg.org>
+Date: Tue, 25 Jun 2024 09:06:04 +0200
+Subject: [PATCH] Remove an declaration for an unused function
+
+* src/assuan-defs.h (putc_unlocked): Remove declaration.
+--
+
+It seems the test for putc_unlocked was remove a long time ago.
+GnuPG-bug-id: 7111
+---
+ src/assuan-defs.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/assuan-defs.h b/src/assuan-defs.h
+index faf9aae..5052e8e 100644
+--- a/src/assuan-defs.h
++++ b/src/assuan-defs.h
+@@ -431,9 +431,6 @@ char *stpcpy (char *dest, const char *src);
+ #define clearenv _assuan_clearenv
+ int setenv (const char *name, const char *value, int replace);
+ #endif
+-#ifndef HAVE_PUTC_UNLOCKED
+-int putc_unlocked (int c, FILE *stream);
+-#endif
+ 
+ 
+ #define DIM(v)		     (sizeof(v)/sizeof((v)[0]))

--- a/dev-libs/libassuan/libassuan-3.0.0-r1.ebuild
+++ b/dev-libs/libassuan/libassuan-3.0.0-r1.ebuild
@@ -27,6 +27,7 @@ BDEPEND="verify-sig? ( sec-keys/openpgp-keys-gnupg )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.0.0-fix-typo.patch
+	"${FILESDIR}"/${PN}-3.0.0-remove-putc.patch
 )
 
 src_prepare() {

--- a/dev-libs/libassuan/libassuan-3.0.1-r1.ebuild
+++ b/dev-libs/libassuan/libassuan-3.0.1-r1.ebuild
@@ -27,6 +27,7 @@ BDEPEND="verify-sig? ( sec-keys/openpgp-keys-gnupg )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.0.0-fix-typo.patch
+	"${FILESDIR}"/${PN}-3.0.0-remove-putc.patch
 )
 
 src_prepare() {

--- a/llvm-core/clang-common/clang-common-22.1.8.ebuild
+++ b/llvm-core/clang-common/clang-common-22.1.8.ebuild
@@ -301,6 +301,7 @@ src_install() {
 				-Wl,-rpath,${EPREFIX}/../usr/lib
 				-Wl,-L,${EPREFIX}/../usr/lib
 				-isystem ${EPREFIX}/../usr/include
+				-stdlib++-isystem ${EPREFIX}/../usr/include/c++/v1
 			EOF
 		fi
 		# Using -Wl,-L instead of -L to trick compiler driver to put it
@@ -309,6 +310,7 @@ src_install() {
 			-Wl,-rpath,${EPREFIX}/usr/lib
 			-Wl,-L,${EPREFIX}/usr/lib
 			-isystem ${EPREFIX}/usr/include
+			-stdlib++-isystem ${EPREFIX}/usr/include/c++/v1
 			-isysroot ${EPREFIX}/MacOSX.sdk
 		EOF
 	fi

--- a/llvm-core/clang-common/clang-common-23.1.0.ebuild
+++ b/llvm-core/clang-common/clang-common-23.1.0.ebuild
@@ -301,6 +301,7 @@ src_install() {
 				-Wl,-rpath,${EPREFIX}/../usr/lib
 				-Wl,-L,${EPREFIX}/../usr/lib
 				-isystem ${EPREFIX}/../usr/include
+				-stdlib++-isystem ${EPREFIX}/../usr/include/c++/v1
 			EOF
 		fi
 		# Using -Wl,-L instead of -L to trick compiler driver to put it
@@ -309,6 +310,7 @@ src_install() {
 			-Wl,-rpath,${EPREFIX}/usr/lib
 			-Wl,-L,${EPREFIX}/usr/lib
 			-isystem ${EPREFIX}/usr/include
+			-stdlib++-isystem ${EPREFIX}/usr/include/c++/v1
 			-isysroot ${EPREFIX}/MacOSX.sdk
 		EOF
 	fi

--- a/llvm-core/clang-common/clang-common-24.0.0.9999.ebuild
+++ b/llvm-core/clang-common/clang-common-24.0.0.9999.ebuild
@@ -300,6 +300,7 @@ src_install() {
 				-Wl,-rpath,${EPREFIX}/../usr/lib
 				-Wl,-L,${EPREFIX}/../usr/lib
 				-isystem ${EPREFIX}/../usr/include
+				-stdlib++-isystem ${EPREFIX}/../usr/include/c++/v1
 			EOF
 		fi
 		# Using -Wl,-L instead of -L to trick compiler driver to put it
@@ -308,6 +309,7 @@ src_install() {
 			-Wl,-rpath,${EPREFIX}/usr/lib
 			-Wl,-L,${EPREFIX}/usr/lib
 			-isystem ${EPREFIX}/usr/include
+			-stdlib++-isystem ${EPREFIX}/usr/include/c++/v1
 			-isysroot ${EPREFIX}/MacOSX.sdk
 		EOF
 	fi

--- a/llvm-core/clang-common/clang-common-24.0.0_pre20260725.ebuild
+++ b/llvm-core/clang-common/clang-common-24.0.0_pre20260725.ebuild
@@ -300,6 +300,7 @@ src_install() {
 				-Wl,-rpath,${EPREFIX}/../usr/lib
 				-Wl,-L,${EPREFIX}/../usr/lib
 				-isystem ${EPREFIX}/../usr/include
+				-stdlib++-isystem ${EPREFIX}/../usr/include/c++/v1
 			EOF
 		fi
 		# Using -Wl,-L instead of -L to trick compiler driver to put it
@@ -308,6 +309,7 @@ src_install() {
 			-Wl,-rpath,${EPREFIX}/usr/lib
 			-Wl,-L,${EPREFIX}/usr/lib
 			-isystem ${EPREFIX}/usr/include
+			-stdlib++-isystem ${EPREFIX}/usr/include/c++/v1
 			-isysroot ${EPREFIX}/MacOSX.sdk
 		EOF
 	fi

--- a/llvm-runtimes/libcxx/libcxx-22.1.8.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-22.1.8.ebuild
@@ -163,6 +163,10 @@ multilib_src_configure() {
 			-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/${CTARGET}/usr"
 		)
 	fi
+	if use kernel_Darwin; then
+		# For Darwin it ships libc++ in system by default, conflicting prefix
+		mycmakeargs+=( -DLIBCXX_ABI_NAMESPACE=__gentoo1 )
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libcxx/libcxx-23.1.0.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-23.1.0.ebuild
@@ -157,6 +157,10 @@ multilib_src_configure() {
 			-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/${CTARGET}/usr"
 		)
 	fi
+	if use kernel_Darwin; then
+		# For Darwin it ships libc++ in system by default, conflicting prefix
+		mycmakeargs+=( -DLIBCXX_ABI_NAMESPACE=__gentoo1 )
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libcxx/libcxx-24.0.0.9999.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-24.0.0.9999.ebuild
@@ -156,6 +156,10 @@ multilib_src_configure() {
 			-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/${CTARGET}/usr"
 		)
 	fi
+	if use kernel_Darwin; then
+		# For Darwin it ships libc++ in system by default, conflicting prefix
+		mycmakeargs+=( -DLIBCXX_ABI_NAMESPACE=__gentoo1 )
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/llvm-runtimes/libcxx/libcxx-24.0.0_pre20260725.ebuild
+++ b/llvm-runtimes/libcxx/libcxx-24.0.0_pre20260725.ebuild
@@ -156,6 +156,10 @@ multilib_src_configure() {
 			-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/${CTARGET}/usr"
 		)
 	fi
+	if use kernel_Darwin; then
+		# For Darwin it ships libc++ in system by default, conflicting prefix
+		mycmakeargs+=( -DLIBCXX_ABI_NAMESPACE=__gentoo1 )
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"


### PR DESCRIPTION
https://bugs.gentoo.org/758167

Corresponding with push https://github.com/gentoo/prefix/pull/45, it now successfully boots but may requires furthur discussion.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
