### PR TITLE
app-crypt/tpm2-tools: Fix FAPI sign and verify test failures

### DIFF
--- a/app-crypt/tpm2-tools/files/tpm2-tools-5.8-fix-fapi-verify-sign.sh.patch
+++ b/app-crypt/tpm2-tools/files/tpm2-tools-5.8-fix-fapi-verify-sign.sh.patch
@@ -1,0 +1,68 @@
+diff --git a/configure.ac b/configure.ac
+index fcafc921..3a0262f0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -82,10 +82,24 @@ AC_CHECK_LIB(crypto, [EVP_sm3], [
+ AC_CHECK_LIB(crypto, [EVP_sm4_cfb128], [
+         AC_DEFINE([HAVE_EVP_SM4_CFB], [1], [Support EVP_sm4_cfb in openssl])],
+         [])
+-AC_CHECK_LIB(tss2-fapi, [Fapi_DigestAndSign], [
+-        AC_DEFINE([HAVE_FAPI_DIGEST_AND_SIGN], [1], [Support signing with restricted keys])],
+-        [])
+-LIBS="${LIBS_save}"
++save_CPPFLAGS="$CPPFLAGS"
++save_LIBS="$LIBS"
++
++save_LIBS="$LIBS"
++
++LIBS="$TSS2_FAPI_LIBS $LIBS"
++
++AC_CHECK_FUNC(
++    [Fapi_DigestAndSign],
++    [AC_DEFINE(
++        [HAVE_FAPI_DIGEST_AND_SIGN],
++        [1],
++        [Define if Fapi_DigestAndSign is available]
++    )]
++)
++
++LIBS="$save_LIBS"
++
+ PKG_CHECK_MODULES([CURL], [libcurl])
+ 
+ # pretty print of devicepath if efivar library is present
+diff --git a/test/integration/fapi/fapi-sign-verify.sh b/test/integration/fapi/fapi-sign-verify.sh
+index 24635ed1..5181dd00 100644
+--- a/test/integration/fapi/fapi-sign-verify.sh
++++ b/test/integration/fapi/fapi-sign-verify.sh
+@@ -337,19 +337,23 @@ dd if=/dev/zero of=$DATA_FILE bs=1 count=1024
+ if [ "$CRYPTO_PROFILE" = "RSA" ]; then
+     PADDING="--padding=RSA_PSS"
+ fi
+-if nm -D $(ldconfig -p | grep "libtss2-fapi" | head -n1 | awk '{print $NF}') | \
+-        grep "Fapi_DigestAndSign";
++
++if printf '%s\n' \
++    'extern void Fapi_DigestAndSign(void);' \
++    'int main(void) { Fapi_DigestAndSign(); return 0; }' |
++   "${CC:-cc}" -x c - -L/usr/local/lib -ltss2-fapi -o /tmp/check-fapi
+ then
+     tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
+          --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE -f
+-
+-    shasum -a 256 $DATA_FILE | awk '{ $1 }' | xxd -r -p > $DIGEST_FILE
++    shasum -a 256 $DATA_FILE | awk '{ print $1 }' | xxd -r -p > $DIGEST_FILE
+     tss2 verifysignature --keyPath=$PUB_KEY_DIR/$IMPORTED_KEY_NAME \
+          --digest=$DIGEST_FILE --signature=$SIGNATURE_FILE
+ else
+     # The sign should fail because Fapi_DigestAndSign is not available
+-    ! tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
+-      --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE
++    if tss2 sign --data=$DATA_FILE --keyPath=$KEY_PATH $PADDING \
++            --signature=$SIGNATURE_FILE --publicKey=$PUBLIC_KEY_FILE ; then
++        echo "ERROR: tss2_sign unexpectedly succeeded"
++        exit 1;
++    fi
+ fi
+-
+ exit 0

--- a/app-crypt/tpm2-tools/tpm2-tools-5.8.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-5.8.ebuild
@@ -38,6 +38,7 @@ BDEPEND="virtual/pkgconfig
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.6-Makefile-am-Dont-require-pandoc-for-tests.patch"
+	"${FILESDIR}/${PN}-5.8-fix-fapi-verify-sign.sh.patch"
 )
 
 python_check_deps() {
@@ -50,6 +51,13 @@ pkg_setup() {
 
 src_prepare() {
 	default
+
+	# Regenerate faulty test, see ${S}/bootstrap
+	find "test/integration/fapi" \( -iname "*.sh" ! -iname "*ecc.sh" \) | while read fname; do
+		cp $fname ${fname%.sh}_ecc.sh || die
+		sed -i -e 's/CRYPTO_PROFILE="RSA"/CRYPTO_PROFILE="ECC"/g' ${fname%.sh}_ecc.sh || die
+	done
+
 	eautoreconf
 }
 


### PR DESCRIPTION
Upstream released a patch to fix it, but that wasn't enough. The test must be regenerated using the bootstrap script provided by upstream as well.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
