### PR TITLE
dev-util/nvidia-cuda-toolkit: Fix clang warning message

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.6.3-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.6.3-r1.ebuild
@@ -360,8 +360,8 @@ pkg_postinst_check() {
 			ewarn
 			ewarn "Append --ccbin= pointing to a clang bindir to the nvcc compiler flags (NVCCFLAGS)"
 			ewarn "or set NVCC_CCBIN to the same bindir."
-			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")\""
-			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")"
+			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")\""
+			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")"
 			ewarn
 		fi
 	fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.1-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.1-r1.ebuild
@@ -360,8 +360,8 @@ pkg_postinst_check() {
 			ewarn
 			ewarn "Append --ccbin= pointing to a clang bindir to the nvcc compiler flags (NVCCFLAGS)"
 			ewarn "or set NVCC_CCBIN to the same bindir."
-			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")\""
-			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")"
+			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")\""
+			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")"
 			ewarn
 		fi
 	fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.2.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.8.2.ebuild
@@ -362,8 +362,8 @@ pkg_postinst_check() {
 			ewarn
 			ewarn "Append --ccbin= pointing to a clang bindir to the nvcc compiler flags (NVCCFLAGS)"
 			ewarn "or set NVCC_CCBIN to the same bindir."
-			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")\""
-			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")"
+			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")\""
+			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")"
 			ewarn
 		fi
 	fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.9.1-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.9.1-r1.ebuild
@@ -363,8 +363,8 @@ pkg_postinst_check() {
 			ewarn
 			ewarn "Append --ccbin= pointing to a clang bindir to the nvcc compiler flags (NVCCFLAGS)"
 			ewarn "or set NVCC_CCBIN to the same bindir."
-			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")\""
-			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")"
+			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")\""
+			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")"
 			ewarn
 		fi
 	fi

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.9.2.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-12.9.2.ebuild
@@ -362,8 +362,8 @@ pkg_postinst_check() {
 			ewarn
 			ewarn "Append --ccbin= pointing to a clang bindir to the nvcc compiler flags (NVCCFLAGS)"
 			ewarn "or set NVCC_CCBIN to the same bindir."
-			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")\""
-			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/*/bin${CLANG_MAX_VER}")"
+			ewarn "	NVCCFLAGS=\"--ccbin=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")\""
+			ewarn "	NVCC_CCBIN=$(eval echo "${EPREFIX}/usr/lib/llvm/${CLANG_MAX_VER}/bin")"
 			ewarn
 		fi
 	fi


### PR DESCRIPTION
We install clang binary to /usr/lib/llvm/<version>/bin/ instead of /usr/lib/llvm/<arch>/bin<version>. Correctly pass the binary location on hostcc setup message.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
