### PR TITLE
media-libs/mesa: add VIDEO_CARDS=tegra

### DIFF
--- a/media-libs/mesa/mesa-26.0.8.ebuild
+++ b/media-libs/mesa/mesa-26.0.8.ebuild
@@ -55,7 +55,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -74,6 +74,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -313,6 +314,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.1.4.ebuild
+++ b/media-libs/mesa/mesa-26.1.4.ebuild
@@ -55,7 +55,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -74,6 +74,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -313,6 +314,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.1.5.ebuild
+++ b/media-libs/mesa/mesa-26.1.5.ebuild
@@ -55,7 +55,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -74,6 +74,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -313,6 +314,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.1.6.ebuild
+++ b/media-libs/mesa/mesa-26.1.6.ebuild
@@ -55,7 +55,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -74,6 +74,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -313,6 +314,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.1.7.ebuild
+++ b/media-libs/mesa/mesa-26.1.7.ebuild
@@ -55,7 +55,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -74,6 +74,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -313,6 +314,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.1.8.ebuild
+++ b/media-libs/mesa/mesa-26.1.8.ebuild
@@ -56,7 +56,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -75,6 +75,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.121"
@@ -329,6 +330,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-26.2.1.ebuild
+++ b/media-libs/mesa/mesa-26.2.1.ebuild
@@ -56,7 +56,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -75,6 +75,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.133"
@@ -328,6 +329,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -56,7 +56,7 @@ SLOT="0"
 
 VIDEO_CARDS="
 	asahi d3d12 freedreno i915 imagination intel lavapipe lima nouveau nvk
-	panfrost r300 r600 radeon radeonsi v3d vc4 virgl vivante vmware zink"
+	panfrost r300 r600 radeon radeonsi tegra v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -75,6 +75,7 @@ REQUIRED_USE="
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
+	video_cards_tegra? ( video_cards_nouveau )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.133"
@@ -328,6 +329,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_lima lima
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
+	gallium_enable video_cards_tegra tegra
 	gallium_enable video_cards_v3d v3d
 	gallium_enable video_cards_vc4 vc4
 	gallium_enable video_cards_virgl virgl


### PR DESCRIPTION
Enables tegra gallium driver, which is required for Tegra X1 devices such as Jetson Nano.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
