### PR TITLE
app-text/ghostscript-gpl: fix cross-compile

### DIFF
--- a/app-text/ghostscript-gpl/ghostscript-gpl-10.06.0-r2.ebuild
+++ b/app-text/ghostscript-gpl/ghostscript-gpl-10.06.0-r2.ebuild
@@ -159,6 +159,9 @@ src_configure() {
 		FONTPATH="${FONTPATH}${FONTPATH:+:}${EPREFIX}${path}"
 	done
 
+	# use target config in cross build, bug #982024
+	use cups && local -x CUPSCONFIG="${ESYSROOT}/usr/bin/cups-config"
+
 	# Do not add --enable-dynamic here, it's not supported fully upstream
 	# https://bugs.ghostscript.com/show_bug.cgi?id=705895
 	# bug #884707

--- a/app-text/ghostscript-gpl/ghostscript-gpl-10.06.0.ebuild
+++ b/app-text/ghostscript-gpl/ghostscript-gpl-10.06.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -145,6 +145,9 @@ src_configure() {
 	do
 		FONTPATH="${FONTPATH}${FONTPATH:+:}${EPREFIX}${path}"
 	done
+
+	# use target config in cross build, bug #982024
+	use cups && local -x CUPSCONFIG="${ESYSROOT}/usr/bin/cups-config"
 
 	# Do not add --enable-dynamic here, it's not supported fully upstream
 	# https://bugs.ghostscript.com/show_bug.cgi?id=705895


### PR DESCRIPTION
cross compiling fails with error
```
configure: error: libcups/libcupsimage not found
```

set target config for `CUPSCONFIG` in cross build

Bug: https://bugs.gentoo.org/982024

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
