### PR TITLE
app-text/poppler: fix cross-compile

### DIFF
--- a/app-text/poppler/poppler-26.03.0.ebuild
+++ b/app-text/poppler/poppler-26.03.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{11..15} )
 inherit cmake flag-o-matic python-any-r1 toolchain-funcs xdg-utils
 
 if [[ ${PV} == *9999* ]] ; then
@@ -59,6 +59,7 @@ BDEPEND="
 	${PYTHON_DEPS}
 	>=dev-util/glib-utils-2.64
 	virtual/pkgconfig
+	qt6? ( dev-qt/qtbase:6 )
 "
 
 if [[ ${PV} != *9999* ]] ; then
@@ -128,6 +129,7 @@ src_configure() {
 		-DENABLE_UTILS=$(usex utils)
 	)
 	use cairo && mycmakeargs+=( -DWITH_GObjectIntrospection=$(usex introspection) )
+	use qt6 && tc-is-cross-compiler && mycmakeargs+=( -DQT_HOST_PATH="${BROOT}" )
 
 	cmake_src_configure
 }

--- a/app-text/poppler/poppler-26.05.0-r1.ebuild
+++ b/app-text/poppler/poppler-26.05.0-r1.ebuild
@@ -58,6 +58,7 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="${PYTHON_DEPS}
 	>=dev-util/glib-utils-2.80
 	virtual/pkgconfig
+	qt6? ( dev-qt/qtbase:6 )
 "
 
 if [[ ${PV} != *9999* ]] ; then
@@ -128,6 +129,7 @@ src_configure() {
 		-DENABLE_UTILS=$(usex utils)
 	)
 	use cairo && mycmakeargs+=( -DWITH_GObjectIntrospection=$(usex introspection) )
+	use qt6 && tc-is-cross-compiler && mycmakeargs+=( -DQT_HOST_PATH="${BROOT}" )
 
 	cmake_src_configure
 }

--- a/app-text/poppler/poppler-9999.ebuild
+++ b/app-text/poppler/poppler-9999.ebuild
@@ -58,6 +58,7 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="${PYTHON_DEPS}
 	>=dev-util/glib-utils-2.80
 	virtual/pkgconfig
+	qt6? ( dev-qt/qtbase:6 )
 "
 
 if [[ ${PV} != *9999* ]] ; then
@@ -127,6 +128,7 @@ src_configure() {
 		-DENABLE_UTILS=$(usex utils)
 	)
 	use cairo && mycmakeargs+=( -DWITH_GObjectIntrospection=$(usex introspection) )
+	use qt6 && tc-is-cross-compiler && mycmakeargs+=( -DQT_HOST_PATH="${BROOT}" )
 
 	cmake_src_configure
 }


### PR DESCRIPTION
cross compiling fails with error
```
qemu-${arch}: Could not open '/lib/ld-musl-${arch}.so.1': No such file or directory
```
use host instead of target qt-tool `moc`  for build

Bug: https://bugs.gentoo.org/982028

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
