### PR TITLE
app-text/doxygen: fix cross-compile

### DIFF
--- a/app-text/doxygen/doxygen-1.13.2.ebuild
+++ b/app-text/doxygen/doxygen-1.13.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -75,7 +75,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 

--- a/app-text/doxygen/doxygen-1.14.0.ebuild
+++ b/app-text/doxygen/doxygen-1.14.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -75,7 +75,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 

--- a/app-text/doxygen/doxygen-1.15.0-r2.ebuild
+++ b/app-text/doxygen/doxygen-1.15.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -79,7 +79,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 

--- a/app-text/doxygen/doxygen-1.15.0.ebuild
+++ b/app-text/doxygen/doxygen-1.15.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,7 @@ LLVM_OPTIONAL=1
 PYTHON_COMPAT=( python3_{11..14} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -75,7 +75,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 

--- a/app-text/doxygen/doxygen-1.16.1.ebuild
+++ b/app-text/doxygen/doxygen-1.16.1.ebuild
@@ -5,10 +5,10 @@ EAPI=8
 
 LLVM_COMPAT=( 18 19 20 21 22 )
 LLVM_OPTIONAL=1
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{11..15} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -78,7 +78,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 

--- a/app-text/doxygen/doxygen-9999.ebuild
+++ b/app-text/doxygen/doxygen-9999.ebuild
@@ -1,14 +1,14 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-LLVM_COMPAT=( 18 19 20 21 )
+LLVM_COMPAT=( 18 19 20 21 22 )
 LLVM_OPTIONAL=1
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{11..15} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit cmake flag-o-matic llvm-r1 python-any-r1
+inherit cmake flag-o-matic llvm-r2 python-any-r1
 
 DESCRIPTION="Documentation system for most programming languages"
 HOMEPAGE="https://www.doxygen.nl/"
@@ -75,7 +75,7 @@ PATCHES=(
 DOCS=( LANGUAGE.HOWTO README.md )
 
 pkg_setup() {
-	use clang && llvm-r1_pkg_setup
+	use clang && llvm-r2_pkg_setup
 	python-any-r1_pkg_setup
 }
 


### PR DESCRIPTION
cross compiling fails due to target c compiler being used, instead of the hosts cross compiler.

use `llvm-r2.eclass`

Bug: https://bugs.gentoo.org/982030

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
