### PR TITLE
sys-apps/intune-portal: Resolve symlinks before doing bind mounts

### DIFF
--- a/sys-apps/intune-portal/files/wrapper
+++ b/sys-apps/intune-portal/files/wrapper
@@ -1,10 +1,14 @@
 #!/bin/sh
 
+lsb_release=$(realpath /etc/lsb-release)
+os_release=$(realpath /etc/os-release)
+common_password=$(realpath /etc/pam.d/common-password)
+
 exec bwrap \
     --bind / / \
     --dev-bind /dev /dev \
-    --ro-bind /etc/microsoft/identity-broker/etc/lsb-release /etc/lsb-release \
-    --ro-bind /etc/microsoft/identity-broker/etc/os-release /etc/os-release \
-    --ro-bind /etc/pam.d/system-auth /etc/pam.d/common-password \
+    --ro-bind /etc/microsoft/identity-broker/etc/lsb-release "${lsb_release}" \
+    --ro-bind /etc/microsoft/identity-broker/etc/os-release "${os_release}" \
+    --ro-bind /etc/pam.d/system-auth "${common_password}" \
     -- \
     /opt/microsoft/intune/libexec/"${0##*/}" "${@}"


### PR DESCRIPTION
bubblewrap 0.12.0 got some symlink-related security fixes that broke a setup of intune portal, where /etc/os-release is a symlink to /usr/lib/os-release.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
